### PR TITLE
Support globals in stencil functions

### DIFF
--- a/src/dawn/CodeGen/ASTCodeGenCXX.h
+++ b/src/dawn/CodeGen/ASTCodeGenCXX.h
@@ -73,8 +73,8 @@ public:
 
   /// @brief Mapping of VarDeclStmt and Var/FieldAccessExpr to their name
   /// @{
-  virtual const std::string& getName(const std::shared_ptr<Expr>& expr) const = 0;
-  virtual const std::string& getName(const std::shared_ptr<Stmt>& stmt) const = 0;
+  virtual std::string getName(const std::shared_ptr<Expr>& expr) const = 0;
+  virtual std::string getName(const std::shared_ptr<Stmt>& stmt) const = 0;
   /// @}
 
   /// @brief Convert builtin type to the corresponding C++ type

--- a/src/dawn/CodeGen/CXXNaive/ASTStencilBody.cpp
+++ b/src/dawn/CodeGen/CXXNaive/ASTStencilBody.cpp
@@ -34,14 +34,14 @@ ASTStencilBody::ASTStencilBody(const dawn::StencilInstantiation* stencilInstanti
 
 ASTStencilBody::~ASTStencilBody() {}
 
-const std::string& ASTStencilBody::getName(const std::shared_ptr<Stmt>& stmt) const {
+std::string ASTStencilBody::getName(const std::shared_ptr<Stmt>& stmt) const {
   if(currentFunction_)
     return currentFunction_->getNameFromAccessID(currentFunction_->getAccessIDFromStmt(stmt));
   else
     return instantiation_->getNameFromAccessID(instantiation_->getAccessIDFromStmt(stmt));
 }
 
-const std::string& ASTStencilBody::getName(const std::shared_ptr<Expr>& expr) const {
+std::string ASTStencilBody::getName(const std::shared_ptr<Expr>& expr) const {
   if(currentFunction_)
     return currentFunction_->getNameFromAccessID(currentFunction_->getAccessIDFromExpr(expr));
   else

--- a/src/dawn/CodeGen/CXXNaive/ASTStencilBody.h
+++ b/src/dawn/CodeGen/CXXNaive/ASTStencilBody.h
@@ -111,8 +111,8 @@ public:
   void setCurrentStencilFunction(const StencilFunctionInstantiation* currentFunction);
 
   /// @brief Mapping of VarDeclStmt and Var/FieldAccessExpr to their name
-  const std::string& getName(const std::shared_ptr<Expr>& expr) const override;
-  const std::string& getName(const std::shared_ptr<Stmt>& stmt) const override;
+  std::string getName(const std::shared_ptr<Expr>& expr) const override;
+  std::string getName(const std::shared_ptr<Stmt>& stmt) const override;
   int getAccessID(const std::shared_ptr<Expr>& expr) const;
 };
 

--- a/src/dawn/CodeGen/CXXNaive/ASTStencilDesc.cpp
+++ b/src/dawn/CodeGen/CXXNaive/ASTStencilDesc.cpp
@@ -30,11 +30,11 @@ ASTStencilDesc::ASTStencilDesc(
 
 ASTStencilDesc::~ASTStencilDesc() {}
 
-const std::string& ASTStencilDesc::getName(const std::shared_ptr<Stmt>& stmt) const {
+std::string ASTStencilDesc::getName(const std::shared_ptr<Stmt>& stmt) const {
   return instantiation_->getNameFromAccessID(instantiation_->getAccessIDFromStmt(stmt));
 }
 
-const std::string& ASTStencilDesc::getName(const std::shared_ptr<Expr>& expr) const {
+std::string ASTStencilDesc::getName(const std::shared_ptr<Expr>& expr) const {
   return instantiation_->getNameFromAccessID(instantiation_->getAccessIDFromExpr(expr));
 }
 

--- a/src/dawn/CodeGen/CXXNaive/ASTStencilDesc.h
+++ b/src/dawn/CodeGen/CXXNaive/ASTStencilDesc.h
@@ -60,8 +60,8 @@ public:
   virtual void visit(const std::shared_ptr<FieldAccessExpr>& expr) override;
   /// @}
 
-  const std::string& getName(const std::shared_ptr<Stmt>& stmt) const override;
-  const std::string& getName(const std::shared_ptr<Expr>& expr) const override;
+  std::string getName(const std::shared_ptr<Stmt>& stmt) const override;
+  std::string getName(const std::shared_ptr<Expr>& expr) const override;
 };
 
 } // namespace cxxnaive

--- a/src/dawn/CodeGen/GridTools/ASTStencilBody.cpp
+++ b/src/dawn/CodeGen/GridTools/ASTStencilBody.cpp
@@ -24,22 +24,21 @@ namespace dawn {
 namespace codegen {
 namespace gt {
 
-ASTStencilBody::ASTStencilBody(
-    const StencilInstantiation* stencilInstantiation,
-    const std::unordered_map<Interval, std::string>& intervalToNameMap)
+ASTStencilBody::ASTStencilBody(const StencilInstantiation* stencilInstantiation,
+                               const std::unordered_map<Interval, std::string>& intervalToNameMap)
     : ASTCodeGenCXX(), instantiation_(stencilInstantiation), intervalToNameMap_(intervalToNameMap),
       offsetPrinter_(",", "(", ")"), currentFunction_(nullptr), nestingOfStencilFunArgLists_(0) {}
 
 ASTStencilBody::~ASTStencilBody() {}
 
-const std::string& ASTStencilBody::getName(const std::shared_ptr<Stmt>& stmt) const {
+std::string ASTStencilBody::getName(const std::shared_ptr<Stmt>& stmt) const {
   if(currentFunction_)
     return currentFunction_->getNameFromAccessID(currentFunction_->getAccessIDFromStmt(stmt));
   else
     return instantiation_->getNameFromAccessID(instantiation_->getAccessIDFromStmt(stmt));
 }
 
-const std::string& ASTStencilBody::getName(const std::shared_ptr<Expr>& expr) const {
+std::string ASTStencilBody::getName(const std::shared_ptr<Expr>& expr) const {
   if(currentFunction_)
     return currentFunction_->getNameFromAccessID(currentFunction_->getAccessIDFromExpr(expr));
   else
@@ -96,21 +95,13 @@ void ASTStencilBody::visit(const std::shared_ptr<IfStmt>& stmt) { Base::visit(st
 //     Expr
 //===------------------------------------------------------------------------------------------===//
 
-void ASTStencilBody::visit(const std::shared_ptr<UnaryOperator>& expr) {
-  Base::visit(expr);
-}
+void ASTStencilBody::visit(const std::shared_ptr<UnaryOperator>& expr) { Base::visit(expr); }
 
-void ASTStencilBody::visit(const std::shared_ptr<BinaryOperator>& expr) {
-  Base::visit(expr);
-}
+void ASTStencilBody::visit(const std::shared_ptr<BinaryOperator>& expr) { Base::visit(expr); }
 
-void ASTStencilBody::visit(const std::shared_ptr<AssignmentExpr>& expr) {
-  Base::visit(expr);
-}
+void ASTStencilBody::visit(const std::shared_ptr<AssignmentExpr>& expr) { Base::visit(expr); }
 
-void ASTStencilBody::visit(const std::shared_ptr<TernaryOperator>& expr) {
-  Base::visit(expr);
-}
+void ASTStencilBody::visit(const std::shared_ptr<TernaryOperator>& expr) { Base::visit(expr); }
 
 void ASTStencilBody::visit(const std::shared_ptr<FunCallExpr>& expr) { Base::visit(expr); }
 
@@ -160,9 +151,7 @@ void ASTStencilBody::visit(const std::shared_ptr<VarAccessExpr>& expr) {
   }
 }
 
-void ASTStencilBody::visit(const std::shared_ptr<LiteralAccessExpr>& expr) {
-  Base::visit(expr);
-}
+void ASTStencilBody::visit(const std::shared_ptr<LiteralAccessExpr>& expr) { Base::visit(expr); }
 
 void ASTStencilBody::visit(const std::shared_ptr<FieldAccessExpr>& expr) {
   if(!nestingOfStencilFunArgLists_)

--- a/src/dawn/CodeGen/GridTools/ASTStencilBody.h
+++ b/src/dawn/CodeGen/GridTools/ASTStencilBody.h
@@ -80,8 +80,8 @@ public:
   void setCurrentStencilFunction(const StencilFunctionInstantiation* currentFunction);
 
   /// @brief Mapping of VarDeclStmt and Var/FieldAccessExpr to their name
-  const std::string& getName(const std::shared_ptr<Expr>& expr) const override;
-  const std::string& getName(const std::shared_ptr<Stmt>& stmt) const override;
+  std::string getName(const std::shared_ptr<Expr>& expr) const override;
+  std::string getName(const std::shared_ptr<Stmt>& stmt) const override;
   int getAccessID(const std::shared_ptr<Expr>& expr) const;
 };
 

--- a/src/dawn/CodeGen/GridTools/ASTStencilDesc.cpp
+++ b/src/dawn/CodeGen/GridTools/ASTStencilDesc.cpp
@@ -30,11 +30,11 @@ ASTStencilDesc::ASTStencilDesc(
 
 ASTStencilDesc::~ASTStencilDesc() {}
 
-const std::string& ASTStencilDesc::getName(const std::shared_ptr<Stmt>& stmt) const {
+std::string ASTStencilDesc::getName(const std::shared_ptr<Stmt>& stmt) const {
   return instantiation_->getNameFromAccessID(instantiation_->getAccessIDFromStmt(stmt));
 }
 
-const std::string& ASTStencilDesc::getName(const std::shared_ptr<Expr>& expr) const {
+std::string ASTStencilDesc::getName(const std::shared_ptr<Expr>& expr) const {
   return instantiation_->getNameFromAccessID(instantiation_->getAccessIDFromExpr(expr));
 }
 

--- a/src/dawn/CodeGen/GridTools/ASTStencilDesc.h
+++ b/src/dawn/CodeGen/GridTools/ASTStencilDesc.h
@@ -71,8 +71,8 @@ public:
   virtual void visit(const std::shared_ptr<FieldAccessExpr>& expr) override;
   /// @}
 
-  const std::string& getName(const std::shared_ptr<Stmt>& stmt) const override;
-  const std::string& getName(const std::shared_ptr<Expr>& expr) const override;
+  std::string getName(const std::shared_ptr<Stmt>& stmt) const override;
+  std::string getName(const std::shared_ptr<Expr>& expr) const override;
 };
 
 } // namespace gt

--- a/src/dawn/CodeGen/GridTools/GTCodeGen.cpp
+++ b/src/dawn/CodeGen/GridTools/GTCodeGen.cpp
@@ -206,6 +206,18 @@ GTCodeGen::generateStencilInstantiation(const StencilInstantiation* stencilInsta
           arglist.push_back(std::move(paramName));
         }
 
+        // Global accessor declaration
+        for(auto accessID : stencilFun->getAccessIDSetGlobalVariables()) {
+          std::string paramName = stencilFun->getNameFromAccessID(accessID);
+          StencilFunStruct.addTypeDef(paramName)
+              .addType(c_gt() + "global_accessor")
+              .addTemplate(Twine(accessorID))
+              .addTemplate(c_gt_enum() + "in");
+          accessorID++;
+
+          arglist.push_back(std::move(paramName));
+        }
+
         // Generate arglist
         StencilFunStruct.addTypeDef("arg_list").addType("boost::mpl::vector").addTemplates(arglist);
         mplContainerMaxSize_ = std::max(mplContainerMaxSize_, arglist.size());
@@ -321,16 +333,14 @@ GTCodeGen::generateStencilInstantiation(const StencilInstantiation* stencilInsta
 
           // Generate placeholder mapping of the field in `make_stage`
           ssMS << "p_" << paramName << "()"
-               << ((stage.getGlobalVariables().empty() && (accessorIdx == fields.size() - 1))
-                       ? ""
-                       : ", ");
+               << ((stage.hasGlobalVariables() && (accessorIdx == fields.size() - 1)) ? "" : ", ");
 
           arglist.push_back(std::move(paramName));
         }
 
         // Global accessor declaration
-        std::size_t maxAccessors = fields.size() + stage.getGlobalVariables().size();
-        for(int AccessID : stage.getGlobalVariables()) {
+        std::size_t maxAccessors = fields.size() + stage.getAllGlobalVariables().size();
+        for(int AccessID : stage.getAllGlobalVariables()) {
           std::string paramName = stencilInstantiation->getNameFromAccessID(AccessID);
 
           StageStruct.addTypeDef(paramName)

--- a/src/dawn/Optimizer/PassInlining.cpp
+++ b/src/dawn/Optimizer/PassInlining.cpp
@@ -124,8 +124,8 @@ public:
 
       // Register the variable
       instantiation_->setAccessIDNamePair(AccessID, returnVarName);
-      instantiation_->getStmtToAccessIDMap().emplace(newStmt, AccessID);
-      instantiation_->getExprToAccessIDMap().emplace(newExpr_, AccessID);
+      instantiation_->mapStmtToAccessID(newStmt, AccessID);
+      instantiation_->mapExprToAccessID(newExpr_, AccessID);
 
     } else {
       // We are called within an arugment list of a stencil function, we thus need to store the
@@ -141,7 +141,7 @@ public:
 
       // Promote the "temporary" storage we used to mock the argument to an actual temporary field
       instantiation_->setAccessIDNamePairOfField(AccessIDOfCaller_, returnFieldName, true);
-      instantiation_->getExprToAccessIDMap().emplace(newExpr_, AccessIDOfCaller_);
+      instantiation_->mapExprToAccessID(newExpr_, AccessIDOfCaller_);
     }
 
     // Resolve the actual expression of the return statement
@@ -161,7 +161,7 @@ public:
     int AccessID = curStencilFunctioninstantiation_->getAccessIDFromStmt(stmt);
     const std::string& name = curStencilFunctioninstantiation_->getNameFromAccessID(AccessID);
     instantiation_->setAccessIDNamePair(AccessID, name);
-    instantiation_->getStmtToAccessIDMap().emplace(stmt, AccessID);
+    instantiation_->mapStmtToAccessID(stmt, AccessID);
 
     // Push back the statement and move on
     appendNewStatementAccessesPair(stmt);
@@ -279,15 +279,15 @@ public:
 
   void visit(const std::shared_ptr<VarAccessExpr>& expr) override {
 
-    instantiation_->getExprToAccessIDMap().emplace(
-        expr, curStencilFunctioninstantiation_->getAccessIDFromExpr(expr));
+    instantiation_->mapExprToAccessID(expr,
+                                      curStencilFunctioninstantiation_->getAccessIDFromExpr(expr));
     if(expr->isArrayAccess())
       expr->getIndex()->accept(*this);
   }
 
   void visit(const std::shared_ptr<FieldAccessExpr>& expr) override {
-    instantiation_->getExprToAccessIDMap().emplace(
-        expr, curStencilFunctioninstantiation_->getAccessIDFromExpr(expr));
+    instantiation_->mapExprToAccessID(expr,
+                                      curStencilFunctioninstantiation_->getAccessIDFromExpr(expr));
 
     // Set the fully evaluated offset as the new offset of the field. Note that this renders the
     // AST of the current stencil function incorrent which is why it needs to be removed!
@@ -300,7 +300,7 @@ public:
   void visit(const std::shared_ptr<LiteralAccessExpr>& expr) override {
     int AccessID = curStencilFunctioninstantiation_->getAccessIDFromExpr(expr);
     instantiation_->getLiteralAccessIDToNameMap().emplace(AccessID, expr->getValue());
-    instantiation_->getExprToAccessIDMap().emplace(expr, AccessID);
+    instantiation_->mapExprToAccessID(expr, AccessID);
   }
 };
 

--- a/src/dawn/Optimizer/PassSetNonTempCaches.cpp
+++ b/src/dawn/Optimizer/PassSetNonTempCaches.cpp
@@ -217,8 +217,8 @@ private:
     domethod->getStatementAccessesPairs().push_back(pair);
 
     // Add the new expressions to the map
-    instantiation_->getExprToAccessIDMap().emplace(fa_assignment, assignmentID);
-    instantiation_->getExprToAccessIDMap().emplace(fa_assignee, assigneeID);
+    instantiation_->mapExprToAccessID(fa_assignment, assignmentID);
+    instantiation_->mapExprToAccessID(fa_assignee, assigneeID);
   }
 
   /// @brief Checks if there is a read operation before the first write operation in the given

--- a/src/dawn/Optimizer/Replacing.cpp
+++ b/src/dawn/Optimizer/Replacing.cpp
@@ -78,8 +78,8 @@ void replaceFieldWithVarAccessInStmts(
 
       replaceOldExprWithNewExprInStmt(stmt, oldExpr, newExpr);
 
-      instantiation->getExprToAccessIDMap().emplace(newExpr, AccessID);
-      instantiation->getExprToAccessIDMap().erase(oldExpr);
+      instantiation->mapExprToAccessID(newExpr, AccessID);
+      instantiation->eraseExprToAccessID(oldExpr);
     }
   }
 }
@@ -101,8 +101,8 @@ void replaceVarWithFieldAccessInStmts(
 
       replaceOldExprWithNewExprInStmt(stmt, oldExpr, newExpr);
 
-      instantiation->getExprToAccessIDMap().emplace(newExpr, AccessID);
-      instantiation->getExprToAccessIDMap().erase(oldExpr);
+      instantiation->mapExprToAccessID(newExpr, AccessID);
+      instantiation->eraseExprToAccessID(oldExpr);
     }
   }
 }

--- a/src/dawn/Optimizer/Stage.h
+++ b/src/dawn/Optimizer/Stage.h
@@ -51,7 +51,9 @@ class Stage {
   std::vector<Field> fields_;
 
   /// AccessIDs of the global variable accesses of this stage
+  std::unordered_set<int> allGlobalVariables_;
   std::unordered_set<int> globalVariables_;
+  std::unordered_set<int> globalVariablesFromStencilFunctionCalls_;
 
 public:
   /// @name Constructors and Assignment
@@ -123,10 +125,27 @@ public:
   /// the @b accumulated extent of each field
   void update();
 
+  /// @brief checks whether the stage contains global variables
+  bool hasGlobalVariables() const;
+
   /// @brief Get the global variables accessed in this stage
   ///
+  /// only returns those global variables used within the stage,
+  /// but not inside stencil functions called from the stage
   /// The global variables are computed during `Stage::update`.
   const std::unordered_set<int>& getGlobalVariables() const;
+
+  /// @brief Get the global variables accessed in stencil functions that
+  /// are called from within the stage
+  ///
+  /// The global variables are computed during `Stage::update`.
+  const std::unordered_set<int>& getGlobalVariablesFromStencilFunctionCalls() const;
+
+  /// @brief Get the all global variables used in the stage:
+  /// i.e. the union of getGlovalVariables() and getGlobalVariablesFromStencilFunctionCalls()
+  ///
+  /// The global variables are computed during `Stage::update`.
+  const std::unordered_set<int>& getAllGlobalVariables() const;
 
   /// @brief Add the given Do-Method to the list of Do-Methods of this stage
   ///

--- a/src/dawn/Optimizer/Stencil.cpp
+++ b/src/dawn/Optimizer/Stencil.cpp
@@ -137,10 +137,12 @@ std::vector<Stencil::FieldInfo> Stencil::getFields(bool withTemporaries) const {
 
 std::vector<std::string> Stencil::getGlobalVariables() const {
   std::set<int> globalVariableAccessIDs;
-  for(const auto& multistage : multistages_)
-    for(const auto& stage : multistage->getStages())
-      for(const auto& varAccessID : stage->getGlobalVariables())
-        globalVariableAccessIDs.insert(varAccessID);
+  for(const auto& multistage : multistages_) {
+    for(const auto& stage : multistage->getStages()) {
+      globalVariableAccessIDs.insert(stage->getAllGlobalVariables().begin(),
+                                     stage->getAllGlobalVariables().end());
+    }
+  }
 
   std::vector<std::string> globalVariables;
   for(const auto& AccessID : globalVariableAccessIDs)

--- a/src/dawn/Optimizer/StencilFunctionInstantiation.cpp
+++ b/src/dawn/Optimizer/StencilFunctionInstantiation.cpp
@@ -41,7 +41,10 @@ StencilFunctionInstantiation::StencilFunctionInstantiation(
     sir::StencilFunction* function, const std::shared_ptr<AST>& ast, const Interval& interval,
     bool isNested)
     : stencilInstantiation_(context), expr_(expr), function_(function), ast_(ast),
-      interval_(interval), hasReturn_(false), isNested_(isNested) {}
+      interval_(interval), hasReturn_(false), isNested_(isNested) {
+  DAWN_ASSERT(context);
+  DAWN_ASSERT(function);
+}
 
 Array3i StencilFunctionInstantiation::evalOffsetOfFieldAccessExpr(
     const std::shared_ptr<FieldAccessExpr>& expr, bool applyInitialOffset) const {
@@ -265,24 +268,23 @@ int StencilFunctionInstantiation::getAccessIDFromStmt(const std::shared_ptr<Stmt
   return it->second;
 }
 
-const std::unordered_map<std::shared_ptr<Expr>, int>&
-StencilFunctionInstantiation::getExprToCallerAccessIDMap() const {
-  return ExprToCallerAccessIDMap_;
+void StencilFunctionInstantiation::setAccessIDOfExpr(const std::shared_ptr<Expr>& expr,
+                                                     const int accessID) {
+  ExprToCallerAccessIDMap_[expr] = accessID;
 }
 
-std::unordered_map<std::shared_ptr<Expr>, int>&
-StencilFunctionInstantiation::getExprToCallerAccessIDMap() {
-  return ExprToCallerAccessIDMap_;
+void StencilFunctionInstantiation::mapExprToAccessID(std::shared_ptr<Expr> expr, int accessID) {
+  ExprToCallerAccessIDMap_.emplace(expr, accessID);
 }
 
-const std::unordered_map<std::shared_ptr<Stmt>, int>&
-StencilFunctionInstantiation::getStmtToCallerAccessIDMap() const {
-  return StmtToCallerAccessIDMap_;
+void StencilFunctionInstantiation::setAccessIDOfStmt(const std::shared_ptr<Stmt>& stmt,
+                                                     const int accessID) {
+  DAWN_ASSERT(StmtToCallerAccessIDMap_.count(stmt));
+  StmtToCallerAccessIDMap_[stmt] = accessID;
 }
 
-std::unordered_map<std::shared_ptr<Stmt>, int>&
-StencilFunctionInstantiation::getStmtToCallerAccessIDMap() {
-  return StmtToCallerAccessIDMap_;
+void StencilFunctionInstantiation::mapStmtToAccessID(std::shared_ptr<Stmt> stmt, int accessID) {
+  StmtToCallerAccessIDMap_.emplace(stmt, accessID);
 }
 
 std::unordered_map<int, std::string>& StencilFunctionInstantiation::getLiteralAccessIDToNameMap() {

--- a/src/dawn/Optimizer/StencilFunctionInstantiation.cpp
+++ b/src/dawn/Optimizer/StencilFunctionInstantiation.cpp
@@ -240,14 +240,22 @@ void StencilFunctionInstantiation::renameCallerAccessID(int oldAccessID, int new
 //     Expr/Stmt to Caller AccessID Maps
 //===----------------------------------------------------------------------------------------===//
 
-const std::string& StencilFunctionInstantiation::getNameFromAccessID(int AccessID) const {
+std::string StencilFunctionInstantiation::getNameFromAccessID(int AccessID) const {
   // As we store the caller accessIDs, we have to get the name of the field from the context!
   if(AccessID < 0)
     return getNameFromLiteralAccessID(AccessID);
-  else if(stencilInstantiation_->isField(AccessID))
+  else if(stencilInstantiation_->isField(AccessID) ||
+          stencilInstantiation_->isGlobalVariable(AccessID))
     return stencilInstantiation_->getNameFromAccessID(AccessID);
-  else
+  else {
+    DAWN_ASSERT(AccessIDToNameMap_.count(AccessID));
     return AccessIDToNameMap_.find(AccessID)->second;
+  }
+}
+
+void StencilFunctionInstantiation::setAccessIDOfGlobalVariable(int AccessID) {
+  //  setAccessIDNamePair(AccessID, name);
+  GlobalVariableAccessIDSet_.insert(AccessID);
 }
 
 const std::string& StencilFunctionInstantiation::getNameFromLiteralAccessID(int AccessID) const {

--- a/src/dawn/Optimizer/StencilFunctionInstantiation.h
+++ b/src/dawn/Optimizer/StencilFunctionInstantiation.h
@@ -142,11 +142,45 @@ private:
   /// Set of AccessID of fields which are not used
   std::set<int> unusedFields_;
 
+  /// Set containing the AccessIDs of "global variable" accesses. Global variable accesses are
+  /// represented by global_accessor or if we know the value at compile time we do a constant
+  /// folding of the variable
+  std::set<int> GlobalVariableAccessIDSet_;
+
 public:
   StencilFunctionInstantiation(StencilInstantiation* context,
                                const std::shared_ptr<StencilFunCallExpr>& expr,
                                sir::StencilFunction* function, const std::shared_ptr<AST>& ast,
                                const Interval& interval, bool isNested);
+
+  std::unordered_map<int, int>& ArgumentIndexToCallerAccessIDMap() {
+    return ArgumentIndexToCallerAccessIDMap_;
+  }
+  std::unordered_map<int, int> const& ArgumentIndexToCallerAccessIDMap() const {
+    return ArgumentIndexToCallerAccessIDMap_;
+  }
+
+  size_t numArgs() const;
+
+  /// @brief register the access id of a global variable access
+  void setAccessIDOfGlobalVariable(int AccessID);
+
+  /// @brief get the access id set of a global variables
+  /// @{
+  std::set<int>& getAccessIDSetGlobalVariables() { return GlobalVariableAccessIDSet_; }
+  std::set<int> const& getAccessIDSetGlobalVariables() const { return GlobalVariableAccessIDSet_; }
+  /// @}
+
+  /// @brief get the name of the arg parameter of the stencil function which is called passing
+  /// another function
+  ///
+  /// In the following example
+  /// stencil_function fn {
+  ///   storage arg_st1, arg_st2;
+  /// }
+  /// fn(storage1, fn(storage2) )
+  /// it will return arg_st2
+  std::string getArgNameFromFunctionCall(std::string fnCallName) const;
 
   /// @brief Get the associated StencilInstantiation
   StencilInstantiation* getStencilInstantiation() { return stencilInstantiation_; }
@@ -242,7 +276,7 @@ public:
   //===----------------------------------------------------------------------------------------===//
 
   /// @brief Get the `name` associated with the `AccessID`
-  const std::string& getNameFromAccessID(int AccessID) const;
+  std::string getNameFromAccessID(int AccessID) const;
 
   /// @brief Get the `name` associated with the literal `AccessID`
   const std::string& getNameFromLiteralAccessID(int AccessID) const;

--- a/src/dawn/Optimizer/StencilFunctionInstantiation.h
+++ b/src/dawn/Optimizer/StencilFunctionInstantiation.h
@@ -253,13 +253,17 @@ public:
   /// @brief Get the `AccessID` of the Stmt (VarDeclStmt)
   int getAccessIDFromStmt(const std::shared_ptr<Stmt>& stmt) const;
 
-  /// @brief Get map which associates Exprs with `caller` AccessIDs
-  std::unordered_map<std::shared_ptr<Expr>, int>& getExprToCallerAccessIDMap();
-  const std::unordered_map<std::shared_ptr<Expr>, int>& getExprToCallerAccessIDMap() const;
+  /// @brief Set the `AccessID` of a Expr (VarAccess or FieldAccess)
+  void setAccessIDOfExpr(const std::shared_ptr<Expr>& expr, const int accessID);
 
-  /// @brief Get map which associates Stmts with `caller` AccessIDs
-  std::unordered_map<std::shared_ptr<Stmt>, int>& getStmtToCallerAccessIDMap();
-  const std::unordered_map<std::shared_ptr<Stmt>, int>& getStmtToCallerAccessIDMap() const;
+  /// @brief Add entry to the map between a given expr to its access ID
+  void mapExprToAccessID(std::shared_ptr<Expr> expr, int AccessID);
+
+  /// @brief Set the `AccessID` of a Stmt (VarDecl)
+  void setAccessIDOfStmt(const std::shared_ptr<Stmt>& stmt, const int accessID);
+
+  /// @brief Add entry to the map between a given stmt to its access ID
+  void mapStmtToAccessID(std::shared_ptr<Stmt> stmt, int AccessID);
 
   /// @brief Get the Literal-AccessID-to-Name map
   std::unordered_map<int, std::string>& getLiteralAccessIDToNameMap();

--- a/src/dawn/Optimizer/StencilInstantiation.cpp
+++ b/src/dawn/Optimizer/StencilInstantiation.cpp
@@ -402,8 +402,6 @@ public:
       }
 
     } else {
-      DAWN_ASSERT(!function);
-
       // Register the mapping between VarAccessExpr and AccessID.
       if(function)
         function->mapExprToAccessID(expr, scope_.top()->LocalVarNameToAccessIDMap[varname]);

--- a/src/dawn/Optimizer/StencilInstantiation.cpp
+++ b/src/dawn/Optimizer/StencilInstantiation.cpp
@@ -199,7 +199,7 @@ public:
     auto& function = scope_.top()->FunctionInstantiation;
     if(function) {
       function->getAccessIDToNameMap().emplace(AccessID, globalName);
-      function->getStmtToCallerAccessIDMap().emplace(stmt, AccessID);
+      function->mapStmtToAccessID(stmt, AccessID);
     } else {
       instantiation_->setAccessIDNamePair(AccessID, globalName);
       instantiation_->getStmtToAccessIDMap().emplace(stmt, AccessID);
@@ -367,7 +367,6 @@ public:
     const auto& varname = expr->getName();
 
     if(expr->isExternal()) {
-      DAWN_ASSERT(!function);
       DAWN_ASSERT_MSG(!expr->isArrayAccess(), "global array access is not supported");
 
       const auto& value = instantiation_->getGlobalVariableValue(varname);
@@ -382,27 +381,34 @@ public:
 
         int AccessID = instantiation_->nextUID();
         instantiation_->getLiteralAccessIDToNameMap().emplace(AccessID, newExpr->getValue());
-        instantiation_->getExprToAccessIDMap().emplace(newExpr, AccessID);
+        instantiation_->mapExprToAccessID(newExpr, AccessID);
 
       } else {
+        StencilInstantiation* stencilInstantiation =
+            (function) ? function->getStencilInstantiation() : instantiation_;
+
         int AccessID = 0;
-        if(!instantiation_->isGlobalVariable(varname)) {
-          AccessID = instantiation_->nextUID();
-          instantiation_->setAccessIDNamePairOfGlobalVariable(AccessID, varname);
+        if(!stencilInstantiation->isGlobalVariable(varname)) {
+          AccessID = stencilInstantiation->nextUID();
+          stencilInstantiation->setAccessIDNamePairOfGlobalVariable(AccessID, varname);
         } else {
-          AccessID = instantiation_->getAccessIDFromName(varname);
+          AccessID = stencilInstantiation->getAccessIDFromName(varname);
         }
-        instantiation_->getExprToAccessIDMap().emplace(expr, AccessID);
+
+        if(function)
+          function->mapExprToAccessID(expr, AccessID);
+        else
+          instantiation_->mapExprToAccessID(expr, AccessID);
       }
 
     } else {
+      DAWN_ASSERT(!function);
+
       // Register the mapping between VarAccessExpr and AccessID.
       if(function)
-        function->getExprToCallerAccessIDMap().emplace(
-            expr, scope_.top()->LocalVarNameToAccessIDMap[varname]);
+        function->mapExprToAccessID(expr, scope_.top()->LocalVarNameToAccessIDMap[varname]);
       else
-        instantiation_->getExprToAccessIDMap().emplace(
-            expr, scope_.top()->LocalVarNameToAccessIDMap[varname]);
+        instantiation_->mapExprToAccessID(expr, scope_.top()->LocalVarNameToAccessIDMap[varname]);
 
       // Resolve the index if this is an array access
       if(expr->isArrayAccess())
@@ -417,10 +423,10 @@ public:
     auto& function = scope_.top()->FunctionInstantiation;
     if(function) {
       function->getLiteralAccessIDToNameMap().emplace(AccessID, expr->getValue());
-      function->getExprToCallerAccessIDMap().emplace(expr, AccessID);
+      function->mapExprToAccessID(expr, AccessID);
     } else {
       instantiation_->getLiteralAccessIDToNameMap().emplace(AccessID, expr->getValue());
-      instantiation_->getExprToAccessIDMap().emplace(expr, AccessID);
+      instantiation_->mapExprToAccessID(expr, AccessID);
     }
   }
 
@@ -430,9 +436,9 @@ public:
 
     auto& function = scope_.top()->FunctionInstantiation;
     if(function) {
-      function->getExprToCallerAccessIDMap().emplace(expr, AccessID);
+      function->mapExprToAccessID(expr, AccessID);
     } else {
-      instantiation_->getExprToAccessIDMap().emplace(expr, AccessID);
+      instantiation_->mapExprToAccessID(expr, AccessID);
     }
 
     if(Scope* candiateScope = getCurrentCandidateScope()) {
@@ -686,7 +692,7 @@ public:
           auto voidStmt = std::make_shared<ExprStmt>(voidExpr);
           int AccessID = -instantiation_->nextUID();
           instantiation_->getLiteralAccessIDToNameMap().emplace(AccessID, "0");
-          instantiation_->getExprToAccessIDMap().emplace(voidExpr, AccessID);
+          instantiation_->mapExprToAccessID(voidExpr, AccessID);
           replaceOldStmtWithNewStmtInStmt(scope_.top()->Statements.back()->ASTStmt, stmt, voidStmt);
         }
       }
@@ -942,7 +948,7 @@ public:
 
         int AccessID = instantiation_->nextUID();
         instantiation_->getLiteralAccessIDToNameMap().emplace(AccessID, newExpr->getValue());
-        instantiation_->getExprToAccessIDMap().emplace(newExpr, AccessID);
+        instantiation_->mapExprToAccessID(newExpr, AccessID);
 
       } else {
         int AccessID = 0;
@@ -953,13 +959,12 @@ public:
           AccessID = instantiation_->getAccessIDFromName(varname);
         }
 
-        instantiation_->getExprToAccessIDMap().emplace(expr, AccessID);
+        instantiation_->mapExprToAccessID(expr, AccessID);
       }
 
     } else {
       // Register the mapping between VarAccessExpr and AccessID.
-      instantiation_->getExprToAccessIDMap().emplace(
-          expr, scope_.top()->LocalVarNameToAccessIDMap[varname]);
+      instantiation_->mapExprToAccessID(expr, scope_.top()->LocalVarNameToAccessIDMap[varname]);
 
       // Resolve the index if this is an array access
       if(expr->isArrayAccess())
@@ -971,7 +976,7 @@ public:
     // Register a literal access (Note: the negative AccessID we assign!)
     int AccessID = -instantiation_->nextUID();
     instantiation_->getLiteralAccessIDToNameMap().emplace(AccessID, expr->getValue());
-    instantiation_->getExprToAccessIDMap().emplace(expr, AccessID);
+    instantiation_->mapExprToAccessID(expr, AccessID);
   }
 
   void visit(const std::shared_ptr<FieldAccessExpr>& expr) override {}
@@ -1054,15 +1059,6 @@ void StencilInstantiation::removeAccessID(int AccesssID) {
 
 const std::string& StencilInstantiation::getName() const { return SIRStencil_->Name; }
 
-const std::unordered_map<std::shared_ptr<Expr>, int>&
-StencilInstantiation::getExprToAccessIDMap() const {
-  return ExprToAccessIDMap_;
-}
-
-std::unordered_map<std::shared_ptr<Expr>, int>& StencilInstantiation::getExprToAccessIDMap() {
-  return ExprToAccessIDMap_;
-}
-
 const std::unordered_map<std::shared_ptr<Stmt>, int>&
 StencilInstantiation::getStmtToAccessIDMap() const {
   return StmtToAccessIDMap_;
@@ -1084,6 +1080,19 @@ const std::string& StencilInstantiation::getNameFromStageID(int StageID) const {
   auto it = StageIDToNameMap_.find(StageID);
   DAWN_ASSERT_MSG(it != StageIDToNameMap_.end(), "Invalid StageID");
   return it->second;
+}
+
+void StencilInstantiation::mapExprToAccessID(std::shared_ptr<Expr> expr, int accessID) {
+  ExprToAccessIDMap_.emplace(expr, accessID);
+}
+
+void StencilInstantiation::eraseExprToAccessID(std::shared_ptr<Expr> expr) {
+  DAWN_ASSERT(ExprToAccessIDMap_.count(expr));
+  ExprToAccessIDMap_.erase(expr);
+}
+
+void StencilInstantiation::mapStmtToAccessID(std::shared_ptr<Stmt> stmt, int accessID) {
+  StmtToAccessIDMap_.emplace(stmt, accessID);
 }
 
 const std::string& StencilInstantiation::getNameFromLiteralAccessID(int AccessID) const {
@@ -1353,6 +1362,18 @@ int StencilInstantiation::getAccessIDFromStmt(const std::shared_ptr<Stmt>& stmt)
   auto it = StmtToAccessIDMap_.find(stmt);
   DAWN_ASSERT_MSG(it != StmtToAccessIDMap_.end(), "Invalid Stmt");
   return it->second;
+}
+
+void StencilInstantiation::setAccessIDOfStmt(const std::shared_ptr<Stmt>& stmt,
+                                             const int accessID) {
+  DAWN_ASSERT(StmtToAccessIDMap_.count(stmt));
+  StmtToAccessIDMap_[stmt] = accessID;
+}
+
+void StencilInstantiation::setAccessIDOfExpr(const std::shared_ptr<Expr>& expr,
+                                             const int accessID) {
+  DAWN_ASSERT(ExprToAccessIDMap_.count(expr));
+  ExprToAccessIDMap_[expr] = accessID;
 }
 
 void StencilInstantiation::removeStencilFunctionInstantiation(

--- a/src/dawn/Optimizer/StencilInstantiation.cpp
+++ b/src/dawn/Optimizer/StencilInstantiation.cpp
@@ -321,7 +321,6 @@ public:
           candiateScope->FunctionInstantiation->setCallerInitialOffsetFromAccessID(
               AccessID, Array3i{{0, 0, 0}});
           candiateScope->LocalFieldnameToAccessIDMap.emplace(field->Name, AccessID);
-
         } else {
           int AccessID = candiateScope->FunctionInstantiation->getCallerAccessIDOfArgField(argIdx);
           candiateScope->LocalFieldnameToAccessIDMap.emplace(field->Name, AccessID);
@@ -331,6 +330,11 @@ public:
     // Resolve the function
     scope_.push(scope_.top()->CandiateScopes.top());
     scope_.top()->FunctionInstantiation->getAST()->accept(*this);
+
+    for(auto id : stencilFun->getAccessIDSetGlobalVariables()) {
+      scope_.top()->LocalVarNameToAccessIDMap.emplace(stencilFun->getNameFromAccessID(id), id);
+    }
+
     scope_.pop();
 
     // We resolved the candiate function, move on ...
@@ -396,8 +400,12 @@ public:
         }
 
         if(function)
+          function->setAccessIDOfGlobalVariable(AccessID);
+
+        if(function) {
           function->mapExprToAccessID(expr, AccessID);
-        else
+          instantiation_->mapExprToAccessID(expr, AccessID);
+        } else
           instantiation_->mapExprToAccessID(expr, AccessID);
       }
 

--- a/src/dawn/Optimizer/StencilInstantiation.h
+++ b/src/dawn/Optimizer/StencilInstantiation.h
@@ -258,6 +258,12 @@ public:
   /// @brief Get the `AccessID` of the Expr (VarAccess or FieldAccess)
   int getAccessIDFromExpr(const std::shared_ptr<Expr>& expr) const;
 
+  /// @brief Set the `AccessID` of the Expr (VarAccess or FieldAccess)
+  void setAccessIDOfExpr(const std::shared_ptr<Expr>& expr, const int accessID);
+
+  /// @brief Set the `AccessID` of the Stmt (VarDeclStmt)
+  void setAccessIDOfStmt(const std::shared_ptr<Stmt>& stmt, const int accessID);
+
   /// @brief Get the `AccessID` of the Stmt (VarDeclStmt)
   int getAccessIDFromStmt(const std::shared_ptr<Stmt>& stmt) const;
 
@@ -267,6 +273,15 @@ public:
   const StencilFunctionInstantiation*
   getStencilFunctionInstantiation(const std::shared_ptr<StencilFunCallExpr>& expr) const;
 
+  /// @brief Add entry to the map between a given expr to its access ID
+  void mapExprToAccessID(std::shared_ptr<Expr> expr, int accessID);
+
+  /// @brief Add entry to the map between a given stmt to its access ID
+  void mapStmtToAccessID(std::shared_ptr<Stmt> stmt, int accessID);
+
+  /// @brief Add entry of the Expr to AccessID map
+  void eraseExprToAccessID(std::shared_ptr<Expr> expr);
+
   /// @brief Get StencilFunctionInstantiation of the `StencilFunCallExpr`
   std::unordered_map<std::shared_ptr<StencilFunCallExpr>, StencilFunctionInstantiation*>&
   getExprToStencilFunctionInstantiationMap();
@@ -275,7 +290,8 @@ public:
 
   /// @brief Remove the stencil function given by `expr`
   ///
-  /// If `callerStencilFunctionInstantiation` is not NULL (i.e the stencil function is called within
+  /// If `callerStencilFunctionInstantiation` is not NULL (i.e the stencil function is called
+  /// within
   /// the scope of another stencil function), the stencil function will be removed
   /// from the `callerStencilFunctionInstantiation` instead of this `StencilInstantiation`.
   void removeStencilFunctionInstantiation(
@@ -284,7 +300,8 @@ public:
 
   /// @brief Register a new stencil function
   ///
-  /// If `curStencilFunctionInstantiation` is not NULL, the stencil function is treated as a nested
+  /// If `curStencilFunctionInstantiation` is not NULL, the stencil function is treated as a
+  /// nested
   /// stencil function.
   StencilFunctionInstantiation*
   makeStencilFunctionInstantiation(const std::shared_ptr<StencilFunCallExpr>& expr,
@@ -317,10 +334,6 @@ public:
   getStencilFunctionInstantiations() const {
     return stencilFunctionInstantiations_;
   }
-
-  /// @brief Get map which associates Exprs with AccessIDs
-  std::unordered_map<std::shared_ptr<Expr>, int>& getExprToAccessIDMap();
-  const std::unordered_map<std::shared_ptr<Expr>, int>& getExprToAccessIDMap() const;
 
   /// @brief Get map which associates Stmts with AccessIDs
   std::unordered_map<std::shared_ptr<Stmt>, int>& getStmtToAccessIDMap();

--- a/src/dawn/Optimizer/StencilInstantiation.h
+++ b/src/dawn/Optimizer/StencilInstantiation.h
@@ -290,8 +290,7 @@ public:
 
   /// @brief Remove the stencil function given by `expr`
   ///
-  /// If `callerStencilFunctionInstantiation` is not NULL (i.e the stencil function is called
-  /// within
+  /// If `callerStencilFunctionInstantiation` is not NULL (i.e the stencil function is called within
   /// the scope of another stencil function), the stencil function will be removed
   /// from the `callerStencilFunctionInstantiation` instead of this `StencilInstantiation`.
   void removeStencilFunctionInstantiation(
@@ -300,8 +299,7 @@ public:
 
   /// @brief Register a new stencil function
   ///
-  /// If `curStencilFunctionInstantiation` is not NULL, the stencil function is treated as a
-  /// nested
+  /// If `curStencilFunctionInstantiation` is not NULL, the stencil function is treated as a nested
   /// stencil function.
   StencilFunctionInstantiation*
   makeStencilFunctionInstantiation(const std::shared_ptr<StencilFunCallExpr>& expr,


### PR DESCRIPTION
Technical Description
==================

added support for using globals inside stencil functions. 

Additional change: in StencilInstantiation and StencilFunctionInstantiation add interfaces to add/retrieve entries from the maps of Expr/Stmt to AccessID. Currently the whole map is returning as a ref, and then from the caller scope it is modified. In the changes proposed here we have specific API for adding or retrieving entries to the maps. 