### PR TITLE
Issue #28, Caching of Non-Temporaries in the IJ-Plane

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,11 @@ Using Dawn as a common compiler infrastructure can drastically reduce developmen
 Dawn only depends on [Protobuf](https://developers.google.com/protocol-buffers/) (>= 3.4) and requires a C++11 compiler as well as [CMake](https://cmake.org/). To compile the library you need to point CMake to `protobuf-config.cmake` (the CMake configuration file of Protobuf). The following will install Dawn locally into `<dawn-dir>/install/` 
 
 ```bash
+git clone git@github.com:MeteoSwiss-APN/dawn.git
+cd dawn
 mkdir build && cd build
 cmake .. -DProtobuf_DIR=<protobuf-dir>/lib/cmake/protobuf
-make
+make -j4
 make install
 ```
 

--- a/src/dawn/Compiler/DawnCompiler.cpp
+++ b/src/dawn/Compiler/DawnCompiler.cpp
@@ -39,6 +39,7 @@
 #include "dawn/Optimizer/PassTemporaryFirstAccess.h"
 #include "dawn/Optimizer/PassTemporaryMerger.h"
 #include "dawn/Optimizer/PassTemporaryType.h"
+#include "dawn/Optimizer/PassSetNonTempCaches.h"
 
 namespace dawn {
 
@@ -162,6 +163,7 @@ std::unique_ptr<TranslationUnit> DawnCompiler::compile(const SIR* SIR, CodeGenKi
   passManager.pushBackPass<PassStencilSplitter>();
   passManager.pushBackPass<PassTemporaryType>();
   passManager.pushBackPass<PassTemporaryMerger>();
+  passManager.pushBackPass<PassSetNonTempCaches>();
   passManager.pushBackPass<PassSetCaches>();
   passManager.pushBackPass<PassDataLocalityMetric>();
 

--- a/src/dawn/Compiler/DawnCompiler.cpp
+++ b/src/dawn/Compiler/DawnCompiler.cpp
@@ -30,6 +30,7 @@
 #include "dawn/Optimizer/PassPrintStencilGraph.h"
 #include "dawn/Optimizer/PassSSA.h"
 #include "dawn/Optimizer/PassSetCaches.h"
+#include "dawn/Optimizer/PassSetNonTempCaches.h"
 #include "dawn/Optimizer/PassSetStageGraph.h"
 #include "dawn/Optimizer/PassSetStageName.h"
 #include "dawn/Optimizer/PassStageMerger.h"
@@ -39,7 +40,6 @@
 #include "dawn/Optimizer/PassTemporaryFirstAccess.h"
 #include "dawn/Optimizer/PassTemporaryMerger.h"
 #include "dawn/Optimizer/PassTemporaryType.h"
-#include "dawn/Optimizer/PassSetNonTempCaches.h"
 
 namespace dawn {
 

--- a/src/dawn/Compiler/Options.inc
+++ b/src/dawn/Compiler/Options.inc
@@ -91,9 +91,9 @@ OPT(bool, ReportPassStageMerger, false, "report-pass-stage-merger", "",
     "Dump the stencil-instantiation before and after the stage merger pass to JSON", "", false, true)
 OPT(bool, ReportPassSetCaches, false, "report-pass-set-caches", "", 
     "Report which fields are cached for each multi-stage", "", false, true)
-OPT(bool, UseNonTempCaches, true, "cache-non-temp-fields", "",
+OPT(bool, UseNonTempCaches, false, "cache-non-temp-fields", "",
     "Allows for caching of non-temporary fields", "", false, true)
-OPT(bool, ReportPassSetNonTempCaches, true, "report cache-non-temp-fields", "",
+OPT(bool, ReportPassSetNonTempCaches, false, "report-cache-non-temp-fields", "",
     "Report which non temporary fields are cached for each multi-stage", "", false, true)
 
 // clang-format on

--- a/src/dawn/Compiler/Options.inc
+++ b/src/dawn/Compiler/Options.inc
@@ -91,5 +91,7 @@ OPT(bool, ReportPassStageMerger, false, "report-pass-stage-merger", "",
     "Dump the stencil-instantiation before and after the stage merger pass to JSON", "", false, true)
 OPT(bool, ReportPassSetCaches, false, "report-pass-set-caches", "", 
     "Report which fields are cached for each multi-stage", "", false, true)
+OPT(bool, UseNonTempCaches, true, "cache-non-temp-fields", "",
+    "Allows for caching of non-temporary fields", "", false, true)
 
 // clang-format on

--- a/src/dawn/Compiler/Options.inc
+++ b/src/dawn/Compiler/Options.inc
@@ -93,5 +93,7 @@ OPT(bool, ReportPassSetCaches, false, "report-pass-set-caches", "",
     "Report which fields are cached for each multi-stage", "", false, true)
 OPT(bool, UseNonTempCaches, true, "cache-non-temp-fields", "",
     "Allows for caching of non-temporary fields", "", false, true)
+OPT(bool, ReportPassSetNonTempCaches, true, "report cache-non-temp-fields", "",
+    "Report which non temporary fields are cached for each multi-stage", "", false, true)
 
 // clang-format on

--- a/src/dawn/Optimizer/CMakeLists.txt
+++ b/src/dawn/Optimizer/CMakeLists.txt
@@ -55,6 +55,8 @@ dawn_add_library(
           PassPrintStencilGraph.h
           PassSetCaches.cpp
           PassSetCaches.h
+          PassSetNonTempCaches.cpp
+          PassSetNonTempCaches.h
           PassSetStageGraph.cpp
           PassSetStageGraph.h
           PassSetStageName.cpp

--- a/src/dawn/Optimizer/MultiStage.cpp
+++ b/src/dawn/Optimizer/MultiStage.cpp
@@ -16,6 +16,7 @@
 #include "dawn/Optimizer/Accesses.h"
 #include "dawn/Optimizer/DependencyGraphAccesses.h"
 #include "dawn/Optimizer/ReadBeforeWriteConflict.h"
+#include "dawn/Optimizer/Renaming.h"
 #include "dawn/Optimizer/Stage.h"
 #include "dawn/Optimizer/StencilInstantiation.h"
 #include "dawn/Support/STLExtras.h"
@@ -146,6 +147,25 @@ std::unordered_map<int, Field> MultiStage::getFields() const {
   }
 
   return fields;
+}
+
+void MultiStage::renameAllOccurrences(int oldAccessID, int newAccessID) {
+  for(auto stageIt = getStages().begin(); stageIt != getStages().end(); ++stageIt) {
+    Stage& stage = (**stageIt);
+    for(auto& doMethodPtr : stage.getDoMethods()) {
+      DoMethod& doMethod = *doMethodPtr;
+      std::cout << "we are renaming from "
+                << stencilInstantiation_->getNameFromAccessID(oldAccessID) << " to  "
+                << stencilInstantiation_->getNameFromAccessID(newAccessID) << " in Stage "
+                << stage.getStageID() << std::endl;
+      renameAccessIDInStmts(stencilInstantiation_, oldAccessID, newAccessID,
+                            doMethod.getStatementAccessesPairs());
+      renameAccessIDInAccesses(stencilInstantiation_, oldAccessID, newAccessID,
+                               doMethod.getStatementAccessesPairs());
+    }
+
+    stage.update();
+  }
 }
 
 } // namespace dawn

--- a/src/dawn/Optimizer/MultiStage.cpp
+++ b/src/dawn/Optimizer/MultiStage.cpp
@@ -154,10 +154,6 @@ void MultiStage::renameAllOccurrences(int oldAccessID, int newAccessID) {
     Stage& stage = (**stageIt);
     for(auto& doMethodPtr : stage.getDoMethods()) {
       DoMethod& doMethod = *doMethodPtr;
-      std::cout << "we are renaming from "
-                << stencilInstantiation_->getNameFromAccessID(oldAccessID) << " to  "
-                << stencilInstantiation_->getNameFromAccessID(newAccessID) << " in Stage "
-                << stage.getStageID() << std::endl;
       renameAccessIDInStmts(stencilInstantiation_, oldAccessID, newAccessID,
                             doMethod.getStatementAccessesPairs());
       renameAccessIDInAccesses(stencilInstantiation_, oldAccessID, newAccessID,

--- a/src/dawn/Optimizer/MultiStage.h
+++ b/src/dawn/Optimizer/MultiStage.h
@@ -118,6 +118,9 @@ public:
   /// @brief Get the caches
   std::unordered_map<int, Cache>& getCaches() { return caches_; }
   const std::unordered_map<int, Cache>& getCaches() const { return caches_; }
+
+  /// @brief Rename all the occurances in the multi-stage
+  void renameAllOccurrences(int oldAccessID, int newAccessID);
 };
 
 } // namespace dawn

--- a/src/dawn/Optimizer/OptimizerContext.h
+++ b/src/dawn/Optimizer/OptimizerContext.h
@@ -75,8 +75,8 @@ public:
   DiagnosticsEngine& getDiagnostics();
 
   /// @brief Get the hardware configuration
-  const HardwareConfig& getHardwareConfiguration() const { return hardwareConfiguration_;}
-  HardwareConfig& getHardwareConfiguration() { return hardwareConfiguration_;}
+  const HardwareConfig& getHardwareConfiguration() const { return hardwareConfiguration_; }
+  HardwareConfig& getHardwareConfiguration() { return hardwareConfiguration_; }
 };
 
 } // namespace dawn

--- a/src/dawn/Optimizer/OptimizerContext.h
+++ b/src/dawn/Optimizer/OptimizerContext.h
@@ -29,6 +29,14 @@ struct SIR;
 class StencilInstantiation;
 class DawnCompiler;
 
+struct HardwareConfig {
+  /// Maximum number of fields concurrently in shared memory
+  int SMemMaxFields = 8;
+
+  /// Maximum number of fields concurrently in the texture cache
+  int TexCacheMaxFields = 3;
+};
+
 /// @brief Context of handling all Optimizations
 /// @ingroup optimizer
 class OptimizerContext : NonCopyable {
@@ -37,6 +45,7 @@ class OptimizerContext : NonCopyable {
   const SIR* SIR_;
   std::map<std::string, std::unique_ptr<StencilInstantiation>> stencilInstantiationMap_;
   PassManager passManager_;
+  HardwareConfig hardwareConfiguration_;
 
 public:
   /// @brief Initialize the context with a SIR
@@ -64,6 +73,10 @@ public:
   /// @brief Get the diagnostics engine
   const DiagnosticsEngine& getDiagnostics() const;
   DiagnosticsEngine& getDiagnostics();
+
+  /// @brief Get the hardware configuration
+  const HardwareConfig& getHardwareConfiguration() const { return hardwareConfiguration_;}
+  HardwareConfig& getHardwareConfiguration() { return hardwareConfiguration_;}
 };
 
 } // namespace dawn

--- a/src/dawn/Optimizer/PassDataLocalityMetric.cpp
+++ b/src/dawn/Optimizer/PassDataLocalityMetric.cpp
@@ -54,23 +54,20 @@ class ReadWriteCounter : public ASTVisitorForwarding {
   /// Current stencil function call
   std::stack<StencilFunctionInstantiation*> stencilFunCalls_;
 
-  /// Hardware configuration
-  const HardwareConfig& config_;
 
   /// Map of ID's to their respective number of reads / writes
   std::unordered_map<int, ReadWriteAccumulator> individualReadWrites_;
 
 public:
-  ReadWriteCounter(StencilInstantiation* instantiation, const MultiStage& multiStage,
-                   const HardwareConfig& config)
+  ReadWriteCounter(StencilInstantiation* instantiation, const MultiStage& multiStage)
       : instantiation_(instantiation), numReads_(0), numWrites_(0), multiStage_(multiStage),
-        fields_(multiStage_.getFields()), config_(config) {}
+        fields_(multiStage_.getFields()) {}
 
   std::size_t getNumReads() const { return numReads_; }
   std::size_t getNumWrites() const { return numWrites_; }
 
   void updateTextureCache(int AccessID, int kOffset) {
-    if(textureCache_.size() < config_.TexCacheMaxFields)
+    if(textureCache_.size() < instantiation_->getOptimizerContext()->getHardwareConfiguration().TexCacheMaxFields)
       textureCache_.emplace_front(AccessID, kOffset);
     else {
       auto it = std::find_if(
@@ -128,23 +125,13 @@ public:
     if(cache.getCacheType() == Cache::K) {
       if(cache.getCacheIOPolicy() == Cache::fill ||
          cache.getCacheIOPolicy() == Cache::fill_and_flush) {
-//        std::cout << "   Fill: " << getNameFromAccessID(AccessID) << std::endl;
         numReads_++;
-        auto iter = individualReadWrites_.find(AccessID);
-        if(iter != individualReadWrites_.end())
-          (*iter).second.numReads++;
-        else
-          individualReadWrites_.emplace(AccessID, ReadWriteAccumulator{1, 0});
+        individualReadWrites_[AccessID].numReads++;
       }
       if(cache.getCacheIOPolicy() == Cache::flush ||
          cache.getCacheIOPolicy() == Cache::fill_and_flush) {
-//        std::cout << "   Flush: " << getNameFromAccessID(AccessID) << std::endl;
         numWrites_++;
-        auto iter = individualReadWrites_.find(AccessID);
-        if(iter != individualReadWrites_.end())
-          (*iter).second.numWrites++;
-        else
-          individualReadWrites_.emplace(AccessID, ReadWriteAccumulator{0, 1});
+        individualReadWrites_[AccessID].numWrites++;
       }
     }
     kCacheLoaded_.insert(AccessID);
@@ -155,13 +142,8 @@ public:
 
     // Is field stored in cache?
     if(!multiStage_.getCaches().count(AccessID)) {
-//      std::cout << "   Write: " << getNameFromAccessID(AccessID) << std::endl;
       numWrites_++;
-      auto iter = individualReadWrites_.find(AccessID);
-      if(iter != individualReadWrites_.end())
-        (*iter).second.numWrites++;
-      else
-        individualReadWrites_.emplace(AccessID, ReadWriteAccumulator{0, 1});
+      individualReadWrites_[AccessID].numWrites++;
 
       // The written value is stored in a register
       register_.insert(AccessID);
@@ -188,13 +170,8 @@ public:
 
         // Check if the field is either cached or stored in the texture cache
         if(!(multiStage_.isCached(AccessID) || isTextureCached(AccessID, kOffset))) {
-//          std::cout << "   Read: " << getNameFromAccessID(AccessID) << std::endl;
           numReads_++;
-          auto iter = individualReadWrites_.find(AccessID);
-          if(iter != individualReadWrites_.end())
-            (*iter).second.numReads++;
-          else
-            individualReadWrites_.emplace(AccessID, ReadWriteAccumulator{1, 0});
+          individualReadWrites_[AccessID].numReads++;
         } else {
           updateKCache(AccessID);
         }
@@ -204,13 +181,8 @@ public:
 
         // Check if the center is stored in a register
         if(!(register_.count(AccessID) && getOffset(fieldExpr) == Array3i{{0, 0, 0}})) {
-//          std::cout << "   Read: " << getNameFromAccessID(AccessID) << std::endl;
           numReads_++;
-          auto iter = individualReadWrites_.find(AccessID);
-          if(iter != individualReadWrites_.end())
-            (*iter).second.numReads++;
-          else
-            individualReadWrites_.emplace(AccessID, ReadWriteAccumulator{1, 0});
+          individualReadWrites_[AccessID].numReads++;
         }
 
       } else {
@@ -257,7 +229,7 @@ public:
 /// every output at most 1 store.
 DAWN_ATTRIBUTE_UNUSED static std::pair<int, int>
 computeReadWriteAccessesLowerBound(StencilInstantiation* instantiation,
-                                   const MultiStage& multiStage, const HardwareConfig& config) {
+                                   const MultiStage& multiStage) {
   std::size_t numReads = 0, numWrites = 0;
   std::unordered_map<int, Field> fields = multiStage.getFields();
 
@@ -305,9 +277,8 @@ computeReadWriteAccessesLowerBound(StencilInstantiation* instantiation,
 /// @brief Approximate the reads and writes individually for each ID
 std::unordered_map<int, ReadWriteAccumulator>
 computeReadWriteAccessesMetricPerAccessID(StencilInstantiation* instantiation,
-                                          const MultiStage& multiStage,
-                                          const HardwareConfig& config) {
-  ReadWriteCounter readWriteCounter(instantiation, multiStage, config);
+                                          const MultiStage& multiStage) {
+  ReadWriteCounter readWriteCounter(instantiation, multiStage);
 
   for(const auto& stage : multiStage.getStages())
     for(const auto& DoMethod : stage->getDoMethods())
@@ -318,12 +289,10 @@ computeReadWriteAccessesMetricPerAccessID(StencilInstantiation* instantiation,
   return readWriteCounter.getIndividualReadWrites();
 }
 
-
 /// @brief Approximate the reads and writes accoding to our data locality metric
 std::pair<int, int> computeReadWriteAccessesMetric(StencilInstantiation* instantiation,
-                                                   const MultiStage& multiStage,
-                                                   const HardwareConfig& config) {
-  ReadWriteCounter readWriteCounter(instantiation, multiStage, config);
+                                                   const MultiStage& multiStage) {
+  ReadWriteCounter readWriteCounter(instantiation, multiStage);
 
   for(const auto& stage : multiStage.getStages())
     for(const auto& DoMethod : stage->getDoMethods())
@@ -359,10 +328,10 @@ bool PassDataLocalityMetric::run(StencilInstantiation* stencilInstantiation) {
         std::cout << "  MultiStage " << multiStageIdx << ":\n";
 
         auto readAndWrite =
-            computeReadWriteAccessesMetric(stencilInstantiation, multiStage, config_);
+            computeReadWriteAccessesMetric(stencilInstantiation, multiStage);
 
         //        auto readAndWrite =
-        //            computeReadWriteAccessesLowerBound(stencilInstantiation, multiStage, config_);
+        //            computeReadWriteAccessesLowerBound(stencilInstantiation, multiStage);
 
         std::size_t numReads = readAndWrite.first, numWrites = readAndWrite.second;
 

--- a/src/dawn/Optimizer/PassDataLocalityMetric.cpp
+++ b/src/dawn/Optimizer/PassDataLocalityMetric.cpp
@@ -54,7 +54,6 @@ class ReadWriteCounter : public ASTVisitorForwarding {
   /// Current stencil function call
   std::stack<StencilFunctionInstantiation*> stencilFunCalls_;
 
-
   /// Map of ID's to their respective number of reads / writes
   std::unordered_map<int, ReadWriteAccumulator> individualReadWrites_;
 
@@ -67,7 +66,8 @@ public:
   std::size_t getNumWrites() const { return numWrites_; }
 
   void updateTextureCache(int AccessID, int kOffset) {
-    if(textureCache_.size() < instantiation_->getOptimizerContext()->getHardwareConfiguration().TexCacheMaxFields)
+    if(textureCache_.size() <
+       instantiation_->getOptimizerContext()->getHardwareConfiguration().TexCacheMaxFields)
       textureCache_.emplace_front(AccessID, kOffset);
     else {
       auto it = std::find_if(
@@ -327,8 +327,7 @@ bool PassDataLocalityMetric::run(StencilInstantiation* stencilInstantiation) {
 
         std::cout << "  MultiStage " << multiStageIdx << ":\n";
 
-        auto readAndWrite =
-            computeReadWriteAccessesMetric(stencilInstantiation, multiStage);
+        auto readAndWrite = computeReadWriteAccessesMetric(stencilInstantiation, multiStage);
 
         //        auto readAndWrite =
         //            computeReadWriteAccessesLowerBound(stencilInstantiation, multiStage);

--- a/src/dawn/Optimizer/PassDataLocalityMetric.cpp
+++ b/src/dawn/Optimizer/PassDataLocalityMetric.cpp
@@ -134,7 +134,7 @@ public:
         if(iter != individualReadWrites_.end())
           (*iter).second.numReads++;
         else
-          individualReadWrites_.emplace(AccessID, ReadWriteAccumulator(1, 0));
+          individualReadWrites_.emplace(AccessID, ReadWriteAccumulator{1, 0});
       }
       if(cache.getCacheIOPolicy() == Cache::flush ||
          cache.getCacheIOPolicy() == Cache::fill_and_flush) {
@@ -144,7 +144,7 @@ public:
         if(iter != individualReadWrites_.end())
           (*iter).second.numWrites++;
         else
-          individualReadWrites_.emplace(AccessID, ReadWriteAccumulator(0, 1));
+          individualReadWrites_.emplace(AccessID, ReadWriteAccumulator{0, 1});
       }
     }
     kCacheLoaded_.insert(AccessID);
@@ -161,7 +161,7 @@ public:
       if(iter != individualReadWrites_.end())
         (*iter).second.numWrites++;
       else
-        individualReadWrites_.emplace(AccessID, ReadWriteAccumulator(0, 1));
+        individualReadWrites_.emplace(AccessID, ReadWriteAccumulator{0, 1});
 
       // The written value is stored in a register
       register_.insert(AccessID);
@@ -194,7 +194,7 @@ public:
           if(iter != individualReadWrites_.end())
             (*iter).second.numReads++;
           else
-            individualReadWrites_.emplace(AccessID, ReadWriteAccumulator(1, 0));
+            individualReadWrites_.emplace(AccessID, ReadWriteAccumulator{1, 0});
         } else {
           updateKCache(AccessID);
         }
@@ -210,7 +210,7 @@ public:
           if(iter != individualReadWrites_.end())
             (*iter).second.numReads++;
           else
-            individualReadWrites_.emplace(AccessID, ReadWriteAccumulator(1, 0));
+            individualReadWrites_.emplace(AccessID, ReadWriteAccumulator{1, 0});
         }
 
       } else {

--- a/src/dawn/Optimizer/PassDataLocalityMetric.h
+++ b/src/dawn/Optimizer/PassDataLocalityMetric.h
@@ -20,17 +20,10 @@
 
 namespace dawn {
 
-struct HardwareConfig {
-  /// Maximum number of fields concurrently in shared memory
-  int SMemMaxFields = 8;
-
-  /// Maximum number of fields concurrently in the texture cache
-  int TexCacheMaxFields = 3;
-};
 
 struct ReadWriteAccumulator {
-  int numReads;
-  int numWrites;
+  int numReads = 0;
+  int numWrites = 0;
 
   int totalAccesses() const { return numReads + numWrites; }
 };
@@ -45,17 +38,13 @@ public:
   /// @brief Pass implementation
   bool run(StencilInstantiation* stencilInstantiation) override;
 
-private:
-  HardwareConfig config_;
 };
 
 std::pair<int, int> computeReadWriteAccessesMetric(StencilInstantiation* instantiation,
-                                                   const MultiStage& multiStage,
-                                                   const HardwareConfig& config);
+                                                   const MultiStage& multiStage);
 std::unordered_map<int, ReadWriteAccumulator>
 computeReadWriteAccessesMetricPerAccessID(StencilInstantiation* instantiation,
-                                          const MultiStage& multiStage,
-                                          const HardwareConfig& config);
+                                          const MultiStage& multiStage);
 
 } // namespace dawn
 

--- a/src/dawn/Optimizer/PassDataLocalityMetric.h
+++ b/src/dawn/Optimizer/PassDataLocalityMetric.h
@@ -28,14 +28,12 @@ struct HardwareConfig {
   int TexCacheMaxFields = 3;
 };
 
-struct ReadWriteIDspecific {
-  ReadWriteIDspecific() : numReads(0), numWrites(0) {}
-  ReadWriteIDspecific(int nReads, int nRwrites) : numReads(nReads), numWrites(nRwrites) {}
-  int numReads;
-  int numWrites;
-  int total(){
-      return numReads+numWrites;
-  }
+struct ReadWriteAccumulator {
+  ReadWriteAccumulator(int r, int w) : numReads(r), numWrites(w) {}
+  int numReads = 0;
+  int numWrites = 0;
+
+  int totalAccesses() const { return numReads + numWrites; }
 };
 
 /// @brief This Pass computes a heuristic measuring the data-locality of each stencil
@@ -55,10 +53,10 @@ private:
 std::pair<int, int> computeReadWriteAccessesMetric(StencilInstantiation* instantiation,
                                                    const MultiStage& multiStage,
                                                    const HardwareConfig& config);
-std::unordered_map<int, ReadWriteIDspecific>
-computeReadWriteAccessesMetricIndividually(StencilInstantiation* instantiation,
-                                           const MultiStage& multiStage,
-                                           const HardwareConfig& config);
+std::unordered_map<int, ReadWriteAccumulator>
+computeReadWriteAccessesMetricPerAccessID(StencilInstantiation* instantiation,
+                                          const MultiStage& multiStage,
+                                          const HardwareConfig& config);
 
 } // namespace dawn
 

--- a/src/dawn/Optimizer/PassDataLocalityMetric.h
+++ b/src/dawn/Optimizer/PassDataLocalityMetric.h
@@ -29,9 +29,8 @@ struct HardwareConfig {
 };
 
 struct ReadWriteAccumulator {
-  ReadWriteAccumulator(int r, int w) : numReads(r), numWrites(w) {}
-  int numReads = 0;
-  int numWrites = 0;
+  int numReads;
+  int numWrites;
 
   int totalAccesses() const { return numReads + numWrites; }
 };

--- a/src/dawn/Optimizer/PassDataLocalityMetric.h
+++ b/src/dawn/Optimizer/PassDataLocalityMetric.h
@@ -20,7 +20,6 @@
 
 namespace dawn {
 
-
 struct ReadWriteAccumulator {
   int numReads = 0;
   int numWrites = 0;
@@ -37,7 +36,6 @@ public:
 
   /// @brief Pass implementation
   bool run(StencilInstantiation* stencilInstantiation) override;
-
 };
 
 std::pair<int, int> computeReadWriteAccessesMetric(StencilInstantiation* instantiation,

--- a/src/dawn/Optimizer/PassDataLocalityMetric.h
+++ b/src/dawn/Optimizer/PassDataLocalityMetric.h
@@ -15,8 +15,8 @@
 #ifndef DAWN_OPTIMIZER_PASSDATALOCALITYMETRIC_H
 #define DAWN_OPTIMIZER_PASSDATALOCALITYMETRIC_H
 
-#include "dawn/Optimizer/Pass.h"
 #include "dawn/Optimizer/MultiStage.h"
+#include "dawn/Optimizer/Pass.h"
 
 namespace dawn {
 
@@ -26,6 +26,16 @@ struct HardwareConfig {
 
   /// Maximum number of fields concurrently in the texture cache
   int TexCacheMaxFields = 3;
+};
+
+struct ReadWriteIDspecific {
+  ReadWriteIDspecific() : numReads(0), numWrites(0) {}
+  ReadWriteIDspecific(int nReads, int nRwrites) : numReads(nReads), numWrites(nRwrites) {}
+  int numReads;
+  int numWrites;
+  int total(){
+      return numReads+numWrites;
+  }
 };
 
 /// @brief This Pass computes a heuristic measuring the data-locality of each stencil
@@ -45,6 +55,10 @@ private:
 std::pair<int, int> computeReadWriteAccessesMetric(StencilInstantiation* instantiation,
                                                    const MultiStage& multiStage,
                                                    const HardwareConfig& config);
+std::unordered_map<int, ReadWriteIDspecific>
+computeReadWriteAccessesMetricIndividually(StencilInstantiation* instantiation,
+                                           const MultiStage& multiStage,
+                                           const HardwareConfig& config);
 
 } // namespace dawn
 

--- a/src/dawn/Optimizer/PassSetNonTempCaches.cpp
+++ b/src/dawn/Optimizer/PassSetNonTempCaches.cpp
@@ -28,7 +28,6 @@
 namespace dawn {
 
 struct AcessIDTolocalityMetric {
-  AcessIDTolocalityMetric(int id, int gain) : accessID(id), dataLocalityGain(gain) {}
   int accessID;
   int dataLocalityGain;
   bool operator<(const AcessIDTolocalityMetric& rhs) {
@@ -37,8 +36,6 @@ struct AcessIDTolocalityMetric {
 };
 
 struct NameToImprovementMetric {
-  NameToImprovementMetric(std::string name_, Cache cache_, int metric)
-      : name(name_), cache(cache_), dataLocalityImprovement(metric) {}
   std::string name;
   Cache cache;
   int dataLocalityImprovement;
@@ -102,7 +99,7 @@ private:
     }
 
     for(auto& AcessIDMetricPair : accessIDToDataLocality_) {
-      sortedAccesses_.emplace_back(AcessIDMetricPair.first, AcessIDMetricPair.second);
+      sortedAccesses_.emplace_back(AcessIDTolocalityMetric{AcessIDMetricPair.first, AcessIDMetricPair.second});
       std::sort(sortedAccesses_.begin(), sortedAccesses_.end());
     }
   }
@@ -128,8 +125,8 @@ private:
 
       oldAccessIDtoNewAccessID_.emplace(oldID, newID);
       Cache& cache = multiStagePrt_->setCache(Cache::IJ, Cache::local, newID);
-      originalNameToCache_.emplace_back(instantiation_->getOriginalNameFromAccessID(oldID), cache,
-                                        accessIDToDataLocality_.find(oldID)->second);
+      originalNameToCache_.emplace_back(NameToImprovementMetric{instantiation_->getOriginalNameFromAccessID(oldID), cache,
+                                        accessIDToDataLocality_.find(oldID)->second});
     }
 
     // Create the cache-filler stage

--- a/src/dawn/Optimizer/PassSetNonTempCaches.cpp
+++ b/src/dawn/Optimizer/PassSetNonTempCaches.cpp
@@ -57,7 +57,7 @@ public:
     addFlushStages();
   }
 
-  const std::vector<NameToImprovementMetric>& getOriginalNameToCache() {
+  const std::vector<NameToImprovementMetric>& getOriginalNameToCache() const {
     return originalNameToCache_;
   }
 

--- a/src/dawn/Optimizer/PassSetNonTempCaches.cpp
+++ b/src/dawn/Optimizer/PassSetNonTempCaches.cpp
@@ -41,7 +41,7 @@ struct NameToImprovementMetric {
   int dataLocalityImprovement;
 };
 
-  /// @brief The GlobalFieldCacher class handles the caching for a given Multistage
+/// @brief The GlobalFieldCacher class handles the caching for a given Multistage
 class GlobalFieldCacher {
 public:
   /// @param[in, out]  msprt   Pointer to the multistage to handle
@@ -49,7 +49,7 @@ public:
   GlobalFieldCacher(MultiStage* msptr, StencilInstantiation* si)
       : multiStagePrt_(msptr), instantiation_(si) {}
 
-  /// @brief entry method for the pass: processes a given multistage and applies all changes
+  /// @brief Entry method for the pass: processes a given multistage and applies all changes
   /// required
   void process() {
     computeOptimalFields();
@@ -65,8 +65,7 @@ private:
   /// @brief Use the data locality metric to rank the fields in a stencil based on how much they
   /// would benefit from caching
   void computeOptimalFields() {
-    auto dataLocality =
-        computeReadWriteAccessesMetricPerAccessID(instantiation_, *multiStagePrt_);
+    auto dataLocality = computeReadWriteAccessesMetricPerAccessID(instantiation_, *multiStagePrt_);
 
     for(const auto& stagePtr : multiStagePrt_->getStages()) {
       for(const Field& field : stagePtr->getFields()) {
@@ -99,7 +98,8 @@ private:
     }
 
     for(auto& AcessIDMetricPair : accessIDToDataLocality_) {
-      sortedAccesses_.emplace_back(AcessIDTolocalityMetric{AcessIDMetricPair.first, AcessIDMetricPair.second});
+      sortedAccesses_.emplace_back(
+          AcessIDTolocalityMetric{AcessIDMetricPair.first, AcessIDMetricPair.second});
       std::sort(sortedAccesses_.begin(), sortedAccesses_.end());
     }
   }
@@ -111,7 +111,9 @@ private:
   /// We always fill to the extent of the given multistage and we only add one stage to fill all the
   /// variables to reduce synchronisation overhead
   void addFillerStages() {
-    int numVarsToBeCached = std::min((int)sortedAccesses_.size(), instantiation_->getOptimizerContext()->getHardwareConfiguration().SMemMaxFields);
+    int numVarsToBeCached =
+        std::min((int)sortedAccesses_.size(),
+                 instantiation_->getOptimizerContext()->getHardwareConfiguration().SMemMaxFields);
     for(int i = 0; i < numVarsToBeCached; ++i) {
       int oldID = sortedAccesses_[i].accessID;
 
@@ -125,8 +127,9 @@ private:
 
       oldAccessIDtoNewAccessID_.emplace(oldID, newID);
       Cache& cache = multiStagePrt_->setCache(Cache::IJ, Cache::local, newID);
-      originalNameToCache_.emplace_back(NameToImprovementMetric{instantiation_->getOriginalNameFromAccessID(oldID), cache,
-                                        accessIDToDataLocality_.find(oldID)->second});
+      originalNameToCache_.emplace_back(
+          NameToImprovementMetric{instantiation_->getOriginalNameFromAccessID(oldID), cache,
+                                  accessIDToDataLocality_.find(oldID)->second});
     }
 
     // Create the cache-filler stage
@@ -148,7 +151,7 @@ private:
     }
   }
 
-  /// @brief we create one stage at the end of the multistage that flushes back all the variables
+  /// @brief We create one stage at the end of the multistage that flushes back all the variables
   /// that we cached in temporaries
   void addFlushStages() {
     std::vector<int> oldAccessIDs;
@@ -171,7 +174,7 @@ private:
     }
   }
 
-  /// @brief creates the stage in which assignment happens (fill and flush)
+  /// @brief Creates the stage in which assignment happens (fill and flush)
   std::shared_ptr<Stage> createAssignmentStage(const Interval& interval,
                                                const std::vector<int>& assignmentIDs,
                                                const std::vector<int>& assigneeIDs) {
@@ -195,7 +198,7 @@ private:
     return assignmentStage;
   }
 
-  ///@brief add the assignment operator of two unique id's to a given domethod
+  ///@brief Add the assignment operator of two unique id's to a given domethod
   void addAssignmentToDoMethod(std::unique_ptr<DoMethod>& domethod, int assignmentID,
                                int assigneeID) {
     // Create the StatementAccessPair of the assignment with the new and old variables
@@ -218,10 +221,10 @@ private:
     instantiation_->getExprToAccessIDMap().emplace(fa_assignee, assigneeID);
   }
 
-  /// @brief checks if there is a read operation before the first write operation in the given
+  /// @brief Checks if there is a read operation before the first write operation in the given
   /// multistage.
   /// @param[in]    AccessID  original FieldAccessID of the field to check
-  /// @return           true if there is a read-access before the first write access
+  /// @return true if there is a read-access before the first write access
   bool checkReadBeforeWrite(int AccessID) {
     for(auto stageItGlob = multiStagePrt_->getStages().begin();
         stageItGlob != multiStagePrt_->getStages().end(); ++stageItGlob) {

--- a/src/dawn/Optimizer/PassSetNonTempCaches.cpp
+++ b/src/dawn/Optimizer/PassSetNonTempCaches.cpp
@@ -41,9 +41,9 @@ struct NameToImprovementMetric {
   int dataLocalityImprovement;
 };
 
+  /// @brief The GlobalFieldCacher class handles the caching for a given Multistage
 class GlobalFieldCacher {
 public:
-  /// @brief The GlobalFieldCacher class handles the caching for a given Multistage
   /// @param[in, out]  msprt   Pointer to the multistage to handle
   /// @param[in, out]  si      Stencil Instanciation [ISIR] holding all the Stencils
   GlobalFieldCacher(MultiStage* msptr, StencilInstantiation* si)
@@ -66,7 +66,7 @@ private:
   /// would benefit from caching
   void computeOptimalFields() {
     auto dataLocality =
-        computeReadWriteAccessesMetricPerAccessID(instantiation_, *multiStagePrt_, config_);
+        computeReadWriteAccessesMetricPerAccessID(instantiation_, *multiStagePrt_);
 
     for(const auto& stagePtr : multiStagePrt_->getStages()) {
       for(const Field& field : stagePtr->getFields()) {
@@ -111,7 +111,7 @@ private:
   /// We always fill to the extent of the given multistage and we only add one stage to fill all the
   /// variables to reduce synchronisation overhead
   void addFillerStages() {
-    int numVarsToBeCached = std::min((int)sortedAccesses_.size(), config_.SMemMaxFields);
+    int numVarsToBeCached = std::min((int)sortedAccesses_.size(), instantiation_->getOptimizerContext()->getHardwareConfiguration().SMemMaxFields);
     for(int i = 0; i < numVarsToBeCached; ++i) {
       int oldID = sortedAccesses_[i].accessID;
 
@@ -267,7 +267,6 @@ private:
   }
 
   MultiStage* multiStagePrt_;
-  HardwareConfig config_;
   StencilInstantiation* instantiation_;
 
   std::unordered_map<int, int> accessIDToDataLocality_;

--- a/src/dawn/Optimizer/PassSetNonTempCaches.h
+++ b/src/dawn/Optimizer/PassSetNonTempCaches.h
@@ -12,39 +12,25 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
-#ifndef DAWN_OPTIMIZER_PASSDATALOCALITYMETRIC_H
-#define DAWN_OPTIMIZER_PASSDATALOCALITYMETRIC_H
+#ifndef DAWN_OPTIMIZER_PASSNONTEMPCACHES_H
+#define DAWN_OPTIMIZER_PASSNONTEMPCACHES_H
 
 #include "dawn/Optimizer/Pass.h"
-#include "dawn/Optimizer/MultiStage.h"
 
 namespace dawn {
 
-struct HardwareConfig {
-  /// Maximum number of fields concurrently in shared memory
-  int SMemMaxFields = 8;
-
-  /// Maximum number of fields concurrently in the texture cache
-  int TexCacheMaxFields = 3;
-};
-
-/// @brief This Pass computes a heuristic measuring the data-locality of each stencil
+/// @brief This Pass prints the dependency graph of each stencil to a dot file
+///
+/// This Pass depends on `PassStageSplitter` (which sets the dependency graphs).
 ///
 /// @ingroup optimizer
-class PassDataLocalityMetric : public Pass {
+class PassSetNonTempCaches : public Pass {
 public:
-  PassDataLocalityMetric();
+  PassSetNonTempCaches();
 
   /// @brief Pass implementation
   bool run(StencilInstantiation* stencilInstantiation) override;
-
-private:
-  HardwareConfig config_;
 };
-
-std::pair<int, int> computeReadWriteAccessesMetric(StencilInstantiation* instantiation,
-                                                   const MultiStage& multiStage,
-                                                   const HardwareConfig& config);
 
 } // namespace dawn
 

--- a/src/dawn/Optimizer/PassSetNonTempCaches.h
+++ b/src/dawn/Optimizer/PassSetNonTempCaches.h
@@ -21,14 +21,15 @@ namespace dawn {
 
 /// @brief This Pass optimizes data locality on a per-multistage basis
 ///
-/// For all the non-temporary fields that we access in any given multistage, we check how high the
-/// performance gain of using a local ij-cache woud be. This is only beneficial if the fields are
-/// horizontally non-pointwise but vertically pointwise.
-/// If is is beneficial, we cache the fieldswith the most performance gain up to HardwareConfig's
+/// For all the non-temporary, horizontally non-pointwise but vertically pointwise fields that we
+/// access in any given multistage, we check how high the performance gain of using a local ij-cache
+/// woud be.
+///
+/// If is is beneficial, we cache the fields with the most performance gain up to HardwareConfig's
 /// Maximum number of fields concurrently in shared memory (defined in PassDataLocalityMetric.h)
 ///
 /// The caching invokes a renaming of all the occurances of any given field we cache and adds
-/// potentially filler stages and definitly flush stages to the multistage thus changing the ISIR
+/// potentially filler stages and definitely flush stages to the multistage thus changing the ISIR
 /// (StencilInstantation) in memory.
 ///
 /// This Pass has no dependecies

--- a/src/dawn/Optimizer/PassSetNonTempCaches.h
+++ b/src/dawn/Optimizer/PassSetNonTempCaches.h
@@ -19,9 +19,19 @@
 
 namespace dawn {
 
-/// @brief This Pass prints the dependency graph of each stencil to a dot file
+/// @brief This Pass optimizes data locality on a per-multistage basis
 ///
-/// This Pass depends on `PassStageSplitter` (which sets the dependency graphs).
+/// For all the non-temporary fields that we access in any given multistage, we check how high the
+/// performance gain of using a local ij-cache woud be. This is only beneficial if the fields are
+/// horizontally non-pointwise but vertically pointwise.
+/// If is is beneficial, we cache the fieldswith the most performance gain up to HardwareConfig's
+/// Maximum number of fields concurrently in shared memory (defined in PassDataLocalityMetric.h)
+///
+/// The caching invokes a renaming of all the occurances of any given field we cache and adds
+/// potentially filler stages and definitly flush stages to the multistage thus changing the ISIR
+/// (StencilInstantation) in memory.
+///
+/// This Pass has no dependecies
 ///
 /// @ingroup optimizer
 class PassSetNonTempCaches : public Pass {

--- a/src/dawn/Optimizer/Stencil.cpp
+++ b/src/dawn/Optimizer/Stencil.cpp
@@ -325,19 +325,8 @@ Interval Stencil::getAxis(bool useExtendedInterval) const {
 }
 
 void Stencil::renameAllOccurrences(int oldAccessID, int newAccessID) {
-  int numStages = getNumStages();
-  for(int stageIdx = 0; stageIdx < numStages; ++stageIdx) {
-    Stage& stage = *getStage(stageIdx);
-
-    for(auto& doMethodPtr : stage.getDoMethods()) {
-      DoMethod& doMethod = *doMethodPtr;
-      renameAccessIDInStmts(stencilInstantiation_, oldAccessID, newAccessID,
-                            doMethod.getStatementAccessesPairs());
-      renameAccessIDInAccesses(stencilInstantiation_, oldAccessID, newAccessID,
-                               doMethod.getStatementAccessesPairs());
-    }
-
-    stage.update();
+  for(const auto& multistage : getMultiStages()) {
+    multistage->renameAllOccurrences(oldAccessID, newAccessID);
   }
 }
 

--- a/src/dawn/SIR/SIR.cpp
+++ b/src/dawn/SIR/SIR.cpp
@@ -270,7 +270,8 @@ sir::CompareResult sir::Stencil::comparison(const sir::Stencil& rhs) const {
                          false};
 
   if(!Fields.empty() &&
-     !std::equal(Fields.begin(), Fields.end(), rhs.Fields.begin(), pointeeComparisonWithOutput<Field>)) {
+     !std::equal(Fields.begin(), Fields.end(), rhs.Fields.begin(),
+                 pointeeComparisonWithOutput<Field>)) {
     std::string output = "[Stencil mismatch] Fields do not match\n";
     for(int i = 0; i < Fields.size(); ++i) {
       auto comp = pointeeComparisonWithOutput(Fields[i], rhs.Fields[i]);
@@ -279,7 +280,6 @@ sir::CompareResult sir::Stencil::comparison(const sir::Stencil& rhs) const {
                                Fields[i].get()->Name, comp.why());
       }
     }
-
 
     return CompareResult{output, false};
   }

--- a/src/dawn/SIR/SIR.h
+++ b/src/dawn/SIR/SIR.h
@@ -165,9 +165,7 @@ struct Field : public StencilFunctionArg {
   bool IsTemporary;
 
   static bool classof(const StencilFunctionArg* arg) { return arg->Kind == AK_Field; }
-  bool operator==(const Field& rhs) const {
-    return comparison(rhs);
-  }
+  bool operator==(const Field& rhs) const { return comparison(rhs); }
 
   CompareResult comparison(const Field& rhs) const;
 };


### PR DESCRIPTION
## Brief

Addition of PassSetNonTempCaches that decides, which non-temporary variables we should write to a scarchpad based on the metric implemented in  PassDataLocalityMetric . It adds filler / flush stages if need be at the beginning and the end of any given multistage the pass is run on. 
In order to run with this pass enabled, the flag `-fcache-non-temp-fields` can be set.

Small adaptation to the PassDataLocalityMetric to support the updated needs.