### PR TITLE
fix sir serialization of globals

### DIFF
--- a/src/dawn/SIR/SIRSerializer.cpp
+++ b/src/dawn/SIR/SIRSerializer.cpp
@@ -12,18 +12,18 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
+#include "dawn/SIR/SIR.h"
 #include "dawn/SIR/AST.h"
 #include "dawn/SIR/ASTVisitor.h"
-#include "dawn/SIR/SIR.h"
 #include "dawn/SIR/SIR.pb.h"
 #include "dawn/SIR/SIRSerializer.h"
 #include "dawn/Support/Format.h"
-#include "dawn/Support/Unreachable.h"
 #include "dawn/Support/Logging.h"
+#include "dawn/Support/Unreachable.h"
 #include <fstream>
 #include <google/protobuf/util/json_util.h>
-#include <stack>
 #include <list>
+#include <stack>
 #include <tuple>
 
 namespace dawn {
@@ -444,7 +444,7 @@ static void setAST(sir::proto::AST* astProto, const AST* ast) {
 
 static std::string serializeImpl(const SIR* sir, SIRSerializer::SerializationKind kind) {
   GOOGLE_PROTOBUF_VERIFY_VERSION;
-  ProtobufLogger::init();  
+  ProtobufLogger::init();
 
   // Convert SIR to protobuf SIR
   sir::proto::SIR sirProto;
@@ -517,21 +517,23 @@ static std::string serializeImpl(const SIR* sir, SIRSerializer::SerializationKin
 
     sir::proto::GlobalVariableValue valueProto;
     valueProto.set_is_constexpr(value.isConstexpr());
-    switch(value.getType()) {
-    case sir::Value::Boolean:
-      valueProto.set_boolean_value(value.getValue<bool>());
-      break;
-    case sir::Value::Integer:
-      valueProto.set_integer_value(value.getValue<int>());
-      break;
-    case sir::Value::Double:
-      valueProto.set_double_value(value.getValue<double>());
-      break;
-    case sir::Value::String:
-      valueProto.set_string_value(value.getValue<std::string>());
-      break;
-    case sir::Value::None:
-      break;
+    if(!value.empty()) {
+      switch(value.getType()) {
+      case sir::Value::Boolean:
+        valueProto.set_boolean_value(value.getValue<bool>());
+        break;
+      case sir::Value::Integer:
+        valueProto.set_integer_value(value.getValue<int>());
+        break;
+      case sir::Value::Double:
+        valueProto.set_double_value(value.getValue<double>());
+        break;
+      case sir::Value::String:
+        valueProto.set_string_value(value.getValue<std::string>());
+        break;
+      case sir::Value::None:
+        break;
+      }
     }
 
     mapProto->insert({name, valueProto});
@@ -559,7 +561,7 @@ static std::string serializeImpl(const SIR* sir, SIRSerializer::SerializationKin
   default:
     dawn_unreachable("invalid SerializationKind");
   }
-  
+
   return str;
 }
 
@@ -884,7 +886,7 @@ static std::shared_ptr<SIR> deserializeImpl(const std::string& str,
   GOOGLE_PROTOBUF_VERIFY_VERSION;
   using namespace sir;
   ProtobufLogger::init();
-  
+
   // Decode the string
   sir::proto::SIR sirProto;
   switch(kind) {
@@ -903,7 +905,7 @@ static std::shared_ptr<SIR> deserializeImpl(const std::string& str,
   default:
     dawn_unreachable("invalid SerializationKind");
   }
-  
+
   // Convert protobuf SIR to SIR
   std::shared_ptr<SIR> sir = std::make_shared<SIR>();
 


### PR DESCRIPTION
Technical description
====================
`gtclang -write-sir` 

crashes for the example in 
https://github.com/MeteoSwiss-APN/gtclang/blob/master/test/integration-test/CodeGen/globals.cpp
This is a fix. 
