### PR TITLE
Fix clang format

### DIFF
--- a/cmake/Addclang-format.cmake
+++ b/cmake/Addclang-format.cmake
@@ -12,10 +12,11 @@
 ##
 ##===------------------------------------------------------------------------------------------===##
 
-find_package(clang-format)
+find_package(clang-format 3.8)
 
 dawn_export_package(
   NAME clang-format
   FOUND ${CLANG-FORMAT_FOUND}
+  VERSION ${CLANG-FORMAT_VERSION}
   EXECUTABLE ${CLANG-FORMAT_EXECUTABLE}
 )

--- a/cmake/Addclang-format.cmake
+++ b/cmake/Addclang-format.cmake
@@ -12,7 +12,7 @@
 ##
 ##===------------------------------------------------------------------------------------------===##
 
-find_package(clang-format 3.8)
+find_package(clang-format EXACT 3.8)
 
 dawn_export_package(
   NAME clang-format

--- a/cmake/modules/Findclang-format.cmake
+++ b/cmake/modules/Findclang-format.cmake
@@ -47,7 +47,7 @@ include(FindPackageHandleStandardArgs)
 # Find clang-format
 if(NOT DEFINED CLANG-FORMAT_EXECUTABLE)
   find_program(CLANG-FORMAT_EXECUTABLE 
-    NAMES clang-format_${clang-format_FIND_VERSION}
+    NAMES clang-format-${clang-format_FIND_VERSION}
           clang-format
     DOC "Path to clang-format executable"
   )
@@ -65,8 +65,7 @@ if(CLANG-FORMAT_EXECUTABLE)
     string(REGEX MATCH "^clang-format version ([0-9]+)\\.([0-9]+)\\.([0-9]+)(.*)$" match "${stdout}")
     set(major "${CMAKE_MATCH_1}") 
     set(minor "${CMAKE_MATCH_2}") 
-    set(patch "${CMAKE_MATCH_3}") 
-    set(CLANG-FORMAT_VERSION "${major}.${minor}.${patch}")
+    set(CLANG-FORMAT_VERSION "${major}.${minor}")
   endif()
 endif()
 

--- a/cmake/modules/Findclang-format.cmake
+++ b/cmake/modules/Findclang-format.cmake
@@ -32,6 +32,8 @@
 #   System has clang-format.
 # ``CLANG-FORMAT_EXECUTABLE``
 #   Path to the clang-format executable.
+# ``CLANG-FORMAT_VERSION``
+#   Version of clang-format.
 #
 # Hints
 # ^^^^^
@@ -42,11 +44,30 @@
 #
 include(FindPackageHandleStandardArgs)
 
+# Find clang-format
 if(NOT DEFINED CLANG-FORMAT_EXECUTABLE)
   find_program(CLANG-FORMAT_EXECUTABLE 
-    NAMES clang-format
+    NAMES clang-format_${clang-format_FIND_VERSION}
+          clang-format
     DOC "Path to clang-format executable"
   )
+endif()
+  
+# Extract version
+if(CLANG-FORMAT_EXECUTABLE)
+  execute_process(
+    COMMAND ${CLANG-FORMAT_EXECUTABLE} --version
+    RESULT_VARIABLE returncode
+    OUTPUT_VARIABLE stdout
+  )
+
+  if("${returncode}" STREQUAL "0")
+    string(REGEX MATCH "^clang-format version ([0-9]+)\\.([0-9]+)\\.([0-9]+)(.*)$" match "${stdout}")
+    set(major "${CMAKE_MATCH_1}") 
+    set(minor "${CMAKE_MATCH_2}") 
+    set(patch "${CMAKE_MATCH_3}") 
+    set(CLANG-FORMAT_VERSION "${major}.${minor}.${patch}")
+  endif()
 endif()
 
 find_package_handle_standard_args(clang-format 
@@ -54,7 +75,6 @@ find_package_handle_standard_args(clang-format
     CLANG-FORMAT_FOUND 
   REQUIRED_VARS 
     CLANG-FORMAT_EXECUTABLE
+  VERSION_VAR
+    CLANG-FORMAT_VERSION
 )
-
-mark_as_advanced(CLANG-FORMAT_EXECUTABLE)
-


### PR DESCRIPTION
## Technical Description

This PR makes the `find_package` module of clang-format more robust by allowing to search for specific versions. In addition, we fix the version of clang-format to 3.8 when using it. 