### PR TITLE
Temporary intervals

### DIFF
--- a/src/dawn-c/Compiler.cpp
+++ b/src/dawn-c/Compiler.cpp
@@ -95,7 +95,7 @@ dawnTranslationUnit_t* dawnCompile(const char* SIR, size_t size, const dawnOptio
 
     // Run the compiler
     dawn::DawnCompiler compiler(compileOptions.get());
-    auto TU = compiler.compile(inMemorySIR.get(), getCodeGenKind(codeGenKind));
+    auto TU = compiler.compile(inMemorySIR, getCodeGenKind(codeGenKind));
 
     // Report diganostics
     if(compiler.getDiagnostics().hasDiags()) {

--- a/src/dawn/CodeGen/CMakeLists.txt
+++ b/src/dawn/CodeGen/CMakeLists.txt
@@ -17,6 +17,7 @@ mchbuild_add_library(
   SOURCES ASTCodeGenCXX.cpp
           ASTCodeGenCXX.h
           CodeGen.h
+          CodeGen.cpp
           CodeGenProperties.cpp
           CodeGenProperties.h
           CXXUtil.h

--- a/src/dawn/CodeGen/CXXNaive/CXXNaiveCodeGen.cpp
+++ b/src/dawn/CodeGen/CXXNaive/CXXNaiveCodeGen.cpp
@@ -450,7 +450,7 @@ CXXNaiveCodeGen::generateStencilInstantiation(const StencilInstantiation* stenci
   return str;
 }
 
-std::string CXXNaiveCodeGen::generateGlobals(const std::shared_ptr<SIR> sir) {
+std::string CXXNaiveCodeGen::generateGlobals(std::shared_ptr<SIR> const& sir) {
 
   const auto& globalsMap = *(sir->GlobalVariableMap);
   if(globalsMap.empty())

--- a/src/dawn/CodeGen/CXXNaive/CXXNaiveCodeGen.cpp
+++ b/src/dawn/CodeGen/CXXNaive/CXXNaiveCodeGen.cpp
@@ -457,9 +457,9 @@ CXXNaiveCodeGen::generateStencilInstantiation(const StencilInstantiation* stenci
   return str;
 }
 
-std::string CXXNaiveCodeGen::generateGlobals(const SIR* sir) {
+std::string CXXNaiveCodeGen::generateGlobals(const std::shared_ptr<SIR> sir) {
 
-  const auto& globalsMap = *sir->GlobalVariableMap;
+  const auto& globalsMap = *(sir->GlobalVariableMap);
   if(globalsMap.empty())
     return "";
 

--- a/src/dawn/CodeGen/CXXNaive/CXXNaiveCodeGen.cpp
+++ b/src/dawn/CodeGen/CXXNaive/CXXNaiveCodeGen.cpp
@@ -126,7 +126,8 @@ CXXNaiveCodeGen::generateStencilInstantiation(const StencilInstantiation* stenci
       auto& paramNameToType = stencilProperties->paramNameToType_;
       for(std::size_t m = 0; m < fields.size(); ++m) {
 
-        std::string paramName = stencilFun->getOriginalNameFromCallerAccessID(fields[m].AccessID);
+        std::string paramName =
+            stencilFun->getOriginalNameFromCallerAccessID(fields[m].getAccessID());
         paramNameToType.emplace(paramName, stencilFnTemplates[m]);
 
         // each parameter being passed to a stencil function, is wrapped around the param_wrapper
@@ -144,7 +145,8 @@ CXXNaiveCodeGen::generateStencilInstantiation(const StencilInstantiation* stenci
 
       for(std::size_t m = 0; m < fields.size(); ++m) {
 
-        std::string paramName = stencilFun->getOriginalNameFromCallerAccessID(fields[m].AccessID);
+        std::string paramName =
+            stencilFun->getOriginalNameFromCallerAccessID(fields[m].getAccessID());
 
         stencilFunMethod << c_gt() << "data_view<StorageType" + std::to_string(m) + "> "
                          << paramName << " = pw_" << paramName << ".dview_;";
@@ -216,7 +218,7 @@ CXXNaiveCodeGen::generateStencilInstantiation(const StencilInstantiation* stenci
     }
 
     for(auto fieldIt : tempFields) {
-      paramNameToType.emplace((*fieldIt).Name, c_gtc().str() + "storage_t");
+      paramNameToType.emplace((*fieldIt).Name, c_gtc().str() + "tmpstorage_t");
     }
 
     ASTStencilBody stencilBodyCXXVisitor(stencilInstantiation, StencilContext::SC_Stencil);

--- a/src/dawn/CodeGen/CXXNaive/CXXNaiveCodeGen.h
+++ b/src/dawn/CodeGen/CXXNaive/CXXNaiveCodeGen.h
@@ -41,7 +41,7 @@ public:
 
 private:
   std::string generateStencilInstantiation(const StencilInstantiation* stencilInstantiation);
-  std::string generateGlobals(const SIR* sir);
+  std::string generateGlobals(const std::shared_ptr<SIR> sir);
 };
 } // namespace cxxnaive
 } // namespace codegen

--- a/src/dawn/CodeGen/CXXNaive/CXXNaiveCodeGen.h
+++ b/src/dawn/CodeGen/CXXNaive/CXXNaiveCodeGen.h
@@ -41,7 +41,7 @@ public:
 
 private:
   std::string generateStencilInstantiation(const StencilInstantiation* stencilInstantiation);
-  std::string generateGlobals(const std::shared_ptr<SIR> sir);
+  std::string generateGlobals(const std::shared_ptr<SIR>& sir);
 };
 } // namespace cxxnaive
 } // namespace codegen

--- a/src/dawn/CodeGen/CodeGen.cpp
+++ b/src/dawn/CodeGen/CodeGen.cpp
@@ -1,0 +1,51 @@
+#include "dawn/CodeGen/CodeGen.h"
+
+namespace dawn {
+namespace codegen {
+
+// static std::string CodeGen::generateCode()
+
+size_t CodeGen::getVerticalTmpHaloSize(Stencil const& stencil) {
+  std::shared_ptr<Interval> tmpInterval = stencil.getEnclosingIntervalTemporaries();
+  return (tmpInterval != nullptr) ? std::max(tmpInterval->overEnd(), tmpInterval->belowBegin()) : 0;
+}
+
+void CodeGen::addTempStorageTypedef(Structure& stencilClass, Stencil const& stencil) const {
+  std::shared_ptr<Interval> tmpInterval = stencil.getEnclosingIntervalTemporaries();
+  stencilClass.addTypeDef("tmp_halo_t")
+      .addType("gridtools::halo< GRIDTOOLS_CLANG_HALO_EXTEND, GRIDTOOLS_CLANG_HALO_EXTEND, " +
+               std::to_string(getVerticalTmpHaloSize(stencil)) + ">");
+
+  // using tmp_meta_data_t = storage_traits_t::storage_info_t< 0, 3, tmp_halo_t >
+  stencilClass.addTypeDef(tmpMetadataTypename_)
+      .addType("storage_traits_t::storage_info_t< 0, 3, tmp_halo_t >");
+
+  stencilClass.addTypeDef(tmpStorageTypename_)
+      .addType("storage_traits_t::data_store_t< float_type, " + tmpMetadataTypename_ + ">");
+}
+
+void CodeGen::addTmpStorageDeclaration(
+    Structure& stencilClass,
+    IndexRange<const std::vector<dawn::Stencil::FieldInfo>>& tempFields) const {
+  if(!(tempFields.empty())) {
+    stencilClass.addMember(tmpMetadataTypename_, tmpMetadataName_);
+
+    for(auto field : tempFields)
+      stencilClass.addMember(tmpStorageTypename_, "m_" + (*field).Name);
+  }
+}
+
+void CodeGen::addTmpStorageInit(
+    MemberFunction& ctr, Stencil const& stencil,
+    IndexRange<const std::vector<dawn::Stencil::FieldInfo>>& tempFields) const {
+  if(!(tempFields.empty())) {
+    ctr.addInit(tmpMetadataName_ + "(dom_.isize(), dom_.jsize(), dom_.ksize() + 2*" +
+                std::to_string(getVerticalTmpHaloSize(stencil)) + ")");
+    for(auto fieldIt : tempFields) {
+      ctr.addInit("m_" + (*fieldIt).Name + "(" + tmpMetadataName_ + ")");
+    }
+  }
+}
+
+} // namespace codegen
+} // namespace dawn

--- a/src/dawn/CodeGen/CodeGen.h
+++ b/src/dawn/CodeGen/CodeGen.h
@@ -15,8 +15,10 @@
 #ifndef DAWN_CODEGEN_CODEGEN_H
 #define DAWN_CODEGEN_CODEGEN_H
 
+#include "dawn/CodeGen/CXXUtil.h"
 #include "dawn/CodeGen/TranslationUnit.h"
 #include "dawn/Optimizer/OptimizerContext.h"
+#include "dawn/Support/IndexRange.h"
 #include <memory>
 
 namespace dawn {
@@ -27,6 +29,19 @@ namespace codegen {
 class CodeGen {
 protected:
   OptimizerContext* context_;
+
+  static size_t getVerticalTmpHaloSize(Stencil const& stencil);
+  void addTempStorageTypedef(Structure& stencilClass, Stencil const& stencil) const;
+  void addTmpStorageDeclaration(
+      Structure& stencilClass,
+      IndexRange<const std::vector<dawn::Stencil::FieldInfo>>& tmpFields) const;
+  void addTmpStorageInit(MemberFunction& ctr, const Stencil& stencil,
+                         IndexRange<const std::vector<dawn::Stencil::FieldInfo>>& tempFields) const;
+
+  const std::string tmpStorageTypename_ = "tmp_storage_t";
+  const std::string tmpMetadataTypename_ = "tmp_meta_data_t";
+  const std::string tmpMetadataName_ = "m_tmp_meta_data";
+  const std::string tmpStorageName_ = "m_tmp_storage";
 
 public:
   CodeGen(OptimizerContext* context) : context_(context){};

--- a/src/dawn/CodeGen/GridTools/GTCodeGen.cpp
+++ b/src/dawn/CodeGen/GridTools/GTCodeGen.cpp
@@ -660,7 +660,7 @@ GTCodeGen::generateStencilInstantiation(const StencilInstantiation* stencilInsta
   return str;
 }
 
-std::string GTCodeGen::generateGlobals(const std::shared_ptr<SIR> Sir) {
+std::string GTCodeGen::generateGlobals(std::shared_ptr<SIR> const& Sir) {
   using namespace codegen;
 
   const auto& globalsMap = *(Sir->GlobalVariableMap);

--- a/src/dawn/CodeGen/GridTools/GTCodeGen.cpp
+++ b/src/dawn/CodeGen/GridTools/GTCodeGen.cpp
@@ -201,7 +201,7 @@ GTCodeGen::generateStencilInstantiation(const StencilInstantiation* stencilInsta
               .addType(c_gt() + "accessor")
               .addTemplate(Twine(accessorID))
               .addTemplate(c_gt_enum() +
-                           (fields[m].getIntend() == Field::IK_Input ? "in" : "inout"))
+                           ((fields[m].getIntend() == Field::IK_Input) ? "in" : "inout"))
               .addTemplate(extent);
 
           arglist.push_back(std::move(paramName));
@@ -331,7 +331,7 @@ GTCodeGen::generateStencilInstantiation(const StencilInstantiation* stencilInsta
           StageStruct.addTypeDef(paramName)
               .addType(c_gt() + "accessor")
               .addTemplate(Twine(accessorIdx))
-              .addTemplate(c_gt_enum() + (field.getIntend() == Field::IK_Input ? "in" : "inout"))
+              .addTemplate(c_gt_enum() + ((field.getIntend() == Field::IK_Input) ? "in" : "inout"))
               .addTemplate(extent);
 
           // Generate placeholder mapping of the field in `make_stage`

--- a/src/dawn/CodeGen/GridTools/GTCodeGen.cpp
+++ b/src/dawn/CodeGen/GridTools/GTCodeGen.cpp
@@ -39,8 +39,7 @@ GTCodeGen::IntervalDefinitions::IntervalDefinitions(const Stencil& stencil)
   DAWN_ASSERT(!Intervals.empty());
 
   // Add intervals for the stencil functions
-  for(const auto& stencilFun :
-      stencil.getStencilInstantiation()->getStencilFunctionInstantiations())
+  for(const auto& stencilFun : stencil.getStencilInstantiation().getStencilFunctionInstantiations())
     Intervals.insert(stencilFun->getInterval());
 
   // Compute axis and populate the levels
@@ -76,8 +75,7 @@ GTCodeGen::IntervalDefinitions::IntervalDefinitions(const Stencil& stencil)
   }
 
   // Make sure the intervals for the stencil functions exist
-  for(const auto& stencilFun :
-      stencil.getStencilInstantiation()->getStencilFunctionInstantiations())
+  for(const auto& stencilFun : stencil.getStencilInstantiation().getStencilFunctionInstantiations())
     IntervalToNameMap.emplace(stencilFun->getInterval(),
                               Interval::makeCodeGenName(stencilFun->getInterval()));
 }
@@ -660,10 +658,10 @@ GTCodeGen::generateStencilInstantiation(const StencilInstantiation* stencilInsta
   return str;
 }
 
-std::string GTCodeGen::generateGlobals(const SIR* Sir) {
+std::string GTCodeGen::generateGlobals(const std::shared_ptr<SIR> Sir) {
   using namespace codegen;
 
-  const auto& globalsMap = *Sir->GlobalVariableMap;
+  const auto& globalsMap = *(Sir->GlobalVariableMap);
   if(globalsMap.empty())
     return "";
 

--- a/src/dawn/CodeGen/GridTools/GTCodeGen.cpp
+++ b/src/dawn/CodeGen/GridTools/GTCodeGen.cpp
@@ -189,17 +189,19 @@ GTCodeGen::generateStencilInstantiation(const StencilInstantiation* stencilInsta
         }
         // Generate field declarations
         for(std::size_t m = 0; m < fields.size(); ++m, ++accessorID) {
-          std::string paramName = stencilFun->getOriginalNameFromCallerAccessID(fields[m].AccessID);
+          std::string paramName =
+              stencilFun->getOriginalNameFromCallerAccessID(fields[m].getAccessID());
 
           // Generate parameter of stage
           codegen::Type extent(c_gt() + "extent", clear(tss));
-          for(auto& e : fields[m].Extent.getExtents())
+          for(auto& e : fields[m].getExtents().getExtents())
             extent.addTemplate(Twine(e.Minus) + ", " + Twine(e.Plus));
 
           StencilFunStruct.addTypeDef(paramName)
               .addType(c_gt() + "accessor")
               .addTemplate(Twine(accessorID))
-              .addTemplate(c_gt_enum() + (fields[m].Intend == Field::IK_Input ? "in" : "inout"))
+              .addTemplate(c_gt_enum() +
+                           (fields[m].getIntend() == Field::IK_Input ? "in" : "inout"))
               .addTemplate(extent);
 
           arglist.push_back(std::move(paramName));
@@ -319,17 +321,17 @@ GTCodeGen::generateStencilInstantiation(const StencilInstantiation* stencilInsta
         std::size_t accessorIdx = 0;
         for(; accessorIdx < fields.size(); ++accessorIdx) {
           const auto& field = fields[accessorIdx];
-          std::string paramName = stencilInstantiation->getNameFromAccessID(field.AccessID);
+          std::string paramName = stencilInstantiation->getNameFromAccessID(field.getAccessID());
 
           // Generate parameter of stage
           codegen::Type extent(c_gt() + "extent", clear(tss));
-          for(auto& e : field.Extent.getExtents())
+          for(auto& e : field.getExtents().getExtents())
             extent.addTemplate(Twine(e.Minus) + ", " + Twine(e.Plus));
 
           StageStruct.addTypeDef(paramName)
               .addType(c_gt() + "accessor")
               .addTemplate(Twine(accessorIdx))
-              .addTemplate(c_gt_enum() + (field.Intend == Field::IK_Input ? "in" : "inout"))
+              .addTemplate(c_gt_enum() + (field.getIntend() == Field::IK_Input ? "in" : "inout"))
               .addTemplate(extent);
 
           // Generate placeholder mapping of the field in `make_stage`

--- a/src/dawn/CodeGen/GridTools/GTCodeGen.h
+++ b/src/dawn/CodeGen/GridTools/GTCodeGen.h
@@ -62,7 +62,7 @@ public:
 
 private:
   std::string generateStencilInstantiation(const StencilInstantiation* stencilInstantiation);
-  std::string generateGlobals(const SIR* Sir);
+  std::string generateGlobals(const std::shared_ptr<SIR> Sir);
 
   /// Maximum needed vector size of boost::fusion containers
   std::size_t mplContainerMaxSize_;

--- a/src/dawn/CodeGen/GridTools/GTCodeGen.h
+++ b/src/dawn/CodeGen/GridTools/GTCodeGen.h
@@ -62,7 +62,7 @@ public:
 
 private:
   std::string generateStencilInstantiation(const StencilInstantiation* stencilInstantiation);
-  std::string generateGlobals(const std::shared_ptr<SIR> Sir);
+  std::string generateGlobals(const std::shared_ptr<SIR>& Sir);
 
   /// Maximum needed vector size of boost::fusion containers
   std::size_t mplContainerMaxSize_;

--- a/src/dawn/Compiler/DawnCompiler.cpp
+++ b/src/dawn/Compiler/DawnCompiler.cpp
@@ -105,7 +105,7 @@ DawnCompiler::DawnCompiler(Options* options) : diagnostics_(make_unique<Diagnost
   options_ = options ? make_unique<Options>(*options) : make_unique<Options>();
 }
 
-std::unique_ptr<OptimizerContext> DawnCompiler::runOptimizer(const SIR* SIR) {
+std::unique_ptr<OptimizerContext> DawnCompiler::runOptimizer(const std::shared_ptr<SIR> SIR) {
   // -inline
   using InlineStrategyKind = PassInlining::InlineStrategyKind;
   InlineStrategyKind inlineStrategy = StringSwitch<InlineStrategyKind>(options_->InlineStrategy)
@@ -160,7 +160,7 @@ std::unique_ptr<OptimizerContext> DawnCompiler::runOptimizer(const SIR* SIR) {
 
   // Run optimization passes
   for(auto& stencil : optimizer->getStencilInstantiationMap()) {
-    StencilInstantiation* instantiation = stencil.second.get();
+    std::shared_ptr<StencilInstantiation> instantiation = stencil.second;
     DAWN_LOG(INFO) << "Starting Optimization and Analysis passes for `" << instantiation->getName()
                    << "` ...";
 
@@ -174,7 +174,7 @@ std::unique_ptr<OptimizerContext> DawnCompiler::runOptimizer(const SIR* SIR) {
   return optimizer;
 }
 
-std::unique_ptr<codegen::TranslationUnit> DawnCompiler::compile(const SIR* SIR,
+std::unique_ptr<codegen::TranslationUnit> DawnCompiler::compile(const std::shared_ptr<SIR> SIR,
                                                                 CodeGenKind codeGen) {
   diagnostics_->clear();
   diagnostics_->setFilename(SIR->Filename);

--- a/src/dawn/Compiler/DawnCompiler.cpp
+++ b/src/dawn/Compiler/DawnCompiler.cpp
@@ -105,7 +105,7 @@ DawnCompiler::DawnCompiler(Options* options) : diagnostics_(make_unique<Diagnost
   options_ = options ? make_unique<Options>(*options) : make_unique<Options>();
 }
 
-std::unique_ptr<OptimizerContext> DawnCompiler::runOptimizer(const std::shared_ptr<SIR> SIR) {
+std::unique_ptr<OptimizerContext> DawnCompiler::runOptimizer(std::shared_ptr<SIR> const& SIR) {
   // -inline
   using InlineStrategyKind = PassInlining::InlineStrategyKind;
   InlineStrategyKind inlineStrategy = StringSwitch<InlineStrategyKind>(options_->InlineStrategy)
@@ -174,7 +174,7 @@ std::unique_ptr<OptimizerContext> DawnCompiler::runOptimizer(const std::shared_p
   return optimizer;
 }
 
-std::unique_ptr<codegen::TranslationUnit> DawnCompiler::compile(const std::shared_ptr<SIR> SIR,
+std::unique_ptr<codegen::TranslationUnit> DawnCompiler::compile(const std::shared_ptr<SIR>& SIR,
                                                                 CodeGenKind codeGen) {
   diagnostics_->clear();
   diagnostics_->setFilename(SIR->Filename);

--- a/src/dawn/Compiler/DawnCompiler.h
+++ b/src/dawn/Compiler/DawnCompiler.h
@@ -42,10 +42,10 @@ public:
 
   /// @brief Compile the SIR using the provided code generation routine
   /// @returns compiled TranslationUnit on success, `nullptr` otherwise
-  std::unique_ptr<codegen::TranslationUnit> compile(const std::shared_ptr<SIR> SIR,
+  std::unique_ptr<codegen::TranslationUnit> compile(std::shared_ptr<SIR> const& SIR,
                                                     CodeGenKind codeGen);
 
-  std::unique_ptr<OptimizerContext> runOptimizer(const std::shared_ptr<SIR> SIR);
+  std::unique_ptr<OptimizerContext> runOptimizer(std::shared_ptr<SIR> const& SIR);
 
   /// @brief Get options
   const Options& getOptions() const;

--- a/src/dawn/Compiler/DawnCompiler.h
+++ b/src/dawn/Compiler/DawnCompiler.h
@@ -42,9 +42,10 @@ public:
 
   /// @brief Compile the SIR using the provided code generation routine
   /// @returns compiled TranslationUnit on success, `nullptr` otherwise
-  std::unique_ptr<codegen::TranslationUnit> compile(const SIR* SIR, CodeGenKind codeGen);
+  std::unique_ptr<codegen::TranslationUnit> compile(const std::shared_ptr<SIR> SIR,
+                                                    CodeGenKind codeGen);
 
-  std::unique_ptr<OptimizerContext> runOptimizer(const SIR* SIR);
+  std::unique_ptr<OptimizerContext> runOptimizer(const std::shared_ptr<SIR> SIR);
 
   /// @brief Get options
   const Options& getOptions() const;

--- a/src/dawn/Optimizer/AccessComputation.cpp
+++ b/src/dawn/Optimizer/AccessComputation.cpp
@@ -216,7 +216,7 @@ public:
                                 StencilFunctionInstantiation* curStencilFunCall,
                                 std::set<int>& appliedAccessIDs) {
     for(const Field& field : curStencilFunCall->getCallerFields()) {
-      int AccessID = field.AccessID;
+      int AccessID = field.getAccessID();
 
       if(appliedAccessIDs.count(AccessID))
         continue;
@@ -231,11 +231,11 @@ public:
       } else {
         appliedAccessIDs.insert(AccessID);
 
-        if(field.Intend == Field::IK_Input || field.Intend == Field::IK_InputOutput)
+        if(field.getIntend() == Field::IK_Input || field.getIntend() == Field::IK_InputOutput)
           for(auto& callerAccesses : callerAccessesList_)
             callerAccesses->addReadExtent(AccessID, extent);
 
-        if(field.Intend == Field::IK_Output || field.Intend == Field::IK_InputOutput)
+        if(field.getIntend() == Field::IK_Output || field.getIntend() == Field::IK_InputOutput)
           for(auto& callerAccesses : callerAccessesList_)
             callerAccesses->addWriteExtent(AccessID, extent);
       }
@@ -343,11 +343,11 @@ public:
       auto& prevStencilFunCall = previousStencilFunCallScope->FunctionInstantiation;
 
       const Field& field = prevStencilFunCall->getCallerFieldFromArgumentIndex(prevArgumentIndex);
-      DAWN_ASSERT(prevStencilFunCall->isProvidedByStencilFunctionCall(field.AccessID));
+      DAWN_ASSERT(prevStencilFunCall->isProvidedByStencilFunctionCall(field.getAccessID()));
 
       // Add the extent of the field mapping to the stencil function to all fields
       std::set<int> appliedAccessIDs;
-      mergeExtentWithAllFields(field.Extent, curStencilFunCall, appliedAccessIDs);
+      mergeExtentWithAllFields(field.getExtents(), curStencilFunCall, appliedAccessIDs);
 
       prevArgumentIndex += 1;
     }
@@ -424,11 +424,11 @@ public:
       // Get the extent of the field corresponding to the argument index
       const Field& field = functionInstantiation->getCallerFieldFromArgumentIndex(ArgumentIndex);
 
-      if(field.Intend == Field::IK_Input || field.Intend == Field::IK_InputOutput)
-        mergeReadExtent(expr, field.Extent);
+      if(field.getIntend() == Field::IK_Input || field.getIntend() == Field::IK_InputOutput)
+        mergeReadExtent(expr, field.getExtents());
 
-      if(field.Intend == Field::IK_Output || field.Intend == Field::IK_InputOutput)
-        mergeWriteExtent(expr, field.Extent);
+      if(field.getIntend() == Field::IK_Output || field.getIntend() == Field::IK_InputOutput)
+        mergeWriteExtent(expr, field.getExtents());
 
       ArgumentIndex += 1;
 

--- a/src/dawn/Optimizer/AccessUtils.cpp
+++ b/src/dawn/Optimizer/AccessUtils.cpp
@@ -1,0 +1,64 @@
+#include "dawn/Optimizer/AccessUtils.h"
+
+namespace dawn {
+
+namespace AccessUtils {
+
+void recordWriteAccess(std::unordered_map<int, Field>& inputOutputFields,
+                       std::unordered_map<int, Field>& inputFields,
+                       std::unordered_map<int, Field>& outputFields, int AccessID,
+                       Interval const& doMethodInterval) {
+  // Field was recorded as `InputOutput`, state can't change ...
+  if(inputOutputFields.count(AccessID)) {
+    inputOutputFields.at(AccessID).extendInterval(doMethodInterval);
+    return;
+  }
+
+  // Field was recorded as `Input`, change it's state to `InputOutput`
+  if(inputFields.count(AccessID)) {
+    Field& preField = inputFields.at(AccessID);
+    preField.extendInterval(doMethodInterval);
+    preField.setIntend(Field::IK_InputOutput);
+    inputOutputFields.insert({AccessID, preField});
+    inputFields.erase(AccessID);
+    return;
+  }
+
+  // Field not yet present, record it as output
+  if(outputFields.count(AccessID)) {
+    outputFields.at(AccessID).extendInterval(doMethodInterval);
+  } else {
+    outputFields.emplace(AccessID, Field(AccessID, Field::IK_Output, Extents{}, doMethodInterval));
+  }
+}
+
+void recordReadAccess(std::unordered_map<int, Field>& inputOutputFields,
+                      std::unordered_map<int, Field>& inputFields,
+                      std::unordered_map<int, Field>& outputFields, int AccessID,
+                      const Interval& doMethodInterval) {
+
+  // Field was recorded as `InputOutput`, state can't change ...
+  if(inputOutputFields.count(AccessID)) {
+    inputOutputFields.at(AccessID).extendInterval(doMethodInterval);
+    return;
+  }
+
+  // Field was recorded as `Output`, change it's state to `InputOutput`
+  if(outputFields.count(AccessID)) {
+    Field& preField = outputFields.at(AccessID);
+    preField.extendInterval(doMethodInterval);
+    preField.setIntend(Field::IK_InputOutput);
+    inputOutputFields.insert({AccessID, preField});
+
+    outputFields.erase(AccessID);
+    return;
+  }
+
+  // Field not yet present, record it as input
+  if(inputFields.count(AccessID)) {
+    inputFields.at(AccessID).extendInterval(doMethodInterval);
+  } else
+    inputFields.emplace(AccessID, Field(AccessID, Field::IK_Input, Extents{}, doMethodInterval));
+}
+} // namespace AccessUtils
+} // namespace dawn

--- a/src/dawn/Optimizer/AccessUtils.h
+++ b/src/dawn/Optimizer/AccessUtils.h
@@ -1,0 +1,50 @@
+//===--------------------------------------------------------------------------------*- C++ -*-===//
+//                         _       _
+//                        | |     | |
+//                    __ _| |_ ___| | __ _ _ __   __ _
+//                   / _` | __/ __| |/ _` | '_ \ / _` |
+//                  | (_| | || (__| | (_| | | | | (_| |
+//                   \__, |\__\___|_|\__,_|_| |_|\__, | - GridTools Clang DSL
+//                    __/ |                       __/ |
+//                   |___/                       |___/
+//
+//
+//  This file is distributed under the MIT License (MIT).
+//  See LICENSE.txt for details.
+//
+//===------------------------------------------------------------------------------------------===//
+
+#ifndef DAWN_OPTIMIZER_ACCESSUTILS_H
+#define DAWN_OPTIMIZER_ACCESSUTILS_H
+
+#include "dawn/Optimizer/Accesses.h"
+#include "dawn/Optimizer/Field.h"
+#include <unordered_map>
+
+namespace dawn {
+namespace AccessUtils {
+
+/// @brief given a write access, with AccessID, it will recorded in the corresponding map of input,
+/// output or inputOutput
+/// depending on previous accesses to the same field
+///
+/// @ingroup optimizer
+void recordWriteAccess(std::unordered_map<int, Field>& inputOutputFields,
+                       std::unordered_map<int, Field>& inputFields,
+                       std::unordered_map<int, Field>& outputFields, int AccessID,
+                       Interval const& doMethodInterval);
+
+/// @brief given a read access, with AccessID, it will recorded in the corresponding map of input,
+/// output or inputOutput
+/// depending on previous accesses to the same field
+///
+/// @ingroup optimizer
+void recordReadAccess(std::unordered_map<int, Field>& inputOutputFields,
+                      std::unordered_map<int, Field>& inputFields,
+                      std::unordered_map<int, Field>& outputFields, int AccessID,
+                      Interval const& doMethodInterval);
+
+} // namespace AccessUtils
+} // namespace dawn
+
+#endif

--- a/src/dawn/Optimizer/CMakeLists.txt
+++ b/src/dawn/Optimizer/CMakeLists.txt
@@ -18,6 +18,8 @@ mchbuild_add_library(
           AccessComputation.cpp   
           Accesses.cpp  
           Accesses.h
+          AccessUtils.cpp
+          AccessUtils.h
           BoundaryExtent.cpp  
           BoundaryExtent.h
           Cache.cpp

--- a/src/dawn/Optimizer/DependencyGraphStage.h
+++ b/src/dawn/Optimizer/DependencyGraphStage.h
@@ -39,7 +39,7 @@ public:
   using Base = DependencyGraph<DependencyGraphStage, DependencyGraphStageEdgeData>;
   using EdgeData = DependencyGraphStageEdgeData;
 
-  DependencyGraphStage(std::shared_ptr<StencilInstantiation> stencilInstantiation)
+  DependencyGraphStage(const std::shared_ptr<StencilInstantiation>& stencilInstantiation)
       : Base(), stencilInstantiation_(stencilInstantiation) {}
 
   void insertEdge(int StageIDFrom, int StageIDTo);

--- a/src/dawn/Optimizer/DependencyGraphStage.h
+++ b/src/dawn/Optimizer/DependencyGraphStage.h
@@ -33,13 +33,13 @@ enum class DependencyGraphStageEdgeData { EK_Depends };
 class DependencyGraphStage
     : public DependencyGraph<DependencyGraphStage, DependencyGraphStageEdgeData> {
 
-  StencilInstantiation* stencilInstantiation_;
+  std::shared_ptr<StencilInstantiation> stencilInstantiation_;
 
 public:
   using Base = DependencyGraph<DependencyGraphStage, DependencyGraphStageEdgeData>;
   using EdgeData = DependencyGraphStageEdgeData;
 
-  DependencyGraphStage(StencilInstantiation* stencilInstantiation)
+  DependencyGraphStage(std::shared_ptr<StencilInstantiation> stencilInstantiation)
       : Base(), stencilInstantiation_(stencilInstantiation) {}
 
   void insertEdge(int StageIDFrom, int StageIDTo);

--- a/src/dawn/Optimizer/Field.h
+++ b/src/dawn/Optimizer/Field.h
@@ -16,6 +16,7 @@
 #define DAWN_OPTIMIZER_FIELDTYPES_H
 
 #include "dawn/Optimizer/Extents.h"
+#include "dawn/Optimizer/Interval.h"
 #include <utility>
 
 namespace dawn {
@@ -29,11 +30,14 @@ namespace dawn {
 struct Field {
   enum IntendKind { IK_Output = 0, IK_InputOutput = 1, IK_Input = 2 };
 
-  int AccessID;      ///< Unique AccessID of the field
-  IntendKind Intend; ///< Intended usage
-  Extents Extent;    ///< Accumulated extent of the field
+  int AccessID;       ///< Unique AccessID of the field
+  IntendKind Intend;  ///< Intended usage
+  Extents Extent;     ///< Accumulated extent of the field
+  Interval interval_; ///< Enclosing Interval from the iteration space
+                      ///  where the Field has been accessed
 
-  Field(int accessID, IntendKind intend) : AccessID(accessID), Intend(intend), Extent{} {}
+  Field(int accessID, IntendKind intend, Interval interval)
+      : AccessID(accessID), Intend(intend), Extent{}, interval_(interval) {}
 
   /// @name Operators
   /// @{
@@ -45,6 +49,9 @@ struct Field {
     return (Intend < other.Intend || (Intend == other.Intend && AccessID < other.AccessID));
   }
   /// @}
+
+  /// @brief get the interval where field has been accessed
+  Interval getAccessedInterval() const { return Interval(interval_).extendInterval(Extent); }
 };
 
 } // namespace dawn

--- a/src/dawn/Optimizer/Field.h
+++ b/src/dawn/Optimizer/Field.h
@@ -27,31 +27,64 @@ namespace dawn {
 /// Fields are hashed on their `AccessID`.
 ///
 /// @ingroup optimizer
-struct Field {
+class Field {
+public:
   enum IntendKind { IK_Output = 0, IK_InputOutput = 1, IK_Input = 2 };
 
-  int AccessID;       ///< Unique AccessID of the field
-  IntendKind Intend;  ///< Intended usage
-  Extents Extent;     ///< Accumulated extent of the field
-  Interval interval_; ///< Enclosing Interval from the iteration space
-                      ///  where the Field has been accessed
+private:
+  int accessID_;              ///< Unique AccessID of the field
+  IntendKind intend_;         ///< Intended usage
+  Extents extents_;           ///< Accumulated extent of the field
+  Interval interval_;         ///< Enclosing Interval from the iteration space
+                              ///  where the Field has been accessed
+  Interval accessedInterval_; ///< Enclosing interval where accesses where recorded,
+                              /// i.e. interval_.extend(Extent)
 
-  Field(int accessID, IntendKind intend, Interval interval)
-      : AccessID(accessID), Intend(intend), Extent{}, interval_(interval) {}
+  void updateAccessedInterval() {
+    accessedInterval_ = interval_;
+    accessedInterval_ = accessedInterval_.extendInterval(extents_);
+  }
+
+public:
+  Field(int accessID, IntendKind intend, Extents extents, Interval interval)
+      : accessID_(accessID), intend_(intend), extents_(extents), interval_(interval),
+        accessedInterval_(interval) {
+    updateAccessedInterval();
+  }
 
   /// @name Operators
   /// @{
   bool operator==(const Field& other) const {
-    return (AccessID == other.AccessID && Intend == other.Intend);
+    return (accessID_ == other.accessID_ && intend_ == other.intend_);
   }
   bool operator!=(const Field& other) const { return !(*this == other); }
   bool operator<(const Field& other) const {
-    return (Intend < other.Intend || (Intend == other.Intend && AccessID < other.AccessID));
+    return (intend_ < other.intend_ || (intend_ == other.intend_ && accessID_ < other.accessID_));
   }
   /// @}
 
-  /// @brief get the interval where field has been accessed
-  Interval getAccessedInterval() const { return Interval(interval_).extendInterval(Extent); }
+  /// @brief getters
+  /// @{
+  Interval const& getInterval() const { return interval_; }
+  Interval const& getAccessedInterval() const { return accessedInterval_; }
+  Extents const& getExtents() const { return extents_; }
+  IntendKind getIntend() const { return intend_; }
+  int getAccessID() const { return accessID_; }
+  /// @}
+
+  /// @brief setters
+  /// @{
+  void setIntend(IntendKind intend) { intend_ = intend; }
+  /// @}
+
+  void mergeExtents(Extents const& extents) {
+    extents_.merge(extents);
+    updateAccessedInterval();
+  }
+  void extendInterval(Interval const& interval) {
+    interval_.merge(interval);
+    updateAccessedInterval();
+  }
 };
 
 } // namespace dawn
@@ -60,7 +93,9 @@ namespace std {
 
 template <>
 struct hash<dawn::Field> {
-  size_t operator()(const dawn::Field& field) const { return std::hash<int>()(field.AccessID); }
+  size_t operator()(const dawn::Field& field) const {
+    return std::hash<int>()(field.getAccessID());
+  }
 };
 
 } // namespace std

--- a/src/dawn/Optimizer/Interval.h
+++ b/src/dawn/Optimizer/Interval.h
@@ -147,6 +147,12 @@ public:
     return (bound == Bound::lower) ? lowerLevelIsEnd() : upperLevelIsEnd();
   }
 
+  size_t overEnd() const { return (upperLevelIsEnd() && (upperOffset_ > 0)) ? upperOffset_ : 0; }
+
+  size_t belowBegin() const {
+    return (!lowerLevelIsEnd() && (lowerBound() < 0)) ? (size_t)-lowerOffset_ : 0;
+  }
+
   /// @brief returns true if the lower bound of the interval is the end of the axis
   bool lowerLevelIsEnd() const { return (lowerLevel_ == sir::Interval::End); }
 

--- a/src/dawn/Optimizer/LoopOrder.cpp
+++ b/src/dawn/Optimizer/LoopOrder.cpp
@@ -35,7 +35,8 @@ const char* loopOrderToString(LoopOrderKind loopOrder) {
   case LoopOrderKind::LK_Parallel:
     return "parallel";
   }
-  dawn_unreachable("invalid loop order");
+  dawn_unreachable(
+      std::string("invalid loop order" + std::to_string((unsigned int)loopOrder)).c_str());
 }
 
 } // namespace dawn

--- a/src/dawn/Optimizer/MultiStage.h
+++ b/src/dawn/Optimizer/MultiStage.h
@@ -37,7 +37,7 @@ class OptimizerContext;
 ///
 /// @ingroup optimizer
 class MultiStage {
-  StencilInstantiation* stencilInstantiation_;
+  StencilInstantiation& stencilInstantiation_;
 
   LoopOrderKind loopOrder_;
   std::list<std::shared_ptr<Stage>> stages_;
@@ -47,7 +47,7 @@ class MultiStage {
 public:
   /// @name Constructors and Assignment
   /// @{
-  MultiStage(StencilInstantiation* stencilInstantiation, LoopOrderKind loopOrder);
+  MultiStage(StencilInstantiation& stencilInstantiation, LoopOrderKind loopOrder);
   MultiStage(const MultiStage&) = default;
   MultiStage(MultiStage&&) = default;
 
@@ -60,7 +60,7 @@ public:
   const std::list<std::shared_ptr<Stage>>& getStages() const { return stages_; }
 
   /// @brief Get the execution policy
-  StencilInstantiation* getStencilInstantiation() const { return stencilInstantiation_; }
+  StencilInstantiation& getStencilInstantiation() const { return stencilInstantiation_; }
 
   /// @brief Get the loop order
   LoopOrderKind getLoopOrder() const { return loopOrder_; }
@@ -112,7 +112,7 @@ public:
   /// This merges the intervals of all Do-Methods of all stages.
   Interval getEnclosingInterval() const;
 
-  /// @brief Get the fields of the multi-stage
+  /// @brief Get the pair <AccessID, field> for the fields used within the multi-stage
   std::unordered_map<int, Field> getFields() const;
 
   /// @brief Get the caches

--- a/src/dawn/Optimizer/MultiStage.h
+++ b/src/dawn/Optimizer/MultiStage.h
@@ -115,6 +115,9 @@ public:
   /// @brief Get the pair <AccessID, field> for the fields used within the multi-stage
   std::unordered_map<int, Field> getFields() const;
 
+  /// @brief Get the enclosing interval of all access to temporaries
+  std::shared_ptr<Interval> getEnclosingAccessIntervalTemporaries() const;
+
   /// @brief Get the caches
   std::unordered_map<int, Cache>& getCaches() { return caches_; }
   const std::unordered_map<int, Cache>& getCaches() const { return caches_; }

--- a/src/dawn/Optimizer/OptimizerContext.cpp
+++ b/src/dawn/Optimizer/OptimizerContext.cpp
@@ -21,25 +21,26 @@
 
 namespace dawn {
 
-OptimizerContext::OptimizerContext(DiagnosticsEngine& diagnostics, Options& options, const SIR* SIR)
+OptimizerContext::OptimizerContext(DiagnosticsEngine& diagnostics, Options& options,
+                                   const std::shared_ptr<SIR> SIR)
     : diagnostics_(diagnostics), options_(options), SIR_(SIR) {
   DAWN_LOG(INFO) << "Intializing OptimizerContext ... ";
 
   for(const auto& stencil : SIR_->Stencils)
     if(!stencil->Attributes.has(sir::Attr::AK_NoCodeGen)) {
       stencilInstantiationMap_.insert(std::make_pair(
-          stencil->Name, make_unique<StencilInstantiation>(this, stencil.get(), SIR)));
+          stencil->Name, std::make_shared<StencilInstantiation>(this, stencil, SIR)));
     } else {
       DAWN_LOG(INFO) << "Skipping processing of `" << stencil->Name << "`";
     }
 }
 
-std::map<std::string, std::unique_ptr<StencilInstantiation>>&
+std::map<std::string, std::shared_ptr<StencilInstantiation>>&
 OptimizerContext::getStencilInstantiationMap() {
   return stencilInstantiationMap_;
 }
 
-const std::map<std::string, std::unique_ptr<StencilInstantiation>>&
+const std::map<std::string, std::shared_ptr<StencilInstantiation>>&
 OptimizerContext::getStencilInstantiationMap() const {
   return stencilInstantiationMap_;
 }

--- a/src/dawn/Optimizer/OptimizerContext.cpp
+++ b/src/dawn/Optimizer/OptimizerContext.cpp
@@ -22,7 +22,7 @@
 namespace dawn {
 
 OptimizerContext::OptimizerContext(DiagnosticsEngine& diagnostics, Options& options,
-                                   const std::shared_ptr<SIR> SIR)
+                                   const std::shared_ptr<SIR>& SIR)
     : diagnostics_(diagnostics), options_(options), SIR_(SIR) {
   DAWN_LOG(INFO) << "Intializing OptimizerContext ... ";
 

--- a/src/dawn/Optimizer/OptimizerContext.h
+++ b/src/dawn/Optimizer/OptimizerContext.h
@@ -52,7 +52,7 @@ class OptimizerContext : NonCopyable {
 public:
   /// @brief Initialize the context with a SIR
   OptimizerContext(DiagnosticsEngine& diagnostics, Options& options,
-                   const std::shared_ptr<SIR> SIR);
+                   const std::shared_ptr<SIR>& SIR);
 
   /// @brief Get StencilInstantiation map
   std::map<std::string, std::shared_ptr<StencilInstantiation>>& getStencilInstantiationMap();

--- a/src/dawn/Optimizer/OptimizerContext.h
+++ b/src/dawn/Optimizer/OptimizerContext.h
@@ -44,18 +44,19 @@ class OptimizerContext : NonCopyable {
   DiagnosticsEngine& diagnostics_;
   Options& options_;
 
-  const SIR* SIR_;
-  std::map<std::string, std::unique_ptr<StencilInstantiation>> stencilInstantiationMap_;
+  const std::shared_ptr<SIR> SIR_;
+  std::map<std::string, std::shared_ptr<StencilInstantiation>> stencilInstantiationMap_;
   PassManager passManager_;
   HardwareConfig hardwareConfiguration_;
 
 public:
   /// @brief Initialize the context with a SIR
-  OptimizerContext(DiagnosticsEngine& diagnostics, Options& options, const SIR* SIR);
+  OptimizerContext(DiagnosticsEngine& diagnostics, Options& options,
+                   const std::shared_ptr<SIR> SIR);
 
   /// @brief Get StencilInstantiation map
-  std::map<std::string, std::unique_ptr<StencilInstantiation>>& getStencilInstantiationMap();
-  const std::map<std::string, std::unique_ptr<StencilInstantiation>>&
+  std::map<std::string, std::shared_ptr<StencilInstantiation>>& getStencilInstantiationMap();
+  const std::map<std::string, std::shared_ptr<StencilInstantiation>>&
   getStencilInstantiationMap() const;
 
   /// @brief Check if there are errors
@@ -66,7 +67,7 @@ public:
   const PassManager& getPassManager() const { return passManager_; }
 
   /// @brief Get the SIR
-  const SIR* getSIR() const { return SIR_; }
+  const std::shared_ptr<SIR> getSIR() const { return SIR_; }
 
   /// @brief Get options
   const Options& getOptions() const;

--- a/src/dawn/Optimizer/Pass.h
+++ b/src/dawn/Optimizer/Pass.h
@@ -15,6 +15,7 @@
 #ifndef DAWN_OPTIMIZER_PASS_H
 #define DAWN_OPTIMIZER_PASS_H
 
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -46,7 +47,7 @@ public:
 
   /// @brief Run the the Pass
   /// @returns `true` on success, `false` otherwise
-  virtual bool run(StencilInstantiation* stencilInstantiation) = 0;
+  virtual bool run(std::shared_ptr<StencilInstantiation> stencilInstantiation) = 0;
 
   /// @brief Get the name of the Pass
   const std::string& getName() const { return name_; }

--- a/src/dawn/Optimizer/Pass.h
+++ b/src/dawn/Optimizer/Pass.h
@@ -47,7 +47,7 @@ public:
 
   /// @brief Run the the Pass
   /// @returns `true` on success, `false` otherwise
-  virtual bool run(std::shared_ptr<StencilInstantiation> stencilInstantiation) = 0;
+  virtual bool run(const std::shared_ptr<StencilInstantiation>& stencilInstantiation) = 0;
 
   /// @brief Get the name of the Pass
   const std::string& getName() const { return name_; }

--- a/src/dawn/Optimizer/PassComputeStageExtents.cpp
+++ b/src/dawn/Optimizer/PassComputeStageExtents.cpp
@@ -41,10 +41,11 @@ bool PassComputeStageExtents::run(std::shared_ptr<StencilInstantiation> stencilI
         // notice that IO (if read happens before write) would also be a valid pattern
         // to trigger the propagation of the stage extents, however this is not a legal
         // pattern within a stage if the extent is not pointwise
-        if(fromField.Extent.isPointwise() || fromField.Intend != Field::IntendKind::IK_Input)
+        if(fromField.getExtents().isPointwise() ||
+           fromField.getIntend() != Field::IntendKind::IK_Input)
           continue;
 
-        Extents fieldExtent = fromField.Extent;
+        Extents fieldExtent = fromField.getExtents();
 
         fieldExtent.expand(stageExtent);
 
@@ -53,7 +54,8 @@ bool PassComputeStageExtents::run(std::shared_ptr<StencilInstantiation> stencilI
           Stage& toStage = *(stencil.getStage(j));
           auto fields = toStage.getFields();
           auto it = std::find_if(fields.begin(), fields.end(), [&](Field const& f) {
-            return (f.Intend != Field::IntendKind::IK_Input) && (f.AccessID == fromField.AccessID);
+            return (f.getIntend() != Field::IntendKind::IK_Input) &&
+                   (f.getAccessID() == fromField.getAccessID());
           });
           if(it == fields.end())
             continue;

--- a/src/dawn/Optimizer/PassComputeStageExtents.cpp
+++ b/src/dawn/Optimizer/PassComputeStageExtents.cpp
@@ -24,7 +24,8 @@ PassComputeStageExtents::PassComputeStageExtents() : Pass("PassComputeStageExten
   dependencies_.push_back("PassSetStageName");
 }
 
-bool PassComputeStageExtents::run(std::shared_ptr<StencilInstantiation> stencilInstantiation) {
+bool PassComputeStageExtents::run(
+    const std::shared_ptr<StencilInstantiation>& stencilInstantiation) {
   for(auto& stencilPtr : stencilInstantiation->getStencils()) {
     Stencil& stencil = *stencilPtr;
 

--- a/src/dawn/Optimizer/PassComputeStageExtents.cpp
+++ b/src/dawn/Optimizer/PassComputeStageExtents.cpp
@@ -24,7 +24,7 @@ PassComputeStageExtents::PassComputeStageExtents() : Pass("PassComputeStageExten
   dependencies_.push_back("PassSetStageName");
 }
 
-bool PassComputeStageExtents::run(StencilInstantiation* stencilInstantiation) {
+bool PassComputeStageExtents::run(std::shared_ptr<StencilInstantiation> stencilInstantiation) {
   for(auto& stencilPtr : stencilInstantiation->getStencils()) {
     Stencil& stencil = *stencilPtr;
 

--- a/src/dawn/Optimizer/PassComputeStageExtents.h
+++ b/src/dawn/Optimizer/PassComputeStageExtents.h
@@ -31,7 +31,7 @@ public:
   PassComputeStageExtents();
 
   /// @brief Pass implementation
-  bool run(StencilInstantiation* stencilInstantiation) override;
+  bool run(std::shared_ptr<StencilInstantiation> stencilInstantiation) override;
 };
 
 } // namespace dawn

--- a/src/dawn/Optimizer/PassComputeStageExtents.h
+++ b/src/dawn/Optimizer/PassComputeStageExtents.h
@@ -31,7 +31,7 @@ public:
   PassComputeStageExtents();
 
   /// @brief Pass implementation
-  bool run(std::shared_ptr<StencilInstantiation> stencilInstantiation) override;
+  bool run(const std::shared_ptr<StencilInstantiation>& stencilInstantiation) override;
 };
 
 } // namespace dawn

--- a/src/dawn/Optimizer/PassDataLocalityMetric.cpp
+++ b/src/dawn/Optimizer/PassDataLocalityMetric.cpp
@@ -162,7 +162,7 @@ public:
     DAWN_ASSERT(it != fields_.end());
     Field& field = it->second;
 
-    if(field.Intend == Field::IK_Input) {
+    if(field.getIntend() == Field::IK_Input) {
       if(!register_.count(AccessID)) {
 
         // Cache the center access
@@ -191,7 +191,7 @@ public:
       }
     }
 
-    if(multiStage_.isCached(AccessID) && field.Intend == Field::IK_Input)
+    if(multiStage_.isCached(AccessID) && field.getIntend() == Field::IK_Input)
       updateTextureCache(AccessID, kOffset);
   }
 
@@ -255,7 +255,7 @@ computeReadWriteAccessesLowerBound(StencilInstantiation* instantiation,
       }
 
     } else {
-      switch(field.Intend) {
+      switch(field.getIntend()) {
       case Field::IK_Output:
         numWrites += 1;
         break;

--- a/src/dawn/Optimizer/PassDataLocalityMetric.cpp
+++ b/src/dawn/Optimizer/PassDataLocalityMetric.cpp
@@ -58,7 +58,7 @@ class ReadWriteCounter : public ASTVisitorForwarding {
   std::unordered_map<int, ReadWriteAccumulator> individualReadWrites_;
 
 public:
-  ReadWriteCounter(std::shared_ptr<StencilInstantiation> instantiation,
+  ReadWriteCounter(const std::shared_ptr<StencilInstantiation>& instantiation,
                    const MultiStage& multiStage)
       : instantiation_(instantiation), numReads_(0), numWrites_(0), multiStage_(multiStage),
         fields_(multiStage_.getFields()) {}
@@ -276,9 +276,8 @@ computeReadWriteAccessesLowerBound(StencilInstantiation* instantiation,
 } // anonymous namespace
 
 /// @brief Approximate the reads and writes individually for each ID
-std::unordered_map<int, ReadWriteAccumulator>
-computeReadWriteAccessesMetricPerAccessID(std::shared_ptr<StencilInstantiation> instantiation,
-                                          const MultiStage& multiStage) {
+std::unordered_map<int, ReadWriteAccumulator> computeReadWriteAccessesMetricPerAccessID(
+    const std::shared_ptr<StencilInstantiation>& instantiation, const MultiStage& multiStage) {
   ReadWriteCounter readWriteCounter(instantiation, multiStage);
 
   for(const auto& stage : multiStage.getStages())
@@ -292,7 +291,7 @@ computeReadWriteAccessesMetricPerAccessID(std::shared_ptr<StencilInstantiation> 
 
 /// @brief Approximate the reads and writes accoding to our data locality metric
 std::pair<int, int>
-computeReadWriteAccessesMetric(std::shared_ptr<StencilInstantiation> instantiation,
+computeReadWriteAccessesMetric(const std::shared_ptr<StencilInstantiation>& instantiation,
                                const MultiStage& multiStage) {
   ReadWriteCounter readWriteCounter(instantiation, multiStage);
 
@@ -307,7 +306,8 @@ computeReadWriteAccessesMetric(std::shared_ptr<StencilInstantiation> instantiati
 
 PassDataLocalityMetric::PassDataLocalityMetric() : Pass("PassDataLocalityMetric") {}
 
-bool PassDataLocalityMetric::run(std::shared_ptr<StencilInstantiation> stencilInstantiation) {
+bool PassDataLocalityMetric::run(
+    const std::shared_ptr<StencilInstantiation>& stencilInstantiation) {
   OptimizerContext* context = stencilInstantiation->getOptimizerContext();
 
   if(context->getOptions().ReportDataLocalityMetric) {

--- a/src/dawn/Optimizer/PassDataLocalityMetric.cpp
+++ b/src/dawn/Optimizer/PassDataLocalityMetric.cpp
@@ -29,7 +29,7 @@ namespace dawn {
 namespace {
 
 class ReadWriteCounter : public ASTVisitorForwarding {
-  StencilInstantiation* instantiation_;
+  std::shared_ptr<StencilInstantiation> instantiation_;
 
   std::size_t numReads_, numWrites_;
 
@@ -58,7 +58,8 @@ class ReadWriteCounter : public ASTVisitorForwarding {
   std::unordered_map<int, ReadWriteAccumulator> individualReadWrites_;
 
 public:
-  ReadWriteCounter(StencilInstantiation* instantiation, const MultiStage& multiStage)
+  ReadWriteCounter(std::shared_ptr<StencilInstantiation> instantiation,
+                   const MultiStage& multiStage)
       : instantiation_(instantiation), numReads_(0), numWrites_(0), multiStage_(multiStage),
         fields_(multiStage_.getFields()) {}
 
@@ -276,7 +277,7 @@ computeReadWriteAccessesLowerBound(StencilInstantiation* instantiation,
 
 /// @brief Approximate the reads and writes individually for each ID
 std::unordered_map<int, ReadWriteAccumulator>
-computeReadWriteAccessesMetricPerAccessID(StencilInstantiation* instantiation,
+computeReadWriteAccessesMetricPerAccessID(std::shared_ptr<StencilInstantiation> instantiation,
                                           const MultiStage& multiStage) {
   ReadWriteCounter readWriteCounter(instantiation, multiStage);
 
@@ -290,8 +291,9 @@ computeReadWriteAccessesMetricPerAccessID(StencilInstantiation* instantiation,
 }
 
 /// @brief Approximate the reads and writes accoding to our data locality metric
-std::pair<int, int> computeReadWriteAccessesMetric(StencilInstantiation* instantiation,
-                                                   const MultiStage& multiStage) {
+std::pair<int, int>
+computeReadWriteAccessesMetric(std::shared_ptr<StencilInstantiation> instantiation,
+                               const MultiStage& multiStage) {
   ReadWriteCounter readWriteCounter(instantiation, multiStage);
 
   for(const auto& stage : multiStage.getStages())
@@ -305,7 +307,7 @@ std::pair<int, int> computeReadWriteAccessesMetric(StencilInstantiation* instant
 
 PassDataLocalityMetric::PassDataLocalityMetric() : Pass("PassDataLocalityMetric") {}
 
-bool PassDataLocalityMetric::run(StencilInstantiation* stencilInstantiation) {
+bool PassDataLocalityMetric::run(std::shared_ptr<StencilInstantiation> stencilInstantiation) {
   OptimizerContext* context = stencilInstantiation->getOptimizerContext();
 
   if(context->getOptions().ReportDataLocalityMetric) {

--- a/src/dawn/Optimizer/PassDataLocalityMetric.cpp
+++ b/src/dawn/Optimizer/PassDataLocalityMetric.cpp
@@ -97,7 +97,7 @@ public:
                                     : stencilFunCalls_.top()->getAccessIDFromExpr(expr);
   }
 
-  const std::string& getNameFromAccessID(int AccessID) {
+  std::string getNameFromAccessID(int AccessID) {
     return stencilFunCalls_.empty() ? instantiation_->getNameFromAccessID(AccessID)
                                     : stencilFunCalls_.top()->getNameFromAccessID(AccessID);
   }

--- a/src/dawn/Optimizer/PassDataLocalityMetric.h
+++ b/src/dawn/Optimizer/PassDataLocalityMetric.h
@@ -35,15 +35,14 @@ public:
   PassDataLocalityMetric();
 
   /// @brief Pass implementation
-  bool run(std::shared_ptr<StencilInstantiation> stencilInstantiation) override;
+  bool run(const std::shared_ptr<StencilInstantiation>& stencilInstantiation) override;
 };
 
 std::pair<int, int>
-computeReadWriteAccessesMetric(std::shared_ptr<StencilInstantiation> instantiation,
+computeReadWriteAccessesMetric(const std::shared_ptr<StencilInstantiation>& instantiation,
                                const MultiStage& multiStage);
-std::unordered_map<int, ReadWriteAccumulator>
-computeReadWriteAccessesMetricPerAccessID(std::shared_ptr<StencilInstantiation> instantiation,
-                                          const MultiStage& multiStage);
+std::unordered_map<int, ReadWriteAccumulator> computeReadWriteAccessesMetricPerAccessID(
+    const std::shared_ptr<StencilInstantiation>& instantiation, const MultiStage& multiStage);
 
 } // namespace dawn
 

--- a/src/dawn/Optimizer/PassDataLocalityMetric.h
+++ b/src/dawn/Optimizer/PassDataLocalityMetric.h
@@ -35,13 +35,14 @@ public:
   PassDataLocalityMetric();
 
   /// @brief Pass implementation
-  bool run(StencilInstantiation* stencilInstantiation) override;
+  bool run(std::shared_ptr<StencilInstantiation> stencilInstantiation) override;
 };
 
-std::pair<int, int> computeReadWriteAccessesMetric(StencilInstantiation* instantiation,
-                                                   const MultiStage& multiStage);
+std::pair<int, int>
+computeReadWriteAccessesMetric(std::shared_ptr<StencilInstantiation> instantiation,
+                               const MultiStage& multiStage);
 std::unordered_map<int, ReadWriteAccumulator>
-computeReadWriteAccessesMetricPerAccessID(StencilInstantiation* instantiation,
+computeReadWriteAccessesMetricPerAccessID(std::shared_ptr<StencilInstantiation> instantiation,
                                           const MultiStage& multiStage);
 
 } // namespace dawn

--- a/src/dawn/Optimizer/PassFieldVersioning.cpp
+++ b/src/dawn/Optimizer/PassFieldVersioning.cpp
@@ -91,7 +91,7 @@ static void reportRaceCondition(const Statement& statement, StencilInstantiation
 
 PassFieldVersioning::PassFieldVersioning() : Pass("PassFieldVersioning"), numRenames_(0) {}
 
-bool PassFieldVersioning::run(std::shared_ptr<StencilInstantiation> stencilInstantiation) {
+bool PassFieldVersioning::run(const std::shared_ptr<StencilInstantiation>& stencilInstantiation) {
   OptimizerContext* context = stencilInstantiation->getOptimizerContext();
   numRenames_ = 0;
 

--- a/src/dawn/Optimizer/PassFieldVersioning.cpp
+++ b/src/dawn/Optimizer/PassFieldVersioning.cpp
@@ -32,18 +32,18 @@ namespace {
 
 /// @brief Register all referenced AccessIDs
 struct AccessIDGetter : public ASTVisitorForwarding {
-  const StencilInstantiation* Instantiation;
+  const StencilInstantiation& Instantiation;
   std::set<int> AccessIDs;
 
-  AccessIDGetter(const StencilInstantiation* instantiation) : Instantiation(instantiation) {}
+  AccessIDGetter(const StencilInstantiation& instantiation) : Instantiation(instantiation) {}
 
   virtual void visit(const std::shared_ptr<FieldAccessExpr>& expr) override {
-    AccessIDs.insert(Instantiation->getAccessIDFromExpr(expr));
+    AccessIDs.insert(Instantiation.getAccessIDFromExpr(expr));
   }
 };
 
 /// @brief Compute the AccessIDs of the left and right hand side expression of the assignment
-static void getAccessIDFromAssignment(const StencilInstantiation* instantiation,
+static void getAccessIDFromAssignment(const StencilInstantiation& instantiation,
                                       AssignmentExpr* assignment, std::set<int>& LHSAccessIDs,
                                       std::set<int>& RHSAccessIDs) {
   auto computeAccessIDs = [&](const std::shared_ptr<Expr>& expr, std::set<int>& AccessIDs) {
@@ -65,7 +65,7 @@ static bool isHorizontalStencilOrCounterLoopOrderExtent(const Extents& extent,
 }
 
 /// @brief Report a race condition in the given `statement`
-static void reportRaceCondition(const Statement& statement, StencilInstantiation* instantiation) {
+static void reportRaceCondition(const Statement& statement, StencilInstantiation& instantiation) {
   DiagnosticsBuilder diag(DiagnosticsKind::Error, statement.ASTStmt->getSourceLocation());
 
   if(isa<IfStmt>(statement.ASTStmt.get())) {
@@ -74,7 +74,7 @@ static void reportRaceCondition(const Statement& statement, StencilInstantiation
     diag << "unresolvable race-condition in statement";
   }
 
-  instantiation->getOptimizerContext()->getDiagnostics().report(diag);
+  instantiation.getOptimizerContext()->getDiagnostics().report(diag);
 
   // Print stack trace of stencil calls
   if(statement.StackTrace) {
@@ -82,7 +82,7 @@ static void reportRaceCondition(const Statement& statement, StencilInstantiation
     for(int i = stackTrace.size() - 1; i >= 0; --i) {
       DiagnosticsBuilder note(DiagnosticsKind::Note, stackTrace[i]->Loc);
       note << "detected during instantiation of stencil-call '" << stackTrace[i]->Callee << "'";
-      instantiation->getOptimizerContext()->getDiagnostics().report(note);
+      instantiation.getOptimizerContext()->getDiagnostics().report(note);
     }
   }
 }
@@ -91,7 +91,7 @@ static void reportRaceCondition(const Statement& statement, StencilInstantiation
 
 PassFieldVersioning::PassFieldVersioning() : Pass("PassFieldVersioning"), numRenames_(0) {}
 
-bool PassFieldVersioning::run(StencilInstantiation* stencilInstantiation) {
+bool PassFieldVersioning::run(std::shared_ptr<StencilInstantiation> stencilInstantiation) {
   OptimizerContext* context = stencilInstantiation->getOptimizerContext();
   numRenames_ = 0;
 
@@ -107,7 +107,7 @@ bool PassFieldVersioning::run(StencilInstantiation* stencilInstantiation) {
       LoopOrderKind loopOrder = multiStage.getLoopOrder();
 
       std::shared_ptr<DependencyGraphAccesses> newGraph, oldGraph;
-      newGraph = std::make_shared<DependencyGraphAccesses>(stencilInstantiation);
+      newGraph = std::make_shared<DependencyGraphAccesses>(stencilInstantiation.get());
 
       // Iterate stages bottom -> top
       for(auto stageRit = multiStage.getStages().rbegin(),
@@ -158,8 +158,8 @@ PassFieldVersioning::fixRaceCondition(const DependencyGraphAccesses* graph, Sten
 
   Statement& statement = *doMethod.getStatementAccessesPairs()[index]->getStatement();
 
-  StencilInstantiation* instantiation = stencil.getStencilInstantiation();
-  OptimizerContext* context = instantiation->getOptimizerContext();
+  auto& instantiation = stencil.getStencilInstantiation();
+  OptimizerContext* context = instantiation.getOptimizerContext();
   int numRenames = 0;
 
   // Vector of strongly connected components with atleast one stencil access
@@ -233,7 +233,7 @@ PassFieldVersioning::fixRaceCondition(const DependencyGraphAccesses* graph, Sten
 
   if(!assignment) {
     if(context->getOptions().DumpRaceConditionGraph)
-      graph->toDot("rc_" + instantiation->getName() + ".dot");
+      graph->toDot("rc_" + instantiation.getName() + ".dot");
     reportRaceCondition(statement, instantiation);
     return RCKind::RK_Unresolvable;
   }
@@ -249,7 +249,7 @@ PassFieldVersioning::fixRaceCondition(const DependencyGraphAccesses* graph, Sten
   for(std::set<int>& scc : *stencilSCCs) {
     if(!scc.count(LHSAccessID)) {
       if(context->getOptions().DumpRaceConditionGraph)
-        graph->toDot("rc_" + instantiation->getName() + ".dot");
+        graph->toDot("rc_" + instantiation.getName() + ".dot");
       reportRaceCondition(statement, instantiation);
       return RCKind::RK_Unresolvable;
     }
@@ -265,18 +265,18 @@ PassFieldVersioning::fixRaceCondition(const DependencyGraphAccesses* graph, Sten
   }
 
   if(context->getOptions().ReportPassFieldVersioning)
-    std::cout << "\nPASS: " << getName() << ": " << instantiation->getName()
+    std::cout << "\nPASS: " << getName() << ": " << instantiation.getName()
               << ": rename:" << statement.ASTStmt->getSourceLocation().Line;
 
   // Create a new multi-versioned field and rename all occurences
   for(int oldAccessID : renameCandiates) {
-    int newAccessID = instantiation->createVersionAndRename(oldAccessID, &stencil, stageIdx, index,
-                                                            assignment->getRight(),
-                                                            StencilInstantiation::RD_Above);
+    int newAccessID = instantiation.createVersionAndRename(oldAccessID, &stencil, stageIdx, index,
+                                                           assignment->getRight(),
+                                                           StencilInstantiation::RD_Above);
 
     if(context->getOptions().ReportPassFieldVersioning)
-      std::cout << (numRenames != 0 ? ", " : " ") << instantiation->getNameFromAccessID(oldAccessID)
-                << ":" << instantiation->getNameFromAccessID(newAccessID);
+      std::cout << (numRenames != 0 ? ", " : " ") << instantiation.getNameFromAccessID(oldAccessID)
+                << ":" << instantiation.getNameFromAccessID(newAccessID);
 
     numRenames++;
   }

--- a/src/dawn/Optimizer/PassFieldVersioning.h
+++ b/src/dawn/Optimizer/PassFieldVersioning.h
@@ -36,7 +36,7 @@ public:
   PassFieldVersioning();
 
   /// @brief Pass implementation
-  bool run(std::shared_ptr<StencilInstantiation> stencilInstantiation) override;
+  bool run(const std::shared_ptr<StencilInstantiation>& stencilInstantiation) override;
 
   /// @brief Kind of race condition encountered
   enum class RCKind {

--- a/src/dawn/Optimizer/PassFieldVersioning.h
+++ b/src/dawn/Optimizer/PassFieldVersioning.h
@@ -36,7 +36,7 @@ public:
   PassFieldVersioning();
 
   /// @brief Pass implementation
-  bool run(StencilInstantiation* stencilInstantiation) override;
+  bool run(std::shared_ptr<StencilInstantiation> stencilInstantiation) override;
 
   /// @brief Kind of race condition encountered
   enum class RCKind {

--- a/src/dawn/Optimizer/PassInlining.cpp
+++ b/src/dawn/Optimizer/PassInlining.cpp
@@ -448,8 +448,8 @@ tryInlineStencilFunction(PassInlining::InlineStrategyKind strategy,
   if(!stencilFunc->hasReturn() || strategy == PassInlining::IK_Precomputation) {
     auto inliner = std::make_shared<Inliner>(strategy, stencilFunc, oldStmtAccessesPair,
                                              newStmtAccessesPairs, AccessIDOfCaller);
-    //    stencilFunc->getAST()->accept(*inliner);
-    //    return std::pair<bool, std::shared_ptr<Inliner>>(true, std::move(inliner));
+    stencilFunc->getAST()->accept(*inliner);
+    return std::pair<bool, std::shared_ptr<Inliner>>(true, std::move(inliner));
   }
   return std::pair<bool, std::shared_ptr<Inliner>>(false, nullptr);
 }

--- a/src/dawn/Optimizer/PassInlining.cpp
+++ b/src/dawn/Optimizer/PassInlining.cpp
@@ -33,7 +33,7 @@ class Inliner;
 static std::pair<bool, std::shared_ptr<Inliner>>
 tryInlineStencilFunction(PassInlining::InlineStrategyKind strategy,
                          StencilFunctionInstantiation* stencilFunctioninstantiation,
-                         std::shared_ptr<StatementAccessesPair> oldStmt,
+                         std::shared_ptr<StatementAccessesPair>& oldStmt,
                          std::vector<std::shared_ptr<StatementAccessesPair>>& newStmts,
                          int AccessIDOfCaller);
 
@@ -74,7 +74,7 @@ class Inliner : public ASTVisitor {
 public:
   Inliner(PassInlining::InlineStrategyKind strategy,
           StencilFunctionInstantiation* stencilFunctioninstantiation,
-          std::shared_ptr<StatementAccessesPair> oldStmtAccessesPair,
+          std::shared_ptr<StatementAccessesPair>& oldStmtAccessesPair,
           std::vector<std::shared_ptr<StatementAccessesPair>>& newStmtAccessesPairs,
           int AccessIDOfCaller = 0)
       : strategy_(strategy), curStencilFunctioninstantiation_(stencilFunctioninstantiation),
@@ -93,7 +93,7 @@ public:
     scopeDepth_--;
   }
 
-  void appendNewStatementAccessesPair(const std::shared_ptr<Stmt> stmt) {
+  void appendNewStatementAccessesPair(const std::shared_ptr<Stmt>& stmt) {
     if(scopeDepth_ == 1)
       newStmtAccessesPairs_.emplace_back(std::make_shared<StatementAccessesPair>(
           std::make_shared<Statement>(stmt, oldStmtAccessesPair_->getStatement()->StackTrace)));
@@ -307,7 +307,7 @@ public:
 /// @brief Detect inline candidates
 class DetectInlineCandiates : public ASTVisitorForwarding {
   PassInlining::InlineStrategyKind strategy_;
-  std::shared_ptr<StencilInstantiation> instantiation_;
+  const std::shared_ptr<StencilInstantiation>& instantiation_;
 
   /// The statement we are currently analyzing
   std::shared_ptr<StatementAccessesPair> oldStmtAccessesPair_;
@@ -335,7 +335,7 @@ public:
   using Base = ASTVisitorForwarding;
 
   DetectInlineCandiates(PassInlining::InlineStrategyKind strategy,
-                        std::shared_ptr<StencilInstantiation> instantiation)
+                        const std::shared_ptr<StencilInstantiation>& instantiation)
       : strategy_(strategy), instantiation_(instantiation), inlineCandiatesFound_(false) {}
 
   /// @brief Process the given statement
@@ -439,7 +439,7 @@ public:
 static std::pair<bool, std::shared_ptr<Inliner>>
 tryInlineStencilFunction(PassInlining::InlineStrategyKind strategy,
                          StencilFunctionInstantiation* stencilFunc,
-                         std::shared_ptr<StatementAccessesPair> oldStmtAccessesPair,
+                         std::shared_ptr<StatementAccessesPair>& oldStmtAccessesPair,
                          std::vector<std::shared_ptr<StatementAccessesPair>>& newStmtAccessesPairs,
                          int AccessIDOfCaller) {
 
@@ -459,7 +459,7 @@ tryInlineStencilFunction(PassInlining::InlineStrategyKind strategy,
 PassInlining::PassInlining(InlineStrategyKind strategy)
     : Pass("PassInlining"), strategy_(strategy) {}
 
-bool PassInlining::run(std::shared_ptr<StencilInstantiation> stencilInstantiation) {
+bool PassInlining::run(const std::shared_ptr<StencilInstantiation>& stencilInstantiation) {
   // Nothing to do ...
   if(strategy_ == IK_None)
     return true;

--- a/src/dawn/Optimizer/PassInlining.cpp
+++ b/src/dawn/Optimizer/PassInlining.cpp
@@ -41,7 +41,7 @@ tryInlineStencilFunction(PassInlining::InlineStrategyKind strategy,
 class Inliner : public ASTVisitor {
   PassInlining::InlineStrategyKind strategy_;
   StencilFunctionInstantiation* curStencilFunctioninstantiation_;
-  StencilInstantiation* instantiation_;
+  std::shared_ptr<StencilInstantiation> instantiation_;
 
   /// The statement which we are currently processing in the `DetectInlineCandiates`
   std::shared_ptr<StatementAccessesPair>& oldStmtAccessesPair_;
@@ -307,7 +307,7 @@ public:
 /// @brief Detect inline candidates
 class DetectInlineCandiates : public ASTVisitorForwarding {
   PassInlining::InlineStrategyKind strategy_;
-  StencilInstantiation* instantiation_;
+  std::shared_ptr<StencilInstantiation> instantiation_;
 
   /// The statement we are currently analyzing
   std::shared_ptr<StatementAccessesPair> oldStmtAccessesPair_;
@@ -335,7 +335,7 @@ public:
   using Base = ASTVisitorForwarding;
 
   DetectInlineCandiates(PassInlining::InlineStrategyKind strategy,
-                        StencilInstantiation* instantiation)
+                        std::shared_ptr<StencilInstantiation> instantiation)
       : strategy_(strategy), instantiation_(instantiation), inlineCandiatesFound_(false) {}
 
   /// @brief Process the given statement
@@ -459,7 +459,7 @@ tryInlineStencilFunction(PassInlining::InlineStrategyKind strategy,
 PassInlining::PassInlining(InlineStrategyKind strategy)
     : Pass("PassInlining"), strategy_(strategy) {}
 
-bool PassInlining::run(StencilInstantiation* stencilInstantiation) {
+bool PassInlining::run(std::shared_ptr<StencilInstantiation> stencilInstantiation) {
   // Nothing to do ...
   if(strategy_ == IK_None)
     return true;
@@ -483,7 +483,7 @@ bool PassInlining::run(StencilInstantiation* stencilInstantiation) {
             const auto& newStmtAccList = inliner.getNewStatementAccessesPairs();
 
             // Compute the accesses of the new statements
-            computeAccesses(stencilInstantiation, newStmtAccList);
+            computeAccesses(stencilInstantiation.get(), newStmtAccList);
 
             // Erase the old StatementAccessPair ...
             stmtAccIt = stmtAccList.erase(stmtAccIt);

--- a/src/dawn/Optimizer/PassInlining.h
+++ b/src/dawn/Optimizer/PassInlining.h
@@ -42,7 +42,7 @@ public:
   PassInlining(InlineStrategyKind strategy);
 
   /// @brief Pass implementation
-  bool run(std::shared_ptr<StencilInstantiation> stencilInstantiation) override;
+  bool run(const std::shared_ptr<StencilInstantiation>& stencilInstantiation) override;
 
 private:
   InlineStrategyKind strategy_;

--- a/src/dawn/Optimizer/PassInlining.h
+++ b/src/dawn/Optimizer/PassInlining.h
@@ -42,7 +42,7 @@ public:
   PassInlining(InlineStrategyKind strategy);
 
   /// @brief Pass implementation
-  bool run(StencilInstantiation* stencilInstantiation) override;
+  bool run(std::shared_ptr<StencilInstantiation> stencilInstantiation) override;
 
 private:
   InlineStrategyKind strategy_;

--- a/src/dawn/Optimizer/PassManager.cpp
+++ b/src/dawn/Optimizer/PassManager.cpp
@@ -21,7 +21,7 @@
 namespace dawn {
 
 bool PassManager::runAllPassesOnStecilInstantiation(
-    std::shared_ptr<StencilInstantiation> instantiation) {
+    const std::shared_ptr<StencilInstantiation>& instantiation) {
   std::vector<std::string> passesRan;
 
   for(auto& pass : passes_) {
@@ -42,8 +42,8 @@ bool PassManager::runAllPassesOnStecilInstantiation(
   return true;
 }
 
-bool PassManager::runPassOnStecilInstantiation(std::shared_ptr<StencilInstantiation> instantiation,
-                                               Pass* pass) {
+bool PassManager::runPassOnStecilInstantiation(
+    const std::shared_ptr<StencilInstantiation>& instantiation, Pass* pass) {
   DAWN_LOG(INFO) << "Starting " << pass->getName() << " ...";
 
   if(!pass->run(instantiation)) {

--- a/src/dawn/Optimizer/PassManager.cpp
+++ b/src/dawn/Optimizer/PassManager.cpp
@@ -20,7 +20,8 @@
 
 namespace dawn {
 
-bool PassManager::runAllPassesOnStecilInstantiation(StencilInstantiation* instantiation) {
+bool PassManager::runAllPassesOnStecilInstantiation(
+    std::shared_ptr<StencilInstantiation> instantiation) {
   std::vector<std::string> passesRan;
 
   for(auto& pass : passes_) {
@@ -41,7 +42,8 @@ bool PassManager::runAllPassesOnStecilInstantiation(StencilInstantiation* instan
   return true;
 }
 
-bool PassManager::runPassOnStecilInstantiation(StencilInstantiation* instantiation, Pass* pass) {
+bool PassManager::runPassOnStecilInstantiation(std::shared_ptr<StencilInstantiation> instantiation,
+                                               Pass* pass) {
   DAWN_LOG(INFO) << "Starting " << pass->getName() << " ...";
 
   if(!pass->run(instantiation)) {

--- a/src/dawn/Optimizer/PassManager.h
+++ b/src/dawn/Optimizer/PassManager.h
@@ -44,11 +44,12 @@ public:
 
   /// @brief Run all passes on the `instantiation`
   /// @returns `true` on success, `false` otherwise
-  bool runAllPassesOnStecilInstantiation(std::shared_ptr<StencilInstantiation> instantiation);
+  bool
+  runAllPassesOnStecilInstantiation(const std::shared_ptr<StencilInstantiation>& instantiation);
 
   /// @brief Run the given pass on the `instantiation`
   /// @returns `true` on success, `false` otherwise
-  bool runPassOnStecilInstantiation(std::shared_ptr<StencilInstantiation> instantiation,
+  bool runPassOnStecilInstantiation(const std::shared_ptr<StencilInstantiation>& instantiation,
                                     Pass* pass);
 
   /// @brief Get all registered passes

--- a/src/dawn/Optimizer/PassManager.h
+++ b/src/dawn/Optimizer/PassManager.h
@@ -44,11 +44,12 @@ public:
 
   /// @brief Run all passes on the `instantiation`
   /// @returns `true` on success, `false` otherwise
-  bool runAllPassesOnStecilInstantiation(StencilInstantiation* instantiation);
+  bool runAllPassesOnStecilInstantiation(std::shared_ptr<StencilInstantiation> instantiation);
 
   /// @brief Run the given pass on the `instantiation`
   /// @returns `true` on success, `false` otherwise
-  bool runPassOnStecilInstantiation(StencilInstantiation* instantiation, Pass* pass);
+  bool runPassOnStecilInstantiation(std::shared_ptr<StencilInstantiation> instantiation,
+                                    Pass* pass);
 
   /// @brief Get all registered passes
   std::list<std::unique_ptr<Pass>>& getPasses() { return passes_; }

--- a/src/dawn/Optimizer/PassMultiStageSplitter.cpp
+++ b/src/dawn/Optimizer/PassMultiStageSplitter.cpp
@@ -29,12 +29,12 @@ namespace dawn {
 
 PassMultiStageSplitter::PassMultiStageSplitter() : Pass("PassMultiStageSplitter") {}
 
-bool PassMultiStageSplitter::run(StencilInstantiation* stencilInstantiation) {
+bool PassMultiStageSplitter::run(std::shared_ptr<StencilInstantiation> stencilInstantiation) {
   OptimizerContext* context = stencilInstantiation->getOptimizerContext();
 
   int numSplit = 0;
   std::deque<MultiStage::SplitIndex> splitterIndices;
-  DependencyGraphAccesses graph(stencilInstantiation);
+  DependencyGraphAccesses graph(stencilInstantiation.get());
 
   // Iterate over all stages in all multistages of all stencils
   for(auto& stencil : stencilInstantiation->getStencils()) {

--- a/src/dawn/Optimizer/PassMultiStageSplitter.cpp
+++ b/src/dawn/Optimizer/PassMultiStageSplitter.cpp
@@ -29,7 +29,8 @@ namespace dawn {
 
 PassMultiStageSplitter::PassMultiStageSplitter() : Pass("PassMultiStageSplitter") {}
 
-bool PassMultiStageSplitter::run(std::shared_ptr<StencilInstantiation> stencilInstantiation) {
+bool PassMultiStageSplitter::run(
+    const std::shared_ptr<StencilInstantiation>& stencilInstantiation) {
   OptimizerContext* context = stencilInstantiation->getOptimizerContext();
 
   int numSplit = 0;

--- a/src/dawn/Optimizer/PassMultiStageSplitter.h
+++ b/src/dawn/Optimizer/PassMultiStageSplitter.h
@@ -28,7 +28,7 @@ public:
   PassMultiStageSplitter();
 
   /// @brief Pass implementation
-  bool run(std::shared_ptr<StencilInstantiation> stencilInstantiation) override;
+  bool run(const std::shared_ptr<StencilInstantiation>& stencilInstantiation) override;
 };
 
 } // namespace dawn

--- a/src/dawn/Optimizer/PassMultiStageSplitter.h
+++ b/src/dawn/Optimizer/PassMultiStageSplitter.h
@@ -28,7 +28,7 @@ public:
   PassMultiStageSplitter();
 
   /// @brief Pass implementation
-  bool run(StencilInstantiation* stencilInstantiation) override;
+  bool run(std::shared_ptr<StencilInstantiation> stencilInstantiation) override;
 };
 
 } // namespace dawn

--- a/src/dawn/Optimizer/PassPrintStencilGraph.cpp
+++ b/src/dawn/Optimizer/PassPrintStencilGraph.cpp
@@ -23,14 +23,14 @@ PassPrintStencilGraph::PassPrintStencilGraph() : Pass("PassPrintStencilGraph") {
   dependencies_.push_back("PassStageSplitter");
 }
 
-bool PassPrintStencilGraph::run(StencilInstantiation* stencilInstantiation) {
+bool PassPrintStencilGraph::run(std::shared_ptr<StencilInstantiation> stencilInstantiation) {
   OptimizerContext* context = stencilInstantiation->getOptimizerContext();
   if(context->getOptions().DumpStencilGraph) {
 
     int stencilIdx = 0;
     for(auto& stencilPtr : stencilInstantiation->getStencils()) {
       Stencil& stencil = *stencilPtr;
-      auto DAG = std::make_shared<DependencyGraphAccesses>(stencilInstantiation);
+      auto DAG = std::make_shared<DependencyGraphAccesses>(stencilInstantiation.get());
 
       // Merge all stages into a single DAG
       int numStages = stencil.getNumStages();

--- a/src/dawn/Optimizer/PassPrintStencilGraph.cpp
+++ b/src/dawn/Optimizer/PassPrintStencilGraph.cpp
@@ -23,7 +23,7 @@ PassPrintStencilGraph::PassPrintStencilGraph() : Pass("PassPrintStencilGraph") {
   dependencies_.push_back("PassStageSplitter");
 }
 
-bool PassPrintStencilGraph::run(std::shared_ptr<StencilInstantiation> stencilInstantiation) {
+bool PassPrintStencilGraph::run(const std::shared_ptr<StencilInstantiation>& stencilInstantiation) {
   OptimizerContext* context = stencilInstantiation->getOptimizerContext();
   if(context->getOptions().DumpStencilGraph) {
 

--- a/src/dawn/Optimizer/PassPrintStencilGraph.h
+++ b/src/dawn/Optimizer/PassPrintStencilGraph.h
@@ -29,7 +29,7 @@ public:
   PassPrintStencilGraph();
 
   /// @brief Pass implementation
-  bool run(std::shared_ptr<StencilInstantiation> stencilInstantiation) override;
+  bool run(const std::shared_ptr<StencilInstantiation>& stencilInstantiation) override;
 };
 
 } // namespace dawn

--- a/src/dawn/Optimizer/PassPrintStencilGraph.h
+++ b/src/dawn/Optimizer/PassPrintStencilGraph.h
@@ -29,7 +29,7 @@ public:
   PassPrintStencilGraph();
 
   /// @brief Pass implementation
-  bool run(StencilInstantiation* stencilInstantiation) override;
+  bool run(std::shared_ptr<StencilInstantiation> stencilInstantiation) override;
 };
 
 } // namespace dawn

--- a/src/dawn/Optimizer/PassSSA.cpp
+++ b/src/dawn/Optimizer/PassSSA.cpp
@@ -23,7 +23,7 @@ namespace dawn {
 
 PassSSA::PassSSA() : Pass("PassSSA") {}
 
-bool PassSSA::run(StencilInstantiation* stencilInstantiation) {
+bool PassSSA::run(std::shared_ptr<StencilInstantiation> stencilInstantiation) {
   OptimizerContext* context = stencilInstantiation->getOptimizerContext();
 
   if(context->getOptions().SSA) {
@@ -32,7 +32,7 @@ bool PassSSA::run(StencilInstantiation* stencilInstantiation) {
       Stencil& stencil = *stencilPtr;
 
       std::shared_ptr<DependencyGraphAccesses> DAG =
-          std::make_shared<DependencyGraphAccesses>(stencilInstantiation);
+          std::make_shared<DependencyGraphAccesses>(stencilInstantiation.get());
 
       std::unordered_set<int> tochedAccessIDs;
 

--- a/src/dawn/Optimizer/PassSSA.cpp
+++ b/src/dawn/Optimizer/PassSSA.cpp
@@ -23,7 +23,7 @@ namespace dawn {
 
 PassSSA::PassSSA() : Pass("PassSSA") {}
 
-bool PassSSA::run(std::shared_ptr<StencilInstantiation> stencilInstantiation) {
+bool PassSSA::run(const std::shared_ptr<StencilInstantiation>& stencilInstantiation) {
   OptimizerContext* context = stencilInstantiation->getOptimizerContext();
 
   if(context->getOptions().SSA) {

--- a/src/dawn/Optimizer/PassSSA.h
+++ b/src/dawn/Optimizer/PassSSA.h
@@ -28,7 +28,7 @@ public:
   PassSSA();
 
   /// @brief Pass implementation
-  bool run(std::shared_ptr<StencilInstantiation> stencilInstantiation) override;
+  bool run(const std::shared_ptr<StencilInstantiation>& stencilInstantiation) override;
 };
 
 } // namespace dawn

--- a/src/dawn/Optimizer/PassSSA.h
+++ b/src/dawn/Optimizer/PassSSA.h
@@ -28,7 +28,7 @@ public:
   PassSSA();
 
   /// @brief Pass implementation
-  bool run(StencilInstantiation* stencilInstantiation) override;
+  bool run(std::shared_ptr<StencilInstantiation> stencilInstantiation) override;
 };
 
 } // namespace dawn

--- a/src/dawn/Optimizer/PassSetCaches.cpp
+++ b/src/dawn/Optimizer/PassSetCaches.cpp
@@ -145,7 +145,7 @@ Cache::CacheIOPolicy combinePolicy(Cache::CacheIOPolicy MS1Policy, Cache::CacheI
 
 PassSetCaches::PassSetCaches() : Pass("PassSetCaches") {}
 
-bool PassSetCaches::run(std::shared_ptr<StencilInstantiation> instantiation) {
+bool PassSetCaches::run(const std::shared_ptr<StencilInstantiation>& instantiation) {
   OptimizerContext* context = instantiation->getOptimizerContext();
 
   for(const auto& stencilPtr : instantiation->getStencils()) {

--- a/src/dawn/Optimizer/PassSetCaches.cpp
+++ b/src/dawn/Optimizer/PassSetCaches.cpp
@@ -145,7 +145,7 @@ Cache::CacheIOPolicy combinePolicy(Cache::CacheIOPolicy MS1Policy, Cache::CacheI
 
 PassSetCaches::PassSetCaches() : Pass("PassSetCaches") {}
 
-bool PassSetCaches::run(StencilInstantiation* instantiation) {
+bool PassSetCaches::run(std::shared_ptr<StencilInstantiation> instantiation) {
   OptimizerContext* context = instantiation->getOptimizerContext();
 
   for(const auto& stencilPtr : instantiation->getStencils()) {

--- a/src/dawn/Optimizer/PassSetCaches.cpp
+++ b/src/dawn/Optimizer/PassSetCaches.cpp
@@ -43,7 +43,7 @@ static FirstAccessKind getFirstAccessKind(const MultiStage& MS, int AccessID) {
   for(const auto& stagePtr : MS.getStages()) {
     Stage& stage = *stagePtr;
     if(std::find_if(stage.getFields().begin(), stage.getFields().end(), [&](const Field& field) {
-         return field.AccessID == AccessID;
+         return field.getAccessID() == AccessID;
        }) != stage.getFields().end()) {
 
       auto getFirstAccessKindFromDoMethod = [&](const DoMethod* doMethod) -> FirstAccessKind {
@@ -159,41 +159,41 @@ bool PassSetCaches::run(std::shared_ptr<StencilInstantiation> instantiation) {
       std::set<int> outputFields;
 
       auto isOutput = [](const Field& field) {
-        return field.Intend == Field::IK_Output || field.Intend == Field::IK_InputOutput;
+        return field.getIntend() == Field::IK_Output || field.getIntend() == Field::IK_InputOutput;
       };
 
       for(const auto& stagePtr : multiStagePtr->getStages()) {
         for(const Field& field : stagePtr->getFields()) {
 
           // Field is already cached, skip
-          if(MS.isCached(field.AccessID))
+          if(MS.isCached(field.getAccessID()))
             continue;
 
           // Field has vertical extents, can't be ij-cached
-          if(!field.Extent.isVerticalPointwise())
+          if(!field.getExtents().isVerticalPointwise())
             continue;
 
           // Currently we only cache temporaries!
-          if(!instantiation->isTemporaryField(field.AccessID))
+          if(!instantiation->isTemporaryField(field.getAccessID()))
             continue;
 
           // Cache the field
-          if(field.Intend == Field::IK_Input && outputFields.count(field.AccessID) &&
-             !field.Extent.isHorizontalPointwise()) {
+          if(field.getIntend() == Field::IK_Input && outputFields.count(field.getAccessID()) &&
+             !field.getExtents().isHorizontalPointwise()) {
 
-            Cache& cache = multiStagePtr->setCache(Cache::IJ, Cache::local, field.AccessID);
+            Cache& cache = multiStagePtr->setCache(Cache::IJ, Cache::local, field.getAccessID());
 
             if(context->getOptions().ReportPassSetCaches) {
               std::cout << "\nPASS: " << getName() << ": " << instantiation->getName() << ": MS"
                         << msIdx << ": "
-                        << instantiation->getOriginalNameFromAccessID(field.AccessID) << ":"
+                        << instantiation->getOriginalNameFromAccessID(field.getAccessID()) << ":"
                         << cache.getCacheTypeAsString() << ":" << cache.getCacheIOPolicyAsString()
                         << std::endl;
             }
           }
 
           if(isOutput(field))
-            outputFields.insert(field.AccessID);
+            outputFields.insert(field.getAccessID());
         }
       }
       msIdx++;
@@ -216,38 +216,40 @@ bool PassSetCaches::run(std::shared_ptr<StencilInstantiation> instantiation) {
           const Field& field = AccessIDFieldPair.second;
 
           // Field is already cached, skip
-          if(MS.isCached(field.AccessID))
+          if(MS.isCached(field.getAccessID()))
             continue;
 
           // Field has horizontal extents, can't be k-cached
-          if(!field.Extent.isHorizontalPointwise())
+          if(!field.getExtents().isHorizontalPointwise())
             continue;
 
           // Currently we only cache temporaries!
-          //          if(!instantiation->isTemporaryField(field.AccessID))
+          //          if(!instantiation->isTemporaryField(field.getAccessID()))
           //            continue;
 
-          if(!instantiation->isTemporaryField(field.AccessID) &&
-             (field.Intend == Field::IK_Output ||
-              (field.Intend == Field::IK_Input && field.Extent.isPointwise())))
+          if(!instantiation->isTemporaryField(field.getAccessID()) &&
+             (field.getIntend() == Field::IK_Output ||
+              (field.getIntend() == Field::IK_Input && field.getExtents().isPointwise())))
             continue;
 
           // Determine if we need to fill the cache by analyzing the current multi-stage
           Cache::CacheIOPolicy policy = Cache::unknown;
-          if(field.Intend == Field::IK_Input) {
+          if(field.getIntend() == Field::IK_Input) {
             policy = Cache::fill;
-          } else if(field.Intend == Field::IK_Output)
+          } else if(field.getIntend() == Field::IK_Output)
             policy = Cache::local;
-          else if(field.Intend == Field::IK_InputOutput) {
+          else if(field.getIntend() == Field::IK_InputOutput) {
             // Do we compute the first levels or do we need to access main memory (i.e fill the
             // fist accesses)?
-            FirstAccessKind firstAccess = getFirstAccessKind(MS, field.AccessID);
+            FirstAccessKind firstAccess = getFirstAccessKind(MS, field.getAccessID());
             if(firstAccess == FK_WriteOnly)
               policy = Cache::local;
             else {
               // Do we have a read in counter loop order or pointwise access?
-              if(field.Extent.getVerticalLoopOrderAccesses(MS.getLoopOrder()).CounterLoopOrder ||
-                 field.Extent.isVerticalPointwise())
+              if(field.getExtents()
+                     .getVerticalLoopOrderAccesses(MS.getLoopOrder())
+                     .CounterLoopOrder ||
+                 field.getExtents().isVerticalPointwise())
                 policy = Cache::fill;
               else
                 policy = Cache::bpfill;
@@ -255,40 +257,42 @@ bool PassSetCaches::run(std::shared_ptr<StencilInstantiation> instantiation) {
           }
 
           // Determine if we need to flush the cache by analyzing the next multi-stage
-          if(MSIndex != (numMS - 1) && fields[MSIndex + 1].count(field.AccessID)) {
+          if(MSIndex != (numMS - 1) && fields[MSIndex + 1].count(field.getAccessID())) {
 
             const MultiStage& nextMS = *stencil.getMultiStageFromMultiStageIndex(MSIndex + 1);
-            const Field& fieldInNextMS = fields[MSIndex + 1].find(field.AccessID)->second;
+            const Field& fieldInNextMS = fields[MSIndex + 1].find(field.getAccessID())->second;
 
-            if(fieldInNextMS.Intend == Field::IK_Input)
+            if(fieldInNextMS.getIntend() == Field::IK_Input)
               policy = combinePolicy(policy, Cache::flush);
-            else if(fieldInNextMS.Intend == Field::IK_InputOutput) {
+            else if(fieldInNextMS.getIntend() == Field::IK_InputOutput) {
               // Do we compute the first levels or do we need to access main memory (i.e flush
               // the last accesses)?
-              FirstAccessKind firstAccess = getFirstAccessKind(nextMS, fieldInNextMS.AccessID);
+              FirstAccessKind firstAccess = getFirstAccessKind(nextMS, fieldInNextMS.getAccessID());
               if(firstAccess == FK_WriteOnly)
                 policy = combinePolicy(policy, Cache::local);
               else {
-                if(fieldInNextMS.Extent.getVerticalLoopOrderAccesses(nextMS.getLoopOrder())
+                if(fieldInNextMS.getExtents()
+                       .getVerticalLoopOrderAccesses(nextMS.getLoopOrder())
                        .CounterLoopOrder ||
-                   fieldInNextMS.Extent.isVerticalPointwise())
+                   fieldInNextMS.getExtents().isVerticalPointwise())
                   policy = combinePolicy(policy, Cache::flush);
                 else
                   policy = combinePolicy(policy, Cache::epflush);
               }
             }
           } else {
-            if(!instantiation->isTemporaryField(field.AccessID) && field.Intend != Field::IK_Input)
+            if(!instantiation->isTemporaryField(field.getAccessID()) &&
+               field.getIntend() != Field::IK_Input)
               policy = combinePolicy(policy, Cache::flush);
           }
 
           // Set the cache
-          Cache& cache = MS.setCache(Cache::K, policy, field.AccessID);
+          Cache& cache = MS.setCache(Cache::K, policy, field.getAccessID());
 
           if(context->getOptions().ReportPassSetCaches) {
             std::cout << "\nPASS: " << getName() << ": " << instantiation->getName() << ": MS"
                       << MSIndex << ": "
-                      << instantiation->getOriginalNameFromAccessID(field.AccessID) << ":"
+                      << instantiation->getOriginalNameFromAccessID(field.getAccessID()) << ":"
                       << cache.getCacheTypeAsString() << ":" << cache.getCacheIOPolicyAsString()
                       << std::endl;
           }

--- a/src/dawn/Optimizer/PassSetCaches.h
+++ b/src/dawn/Optimizer/PassSetCaches.h
@@ -27,7 +27,7 @@ public:
   PassSetCaches();
 
   /// @brief Pass implementation
-  bool run(StencilInstantiation* stencilInstantiation) override;
+  bool run(std::shared_ptr<StencilInstantiation> stencilInstantiation) override;
 };
 
 } // namespace dawn

--- a/src/dawn/Optimizer/PassSetCaches.h
+++ b/src/dawn/Optimizer/PassSetCaches.h
@@ -27,7 +27,7 @@ public:
   PassSetCaches();
 
   /// @brief Pass implementation
-  bool run(std::shared_ptr<StencilInstantiation> stencilInstantiation) override;
+  bool run(const std::shared_ptr<StencilInstantiation>& stencilInstantiation) override;
 };
 
 } // namespace dawn

--- a/src/dawn/Optimizer/PassSetNonTempCaches.cpp
+++ b/src/dawn/Optimizer/PassSetNonTempCaches.cpp
@@ -281,7 +281,8 @@ private:
 
 PassSetNonTempCaches::PassSetNonTempCaches() : Pass("PassSetNonTempCaches") {}
 
-bool dawn::PassSetNonTempCaches::run(std::shared_ptr<StencilInstantiation> stencilInstantiation) {
+bool dawn::PassSetNonTempCaches::run(
+    const std::shared_ptr<StencilInstantiation>& stencilInstantiation) {
 
   OptimizerContext* context = stencilInstantiation->getOptimizerContext();
 

--- a/src/dawn/Optimizer/PassSetNonTempCaches.cpp
+++ b/src/dawn/Optimizer/PassSetNonTempCaches.cpp
@@ -46,7 +46,7 @@ class GlobalFieldCacher {
 public:
   /// @param[in, out]  msprt   Pointer to the multistage to handle
   /// @param[in, out]  si      Stencil Instanciation [ISIR] holding all the Stencils
-  GlobalFieldCacher(MultiStage* msptr, StencilInstantiation* si)
+  GlobalFieldCacher(MultiStage* msptr, std::shared_ptr<StencilInstantiation> si)
       : multiStagePrt_(msptr), instantiation_(si) {}
 
   /// @brief Entry method for the pass: processes a given multistage and applies all changes
@@ -180,7 +180,7 @@ private:
                                                const std::vector<int>& assigneeIDs) {
     // Add the cache Flush stage
     std::shared_ptr<Stage> assignmentStage = std::make_shared<Stage>(
-        instantiation_, multiStagePrt_, instantiation_->nextUID(), interval);
+        *instantiation_, multiStagePrt_, instantiation_->nextUID(), interval);
     std::unique_ptr<DoMethod> domethod = make_unique<DoMethod>(assignmentStage.get(), interval);
     domethod->getStatementAccessesPairs().clear();
 
@@ -270,7 +270,7 @@ private:
   }
 
   MultiStage* multiStagePrt_;
-  StencilInstantiation* instantiation_;
+  std::shared_ptr<StencilInstantiation> instantiation_;
 
   std::unordered_map<int, int> accessIDToDataLocality_;
   std::unordered_map<int, int> oldAccessIDtoNewAccessID_;
@@ -281,7 +281,7 @@ private:
 
 PassSetNonTempCaches::PassSetNonTempCaches() : Pass("PassSetNonTempCaches") {}
 
-bool dawn::PassSetNonTempCaches::run(dawn::StencilInstantiation* stencilInstantiation) {
+bool dawn::PassSetNonTempCaches::run(std::shared_ptr<StencilInstantiation> stencilInstantiation) {
 
   OptimizerContext* context = stencilInstantiation->getOptimizerContext();
 

--- a/src/dawn/Optimizer/PassSetNonTempCaches.cpp
+++ b/src/dawn/Optimizer/PassSetNonTempCaches.cpp
@@ -69,31 +69,31 @@ private:
 
     for(const auto& stagePtr : multiStagePrt_->getStages()) {
       for(const Field& field : stagePtr->getFields()) {
-        auto iter = accessIDToDataLocality_.find(field.AccessID);
+        auto iter = accessIDToDataLocality_.find(field.getAccessID());
 
         // We already checked this field
         if(iter != accessIDToDataLocality_.end())
           continue;
 
         // Only ij-cache fields that are not horizontally pointwise and are vertically pointwise
-        if(!field.Extent.isVerticalPointwise() || field.Extent.isHorizontalPointwise())
+        if(!field.getExtents().isVerticalPointwise() || field.getExtents().isHorizontalPointwise())
           continue;
 
         // This is caching non-temporary fields
-        if(instantiation_->isTemporaryField(field.AccessID))
+        if(instantiation_->isTemporaryField(field.getAccessID()))
           continue;
 
-        int cachedReadAndWrites = dataLocality.find(field.AccessID)->second.totalAccesses();
+        int cachedReadAndWrites = dataLocality.find(field.getAccessID())->second.totalAccesses();
 
         // We check how much the cache-filling costs: 1 Read and if we fill from Memory
-        if(checkReadBeforeWrite(field.AccessID))
+        if(checkReadBeforeWrite(field.getAccessID()))
           cachedReadAndWrites--;
         // We need one more write to flush the cache back to the variable
-        if(!checkReadOnlyAccess(field.AccessID))
+        if(!checkReadOnlyAccess(field.getAccessID()))
           cachedReadAndWrites--;
 
         if(cachedReadAndWrites > 0)
-          accessIDToDataLocality_.emplace(field.AccessID, cachedReadAndWrites);
+          accessIDToDataLocality_.emplace(field.getAccessID(), cachedReadAndWrites);
       }
     }
 

--- a/src/dawn/Optimizer/PassSetNonTempCaches.h
+++ b/src/dawn/Optimizer/PassSetNonTempCaches.h
@@ -40,7 +40,7 @@ public:
   PassSetNonTempCaches();
 
   /// @brief Pass implementation
-  bool run(StencilInstantiation* stencilInstantiation) override;
+  bool run(std::shared_ptr<StencilInstantiation> stencilInstantiation) override;
 };
 
 } // namespace dawn

--- a/src/dawn/Optimizer/PassSetNonTempCaches.h
+++ b/src/dawn/Optimizer/PassSetNonTempCaches.h
@@ -40,7 +40,7 @@ public:
   PassSetNonTempCaches();
 
   /// @brief Pass implementation
-  bool run(std::shared_ptr<StencilInstantiation> stencilInstantiation) override;
+  bool run(const std::shared_ptr<StencilInstantiation>& stencilInstantiation) override;
 };
 
 } // namespace dawn

--- a/src/dawn/Optimizer/PassSetStageGraph.cpp
+++ b/src/dawn/Optimizer/PassSetStageGraph.cpp
@@ -59,7 +59,7 @@ PassSetStageGraph::PassSetStageGraph() : Pass("PassSetStageGraph") {
   dependencies_.push_back("PassSetStageName");
 }
 
-bool PassSetStageGraph::run(std::shared_ptr<StencilInstantiation> stencilInstantiation) {
+bool PassSetStageGraph::run(const std::shared_ptr<StencilInstantiation>& stencilInstantiation) {
   OptimizerContext* context = stencilInstantiation->getOptimizerContext();
 
   int stencilIdx = 0;

--- a/src/dawn/Optimizer/PassSetStageGraph.cpp
+++ b/src/dawn/Optimizer/PassSetStageGraph.cpp
@@ -59,7 +59,7 @@ PassSetStageGraph::PassSetStageGraph() : Pass("PassSetStageGraph") {
   dependencies_.push_back("PassSetStageName");
 }
 
-bool PassSetStageGraph::run(StencilInstantiation* stencilInstantiation) {
+bool PassSetStageGraph::run(std::shared_ptr<StencilInstantiation> stencilInstantiation) {
   OptimizerContext* context = stencilInstantiation->getOptimizerContext();
 
   int stencilIdx = 0;

--- a/src/dawn/Optimizer/PassSetStageGraph.cpp
+++ b/src/dawn/Optimizer/PassSetStageGraph.cpp
@@ -31,11 +31,11 @@ static bool depends(const Stage& fromStage, const Stage& toStage) {
   for(const Field& fromField : fromStage.getFields()) {
     for(const Field& toField : toStage.getFields()) {
 
-      if(fromField.AccessID != toField.AccessID)
+      if(fromField.getAccessID() != toField.getAccessID())
         continue;
 
-      Field::IntendKind fromFieldIntend = fromField.Intend;
-      Field::IntendKind toFieldIntend = toField.Intend;
+      Field::IntendKind fromFieldIntend = fromField.getIntend();
+      Field::IntendKind toFieldIntend = toField.getIntend();
 
       switch(fromFieldIntend) {
       case Field::IK_Output:

--- a/src/dawn/Optimizer/PassSetStageGraph.h
+++ b/src/dawn/Optimizer/PassSetStageGraph.h
@@ -29,7 +29,7 @@ public:
   PassSetStageGraph();
 
   /// @brief Pass implementation
-  bool run(StencilInstantiation* stencilInstantiation) override;
+  bool run(std::shared_ptr<StencilInstantiation> stencilInstantiation) override;
 };
 
 } // namespace dawn

--- a/src/dawn/Optimizer/PassSetStageGraph.h
+++ b/src/dawn/Optimizer/PassSetStageGraph.h
@@ -29,7 +29,7 @@ public:
   PassSetStageGraph();
 
   /// @brief Pass implementation
-  bool run(std::shared_ptr<StencilInstantiation> stencilInstantiation) override;
+  bool run(const std::shared_ptr<StencilInstantiation>& stencilInstantiation) override;
 };
 
 } // namespace dawn

--- a/src/dawn/Optimizer/PassSetStageName.cpp
+++ b/src/dawn/Optimizer/PassSetStageName.cpp
@@ -20,7 +20,7 @@ namespace dawn {
 
 PassSetStageName::PassSetStageName() : Pass("PassSetStageName") {}
 
-bool PassSetStageName::run(std::shared_ptr<StencilInstantiation> stencilInstantiation) {
+bool PassSetStageName::run(const std::shared_ptr<StencilInstantiation>& stencilInstantiation) {
   stencilInstantiation->getStageIDToNameMap().clear();
 
   int stencilIdx = 0;

--- a/src/dawn/Optimizer/PassSetStageName.cpp
+++ b/src/dawn/Optimizer/PassSetStageName.cpp
@@ -20,7 +20,7 @@ namespace dawn {
 
 PassSetStageName::PassSetStageName() : Pass("PassSetStageName") {}
 
-bool PassSetStageName::run(StencilInstantiation* stencilInstantiation) {
+bool PassSetStageName::run(std::shared_ptr<StencilInstantiation> stencilInstantiation) {
   stencilInstantiation->getStageIDToNameMap().clear();
 
   int stencilIdx = 0;

--- a/src/dawn/Optimizer/PassSetStageName.h
+++ b/src/dawn/Optimizer/PassSetStageName.h
@@ -28,7 +28,7 @@ public:
   PassSetStageName();
 
   /// @brief Pass implementation
-  bool run(std::shared_ptr<StencilInstantiation> stencilInstantiation) override;
+  bool run(const std::shared_ptr<StencilInstantiation>& stencilInstantiation) override;
 };
 
 } // namespace dawn

--- a/src/dawn/Optimizer/PassSetStageName.h
+++ b/src/dawn/Optimizer/PassSetStageName.h
@@ -28,7 +28,7 @@ public:
   PassSetStageName();
 
   /// @brief Pass implementation
-  bool run(StencilInstantiation* stencilInstantiation) override;
+  bool run(std::shared_ptr<StencilInstantiation> stencilInstantiation) override;
 };
 
 } // namespace dawn

--- a/src/dawn/Optimizer/PassStageMerger.cpp
+++ b/src/dawn/Optimizer/PassStageMerger.cpp
@@ -26,7 +26,7 @@ PassStageMerger::PassStageMerger() : Pass("PassStageMerger") {
   dependencies_.push_back("PassSetStageGraph");
 }
 
-bool PassStageMerger::run(std::shared_ptr<StencilInstantiation> stencilInstantiation) {
+bool PassStageMerger::run(const std::shared_ptr<StencilInstantiation>& stencilInstantiation) {
   OptimizerContext* context = stencilInstantiation->getOptimizerContext();
 
   // Do we need to run this Pass?

--- a/src/dawn/Optimizer/PassStageMerger.cpp
+++ b/src/dawn/Optimizer/PassStageMerger.cpp
@@ -26,7 +26,7 @@ PassStageMerger::PassStageMerger() : Pass("PassStageMerger") {
   dependencies_.push_back("PassSetStageGraph");
 }
 
-bool PassStageMerger::run(StencilInstantiation* stencilInstantiation) {
+bool PassStageMerger::run(std::shared_ptr<StencilInstantiation> stencilInstantiation) {
   OptimizerContext* context = stencilInstantiation->getOptimizerContext();
 
   // Do we need to run this Pass?
@@ -124,7 +124,7 @@ bool PassStageMerger::run(StencilInstantiation* stencilInstantiation) {
                 auto& curDepGraph = curDoMethod.getDependencyGraph();
 
                 auto newDepGraph = std::make_shared<DependencyGraphAccesses>(
-                    stencilInstantiation, candiateDepGraph, curDepGraph);
+                    stencilInstantiation.get(), candiateDepGraph, curDepGraph);
 
                 if(newDepGraph->isDAG() &&
                    !hasHorizontalReadBeforeWriteConflict(newDepGraph.get())) {

--- a/src/dawn/Optimizer/PassStageMerger.h
+++ b/src/dawn/Optimizer/PassStageMerger.h
@@ -35,7 +35,7 @@ public:
   PassStageMerger();
 
   /// @brief Pass implementation
-  bool run(StencilInstantiation* stencilInstantiation) override;
+  bool run(std::shared_ptr<StencilInstantiation> stencilInstantiation) override;
 };
 
 } // namespace dawn

--- a/src/dawn/Optimizer/PassStageMerger.h
+++ b/src/dawn/Optimizer/PassStageMerger.h
@@ -35,7 +35,7 @@ public:
   PassStageMerger();
 
   /// @brief Pass implementation
-  bool run(std::shared_ptr<StencilInstantiation> stencilInstantiation) override;
+  bool run(const std::shared_ptr<StencilInstantiation>& stencilInstantiation) override;
 };
 
 } // namespace dawn

--- a/src/dawn/Optimizer/PassStageReordering.cpp
+++ b/src/dawn/Optimizer/PassStageReordering.cpp
@@ -28,7 +28,7 @@ PassStageReordering::PassStageReordering(ReorderStrategy::ReorderStrategyKind st
   dependencies_.push_back("PassSetStageGraph");
 }
 
-bool PassStageReordering::run(std::shared_ptr<StencilInstantiation> stencilInstantiation) {
+bool PassStageReordering::run(const std::shared_ptr<StencilInstantiation>& stencilInstantiation) {
   OptimizerContext* context = stencilInstantiation->getOptimizerContext();
 
   std::string filenameWE = getFilenameWithoutExtension(context->getSIR()->Filename);

--- a/src/dawn/Optimizer/PassStageReordering.cpp
+++ b/src/dawn/Optimizer/PassStageReordering.cpp
@@ -28,7 +28,7 @@ PassStageReordering::PassStageReordering(ReorderStrategy::ReorderStrategyKind st
   dependencies_.push_back("PassSetStageGraph");
 }
 
-bool PassStageReordering::run(StencilInstantiation* stencilInstantiation) {
+bool PassStageReordering::run(std::shared_ptr<StencilInstantiation> stencilInstantiation) {
   OptimizerContext* context = stencilInstantiation->getOptimizerContext();
 
   std::string filenameWE = getFilenameWithoutExtension(context->getSIR()->Filename);

--- a/src/dawn/Optimizer/PassStageReordering.h
+++ b/src/dawn/Optimizer/PassStageReordering.h
@@ -30,7 +30,7 @@ public:
   PassStageReordering(ReorderStrategy::ReorderStrategyKind strategy);
 
   /// @brief Pass implementation
-  bool run(std::shared_ptr<StencilInstantiation> stencilInstantiation) override;
+  bool run(const std::shared_ptr<StencilInstantiation>& stencilInstantiation) override;
 
 private:
   ReorderStrategy::ReorderStrategyKind strategy_;

--- a/src/dawn/Optimizer/PassStageReordering.h
+++ b/src/dawn/Optimizer/PassStageReordering.h
@@ -30,7 +30,7 @@ public:
   PassStageReordering(ReorderStrategy::ReorderStrategyKind strategy);
 
   /// @brief Pass implementation
-  bool run(StencilInstantiation* stencilInstantiation) override;
+  bool run(std::shared_ptr<StencilInstantiation> stencilInstantiation) override;
 
 private:
   ReorderStrategy::ReorderStrategyKind strategy_;

--- a/src/dawn/Optimizer/PassStageSplitter.cpp
+++ b/src/dawn/Optimizer/PassStageSplitter.cpp
@@ -30,7 +30,7 @@ namespace dawn {
 
 PassStageSplitter::PassStageSplitter() : Pass("PassStageSplitter") {}
 
-bool PassStageSplitter::run(StencilInstantiation* stencilInstantiation) {
+bool PassStageSplitter::run(std::shared_ptr<StencilInstantiation> stencilInstantiation) {
   int numSplit = 0;
   std::deque<int> splitterIndices;
   std::deque<std::shared_ptr<DependencyGraphAccesses>> graphs;
@@ -53,7 +53,7 @@ bool PassStageSplitter::run(StencilInstantiation* stencilInstantiation) {
         graphs.clear();
 
         std::shared_ptr<DependencyGraphAccesses> newGraph, oldGraph;
-        newGraph = std::make_shared<DependencyGraphAccesses>(stencilInstantiation);
+        newGraph = std::make_shared<DependencyGraphAccesses>(stencilInstantiation.get());
 
         // Build the Dependency graph (bottom to top)
         for(int stmtIndex = doMethod.getStatementAccessesPairs().size() - 1; stmtIndex >= 0;

--- a/src/dawn/Optimizer/PassStageSplitter.cpp
+++ b/src/dawn/Optimizer/PassStageSplitter.cpp
@@ -30,7 +30,7 @@ namespace dawn {
 
 PassStageSplitter::PassStageSplitter() : Pass("PassStageSplitter") {}
 
-bool PassStageSplitter::run(std::shared_ptr<StencilInstantiation> stencilInstantiation) {
+bool PassStageSplitter::run(const std::shared_ptr<StencilInstantiation>& stencilInstantiation) {
   int numSplit = 0;
   std::deque<int> splitterIndices;
   std::deque<std::shared_ptr<DependencyGraphAccesses>> graphs;

--- a/src/dawn/Optimizer/PassStageSplitter.h
+++ b/src/dawn/Optimizer/PassStageSplitter.h
@@ -29,7 +29,7 @@ public:
   PassStageSplitter();
 
   /// @brief Pass implementation
-  bool run(std::shared_ptr<StencilInstantiation> stencilInstantiation) override;
+  bool run(const std::shared_ptr<StencilInstantiation>& stencilInstantiation) override;
 };
 
 } // namespace dawn

--- a/src/dawn/Optimizer/PassStageSplitter.h
+++ b/src/dawn/Optimizer/PassStageSplitter.h
@@ -29,7 +29,7 @@ public:
   PassStageSplitter();
 
   /// @brief Pass implementation
-  bool run(StencilInstantiation* stencilInstantiation) override;
+  bool run(std::shared_ptr<StencilInstantiation> stencilInstantiation) override;
 };
 
 } // namespace dawn

--- a/src/dawn/Optimizer/PassStencilSplitter.cpp
+++ b/src/dawn/Optimizer/PassStencilSplitter.cpp
@@ -46,7 +46,7 @@ PassStencilSplitter::PassStencilSplitter() : Pass("PassStencilSplitter") {
   dependencies_.push_back("PassSetStageGraph");
 }
 
-bool PassStencilSplitter::run(StencilInstantiation* stencilInstantiation) {
+bool PassStencilSplitter::run(std::shared_ptr<StencilInstantiation> stencilInstantiation) {
   OptimizerContext* context = stencilInstantiation->getOptimizerContext();
 
   if(context->getOptions().SplitStencils) {
@@ -66,7 +66,7 @@ bool PassStencilSplitter::run(StencilInstantiation* stencilInstantiation) {
         rerunPassSetStageGraph = true;
 
         newStencils.emplace_back(std::make_shared<Stencil>(
-            stencilInstantiation, stencil.getSIRStencil(), stencilInstantiation->nextUID()));
+            *stencilInstantiation, stencil.getSIRStencil(), stencilInstantiation->nextUID()));
         std::shared_ptr<Stencil> newStencil = newStencils.back();
 
         std::set<int> fieldsInNewStencil;
@@ -78,7 +78,7 @@ bool PassStencilSplitter::run(StencilInstantiation* stencilInstantiation) {
           // Create an empty multi-stage in the current stencil with the same parameter as
           // `multiStage`
           newStencil->getMultiStages().push_back(
-              std::make_shared<MultiStage>(stencilInstantiation, multiStage.getLoopOrder()));
+              std::make_shared<MultiStage>(*stencilInstantiation, multiStage.getLoopOrder()));
 
           for(std::shared_ptr<Stage>& stagePtr : multiStage.getStages()) {
             if(newStencil->isEmpty() ||
@@ -95,13 +95,13 @@ bool PassStencilSplitter::run(StencilInstantiation* stencilInstantiation) {
             } else {
               // Make a new stencil
               newStencils.emplace_back(std::make_shared<Stencil>(
-                  stencilInstantiation, stencil.getSIRStencil(), stencilInstantiation->nextUID()));
+                  *stencilInstantiation, stencil.getSIRStencil(), stencilInstantiation->nextUID()));
               newStencil = newStencils.back();
               fieldsInNewStencil.clear();
 
               // Re-create the current multi-stage in the `newStencil` and insert the stage
               newStencil->getMultiStages().push_back(
-                  std::make_shared<MultiStage>(stencilInstantiation, multiStage.getLoopOrder()));
+                  std::make_shared<MultiStage>(*stencilInstantiation, multiStage.getLoopOrder()));
               newStencil->getMultiStages().back()->getStages().push_back(stagePtr);
             }
           }
@@ -112,7 +112,7 @@ bool PassStencilSplitter::run(StencilInstantiation* stencilInstantiation) {
       if(!newStencils.empty()) {
 
         // Repair broken references to temporaries i.e promote them to real fields
-        PassTemporaryType::fixTemporariesSpanningMultipleStencils(stencilInstantiation,
+        PassTemporaryType::fixTemporariesSpanningMultipleStencils(stencilInstantiation.get(),
                                                                   newStencils);
 
         // Remove empty multi-stages within the stencils

--- a/src/dawn/Optimizer/PassStencilSplitter.cpp
+++ b/src/dawn/Optimizer/PassStencilSplitter.cpp
@@ -46,7 +46,7 @@ PassStencilSplitter::PassStencilSplitter() : Pass("PassStencilSplitter") {
   dependencies_.push_back("PassSetStageGraph");
 }
 
-bool PassStencilSplitter::run(std::shared_ptr<StencilInstantiation> stencilInstantiation) {
+bool PassStencilSplitter::run(const std::shared_ptr<StencilInstantiation>& stencilInstantiation) {
   OptimizerContext* context = stencilInstantiation->getOptimizerContext();
 
   if(context->getOptions().SplitStencils) {

--- a/src/dawn/Optimizer/PassStencilSplitter.cpp
+++ b/src/dawn/Optimizer/PassStencilSplitter.cpp
@@ -32,7 +32,7 @@ static int mergePossible(const std::set<int>& fields, const Stage* stage, int ma
   int numFields = fields.size();
 
   for(const Field& field : stage->getFields())
-    if(!fields.count(field.AccessID))
+    if(!fields.count(field.getAccessID()))
       numFields++;
 
   // Inserting the stage would further increase the number of fields
@@ -90,7 +90,7 @@ bool PassStencilSplitter::run(std::shared_ptr<StencilInstantiation> stencilInsta
               // Update fields of the `newStencil`. Note that the indivudual stages do not need to
               // update their fields as they remain the same.
               for(const Field& field : stagePtr->getFields())
-                fieldsInNewStencil.insert(field.AccessID);
+                fieldsInNewStencil.insert(field.getAccessID());
 
             } else {
               // Make a new stencil

--- a/src/dawn/Optimizer/PassStencilSplitter.h
+++ b/src/dawn/Optimizer/PassStencilSplitter.h
@@ -34,7 +34,7 @@ public:
   static constexpr int MaxFieldPerStencil = 40;
 
   /// @brief Pass implementation
-  bool run(std::shared_ptr<StencilInstantiation> stencilInstantiation) override;
+  bool run(const std::shared_ptr<StencilInstantiation>& stencilInstantiation) override;
 };
 
 } // namespace dawn

--- a/src/dawn/Optimizer/PassStencilSplitter.h
+++ b/src/dawn/Optimizer/PassStencilSplitter.h
@@ -34,7 +34,7 @@ public:
   static constexpr int MaxFieldPerStencil = 40;
 
   /// @brief Pass implementation
-  bool run(StencilInstantiation* stencilInstantiation) override;
+  bool run(std::shared_ptr<StencilInstantiation> stencilInstantiation) override;
 };
 
 } // namespace dawn

--- a/src/dawn/Optimizer/PassTemporaryFirstAccess.cpp
+++ b/src/dawn/Optimizer/PassTemporaryFirstAccess.cpp
@@ -29,11 +29,11 @@ namespace {
 class UnusedFieldVisitor : public ASTVisitorForwarding {
   int AccessID_;
   bool fieldIsUnused_;
-  std::shared_ptr<StencilInstantiation> instantiation_;
+  const std::shared_ptr<StencilInstantiation>& instantiation_;
   std::stack<StencilFunctionInstantiation*> functionInstantiationStack_;
 
 public:
-  UnusedFieldVisitor(int AccessID, std::shared_ptr<StencilInstantiation> instantiation)
+  UnusedFieldVisitor(int AccessID, const std::shared_ptr<StencilInstantiation>& instantiation)
       : AccessID_(AccessID), fieldIsUnused_(false), instantiation_(instantiation) {}
 
   StencilFunctionInstantiation*
@@ -64,7 +64,8 @@ public:
 
 PassTemporaryFirstAccess::PassTemporaryFirstAccess() : Pass("PassTemporaryFirstAccess") {}
 
-bool PassTemporaryFirstAccess::run(std::shared_ptr<StencilInstantiation> stencilInstantiation) {
+bool PassTemporaryFirstAccess::run(
+    const std::shared_ptr<StencilInstantiation>& stencilInstantiation) {
   OptimizerContext* context = stencilInstantiation->getOptimizerContext();
 
   for(auto& stencilPtr : stencilInstantiation->getStencils()) {

--- a/src/dawn/Optimizer/PassTemporaryFirstAccess.cpp
+++ b/src/dawn/Optimizer/PassTemporaryFirstAccess.cpp
@@ -29,11 +29,11 @@ namespace {
 class UnusedFieldVisitor : public ASTVisitorForwarding {
   int AccessID_;
   bool fieldIsUnused_;
-  StencilInstantiation* instantiation_;
+  std::shared_ptr<StencilInstantiation> instantiation_;
   std::stack<StencilFunctionInstantiation*> functionInstantiationStack_;
 
 public:
-  UnusedFieldVisitor(int AccessID, StencilInstantiation* instantiation)
+  UnusedFieldVisitor(int AccessID, std::shared_ptr<StencilInstantiation> instantiation)
       : AccessID_(AccessID), fieldIsUnused_(false), instantiation_(instantiation) {}
 
   StencilFunctionInstantiation*
@@ -64,7 +64,7 @@ public:
 
 PassTemporaryFirstAccess::PassTemporaryFirstAccess() : Pass("PassTemporaryFirstAccess") {}
 
-bool PassTemporaryFirstAccess::run(StencilInstantiation* stencilInstantiation) {
+bool PassTemporaryFirstAccess::run(std::shared_ptr<StencilInstantiation> stencilInstantiation) {
   OptimizerContext* context = stencilInstantiation->getOptimizerContext();
 
   for(auto& stencilPtr : stencilInstantiation->getStencils()) {

--- a/src/dawn/Optimizer/PassTemporaryFirstAccess.h
+++ b/src/dawn/Optimizer/PassTemporaryFirstAccess.h
@@ -27,7 +27,7 @@ public:
   PassTemporaryFirstAccess();
 
   /// @brief Pass implementation
-  bool run(StencilInstantiation* stencilInstantiation) override;
+  bool run(std::shared_ptr<StencilInstantiation> stencilInstantiation) override;
 };
 
 } // namespace dawn

--- a/src/dawn/Optimizer/PassTemporaryFirstAccess.h
+++ b/src/dawn/Optimizer/PassTemporaryFirstAccess.h
@@ -27,7 +27,7 @@ public:
   PassTemporaryFirstAccess();
 
   /// @brief Pass implementation
-  bool run(std::shared_ptr<StencilInstantiation> stencilInstantiation) override;
+  bool run(const std::shared_ptr<StencilInstantiation>& stencilInstantiation) override;
 };
 
 } // namespace dawn

--- a/src/dawn/Optimizer/PassTemporaryMerger.cpp
+++ b/src/dawn/Optimizer/PassTemporaryMerger.cpp
@@ -25,7 +25,7 @@ namespace dawn {
 
 PassTemporaryMerger::PassTemporaryMerger() : Pass("PassTemporaryMerger") {}
 
-bool PassTemporaryMerger::run(std::shared_ptr<StencilInstantiation> stencilInstantiation) {
+bool PassTemporaryMerger::run(const std::shared_ptr<StencilInstantiation>& stencilInstantiation) {
   using Edge = DependencyGraphAccesses::Edge;
   using Vertex = DependencyGraphAccesses::Vertex;
 

--- a/src/dawn/Optimizer/PassTemporaryMerger.cpp
+++ b/src/dawn/Optimizer/PassTemporaryMerger.cpp
@@ -25,7 +25,7 @@ namespace dawn {
 
 PassTemporaryMerger::PassTemporaryMerger() : Pass("PassTemporaryMerger") {}
 
-bool PassTemporaryMerger::run(StencilInstantiation* stencilInstantiation) {
+bool PassTemporaryMerger::run(std::shared_ptr<StencilInstantiation> stencilInstantiation) {
   using Edge = DependencyGraphAccesses::Edge;
   using Vertex = DependencyGraphAccesses::Vertex;
 
@@ -50,7 +50,7 @@ bool PassTemporaryMerger::run(StencilInstantiation* stencilInstantiation) {
     Stencil& stencil = *stencilPtr;
 
     // Build the dependency graph of the stencil (merge all dependency graphs of the multi-stages)
-    DependencyGraphAccesses AccessesDAG(stencilInstantiation);
+    DependencyGraphAccesses AccessesDAG(stencilInstantiation.get());
     for(const auto& multiStagePtr : stencilPtr->getMultiStages()) {
       MultiStage& multiStage = *multiStagePtr;
       AccessesDAG.merge(multiStage.getDependencyGraphOfAxis().get());
@@ -58,7 +58,7 @@ bool PassTemporaryMerger::run(StencilInstantiation* stencilInstantiation) {
     const auto& adjacencyList = AccessesDAG.getAdjacencyList();
 
     // Build the dependency graph of the temporaries
-    DependencyGraphAccesses TemporaryDAG(stencilInstantiation);
+    DependencyGraphAccesses TemporaryDAG(stencilInstantiation.get());
     int AccessIDOfLastTemporary = -1;
     for(std::size_t VertexID : AccessesDAG.getOutputVertexIDs()) {
       nodesToVisit.clear();

--- a/src/dawn/Optimizer/PassTemporaryMerger.h
+++ b/src/dawn/Optimizer/PassTemporaryMerger.h
@@ -26,7 +26,7 @@ public:
   PassTemporaryMerger();
 
   /// @brief Pass implementation
-  bool run(StencilInstantiation* stencilInstantiation) override;
+  bool run(std::shared_ptr<StencilInstantiation> stencilInstantiation) override;
 };
 
 } // namespace dawn

--- a/src/dawn/Optimizer/PassTemporaryMerger.h
+++ b/src/dawn/Optimizer/PassTemporaryMerger.h
@@ -26,7 +26,7 @@ public:
   PassTemporaryMerger();
 
   /// @brief Pass implementation
-  bool run(std::shared_ptr<StencilInstantiation> stencilInstantiation) override;
+  bool run(const std::shared_ptr<StencilInstantiation>& stencilInstantiation) override;
 };
 
 } // namespace dawn

--- a/src/dawn/Optimizer/PassTemporaryType.cpp
+++ b/src/dawn/Optimizer/PassTemporaryType.cpp
@@ -57,7 +57,7 @@ public:
 /// @brief Check if a field, given by `AccessID` is used as an argument of a stencil-function inside
 /// any statement of the `stencil`
 /// @returns `true` if field is used as an argument
-bool usedAsArgumentInStencilFun(std::shared_ptr<Stencil> stencil, int AccessID) {
+bool usedAsArgumentInStencilFun(const std::shared_ptr<Stencil>& stencil, int AccessID) {
   StencilFunArgumentDetector visitor(stencil->getStencilInstantiation(), AccessID);
   stencil->accept(visitor);
   return visitor.usedInStencilFun();
@@ -77,7 +77,7 @@ struct Temporary {
   Extents Extent;             ///< Accumulated access of the temporary during its lifetime
 
   /// @brief Dump the temporary
-  void dump(std::shared_ptr<StencilInstantiation> instantiation) const {
+  void dump(const std::shared_ptr<StencilInstantiation>& instantiation) const {
     std::cout << "Temporary : " << instantiation->getNameFromAccessID(AccessID) << " {"
               << "\n  Type=" << (Type == TT_LocalVariable ? "LocalVariable" : "Field")
               << ",\n  Lifetime=" << Lifetime << ",\n  Extent=" << Extent << "\n}\n";
@@ -88,7 +88,7 @@ struct Temporary {
 
 PassTemporaryType::PassTemporaryType() : Pass("PassTemporaryType") {}
 
-bool PassTemporaryType::run(std::shared_ptr<StencilInstantiation> instantiation) {
+bool PassTemporaryType::run(const std::shared_ptr<StencilInstantiation>& instantiation) {
   OptimizerContext* context = instantiation->getOptimizerContext();
 
   std::unordered_map<int, Temporary> temporaries;

--- a/src/dawn/Optimizer/PassTemporaryType.cpp
+++ b/src/dawn/Optimizer/PassTemporaryType.cpp
@@ -29,14 +29,14 @@ namespace dawn {
 namespace {
 
 class StencilFunArgumentDetector : public ASTVisitorForwarding {
-  StencilInstantiation* instantiation_;
+  StencilInstantiation& instantiation_;
   int AccessID_;
 
   int argListNesting_;
   bool usedInStencilFun_;
 
 public:
-  StencilFunArgumentDetector(StencilInstantiation* instantiation, int AccessID)
+  StencilFunArgumentDetector(StencilInstantiation& instantiation, int AccessID)
       : instantiation_(instantiation), AccessID_(AccessID), argListNesting_(0),
         usedInStencilFun_(false) {}
 
@@ -47,7 +47,7 @@ public:
   }
 
   virtual void visit(const std::shared_ptr<FieldAccessExpr>& expr) override {
-    if(argListNesting_ > 0 && instantiation_->getAccessIDFromExpr(expr) == AccessID_)
+    if(argListNesting_ > 0 && instantiation_.getAccessIDFromExpr(expr) == AccessID_)
       usedInStencilFun_ = true;
   }
 
@@ -57,7 +57,7 @@ public:
 /// @brief Check if a field, given by `AccessID` is used as an argument of a stencil-function inside
 /// any statement of the `stencil`
 /// @returns `true` if field is used as an argument
-bool usedAsArgumentInStencilFun(Stencil* stencil, int AccessID) {
+bool usedAsArgumentInStencilFun(std::shared_ptr<Stencil> stencil, int AccessID) {
   StencilFunArgumentDetector visitor(stencil->getStencilInstantiation(), AccessID);
   stencil->accept(visitor);
   return visitor.usedInStencilFun();
@@ -77,7 +77,7 @@ struct Temporary {
   Extents Extent;             ///< Accumulated access of the temporary during its lifetime
 
   /// @brief Dump the temporary
-  void dump(StencilInstantiation* instantiation) const {
+  void dump(std::shared_ptr<StencilInstantiation> instantiation) const {
     std::cout << "Temporary : " << instantiation->getNameFromAccessID(AccessID) << " {"
               << "\n  Type=" << (Type == TT_LocalVariable ? "LocalVariable" : "Field")
               << ",\n  Lifetime=" << Lifetime << ",\n  Extent=" << Extent << "\n}\n";
@@ -88,7 +88,7 @@ struct Temporary {
 
 PassTemporaryType::PassTemporaryType() : Pass("PassTemporaryType") {}
 
-bool PassTemporaryType::run(StencilInstantiation* instantiation) {
+bool PassTemporaryType::run(std::shared_ptr<StencilInstantiation> instantiation) {
   OptimizerContext* context = instantiation->getOptimizerContext();
 
   std::unordered_map<int, Temporary> temporaries;
@@ -171,8 +171,7 @@ bool PassTemporaryType::run(StencilInstantiation* instantiation) {
         // If the field is only accessed within the same Do-Method, does not have an extent and is
         // not argument to a stencil function, we can demote it to a local variable
         if(temporary.Lifetime.Begin.inSameDoMethod(temporary.Lifetime.End) &&
-           temporary.Extent.isPointwise() &&
-           !usedAsArgumentInStencilFun(stencilPtr.get(), AccessID)) {
+           temporary.Extent.isPointwise() && !usedAsArgumentInStencilFun(stencilPtr, AccessID)) {
 
           if(context->getOptions().ReportPassTemporaryType)
             report("demote");

--- a/src/dawn/Optimizer/PassTemporaryType.h
+++ b/src/dawn/Optimizer/PassTemporaryType.h
@@ -66,7 +66,7 @@ public:
   PassTemporaryType();
 
   /// @brief Pass implementation
-  bool run(StencilInstantiation* stencilInstantiation) override;
+  bool run(std::shared_ptr<StencilInstantiation> stencilInstantiation) override;
 
   /// @brief Promote a temporary fields which span over multiple stencils to real (allocated)
   /// storage

--- a/src/dawn/Optimizer/PassTemporaryType.h
+++ b/src/dawn/Optimizer/PassTemporaryType.h
@@ -66,7 +66,7 @@ public:
   PassTemporaryType();
 
   /// @brief Pass implementation
-  bool run(std::shared_ptr<StencilInstantiation> stencilInstantiation) override;
+  bool run(const std::shared_ptr<StencilInstantiation>& stencilInstantiation) override;
 
   /// @brief Promote a temporary fields which span over multiple stencils to real (allocated)
   /// storage

--- a/src/dawn/Optimizer/ReorderStrategyGreedy.cpp
+++ b/src/dawn/Optimizer/ReorderStrategyGreedy.cpp
@@ -86,7 +86,7 @@ std::shared_ptr<Stencil> ReoderStrategyGreedy::reorder(const std::shared_ptr<Ste
   Stencil& stencil = *stencilPtr;
 
   DependencyGraphStage& stageDAG = *stencil.getStageDependencyGraph();
-  StencilInstantiation* instantiation = stencil.getStencilInstantiation();
+  StencilInstantiation& instantiation = stencil.getStencilInstantiation();
 
   std::shared_ptr<Stencil> newStencil =
       std::make_shared<Stencil>(instantiation, stencil.getSIRStencil(), stencilPtr->getStencilID(),
@@ -94,7 +94,7 @@ std::shared_ptr<Stencil> ReoderStrategyGreedy::reorder(const std::shared_ptr<Ste
   int newNumStages = 0;
   int newNumMultiStages = 0;
 
-  const int maxBoundaryExtent = instantiation->getOptimizerContext()->getOptions().MaxHaloPoints;
+  const int maxBoundaryExtent = instantiation.getOptimizerContext()->getOptions().MaxHaloPoints;
 
   auto pushBackNewMultiStage = [&](LoopOrderKind loopOrder) -> void {
     newStencil->getMultiStages().push_back(std::make_shared<MultiStage>(instantiation, loopOrder));
@@ -143,10 +143,10 @@ std::shared_ptr<Stencil> ReoderStrategyGreedy::reorder(const std::shared_ptr<Ste
             } else if(lastChance) {
               // Our stage exceeds the maximum allowed boundary extents... nothing we can do
               DiagnosticsBuilder diag(DiagnosticsKind::Error, SourceLocation());
-              diag << "stencil '" << instantiation->getName()
+              diag << "stencil '" << instantiation.getName()
                    << "' exceeds maximum number of allowed halo lines (" << maxBoundaryExtent
                    << ")";
-              instantiation->getOptimizerContext()->getDiagnostics().report(diag);
+              instantiation.getOptimizerContext()->getDiagnostics().report(diag);
               return nullptr;
             }
           }

--- a/src/dawn/Optimizer/Replacing.cpp
+++ b/src/dawn/Optimizer/Replacing.cpp
@@ -111,13 +111,13 @@ namespace {
 
 /// @brief Get all field and variable accesses identifier by `AccessID`
 class GetStencilCalls : public ASTVisitorForwarding {
-  std::shared_ptr<StencilInstantiation> instantiation_;
+  const std::shared_ptr<StencilInstantiation>& instantiation_;
   int StencilID_;
 
   std::vector<std::shared_ptr<StencilCallDeclStmt>> stencilCallsToReplace_;
 
 public:
-  GetStencilCalls(std::shared_ptr<StencilInstantiation> instantiation, int StencilID)
+  GetStencilCalls(const std::shared_ptr<StencilInstantiation>& instantiation, int StencilID)
       : instantiation_(instantiation), StencilID_(StencilID) {}
 
   void visit(const std::shared_ptr<StencilCallDeclStmt>& stmt) override {
@@ -134,8 +134,8 @@ public:
 
 } // anonymous namespace
 
-void replaceStencilCalls(std::shared_ptr<StencilInstantiation> instantiation, int oldStencilID,
-                         const std::vector<int>& newStencilIDs) {
+void replaceStencilCalls(const std::shared_ptr<StencilInstantiation>& instantiation,
+                         int oldStencilID, const std::vector<int>& newStencilIDs) {
   GetStencilCalls visitor(instantiation, oldStencilID);
 
   for(auto& statement : instantiation->getStencilDescStatements()) {

--- a/src/dawn/Optimizer/Replacing.cpp
+++ b/src/dawn/Optimizer/Replacing.cpp
@@ -25,23 +25,23 @@ namespace {
 
 /// @brief Get all field and variable accesses identifier by `AccessID`
 class GetFieldAndVarAccesses : public ASTVisitorForwarding {
-  StencilInstantiation* instantiation_;
+  StencilInstantiation& instantiation_;
   int AccessID_;
 
   std::vector<std::shared_ptr<FieldAccessExpr>> fieldAccessExprToReplace_;
   std::vector<std::shared_ptr<VarAccessExpr>> varAccessesToReplace_;
 
 public:
-  GetFieldAndVarAccesses(StencilInstantiation* instantiation, int AccessID)
+  GetFieldAndVarAccesses(StencilInstantiation& instantiation, int AccessID)
       : instantiation_(instantiation), AccessID_(AccessID) {}
 
   void visit(const std::shared_ptr<VarAccessExpr>& expr) override {
-    if(instantiation_->getAccessIDFromExpr(expr) == AccessID_)
+    if(instantiation_.getAccessIDFromExpr(expr) == AccessID_)
       varAccessesToReplace_.emplace_back(expr);
   }
 
   void visit(const std::shared_ptr<FieldAccessExpr>& expr) override {
-    if(instantiation_->getAccessIDFromExpr(expr) == AccessID_)
+    if(instantiation_.getAccessIDFromExpr(expr) == AccessID_)
       fieldAccessExprToReplace_.emplace_back(expr);
   }
 
@@ -64,7 +64,7 @@ public:
 void replaceFieldWithVarAccessInStmts(
     Stencil* stencil, int AccessID, const std::string& varname,
     ArrayRef<std::shared_ptr<StatementAccessesPair>> statementAccessesPairs) {
-  StencilInstantiation* instantiation = stencil->getStencilInstantiation();
+  StencilInstantiation& instantiation = stencil->getStencilInstantiation();
 
   GetFieldAndVarAccesses visitor(instantiation, AccessID);
   for(const auto& statementAccessesPair : statementAccessesPairs) {
@@ -78,8 +78,8 @@ void replaceFieldWithVarAccessInStmts(
 
       replaceOldExprWithNewExprInStmt(stmt, oldExpr, newExpr);
 
-      instantiation->mapExprToAccessID(newExpr, AccessID);
-      instantiation->eraseExprToAccessID(oldExpr);
+      instantiation.mapExprToAccessID(newExpr, AccessID);
+      instantiation.eraseExprToAccessID(oldExpr);
     }
   }
 }
@@ -87,7 +87,7 @@ void replaceFieldWithVarAccessInStmts(
 void replaceVarWithFieldAccessInStmts(
     Stencil* stencil, int AccessID, const std::string& fieldname,
     ArrayRef<std::shared_ptr<StatementAccessesPair>> statementAccessesPairs) {
-  StencilInstantiation* instantiation = stencil->getStencilInstantiation();
+  StencilInstantiation& instantiation = stencil->getStencilInstantiation();
 
   GetFieldAndVarAccesses visitor(instantiation, AccessID);
   for(const auto& statementAccessesPair : statementAccessesPairs) {
@@ -101,8 +101,8 @@ void replaceVarWithFieldAccessInStmts(
 
       replaceOldExprWithNewExprInStmt(stmt, oldExpr, newExpr);
 
-      instantiation->mapExprToAccessID(newExpr, AccessID);
-      instantiation->eraseExprToAccessID(oldExpr);
+      instantiation.mapExprToAccessID(newExpr, AccessID);
+      instantiation.eraseExprToAccessID(oldExpr);
     }
   }
 }
@@ -111,13 +111,13 @@ namespace {
 
 /// @brief Get all field and variable accesses identifier by `AccessID`
 class GetStencilCalls : public ASTVisitorForwarding {
-  StencilInstantiation* instantiation_;
+  std::shared_ptr<StencilInstantiation> instantiation_;
   int StencilID_;
 
   std::vector<std::shared_ptr<StencilCallDeclStmt>> stencilCallsToReplace_;
 
 public:
-  GetStencilCalls(StencilInstantiation* instantiation, int StencilID)
+  GetStencilCalls(std::shared_ptr<StencilInstantiation> instantiation, int StencilID)
       : instantiation_(instantiation), StencilID_(StencilID) {}
 
   void visit(const std::shared_ptr<StencilCallDeclStmt>& stmt) override {
@@ -134,7 +134,7 @@ public:
 
 } // anonymous namespace
 
-void replaceStencilCalls(StencilInstantiation* instantiation, int oldStencilID,
+void replaceStencilCalls(std::shared_ptr<StencilInstantiation> instantiation, int oldStencilID,
                          const std::vector<int>& newStencilIDs) {
   GetStencilCalls visitor(instantiation, oldStencilID);
 

--- a/src/dawn/Optimizer/Replacing.h
+++ b/src/dawn/Optimizer/Replacing.h
@@ -45,8 +45,8 @@ void replaceVarWithFieldAccessInStmts(
 
 /// @brief Replace all stencil calls to `oldStencilID` with a series of stencil calls to
 /// `newStencilIDs` in the stencil description AST of `instantiation`
-void replaceStencilCalls(std::shared_ptr<StencilInstantiation> instantiation, int oldStencilID,
-                         const std::vector<int>& newStencilIDs);
+void replaceStencilCalls(const std::shared_ptr<StencilInstantiation>& instantiation,
+                         int oldStencilID, const std::vector<int>& newStencilIDs);
 
 /// @}
 

--- a/src/dawn/Optimizer/Replacing.h
+++ b/src/dawn/Optimizer/Replacing.h
@@ -45,7 +45,7 @@ void replaceVarWithFieldAccessInStmts(
 
 /// @brief Replace all stencil calls to `oldStencilID` with a series of stencil calls to
 /// `newStencilIDs` in the stencil description AST of `instantiation`
-void replaceStencilCalls(StencilInstantiation* instantiation, int oldStencilID,
+void replaceStencilCalls(std::shared_ptr<StencilInstantiation> instantiation, int oldStencilID,
                          const std::vector<int>& newStencilIDs);
 
 /// @}

--- a/src/dawn/Optimizer/Stage.cpp
+++ b/src/dawn/Optimizer/Stage.cpp
@@ -185,6 +185,7 @@ void Stage::update() {
         if(inputFields.count(AccessID)) {
           Field& preField = inputFields.at(AccessID);
           preField.extendInterval(doMethod.getInterval());
+          preField.setIntend(Field::IK_InputOutput);
           inputOutputFields.insert({AccessID, preField});
           inputFields.erase(AccessID);
           continue;
@@ -218,6 +219,7 @@ void Stage::update() {
         if(outputFields.count(AccessID)) {
           Field& preField = outputFields.at(AccessID);
           preField.extendInterval(doMethod.getInterval());
+          preField.setIntend(Field::IK_InputOutput);
           inputOutputFields.insert({AccessID, preField});
 
           outputFields.erase(AccessID);

--- a/src/dawn/Optimizer/Stage.h
+++ b/src/dawn/Optimizer/Stage.h
@@ -38,7 +38,7 @@ class MultiStage;
 ///
 /// @ingroup optimizer
 class Stage {
-  StencilInstantiation* stencilInstantiation_;
+  StencilInstantiation& stencilInstantiation_;
   MultiStage* multiStage_;
 
   /// Unique identifier of the stage
@@ -60,7 +60,7 @@ class Stage {
 public:
   /// @name Constructors and Assignment
   /// @{
-  Stage(StencilInstantiation* context, MultiStage* multiStage, int StageID,
+  Stage(StencilInstantiation& context, MultiStage* multiStage, int StageID,
         const Interval& interval);
   Stage(const Stage&) = default;
   Stage(Stage&&) = default;

--- a/src/dawn/Optimizer/Stencil.cpp
+++ b/src/dawn/Optimizer/Stencil.cpp
@@ -92,8 +92,9 @@ bool Stencil::Lifetime::overlaps(const Stencil::Lifetime& other) const {
   return lowerBoundOverlap && upperBoundOverlap;
 }
 
-Stencil::Stencil(StencilInstantiation* stencilInstantiation, const sir::Stencil* SIRStencil,
-                 int StencilID, std::shared_ptr<DependencyGraphStage> stageDependencyGraph)
+Stencil::Stencil(StencilInstantiation& stencilInstantiation,
+                 const std::shared_ptr<sir::Stencil> SIRStencil, int StencilID,
+                 std::shared_ptr<DependencyGraphStage> stageDependencyGraph)
     : stencilInstantiation_(stencilInstantiation), SIRStencil_(SIRStencil), StencilID_(StencilID),
       stageDependencyGraph_(stageDependencyGraph) {}
 
@@ -120,8 +121,8 @@ std::vector<Stencil::FieldInfo> Stencil::getFields(bool withTemporaries) const {
   std::vector<FieldInfo> fields;
 
   for(const auto& AccessID : fieldAccessIDs) {
-    std::string name = stencilInstantiation_->getNameFromAccessID(AccessID);
-    bool isTemporary = stencilInstantiation_->isTemporaryField(AccessID);
+    std::string name = stencilInstantiation_.getNameFromAccessID(AccessID);
+    bool isTemporary = stencilInstantiation_.isTemporaryField(AccessID);
 
     if(isTemporary) {
       if(withTemporaries) {
@@ -146,7 +147,7 @@ std::vector<std::string> Stencil::getGlobalVariables() const {
 
   std::vector<std::string> globalVariables;
   for(const auto& AccessID : globalVariableAccessIDs)
-    globalVariables.push_back(stencilInstantiation_->getNameFromAccessID(AccessID));
+    globalVariables.push_back(stencilInstantiation_.getNameFromAccessID(AccessID));
 
   return globalVariables;
 }
@@ -405,7 +406,7 @@ bool Stencil::isEmpty() const {
   return true;
 }
 
-const sir::Stencil* Stencil::getSIRStencil() const { return SIRStencil_; }
+const std::shared_ptr<sir::Stencil> Stencil::getSIRStencil() const { return SIRStencil_; }
 
 void Stencil::accept(ASTVisitor& visitor) {
   for(const auto& multistagePtr : multistages_)
@@ -420,12 +421,12 @@ std::ostream& operator<<(std::ostream& os, const Stencil& stencil) {
   for(const auto& MS : stencil.getMultiStages()) {
     os << "MultiStage " << (multiStageIdx++) << ": (" << MS->getLoopOrder() << ")\n";
     for(const auto& stage : MS->getStages())
-      os << "  " << stencil.getStencilInstantiation()->getNameFromStageID(stage->getStageID())
-         << " " << RangeToString()(stage->getFields(),
-                                   [&](const Field& field) {
-                                     return stencil.getStencilInstantiation()->getNameFromAccessID(
-                                         field.AccessID);
-                                   })
+      os << "  " << stencil.getStencilInstantiation().getNameFromStageID(stage->getStageID()) << " "
+         << RangeToString()(stage->getFields(),
+                            [&](const Field& field) {
+                              return stencil.getStencilInstantiation().getNameFromAccessID(
+                                  field.AccessID);
+                            })
          << "\n";
   }
   return os;

--- a/src/dawn/Optimizer/Stencil.cpp
+++ b/src/dawn/Optimizer/Stencil.cpp
@@ -93,8 +93,8 @@ bool Stencil::Lifetime::overlaps(const Stencil::Lifetime& other) const {
 }
 
 Stencil::Stencil(StencilInstantiation& stencilInstantiation,
-                 const std::shared_ptr<sir::Stencil> SIRStencil, int StencilID,
-                 std::shared_ptr<DependencyGraphStage> stageDependencyGraph)
+                 const std::shared_ptr<sir::Stencil>& SIRStencil, int StencilID,
+                 const std::shared_ptr<DependencyGraphStage>& stageDependencyGraph)
     : stencilInstantiation_(stencilInstantiation), SIRStencil_(SIRStencil), StencilID_(StencilID),
       stageDependencyGraph_(stageDependencyGraph) {}
 

--- a/src/dawn/Optimizer/Stencil.cpp
+++ b/src/dawn/Optimizer/Stencil.cpp
@@ -406,6 +406,19 @@ bool Stencil::isEmpty() const {
   return true;
 }
 
+std::shared_ptr<Interval> Stencil::getEnclosingIntervalTemporaries() const {
+  std::shared_ptr<Interval> tmpInterval;
+  for(auto mss : getMultiStages()) {
+    auto mssInterval = mss->getEnclosingAccessIntervalTemporaries();
+    if(tmpInterval != nullptr && mssInterval != nullptr) {
+      tmpInterval->merge(*mssInterval);
+    } else if(mssInterval != nullptr) {
+      tmpInterval = mssInterval;
+    }
+  }
+  return tmpInterval;
+}
+
 const std::shared_ptr<sir::Stencil> Stencil::getSIRStencil() const { return SIRStencil_; }
 
 void Stencil::accept(ASTVisitor& visitor) {

--- a/src/dawn/Optimizer/Stencil.cpp
+++ b/src/dawn/Optimizer/Stencil.cpp
@@ -113,7 +113,7 @@ std::vector<Stencil::FieldInfo> Stencil::getFields(bool withTemporaries) const {
   for(const auto& multistage : multistages_) {
     for(const auto& stage : multistage->getStages()) {
       for(const auto& field : stage->getFields()) {
-        fieldAccessIDs.insert(field.AccessID);
+        fieldAccessIDs.insert(field.getAccessID());
       }
     }
   }
@@ -425,7 +425,7 @@ std::ostream& operator<<(std::ostream& os, const Stencil& stencil) {
          << RangeToString()(stage->getFields(),
                             [&](const Field& field) {
                               return stencil.getStencilInstantiation().getNameFromAccessID(
-                                  field.AccessID);
+                                  field.getAccessID());
                             })
          << "\n";
   }

--- a/src/dawn/Optimizer/Stencil.h
+++ b/src/dawn/Optimizer/Stencil.h
@@ -33,8 +33,8 @@ class StatementAccessesPair;
 /// @brief A Stencil is represented by a collection of MultiStages
 /// @ingroup optimizer
 class Stencil {
-  StencilInstantiation* stencilInstantiation_;
-  const sir::Stencil* SIRStencil_;
+  StencilInstantiation& stencilInstantiation_;
+  const std::shared_ptr<sir::Stencil> SIRStencil_;
 
   /// Identifier of the stencil. Note that this ID is only for code-generation to associate the
   /// stencil with a stencil-call in the run() method
@@ -158,7 +158,8 @@ public:
 
   /// @name Constructors and Assignment
   /// @{
-  Stencil(StencilInstantiation* stencilInstantiation, const sir::Stencil* SIRStencil, int StencilID,
+  Stencil(StencilInstantiation& stencilInstantiation,
+          const std::shared_ptr<sir::Stencil> SIRStencil, int StencilID,
           std::shared_ptr<DependencyGraphStage> stageDependencyGraph = nullptr);
 
   Stencil(const Stencil&) = default;
@@ -179,7 +180,7 @@ public:
   std::vector<std::string> getGlobalVariables() const;
 
   /// @brief Get the stencil instantiation
-  StencilInstantiation* getStencilInstantiation() const { return stencilInstantiation_; }
+  StencilInstantiation& getStencilInstantiation() const { return stencilInstantiation_; }
 
   /// @brief Get the multi-stages of the stencil
   std::list<std::shared_ptr<MultiStage>>& getMultiStages() { return multistages_; }
@@ -251,7 +252,7 @@ public:
   bool isEmpty() const;
 
   /// @brief Get the SIR Stencil
-  const sir::Stencil* getSIRStencil() const;
+  const std::shared_ptr<sir::Stencil> getSIRStencil() const;
 
   /// @brief Apply the visitor to all statements in the stencil
   void accept(ASTVisitor& visitor);

--- a/src/dawn/Optimizer/Stencil.h
+++ b/src/dawn/Optimizer/Stencil.h
@@ -186,6 +186,9 @@ public:
   std::list<std::shared_ptr<MultiStage>>& getMultiStages() { return multistages_; }
   const std::list<std::shared_ptr<MultiStage>>& getMultiStages() const { return multistages_; }
 
+  /// @brief Get the enclosing interval of accesses of temporaries used in this stencil
+  std::shared_ptr<Interval> getEnclosingIntervalTemporaries() const;
+
   /// @brief Get the multi-stage at given multistage index
   const std::shared_ptr<MultiStage>& getMultiStageFromMultiStageIndex(int multiStageIdx) const;
 

--- a/src/dawn/Optimizer/Stencil.h
+++ b/src/dawn/Optimizer/Stencil.h
@@ -159,8 +159,8 @@ public:
   /// @name Constructors and Assignment
   /// @{
   Stencil(StencilInstantiation& stencilInstantiation,
-          const std::shared_ptr<sir::Stencil> SIRStencil, int StencilID,
-          std::shared_ptr<DependencyGraphStage> stageDependencyGraph = nullptr);
+          const std::shared_ptr<sir::Stencil>& SIRStencil, int StencilID,
+          const std::shared_ptr<DependencyGraphStage>& stageDependencyGraph = nullptr);
 
   Stencil(const Stencil&) = default;
   Stencil(Stencil&&) = default;

--- a/src/dawn/Optimizer/StencilInstantiation.cpp
+++ b/src/dawn/Optimizer/StencilInstantiation.cpp
@@ -995,10 +995,11 @@ public:
 //===------------------------------------------------------------------------------------------===//
 
 StencilInstantiation::StencilInstantiation(OptimizerContext* context,
-                                           const std::shared_ptr<sir::Stencil> SIRStencil,
-                                           const std::shared_ptr<SIR> SIR)
+                                           std::shared_ptr<sir::Stencil> const& SIRStencil,
+                                           std::shared_ptr<SIR> const& SIR)
     : context_(context), SIRStencil_(SIRStencil), SIR_(SIR) {
   DAWN_LOG(INFO) << "Intializing StencilInstantiation of `" << SIRStencil->Name << "`";
+  DAWN_ASSERT_MSG(SIRStencil, "Stencil does not exist");
 
   // Map the fields of the "main stencil" to unique IDs (which are used in the access maps to
   // indentify the field).

--- a/src/dawn/Optimizer/StencilInstantiation.h
+++ b/src/dawn/Optimizer/StencilInstantiation.h
@@ -103,8 +103,8 @@ class StencilInstantiation : NonCopyable {
 
 public:
   /// @brief Assemble StencilInstantiation for stencil
-  StencilInstantiation(OptimizerContext* context, const std::shared_ptr<sir::Stencil> SIRStencil,
-                       const std::shared_ptr<SIR> SIR);
+  StencilInstantiation(OptimizerContext* context, const std::shared_ptr<sir::Stencil>& SIRStencil,
+                       const std::shared_ptr<SIR>& SIR);
 
   /// @brief Insert a new AccessID - Name pair
   void setAccessIDNamePair(int AccessID, const std::string& name);
@@ -363,10 +363,10 @@ public:
   const std::set<int>& getGlobalVariableAccessIDSet() const;
 
   /// @brief Get the SIR
-  const std::shared_ptr<SIR> getSIR() const { return SIR_; }
+  std::shared_ptr<SIR> const& getSIR() const { return SIR_; }
 
   /// @brief Get the SIRStencil this context was built from
-  const std::shared_ptr<sir::Stencil> getSIRStencil() const { return SIRStencil_; }
+  std::shared_ptr<sir::Stencil> const& getSIRStencil() const { return SIRStencil_; }
 
   /// @brief Get the optimizer context
   OptimizerContext* getOptimizerContext() { return context_; }

--- a/src/dawn/Optimizer/StencilInstantiation.h
+++ b/src/dawn/Optimizer/StencilInstantiation.h
@@ -35,8 +35,8 @@ class OptimizerContext;
 /// @ingroup optimizer
 class StencilInstantiation : NonCopyable {
   OptimizerContext* context_;
-  const sir::Stencil* SIRStencil_;
-  const SIR* SIR_;
+  const std::shared_ptr<sir::Stencil> SIRStencil_;
+  const std::shared_ptr<SIR> SIR_;
 
   /// Unique identifier generator
   UIDGenerator UIDGen_;
@@ -103,7 +103,8 @@ class StencilInstantiation : NonCopyable {
 
 public:
   /// @brief Assemble StencilInstantiation for stencil
-  StencilInstantiation(OptimizerContext* context, const sir::Stencil* SIRStencil, const SIR* SIR);
+  StencilInstantiation(OptimizerContext* context, const std::shared_ptr<sir::Stencil> SIRStencil,
+                       const std::shared_ptr<SIR> SIR);
 
   /// @brief Insert a new AccessID - Name pair
   void setAccessIDNamePair(int AccessID, const std::string& name);
@@ -118,7 +119,7 @@ public:
   void removeAccessID(int AccesssID);
 
   /// @brief Get the name of the StencilInstantiation (corresponds to the name of the SIRStencil)
-  const std::string& getName() const;
+  const std::string getName() const;
 
   /// @brief Get the `name` associated with the `AccessID`
   const std::string& getNameFromAccessID(int AccessID) const;
@@ -362,10 +363,10 @@ public:
   const std::set<int>& getGlobalVariableAccessIDSet() const;
 
   /// @brief Get the SIR
-  const SIR* getSIR() const { return SIR_; }
+  const std::shared_ptr<SIR> getSIR() const { return SIR_; }
 
   /// @brief Get the SIRStencil this context was built from
-  const sir::Stencil* getSIRStencil() const { return SIRStencil_; }
+  const std::shared_ptr<sir::Stencil> getSIRStencil() const { return SIRStencil_; }
 
   /// @brief Get the optimizer context
   OptimizerContext* getOptimizerContext() { return context_; }

--- a/test/unit-test/dawn/Optimizer/Passes/CMakeLists.txt
+++ b/test/unit-test/dawn/Optimizer/Passes/CMakeLists.txt
@@ -18,6 +18,7 @@
           TestEnvironment.h
           TestMain.cpp
           TestPassComputeStageExtents.cpp
+          TestFieldAccessIntervals.cpp
     DEPENDS DawnUnittestStatic DawnStatic DawnCStatic ${DAWN_EXTERNAL_LIBRARIES} gtest
     OUTPUT_DIR ${CMAKE_BINARY_DIR}/bin/unittest
     GTEST_ARGS "${CMAKE_CURRENT_LIST_DIR}" "--gtest_color=yes"

--- a/test/unit-test/dawn/Optimizer/Passes/TestFieldAccessIntervals.cpp
+++ b/test/unit-test/dawn/Optimizer/Passes/TestFieldAccessIntervals.cpp
@@ -1,0 +1,141 @@
+//===--------------------------------------------------------------------------------*- C++ -*-===//
+//                          _
+//                         | |
+//                       __| | __ ___      ___ ___
+//                      / _` |/ _` \ \ /\ / / '_  |
+//                     | (_| | (_| |\ V  V /| | | |
+//                      \__,_|\__,_| \_/\_/ |_| |_| - Compiler Toolchain
+//
+//
+//  This file is distributed under the MIT License (MIT).
+//  See LICENSE.txt for details.
+//
+//===------------------------------------------------------------------------------------------===//
+
+#include "dawn/Compiler/DawnCompiler.h"
+#include "dawn/Compiler/Options.h"
+#include "dawn/SIR/SIR.h"
+#include "dawn/SIR/SIRSerializer.h"
+#include "test/unit-test/dawn/Optimizer/Passes/TestEnvironment.h"
+#include <fstream>
+#include <gtest/gtest.h>
+#include <streambuf>
+
+using namespace dawn;
+
+namespace {
+
+class TestFieldAccessIntervals : public ::testing::Test {
+  std::unique_ptr<dawn::Options> compileOptions_;
+
+  dawn::DawnCompiler compiler_;
+
+protected:
+  TestFieldAccessIntervals() : compiler_(compileOptions_.get()) {}
+  virtual void SetUp() {}
+
+  std::vector<std::shared_ptr<Stencil>> loadTest(std::string sirFilename) {
+
+    std::string filename = TestEnvironment::path_ + "/" + sirFilename;
+    std::ifstream file(filename);
+    DAWN_ASSERT_MSG((file.good()), std::string("File " + filename + " does not exists").c_str());
+
+    std::string jsonstr((std::istreambuf_iterator<char>(file)), std::istreambuf_iterator<char>());
+
+    std::shared_ptr<SIR> sir =
+        SIRSerializer::deserializeFromString(jsonstr, SIRSerializer::SK_Json);
+
+    std::unique_ptr<OptimizerContext> optimizer = compiler_.runOptimizer(sir);
+    // Report diganostics
+    if(compiler_.getDiagnostics().hasDiags()) {
+      for(const auto& diag : compiler_.getDiagnostics().getQueue())
+        std::cerr << "Compilation Error " << diag->getMessage() << std::endl;
+      throw std::runtime_error("compilation failed");
+    }
+
+    DAWN_ASSERT_MSG((optimizer->getStencilInstantiationMap().count("compute_extent_test_stencil")),
+                    "compute_extent_test_stencil not found in sir");
+
+    return optimizer->getStencilInstantiationMap()["compute_extent_test_stencil"]->getStencils();
+  }
+};
+
+TEST_F(TestFieldAccessIntervals, test_field_access_interval_01) {
+  auto stencils = loadTest("test_field_access_interval_01.sir");
+  ASSERT_TRUE((stencils.size() == 1));
+  std::shared_ptr<Stencil> stencil = stencils[0];
+
+  ASSERT_TRUE((stencil->getNumStages() == 2));
+  ASSERT_TRUE((stencil->getStage(0)->getExtents() == Extents{-1, 1, -1, 1, 0, 0}));
+  ASSERT_TRUE((stencil->getStage(1)->getExtents() == Extents{0, 0, 0, 0, 0, 0}));
+
+  for(auto fieldPair : stencil->getMultiStages().front()->getFields()) {
+    Field& field = fieldPair.second;
+    int AccessID = fieldPair.first;
+
+    if(AccessID == stencil->getStencilInstantiation().getAccessIDFromName("lap")) {
+      ASSERT_TRUE(field.interval_ == Interval(sir::Interval::Start, sir::Interval::End, 11, 0));
+    }
+    if(AccessID == stencil->getStencilInstantiation().getAccessIDFromName("out") ||
+       AccessID == stencil->getStencilInstantiation().getAccessIDFromName("u")) {
+      ASSERT_TRUE(field.interval_ == Interval(sir::Interval::Start, sir::Interval::End, 0, 0));
+    }
+  }
+}
+
+TEST_F(TestFieldAccessIntervals, test_field_access_interval_02) {
+  auto stencils = loadTest("test_field_access_interval_02.sir");
+  ASSERT_TRUE((stencils.size() == 1));
+  std::shared_ptr<Stencil> stencil = stencils[0];
+
+  ASSERT_TRUE((stencil->getNumStages() == 2));
+  ASSERT_TRUE((stencil->getStage(0)->getExtents() == Extents{-1, 1, -1, 1, 0, 0}));
+  ASSERT_TRUE((stencil->getStage(1)->getExtents() == Extents{0, 0, 0, 0, 0, 0}));
+
+  for(auto fieldPair : stencil->getMultiStages().front()->getFields()) {
+    Field& field = fieldPair.second;
+    int AccessID = fieldPair.first;
+    if(AccessID == stencil->getStencilInstantiation().getAccessIDFromName("lap")) {
+      ASSERT_TRUE(field.interval_ == Interval(sir::Interval::Start + 11, sir::Interval::End));
+    }
+    if(AccessID == stencil->getStencilInstantiation().getAccessIDFromName("out") ||
+       AccessID == stencil->getStencilInstantiation().getAccessIDFromName("u")) {
+      ASSERT_TRUE(field.interval_ == Interval(sir::Interval::Start, sir::Interval::End));
+    }
+    if(AccessID == stencil->getStencilInstantiation().getAccessIDFromName("coeff")) {
+      ASSERT_TRUE(field.interval_ == Interval(sir::Interval::Start, sir::Interval::End, 11, 0));
+      ASSERT_TRUE(field.getAccessedInterval() ==
+                  Interval(sir::Interval::Start, sir::Interval::End, 11, 1));
+    }
+  }
+}
+
+TEST_F(TestFieldAccessIntervals, test_field_access_interval_03) {
+  auto stencils = loadTest("test_field_access_interval_03.sir");
+  ASSERT_TRUE((stencils.size() == 1));
+  std::shared_ptr<Stencil> stencil = stencils[0];
+
+  ASSERT_TRUE((stencil->getNumStages() == 3));
+  ASSERT_TRUE((stencil->getStage(0)->getExtents() == Extents{-1, 1, -1, 1, 0, 0}));
+  ASSERT_TRUE((stencil->getStage(1)->getExtents() == Extents{0, 0, 0, 0, 0, 0}));
+  ASSERT_TRUE((stencil->getStage(2)->getExtents() == Extents{0, 0, 0, 0, 0, 0}));
+
+  for(auto fieldPair : stencil->getMultiStages().front()->getFields()) {
+    Field& field = fieldPair.second;
+    int AccessID = fieldPair.first;
+    if(AccessID == stencil->getStencilInstantiation().getAccessIDFromName("lap")) {
+      ASSERT_TRUE(field.interval_ == Interval(sir::Interval::Start + 11, sir::Interval::End));
+    }
+    if(AccessID == stencil->getStencilInstantiation().getAccessIDFromName("out") ||
+       AccessID == stencil->getStencilInstantiation().getAccessIDFromName("u")) {
+      ASSERT_TRUE(field.interval_ == Interval(sir::Interval::Start, sir::Interval::End));
+    }
+    if(AccessID == stencil->getStencilInstantiation().getAccessIDFromName("coeff")) {
+      ASSERT_TRUE(field.interval_ == Interval(sir::Interval::Start, sir::Interval::End, 4, 0));
+      ASSERT_TRUE(field.getAccessedInterval() ==
+                  Interval(sir::Interval::Start, sir::Interval::End, 2, 1));
+    }
+  }
+}
+
+} // anonymous namespace

--- a/test/unit-test/dawn/Optimizer/Passes/TestFieldAccessIntervals.cpp
+++ b/test/unit-test/dawn/Optimizer/Passes/TestFieldAccessIntervals.cpp
@@ -74,11 +74,11 @@ TEST_F(TestFieldAccessIntervals, test_field_access_interval_01) {
     int AccessID = fieldPair.first;
 
     if(AccessID == stencil->getStencilInstantiation().getAccessIDFromName("lap")) {
-      ASSERT_TRUE(field.interval_ == Interval(sir::Interval::Start, sir::Interval::End, 11, 0));
+      ASSERT_TRUE(field.getInterval() == Interval(sir::Interval::Start, sir::Interval::End, 11, 0));
     }
     if(AccessID == stencil->getStencilInstantiation().getAccessIDFromName("out") ||
        AccessID == stencil->getStencilInstantiation().getAccessIDFromName("u")) {
-      ASSERT_TRUE(field.interval_ == Interval(sir::Interval::Start, sir::Interval::End, 0, 0));
+      ASSERT_TRUE(field.getInterval() == Interval(sir::Interval::Start, sir::Interval::End, 0, 0));
     }
   }
 }
@@ -96,14 +96,15 @@ TEST_F(TestFieldAccessIntervals, test_field_access_interval_02) {
     Field& field = fieldPair.second;
     int AccessID = fieldPair.first;
     if(AccessID == stencil->getStencilInstantiation().getAccessIDFromName("lap")) {
-      ASSERT_TRUE(field.interval_ == Interval(sir::Interval::Start + 11, sir::Interval::End));
+      ASSERT_TRUE(field.getInterval() == Interval(sir::Interval::Start + 11, sir::Interval::End));
     }
     if(AccessID == stencil->getStencilInstantiation().getAccessIDFromName("out") ||
        AccessID == stencil->getStencilInstantiation().getAccessIDFromName("u")) {
-      ASSERT_TRUE(field.interval_ == Interval(sir::Interval::Start, sir::Interval::End));
+      ASSERT_TRUE(field.getInterval() == Interval(sir::Interval::Start, sir::Interval::End));
     }
     if(AccessID == stencil->getStencilInstantiation().getAccessIDFromName("coeff")) {
-      ASSERT_TRUE(field.interval_ == Interval(sir::Interval::Start, sir::Interval::End, 11, 0));
+      ASSERT_TRUE(field.getInterval() == Interval(sir::Interval::Start, sir::Interval::End, 11, 0));
+      std::cout << field.getAccessedInterval() << std::endl;
       ASSERT_TRUE(field.getAccessedInterval() ==
                   Interval(sir::Interval::Start, sir::Interval::End, 11, 1));
     }
@@ -124,18 +125,32 @@ TEST_F(TestFieldAccessIntervals, test_field_access_interval_03) {
     Field& field = fieldPair.second;
     int AccessID = fieldPair.first;
     if(AccessID == stencil->getStencilInstantiation().getAccessIDFromName("lap")) {
-      ASSERT_TRUE(field.interval_ == Interval(sir::Interval::Start + 11, sir::Interval::End));
+      ASSERT_TRUE(field.getInterval() == Interval(sir::Interval::Start + 11, sir::Interval::End));
     }
     if(AccessID == stencil->getStencilInstantiation().getAccessIDFromName("out") ||
        AccessID == stencil->getStencilInstantiation().getAccessIDFromName("u")) {
-      ASSERT_TRUE(field.interval_ == Interval(sir::Interval::Start, sir::Interval::End));
+      ASSERT_TRUE(field.getInterval() == Interval(sir::Interval::Start, sir::Interval::End));
     }
     if(AccessID == stencil->getStencilInstantiation().getAccessIDFromName("coeff")) {
-      ASSERT_TRUE(field.interval_ == Interval(sir::Interval::Start, sir::Interval::End, 4, 0));
+      ASSERT_TRUE(field.getInterval() == Interval(sir::Interval::Start, sir::Interval::End, 4, 0));
       ASSERT_TRUE(field.getAccessedInterval() ==
                   Interval(sir::Interval::Start, sir::Interval::End, 2, 1));
     }
   }
+}
+
+TEST_F(TestFieldAccessIntervals, test_field_access_interval_04) {
+  auto stencils = loadTest("test_field_access_interval_04.sir");
+  ASSERT_TRUE((stencils.size() == 1));
+  std::shared_ptr<Stencil> stencil = stencils[0];
+
+  ASSERT_TRUE((stencil->getNumStages() == 3));
+
+  MultiStage& multiStage = *(stencil->getMultiStages().front());
+
+  std::shared_ptr<Interval> enclosingInterval = multiStage.getEnclosingAccessIntervalTemporaries();
+  ASSERT_TRUE(enclosingInterval != nullptr);
+  ASSERT_TRUE((*enclosingInterval == Interval(sir::Interval::Start, sir::Interval::Start, 0, 14)));
 }
 
 } // anonymous namespace

--- a/test/unit-test/dawn/Optimizer/Passes/TestFieldAccessIntervals.cpp
+++ b/test/unit-test/dawn/Optimizer/Passes/TestFieldAccessIntervals.cpp
@@ -152,4 +152,33 @@ TEST_F(TestFieldAccessIntervals, test_field_access_interval_04) {
   ASSERT_TRUE((*enclosingInterval == Interval(sir::Interval::Start, sir::Interval::Start, 0, 14)));
 }
 
+TEST_F(TestFieldAccessIntervals, test_field_access_interval_05) {
+  auto stencils = loadTest("test_field_access_interval_05.sir");
+  ASSERT_TRUE((stencils.size() == 1));
+  std::shared_ptr<Stencil> stencil = stencils[0];
+
+  ASSERT_TRUE((stencil->getNumStages() == 2));
+  ASSERT_TRUE((stencil->getStage(0)->getExtents() == Extents{-1, 1, -1, 1, -1, 0}));
+  ASSERT_TRUE((stencil->getStage(1)->getExtents() == Extents{0, 0, 0, 0, 0, 0}));
+
+  for(auto fieldPair : stencil->getMultiStages().front()->getFields()) {
+    Field& field = fieldPair.second;
+    int AccessID = fieldPair.first;
+    if(AccessID == stencil->getStencilInstantiation().getAccessIDFromName("lap")) {
+      ASSERT_TRUE(field.getInterval() == Interval(sir::Interval::Start + 11, sir::Interval::End));
+      ASSERT_TRUE(field.getAccessedInterval() ==
+                  Interval(sir::Interval::Start + 10, sir::Interval::End));
+    }
+    if(AccessID == stencil->getStencilInstantiation().getAccessIDFromName("out") ||
+       AccessID == stencil->getStencilInstantiation().getAccessIDFromName("u")) {
+      ASSERT_TRUE(field.getInterval() == Interval(sir::Interval::Start, sir::Interval::End));
+    }
+    if(AccessID == stencil->getStencilInstantiation().getAccessIDFromName("coeff")) {
+      ASSERT_TRUE(field.getInterval() == Interval(sir::Interval::Start, sir::Interval::End, 11, 0));
+      ASSERT_TRUE(field.getAccessedInterval() ==
+                  Interval(sir::Interval::Start, sir::Interval::End, 11, 1));
+    }
+  }
+}
+
 } // anonymous namespace

--- a/test/unit-test/dawn/Optimizer/Passes/TestFieldAccessIntervals.cpp
+++ b/test/unit-test/dawn/Optimizer/Passes/TestFieldAccessIntervals.cpp
@@ -104,7 +104,6 @@ TEST_F(TestFieldAccessIntervals, test_field_access_interval_02) {
     }
     if(AccessID == stencil->getStencilInstantiation().getAccessIDFromName("coeff")) {
       ASSERT_TRUE(field.getInterval() == Interval(sir::Interval::Start, sir::Interval::End, 11, 0));
-      std::cout << field.getAccessedInterval() << std::endl;
       ASSERT_TRUE(field.getAccessedInterval() ==
                   Interval(sir::Interval::Start, sir::Interval::End, 11, 1));
     }

--- a/test/unit-test/dawn/Optimizer/Passes/TestFieldAccessIntervals.cpp
+++ b/test/unit-test/dawn/Optimizer/Passes/TestFieldAccessIntervals.cpp
@@ -34,7 +34,7 @@ protected:
   TestFieldAccessIntervals() : compiler_(compileOptions_.get()) {}
   virtual void SetUp() {}
 
-  std::vector<std::shared_ptr<Stencil>> loadTest(std::string sirFilename) {
+  std::shared_ptr<StencilInstantiation> loadTest(std::string sirFilename) {
 
     std::string filename = TestEnvironment::path_ + "/" + sirFilename;
     std::ifstream file(filename);
@@ -56,12 +56,12 @@ protected:
     DAWN_ASSERT_MSG((optimizer->getStencilInstantiationMap().count("compute_extent_test_stencil")),
                     "compute_extent_test_stencil not found in sir");
 
-    return optimizer->getStencilInstantiationMap()["compute_extent_test_stencil"]->getStencils();
+    return optimizer->getStencilInstantiationMap()["compute_extent_test_stencil"];
   }
 };
 
 TEST_F(TestFieldAccessIntervals, test_field_access_interval_01) {
-  auto stencils = loadTest("test_field_access_interval_01.sir");
+  auto stencils = loadTest("test_field_access_interval_01.sir")->getStencils();
   ASSERT_TRUE((stencils.size() == 1));
   std::shared_ptr<Stencil> stencil = stencils[0];
 
@@ -84,7 +84,7 @@ TEST_F(TestFieldAccessIntervals, test_field_access_interval_01) {
 }
 
 TEST_F(TestFieldAccessIntervals, test_field_access_interval_02) {
-  auto stencils = loadTest("test_field_access_interval_02.sir");
+  auto& stencils = loadTest("test_field_access_interval_02.sir")->getStencils();
   ASSERT_TRUE((stencils.size() == 1));
   std::shared_ptr<Stencil> stencil = stencils[0];
 
@@ -111,7 +111,7 @@ TEST_F(TestFieldAccessIntervals, test_field_access_interval_02) {
 }
 
 TEST_F(TestFieldAccessIntervals, test_field_access_interval_03) {
-  auto stencils = loadTest("test_field_access_interval_03.sir");
+  auto stencils = loadTest("test_field_access_interval_03.sir")->getStencils();
   ASSERT_TRUE((stencils.size() == 1));
   std::shared_ptr<Stencil> stencil = stencils[0];
 
@@ -139,7 +139,7 @@ TEST_F(TestFieldAccessIntervals, test_field_access_interval_03) {
 }
 
 TEST_F(TestFieldAccessIntervals, test_field_access_interval_04) {
-  auto stencils = loadTest("test_field_access_interval_04.sir");
+  auto stencils = loadTest("test_field_access_interval_04.sir")->getStencils();
   ASSERT_TRUE((stencils.size() == 1));
   std::shared_ptr<Stencil> stencil = stencils[0];
 
@@ -153,7 +153,7 @@ TEST_F(TestFieldAccessIntervals, test_field_access_interval_04) {
 }
 
 TEST_F(TestFieldAccessIntervals, test_field_access_interval_05) {
-  auto stencils = loadTest("test_field_access_interval_05.sir");
+  auto stencils = loadTest("test_field_access_interval_05.sir")->getStencils();
   ASSERT_TRUE((stencils.size() == 1));
   std::shared_ptr<Stencil> stencil = stencils[0];
 

--- a/test/unit-test/dawn/Optimizer/Passes/TestPassComputeStageExtents.cpp
+++ b/test/unit-test/dawn/Optimizer/Passes/TestPassComputeStageExtents.cpp
@@ -45,7 +45,7 @@ protected:
     std::shared_ptr<SIR> sir =
         SIRSerializer::deserializeFromString(jsonstr, SIRSerializer::SK_Json);
 
-    std::unique_ptr<OptimizerContext> optimizer = compiler_.runOptimizer(sir.get());
+    std::unique_ptr<OptimizerContext> optimizer = compiler_.runOptimizer(sir);
     // Report diganostics
     if(compiler_.getDiagnostics().hasDiags()) {
       for(const auto& diag : compiler_.getDiagnostics().getQueue())

--- a/test/unit-test/dawn/Optimizer/Passes/samples/test_field_access_interval_01.cpp
+++ b/test/unit-test/dawn/Optimizer/Passes/samples/test_field_access_interval_01.cpp
@@ -1,0 +1,32 @@
+//===--------------------------------------------------------------------------------*- C++ -*-===//
+//                         _       _
+//                        | |     | |
+//                    __ _| |_ ___| | __ _ _ __   __ _
+//                   / _` | __/ __| |/ _` | '_ \ / _` |
+//                  | (_| | || (__| | (_| | | | | (_| |
+//                   \__, |\__\___|_|\__,_|_| |_|\__, | - GridTools Clang DSL
+//                    __/ |                       __/ |
+//                   |___/                       |___/
+//
+//
+//  This file is distributed under the MIT License (MIT).
+//  See LICENSE.txt for details.
+//
+//===------------------------------------------------------------------------------------------===//
+
+#include "gridtools/clang_dsl.hpp"
+
+using namespace gridtools::clang;
+
+stencil compute_extent_test_stencil {
+  storage u, out, lap;
+
+  Do {
+    vertical_region(k_start,k_start+10)
+      out = u;
+    vertical_region(k_start+11, k_end) {
+      lap = u(i + 1) + u(i - 1) + u(j + 1) + u(j - 1) - 4.0 * u;
+      out = lap(i + 1) + lap(i - 1) + lap(j + 1) + lap(j - 1) - 4.0 * lap;
+    }
+  }
+};

--- a/test/unit-test/dawn/Optimizer/Passes/samples/test_field_access_interval_02.cpp
+++ b/test/unit-test/dawn/Optimizer/Passes/samples/test_field_access_interval_02.cpp
@@ -1,0 +1,32 @@
+//===--------------------------------------------------------------------------------*- C++ -*-===//
+//                         _       _
+//                        | |     | |
+//                    __ _| |_ ___| | __ _ _ __   __ _
+//                   / _` | __/ __| |/ _` | '_ \ / _` |
+//                  | (_| | || (__| | (_| | | | | (_| |
+//                   \__, |\__\___|_|\__,_|_| |_|\__, | - GridTools Clang DSL
+//                    __/ |                       __/ |
+//                   |___/                       |___/
+//
+//
+//  This file is distributed under the MIT License (MIT).
+//  See LICENSE.txt for details.
+//
+//===------------------------------------------------------------------------------------------===//
+
+#include "gridtools/clang_dsl.hpp"
+
+using namespace gridtools::clang;
+
+stencil compute_extent_test_stencil {
+  storage u, out, coeff, lap;
+
+  Do {
+    vertical_region(k_start,k_start+10)
+      out = u;
+    vertical_region(k_start+11, k_end) {
+      lap = u(i + 1) + u(i - 1) + u(j + 1) + u(j - 1) - 4.0 * u + coeff(k + 1);
+      out = lap(i + 1) + lap(i - 1) + lap(j + 1) + lap(j - 1) - 4.0 * lap;
+    }
+  }
+};

--- a/test/unit-test/dawn/Optimizer/Passes/samples/test_field_access_interval_03.cpp
+++ b/test/unit-test/dawn/Optimizer/Passes/samples/test_field_access_interval_03.cpp
@@ -1,0 +1,34 @@
+//===--------------------------------------------------------------------------------*- C++ -*-===//
+//                         _       _
+//                        | |     | |
+//                    __ _| |_ ___| | __ _ _ __   __ _
+//                   / _` | __/ __| |/ _` | '_ \ / _` |
+//                  | (_| | || (__| | (_| | | | | (_| |
+//                   \__, |\__\___|_|\__,_|_| |_|\__, | - GridTools Clang DSL
+//                    __/ |                       __/ |
+//                   |___/                       |___/
+//
+//
+//  This file is distributed under the MIT License (MIT).
+//  See LICENSE.txt for details.
+//
+//===------------------------------------------------------------------------------------------===//
+
+#include "gridtools/clang_dsl.hpp"
+
+using namespace gridtools::clang;
+
+stencil compute_extent_test_stencil {
+  storage u, out, coeff, lap, out2;
+
+  Do {
+    vertical_region(k_start,k_start+10)
+      out = u;
+    vertical_region(k_start+4,k_start+14)
+      out2 = u + coeff(k-2);
+    vertical_region(k_start+11, k_end) {
+      lap = u(i + 1) + u(i - 1) + u(j + 1) + u(j - 1) - 4.0 * u + coeff(k + 1);
+      out = lap(i + 1) + lap(i - 1) + lap(j + 1) + lap(j - 1) - 4.0 * lap;
+    }
+  }
+};

--- a/test/unit-test/dawn/Optimizer/Passes/samples/test_field_access_interval_04.cpp
+++ b/test/unit-test/dawn/Optimizer/Passes/samples/test_field_access_interval_04.cpp
@@ -1,0 +1,33 @@
+//===--------------------------------------------------------------------------------*- C++ -*-===//
+//                         _       _
+//                        | |     | |
+//                    __ _| |_ ___| | __ _ _ __   __ _
+//                   / _` | __/ __| |/ _` | '_ \ / _` |
+//                  | (_| | || (__| | (_| | | | | (_| |
+//                   \__, |\__\___|_|\__,_|_| |_|\__, | - GridTools Clang DSL
+//                    __/ |                       __/ |
+//                   |___/                       |___/
+//
+//
+//  This file is distributed under the MIT License (MIT).
+//  See LICENSE.txt for details.
+//
+//===------------------------------------------------------------------------------------------===//
+
+#include "gridtools/clang_dsl.hpp"
+
+using namespace gridtools::clang;
+
+stencil compute_extent_test_stencil {
+  storage in, out1, out2;
+
+  var u;
+  Do {
+    vertical_region(k_start+2, k_start+3)
+      u = in;
+    vertical_region(k_start+2,k_start+10)
+      out1 = u[k+2] + u[k+1];
+    vertical_region(k_start,k_start+8)
+      out2 = u[k+6];
+  }
+};

--- a/test/unit-test/dawn/Optimizer/Passes/samples/test_field_access_interval_05.cpp
+++ b/test/unit-test/dawn/Optimizer/Passes/samples/test_field_access_interval_05.cpp
@@ -1,0 +1,40 @@
+//===--------------------------------------------------------------------------------*- C++ -*-===//
+//                         _       _
+//                        | |     | |
+//                    __ _| |_ ___| | __ _ _ __   __ _
+//                   / _` | __/ __| |/ _` | '_ \ / _` |
+//                  | (_| | || (__| | (_| | | | | (_| |
+//                   \__, |\__\___|_|\__,_|_| |_|\__, | - GridTools Clang DSL
+//                    __/ |                       __/ |
+//                   |___/                       |___/
+//
+//
+//  This file is distributed under the MIT License (MIT).
+//  See LICENSE.txt for details.
+//
+//===------------------------------------------------------------------------------------------===//
+
+#include "gridtools/clang_dsl.hpp"
+
+using namespace gridtools::clang;
+
+stencil_function func {
+
+  storage lap;
+  Do {
+	return lap(i + 1) + lap(i - 1, k-1) + lap(j + 1) + lap(j - 1) - 4.0 * lap;
+  }
+};
+
+stencil compute_extent_test_stencil {
+  storage u, out, coeff, lap;
+
+  Do {
+    vertical_region(k_start,k_start+10)
+      out = u;
+    vertical_region(k_start+11, k_end) {
+      lap = u(i + 1) + u(i - 1) + u(j + 1) + u(j - 1) - 4.0 * u + coeff(k + 1);
+      out = func(lap);
+    }
+  }
+};

--- a/test/unit-test/dawn/Optimizer/Passes/test_field_access_interval_01.sir
+++ b/test/unit-test/dawn/Optimizer/Passes/test_field_access_interval_01.sir
@@ -1,0 +1,635 @@
+{
+ "filename": "/code/dawn/test/unit-test/dawn/Optimizer/Passes/samples/test_temporary_interval_01.cpp",
+ "stencils": [
+  {
+   "name": "compute_extent_test_stencil",
+   "loc": {
+    "Line": 21,
+    "Column": 8
+   },
+   "ast": {
+    "root": {
+     "block_stmt": {
+      "statements": [
+       {
+        "vertical_region_decl_stmt": {
+         "vertical_region": {
+          "loc": {
+           "Line": 25,
+           "Column": 5
+          },
+          "ast": {
+           "root": {
+            "block_stmt": {
+             "statements": [
+              {
+               "expr_stmt": {
+                "expr": {
+                 "assignment_expr": {
+                  "left": {
+                   "field_access_expr": {
+                    "name": "out",
+                    "offset": [
+                     0,
+                     0,
+                     0
+                    ],
+                    "argument_map": [
+                     -1,
+                     -1,
+                     -1
+                    ],
+                    "argument_offset": [
+                     0,
+                     0,
+                     0
+                    ],
+                    "negate_offset": false,
+                    "loc": {
+                     "Line": 26,
+                     "Column": 7
+                    }
+                   }
+                  },
+                  "op": "=",
+                  "right": {
+                   "field_access_expr": {
+                    "name": "u",
+                    "offset": [
+                     0,
+                     0,
+                     0
+                    ],
+                    "argument_map": [
+                     -1,
+                     -1,
+                     -1
+                    ],
+                    "argument_offset": [
+                     0,
+                     0,
+                     0
+                    ],
+                    "negate_offset": false,
+                    "loc": {
+                     "Line": 26,
+                     "Column": 13
+                    }
+                   }
+                  },
+                  "loc": {
+                   "Line": 26,
+                   "Column": 7
+                  }
+                 }
+                },
+                "loc": {
+                 "Line": 26,
+                 "Column": 7
+                }
+               }
+              }
+             ],
+             "loc": {
+              "Line": 25,
+              "Column": 5
+             }
+            }
+           }
+          },
+          "interval": {
+           "lower_offset": 0,
+           "upper_offset": 10,
+           "special_lower_level": "Start",
+           "special_upper_level": "Start"
+          },
+          "loop_order": "Forward"
+         },
+         "loc": {
+          "Line": 25,
+          "Column": 5
+         }
+        }
+       },
+       {
+        "vertical_region_decl_stmt": {
+         "vertical_region": {
+          "loc": {
+           "Line": 27,
+           "Column": 5
+          },
+          "ast": {
+           "root": {
+            "block_stmt": {
+             "statements": [
+              {
+               "expr_stmt": {
+                "expr": {
+                 "assignment_expr": {
+                  "left": {
+                   "field_access_expr": {
+                    "name": "lap",
+                    "offset": [
+                     0,
+                     0,
+                     0
+                    ],
+                    "argument_map": [
+                     -1,
+                     -1,
+                     -1
+                    ],
+                    "argument_offset": [
+                     0,
+                     0,
+                     0
+                    ],
+                    "negate_offset": false,
+                    "loc": {
+                     "Line": 28,
+                     "Column": 7
+                    }
+                   }
+                  },
+                  "op": "=",
+                  "right": {
+                   "binary_operator": {
+                    "left": {
+                     "binary_operator": {
+                      "left": {
+                       "binary_operator": {
+                        "left": {
+                         "binary_operator": {
+                          "left": {
+                           "field_access_expr": {
+                            "name": "u",
+                            "offset": [
+                             1,
+                             0,
+                             0
+                            ],
+                            "argument_map": [
+                             -1,
+                             -1,
+                             -1
+                            ],
+                            "argument_offset": [
+                             0,
+                             0,
+                             0
+                            ],
+                            "negate_offset": false,
+                            "loc": {
+                             "Line": 28,
+                             "Column": 13
+                            }
+                           }
+                          },
+                          "op": "+",
+                          "right": {
+                           "field_access_expr": {
+                            "name": "u",
+                            "offset": [
+                             -1,
+                             0,
+                             0
+                            ],
+                            "argument_map": [
+                             -1,
+                             -1,
+                             -1
+                            ],
+                            "argument_offset": [
+                             0,
+                             0,
+                             0
+                            ],
+                            "negate_offset": false,
+                            "loc": {
+                             "Line": 28,
+                             "Column": 24
+                            }
+                           }
+                          },
+                          "loc": {
+                           "Line": 28,
+                           "Column": 13
+                          }
+                         }
+                        },
+                        "op": "+",
+                        "right": {
+                         "field_access_expr": {
+                          "name": "u",
+                          "offset": [
+                           0,
+                           1,
+                           0
+                          ],
+                          "argument_map": [
+                           -1,
+                           -1,
+                           -1
+                          ],
+                          "argument_offset": [
+                           0,
+                           0,
+                           0
+                          ],
+                          "negate_offset": false,
+                          "loc": {
+                           "Line": 28,
+                           "Column": 35
+                          }
+                         }
+                        },
+                        "loc": {
+                         "Line": 28,
+                         "Column": 13
+                        }
+                       }
+                      },
+                      "op": "+",
+                      "right": {
+                       "field_access_expr": {
+                        "name": "u",
+                        "offset": [
+                         0,
+                         -1,
+                         0
+                        ],
+                        "argument_map": [
+                         -1,
+                         -1,
+                         -1
+                        ],
+                        "argument_offset": [
+                         0,
+                         0,
+                         0
+                        ],
+                        "negate_offset": false,
+                        "loc": {
+                         "Line": 28,
+                         "Column": 46
+                        }
+                       }
+                      },
+                      "loc": {
+                       "Line": 28,
+                       "Column": 13
+                      }
+                     }
+                    },
+                    "op": "-",
+                    "right": {
+                     "binary_operator": {
+                      "left": {
+                       "literal_access_expr": {
+                        "value": "4",
+                        "type": {
+                         "type_id": "Float"
+                        },
+                        "loc": {
+                         "Line": 28,
+                         "Column": 57
+                        }
+                       }
+                      },
+                      "op": "*",
+                      "right": {
+                       "field_access_expr": {
+                        "name": "u",
+                        "offset": [
+                         0,
+                         0,
+                         0
+                        ],
+                        "argument_map": [
+                         -1,
+                         -1,
+                         -1
+                        ],
+                        "argument_offset": [
+                         0,
+                         0,
+                         0
+                        ],
+                        "negate_offset": false,
+                        "loc": {
+                         "Line": 28,
+                         "Column": 63
+                        }
+                       }
+                      },
+                      "loc": {
+                       "Line": 28,
+                       "Column": 57
+                      }
+                     }
+                    },
+                    "loc": {
+                     "Line": 28,
+                     "Column": 13
+                    }
+                   }
+                  },
+                  "loc": {
+                   "Line": 28,
+                   "Column": 7
+                  }
+                 }
+                },
+                "loc": {
+                 "Line": 28,
+                 "Column": 7
+                }
+               }
+              },
+              {
+               "expr_stmt": {
+                "expr": {
+                 "assignment_expr": {
+                  "left": {
+                   "field_access_expr": {
+                    "name": "out",
+                    "offset": [
+                     0,
+                     0,
+                     0
+                    ],
+                    "argument_map": [
+                     -1,
+                     -1,
+                     -1
+                    ],
+                    "argument_offset": [
+                     0,
+                     0,
+                     0
+                    ],
+                    "negate_offset": false,
+                    "loc": {
+                     "Line": 29,
+                     "Column": 7
+                    }
+                   }
+                  },
+                  "op": "=",
+                  "right": {
+                   "binary_operator": {
+                    "left": {
+                     "binary_operator": {
+                      "left": {
+                       "binary_operator": {
+                        "left": {
+                         "binary_operator": {
+                          "left": {
+                           "field_access_expr": {
+                            "name": "lap",
+                            "offset": [
+                             1,
+                             0,
+                             0
+                            ],
+                            "argument_map": [
+                             -1,
+                             -1,
+                             -1
+                            ],
+                            "argument_offset": [
+                             0,
+                             0,
+                             0
+                            ],
+                            "negate_offset": false,
+                            "loc": {
+                             "Line": 29,
+                             "Column": 13
+                            }
+                           }
+                          },
+                          "op": "+",
+                          "right": {
+                           "field_access_expr": {
+                            "name": "lap",
+                            "offset": [
+                             -1,
+                             0,
+                             0
+                            ],
+                            "argument_map": [
+                             -1,
+                             -1,
+                             -1
+                            ],
+                            "argument_offset": [
+                             0,
+                             0,
+                             0
+                            ],
+                            "negate_offset": false,
+                            "loc": {
+                             "Line": 29,
+                             "Column": 26
+                            }
+                           }
+                          },
+                          "loc": {
+                           "Line": 29,
+                           "Column": 13
+                          }
+                         }
+                        },
+                        "op": "+",
+                        "right": {
+                         "field_access_expr": {
+                          "name": "lap",
+                          "offset": [
+                           0,
+                           1,
+                           0
+                          ],
+                          "argument_map": [
+                           -1,
+                           -1,
+                           -1
+                          ],
+                          "argument_offset": [
+                           0,
+                           0,
+                           0
+                          ],
+                          "negate_offset": false,
+                          "loc": {
+                           "Line": 29,
+                           "Column": 39
+                          }
+                         }
+                        },
+                        "loc": {
+                         "Line": 29,
+                         "Column": 13
+                        }
+                       }
+                      },
+                      "op": "+",
+                      "right": {
+                       "field_access_expr": {
+                        "name": "lap",
+                        "offset": [
+                         0,
+                         -1,
+                         0
+                        ],
+                        "argument_map": [
+                         -1,
+                         -1,
+                         -1
+                        ],
+                        "argument_offset": [
+                         0,
+                         0,
+                         0
+                        ],
+                        "negate_offset": false,
+                        "loc": {
+                         "Line": 29,
+                         "Column": 52
+                        }
+                       }
+                      },
+                      "loc": {
+                       "Line": 29,
+                       "Column": 13
+                      }
+                     }
+                    },
+                    "op": "-",
+                    "right": {
+                     "binary_operator": {
+                      "left": {
+                       "literal_access_expr": {
+                        "value": "4",
+                        "type": {
+                         "type_id": "Float"
+                        },
+                        "loc": {
+                         "Line": 29,
+                         "Column": 65
+                        }
+                       }
+                      },
+                      "op": "*",
+                      "right": {
+                       "field_access_expr": {
+                        "name": "lap",
+                        "offset": [
+                         0,
+                         0,
+                         0
+                        ],
+                        "argument_map": [
+                         -1,
+                         -1,
+                         -1
+                        ],
+                        "argument_offset": [
+                         0,
+                         0,
+                         0
+                        ],
+                        "negate_offset": false,
+                        "loc": {
+                         "Line": 29,
+                         "Column": 71
+                        }
+                       }
+                      },
+                      "loc": {
+                       "Line": 29,
+                       "Column": 65
+                      }
+                     }
+                    },
+                    "loc": {
+                     "Line": 29,
+                     "Column": 13
+                    }
+                   }
+                  },
+                  "loc": {
+                   "Line": 29,
+                   "Column": 7
+                  }
+                 }
+                },
+                "loc": {
+                 "Line": 29,
+                 "Column": 7
+                }
+               }
+              }
+             ],
+             "loc": {
+              "Line": 27,
+              "Column": 5
+             }
+            }
+           }
+          },
+          "interval": {
+           "lower_offset": 11,
+           "upper_offset": 0,
+           "special_lower_level": "Start",
+           "special_upper_level": "End"
+          },
+          "loop_order": "Forward"
+         },
+         "loc": {
+          "Line": 27,
+          "Column": 5
+         }
+        }
+       }
+      ],
+      "loc": {
+       "Line": -1,
+       "Column": -1
+      }
+     }
+    }
+   },
+   "fields": [
+    {
+     "name": "u",
+     "loc": {
+      "Line": 22,
+      "Column": 11
+     },
+     "is_temporary": false
+    },
+    {
+     "name": "out",
+     "loc": {
+      "Line": 22,
+      "Column": 14
+     },
+     "is_temporary": false
+    },
+    {
+     "name": "lap",
+     "loc": {
+      "Line": 22,
+      "Column": 19
+     },
+     "is_temporary": false
+    }
+   ]
+  }
+ ],
+ "stencil_functions": [],
+ "global_variables": {
+  "map": {}
+ }
+}

--- a/test/unit-test/dawn/Optimizer/Passes/test_field_access_interval_02.sir
+++ b/test/unit-test/dawn/Optimizer/Passes/test_field_access_interval_02.sir
@@ -1,0 +1,677 @@
+{
+ "filename": "/code/dawn/test/unit-test/dawn/Optimizer/Passes/samples/test_temporary_interval_02.cpp",
+ "stencils": [
+  {
+   "name": "compute_extent_test_stencil",
+   "loc": {
+    "Line": 21,
+    "Column": 8
+   },
+   "ast": {
+    "root": {
+     "block_stmt": {
+      "statements": [
+       {
+        "vertical_region_decl_stmt": {
+         "vertical_region": {
+          "loc": {
+           "Line": 25,
+           "Column": 5
+          },
+          "ast": {
+           "root": {
+            "block_stmt": {
+             "statements": [
+              {
+               "expr_stmt": {
+                "expr": {
+                 "assignment_expr": {
+                  "left": {
+                   "field_access_expr": {
+                    "name": "out",
+                    "offset": [
+                     0,
+                     0,
+                     0
+                    ],
+                    "argument_map": [
+                     -1,
+                     -1,
+                     -1
+                    ],
+                    "argument_offset": [
+                     0,
+                     0,
+                     0
+                    ],
+                    "negate_offset": false,
+                    "loc": {
+                     "Line": 26,
+                     "Column": 7
+                    }
+                   }
+                  },
+                  "op": "=",
+                  "right": {
+                   "field_access_expr": {
+                    "name": "u",
+                    "offset": [
+                     0,
+                     0,
+                     0
+                    ],
+                    "argument_map": [
+                     -1,
+                     -1,
+                     -1
+                    ],
+                    "argument_offset": [
+                     0,
+                     0,
+                     0
+                    ],
+                    "negate_offset": false,
+                    "loc": {
+                     "Line": 26,
+                     "Column": 13
+                    }
+                   }
+                  },
+                  "loc": {
+                   "Line": 26,
+                   "Column": 7
+                  }
+                 }
+                },
+                "loc": {
+                 "Line": 26,
+                 "Column": 7
+                }
+               }
+              }
+             ],
+             "loc": {
+              "Line": 25,
+              "Column": 5
+             }
+            }
+           }
+          },
+          "interval": {
+           "lower_offset": 0,
+           "upper_offset": 10,
+           "special_lower_level": "Start",
+           "special_upper_level": "Start"
+          },
+          "loop_order": "Forward"
+         },
+         "loc": {
+          "Line": 25,
+          "Column": 5
+         }
+        }
+       },
+       {
+        "vertical_region_decl_stmt": {
+         "vertical_region": {
+          "loc": {
+           "Line": 27,
+           "Column": 5
+          },
+          "ast": {
+           "root": {
+            "block_stmt": {
+             "statements": [
+              {
+               "expr_stmt": {
+                "expr": {
+                 "assignment_expr": {
+                  "left": {
+                   "field_access_expr": {
+                    "name": "lap",
+                    "offset": [
+                     0,
+                     0,
+                     0
+                    ],
+                    "argument_map": [
+                     -1,
+                     -1,
+                     -1
+                    ],
+                    "argument_offset": [
+                     0,
+                     0,
+                     0
+                    ],
+                    "negate_offset": false,
+                    "loc": {
+                     "Line": 28,
+                     "Column": 7
+                    }
+                   }
+                  },
+                  "op": "=",
+                  "right": {
+                   "binary_operator": {
+                    "left": {
+                     "binary_operator": {
+                      "left": {
+                       "binary_operator": {
+                        "left": {
+                         "binary_operator": {
+                          "left": {
+                           "binary_operator": {
+                            "left": {
+                             "field_access_expr": {
+                              "name": "u",
+                              "offset": [
+                               1,
+                               0,
+                               0
+                              ],
+                              "argument_map": [
+                               -1,
+                               -1,
+                               -1
+                              ],
+                              "argument_offset": [
+                               0,
+                               0,
+                               0
+                              ],
+                              "negate_offset": false,
+                              "loc": {
+                               "Line": 28,
+                               "Column": 13
+                              }
+                             }
+                            },
+                            "op": "+",
+                            "right": {
+                             "field_access_expr": {
+                              "name": "u",
+                              "offset": [
+                               -1,
+                               0,
+                               0
+                              ],
+                              "argument_map": [
+                               -1,
+                               -1,
+                               -1
+                              ],
+                              "argument_offset": [
+                               0,
+                               0,
+                               0
+                              ],
+                              "negate_offset": false,
+                              "loc": {
+                               "Line": 28,
+                               "Column": 24
+                              }
+                             }
+                            },
+                            "loc": {
+                             "Line": 28,
+                             "Column": 13
+                            }
+                           }
+                          },
+                          "op": "+",
+                          "right": {
+                           "field_access_expr": {
+                            "name": "u",
+                            "offset": [
+                             0,
+                             1,
+                             0
+                            ],
+                            "argument_map": [
+                             -1,
+                             -1,
+                             -1
+                            ],
+                            "argument_offset": [
+                             0,
+                             0,
+                             0
+                            ],
+                            "negate_offset": false,
+                            "loc": {
+                             "Line": 28,
+                             "Column": 35
+                            }
+                           }
+                          },
+                          "loc": {
+                           "Line": 28,
+                           "Column": 13
+                          }
+                         }
+                        },
+                        "op": "+",
+                        "right": {
+                         "field_access_expr": {
+                          "name": "u",
+                          "offset": [
+                           0,
+                           -1,
+                           0
+                          ],
+                          "argument_map": [
+                           -1,
+                           -1,
+                           -1
+                          ],
+                          "argument_offset": [
+                           0,
+                           0,
+                           0
+                          ],
+                          "negate_offset": false,
+                          "loc": {
+                           "Line": 28,
+                           "Column": 46
+                          }
+                         }
+                        },
+                        "loc": {
+                         "Line": 28,
+                         "Column": 13
+                        }
+                       }
+                      },
+                      "op": "-",
+                      "right": {
+                       "binary_operator": {
+                        "left": {
+                         "literal_access_expr": {
+                          "value": "4",
+                          "type": {
+                           "type_id": "Float"
+                          },
+                          "loc": {
+                           "Line": 28,
+                           "Column": 57
+                          }
+                         }
+                        },
+                        "op": "*",
+                        "right": {
+                         "field_access_expr": {
+                          "name": "u",
+                          "offset": [
+                           0,
+                           0,
+                           0
+                          ],
+                          "argument_map": [
+                           -1,
+                           -1,
+                           -1
+                          ],
+                          "argument_offset": [
+                           0,
+                           0,
+                           0
+                          ],
+                          "negate_offset": false,
+                          "loc": {
+                           "Line": 28,
+                           "Column": 63
+                          }
+                         }
+                        },
+                        "loc": {
+                         "Line": 28,
+                         "Column": 57
+                        }
+                       }
+                      },
+                      "loc": {
+                       "Line": 28,
+                       "Column": 13
+                      }
+                     }
+                    },
+                    "op": "+",
+                    "right": {
+                     "field_access_expr": {
+                      "name": "coeff",
+                      "offset": [
+                       0,
+                       0,
+                       1
+                      ],
+                      "argument_map": [
+                       -1,
+                       -1,
+                       -1
+                      ],
+                      "argument_offset": [
+                       0,
+                       0,
+                       0
+                      ],
+                      "negate_offset": false,
+                      "loc": {
+                       "Line": 28,
+                       "Column": 67
+                      }
+                     }
+                    },
+                    "loc": {
+                     "Line": 28,
+                     "Column": 13
+                    }
+                   }
+                  },
+                  "loc": {
+                   "Line": 28,
+                   "Column": 7
+                  }
+                 }
+                },
+                "loc": {
+                 "Line": 28,
+                 "Column": 7
+                }
+               }
+              },
+              {
+               "expr_stmt": {
+                "expr": {
+                 "assignment_expr": {
+                  "left": {
+                   "field_access_expr": {
+                    "name": "out",
+                    "offset": [
+                     0,
+                     0,
+                     0
+                    ],
+                    "argument_map": [
+                     -1,
+                     -1,
+                     -1
+                    ],
+                    "argument_offset": [
+                     0,
+                     0,
+                     0
+                    ],
+                    "negate_offset": false,
+                    "loc": {
+                     "Line": 29,
+                     "Column": 7
+                    }
+                   }
+                  },
+                  "op": "=",
+                  "right": {
+                   "binary_operator": {
+                    "left": {
+                     "binary_operator": {
+                      "left": {
+                       "binary_operator": {
+                        "left": {
+                         "binary_operator": {
+                          "left": {
+                           "field_access_expr": {
+                            "name": "lap",
+                            "offset": [
+                             1,
+                             0,
+                             0
+                            ],
+                            "argument_map": [
+                             -1,
+                             -1,
+                             -1
+                            ],
+                            "argument_offset": [
+                             0,
+                             0,
+                             0
+                            ],
+                            "negate_offset": false,
+                            "loc": {
+                             "Line": 29,
+                             "Column": 13
+                            }
+                           }
+                          },
+                          "op": "+",
+                          "right": {
+                           "field_access_expr": {
+                            "name": "lap",
+                            "offset": [
+                             -1,
+                             0,
+                             0
+                            ],
+                            "argument_map": [
+                             -1,
+                             -1,
+                             -1
+                            ],
+                            "argument_offset": [
+                             0,
+                             0,
+                             0
+                            ],
+                            "negate_offset": false,
+                            "loc": {
+                             "Line": 29,
+                             "Column": 26
+                            }
+                           }
+                          },
+                          "loc": {
+                           "Line": 29,
+                           "Column": 13
+                          }
+                         }
+                        },
+                        "op": "+",
+                        "right": {
+                         "field_access_expr": {
+                          "name": "lap",
+                          "offset": [
+                           0,
+                           1,
+                           0
+                          ],
+                          "argument_map": [
+                           -1,
+                           -1,
+                           -1
+                          ],
+                          "argument_offset": [
+                           0,
+                           0,
+                           0
+                          ],
+                          "negate_offset": false,
+                          "loc": {
+                           "Line": 29,
+                           "Column": 39
+                          }
+                         }
+                        },
+                        "loc": {
+                         "Line": 29,
+                         "Column": 13
+                        }
+                       }
+                      },
+                      "op": "+",
+                      "right": {
+                       "field_access_expr": {
+                        "name": "lap",
+                        "offset": [
+                         0,
+                         -1,
+                         0
+                        ],
+                        "argument_map": [
+                         -1,
+                         -1,
+                         -1
+                        ],
+                        "argument_offset": [
+                         0,
+                         0,
+                         0
+                        ],
+                        "negate_offset": false,
+                        "loc": {
+                         "Line": 29,
+                         "Column": 52
+                        }
+                       }
+                      },
+                      "loc": {
+                       "Line": 29,
+                       "Column": 13
+                      }
+                     }
+                    },
+                    "op": "-",
+                    "right": {
+                     "binary_operator": {
+                      "left": {
+                       "literal_access_expr": {
+                        "value": "4",
+                        "type": {
+                         "type_id": "Float"
+                        },
+                        "loc": {
+                         "Line": 29,
+                         "Column": 65
+                        }
+                       }
+                      },
+                      "op": "*",
+                      "right": {
+                       "field_access_expr": {
+                        "name": "lap",
+                        "offset": [
+                         0,
+                         0,
+                         0
+                        ],
+                        "argument_map": [
+                         -1,
+                         -1,
+                         -1
+                        ],
+                        "argument_offset": [
+                         0,
+                         0,
+                         0
+                        ],
+                        "negate_offset": false,
+                        "loc": {
+                         "Line": 29,
+                         "Column": 71
+                        }
+                       }
+                      },
+                      "loc": {
+                       "Line": 29,
+                       "Column": 65
+                      }
+                     }
+                    },
+                    "loc": {
+                     "Line": 29,
+                     "Column": 13
+                    }
+                   }
+                  },
+                  "loc": {
+                   "Line": 29,
+                   "Column": 7
+                  }
+                 }
+                },
+                "loc": {
+                 "Line": 29,
+                 "Column": 7
+                }
+               }
+              }
+             ],
+             "loc": {
+              "Line": 27,
+              "Column": 5
+             }
+            }
+           }
+          },
+          "interval": {
+           "lower_offset": 11,
+           "upper_offset": 0,
+           "special_lower_level": "Start",
+           "special_upper_level": "End"
+          },
+          "loop_order": "Forward"
+         },
+         "loc": {
+          "Line": 27,
+          "Column": 5
+         }
+        }
+       }
+      ],
+      "loc": {
+       "Line": -1,
+       "Column": -1
+      }
+     }
+    }
+   },
+   "fields": [
+    {
+     "name": "u",
+     "loc": {
+      "Line": 22,
+      "Column": 11
+     },
+     "is_temporary": false
+    },
+    {
+     "name": "out",
+     "loc": {
+      "Line": 22,
+      "Column": 14
+     },
+     "is_temporary": false
+    },
+    {
+     "name": "coeff",
+     "loc": {
+      "Line": 22,
+      "Column": 19
+     },
+     "is_temporary": false
+    },
+    {
+     "name": "lap",
+     "loc": {
+      "Line": 22,
+      "Column": 26
+     },
+     "is_temporary": false
+    }
+   ]
+  }
+ ],
+ "stencil_functions": [],
+ "global_variables": {
+  "map": {}
+ }
+}

--- a/test/unit-test/dawn/Optimizer/Passes/test_field_access_interval_03.sir
+++ b/test/unit-test/dawn/Optimizer/Passes/test_field_access_interval_03.sir
@@ -1,0 +1,819 @@
+{
+ "filename": "/code/dawn/test/unit-test/dawn/Optimizer/Passes/samples/test_temporary_interval_03.cpp",
+ "stencils": [
+  {
+   "name": "compute_extent_test_stencil",
+   "loc": {
+    "Line": 21,
+    "Column": 8
+   },
+   "ast": {
+    "root": {
+     "block_stmt": {
+      "statements": [
+       {
+        "vertical_region_decl_stmt": {
+         "vertical_region": {
+          "loc": {
+           "Line": 25,
+           "Column": 5
+          },
+          "ast": {
+           "root": {
+            "block_stmt": {
+             "statements": [
+              {
+               "expr_stmt": {
+                "expr": {
+                 "assignment_expr": {
+                  "left": {
+                   "field_access_expr": {
+                    "name": "out",
+                    "offset": [
+                     0,
+                     0,
+                     0
+                    ],
+                    "argument_map": [
+                     -1,
+                     -1,
+                     -1
+                    ],
+                    "argument_offset": [
+                     0,
+                     0,
+                     0
+                    ],
+                    "negate_offset": false,
+                    "loc": {
+                     "Line": 26,
+                     "Column": 7
+                    }
+                   }
+                  },
+                  "op": "=",
+                  "right": {
+                   "field_access_expr": {
+                    "name": "u",
+                    "offset": [
+                     0,
+                     0,
+                     0
+                    ],
+                    "argument_map": [
+                     -1,
+                     -1,
+                     -1
+                    ],
+                    "argument_offset": [
+                     0,
+                     0,
+                     0
+                    ],
+                    "negate_offset": false,
+                    "loc": {
+                     "Line": 26,
+                     "Column": 13
+                    }
+                   }
+                  },
+                  "loc": {
+                   "Line": 26,
+                   "Column": 7
+                  }
+                 }
+                },
+                "loc": {
+                 "Line": 26,
+                 "Column": 7
+                }
+               }
+              }
+             ],
+             "loc": {
+              "Line": 25,
+              "Column": 5
+             }
+            }
+           }
+          },
+          "interval": {
+           "lower_offset": 0,
+           "upper_offset": 10,
+           "special_lower_level": "Start",
+           "special_upper_level": "Start"
+          },
+          "loop_order": "Forward"
+         },
+         "loc": {
+          "Line": 25,
+          "Column": 5
+         }
+        }
+       },
+       {
+        "vertical_region_decl_stmt": {
+         "vertical_region": {
+          "loc": {
+           "Line": 27,
+           "Column": 5
+          },
+          "ast": {
+           "root": {
+            "block_stmt": {
+             "statements": [
+              {
+               "expr_stmt": {
+                "expr": {
+                 "assignment_expr": {
+                  "left": {
+                   "field_access_expr": {
+                    "name": "out2",
+                    "offset": [
+                     0,
+                     0,
+                     0
+                    ],
+                    "argument_map": [
+                     -1,
+                     -1,
+                     -1
+                    ],
+                    "argument_offset": [
+                     0,
+                     0,
+                     0
+                    ],
+                    "negate_offset": false,
+                    "loc": {
+                     "Line": 28,
+                     "Column": 7
+                    }
+                   }
+                  },
+                  "op": "=",
+                  "right": {
+                   "binary_operator": {
+                    "left": {
+                     "field_access_expr": {
+                      "name": "u",
+                      "offset": [
+                       0,
+                       0,
+                       0
+                      ],
+                      "argument_map": [
+                       -1,
+                       -1,
+                       -1
+                      ],
+                      "argument_offset": [
+                       0,
+                       0,
+                       0
+                      ],
+                      "negate_offset": false,
+                      "loc": {
+                       "Line": 28,
+                       "Column": 14
+                      }
+                     }
+                    },
+                    "op": "+",
+                    "right": {
+                     "field_access_expr": {
+                      "name": "coeff",
+                      "offset": [
+                       0,
+                       0,
+                       -2
+                      ],
+                      "argument_map": [
+                       -1,
+                       -1,
+                       -1
+                      ],
+                      "argument_offset": [
+                       0,
+                       0,
+                       0
+                      ],
+                      "negate_offset": false,
+                      "loc": {
+                       "Line": 28,
+                       "Column": 18
+                      }
+                     }
+                    },
+                    "loc": {
+                     "Line": 28,
+                     "Column": 14
+                    }
+                   }
+                  },
+                  "loc": {
+                   "Line": 28,
+                   "Column": 7
+                  }
+                 }
+                },
+                "loc": {
+                 "Line": 28,
+                 "Column": 7
+                }
+               }
+              }
+             ],
+             "loc": {
+              "Line": 27,
+              "Column": 5
+             }
+            }
+           }
+          },
+          "interval": {
+           "lower_offset": 4,
+           "upper_offset": 14,
+           "special_lower_level": "Start",
+           "special_upper_level": "Start"
+          },
+          "loop_order": "Forward"
+         },
+         "loc": {
+          "Line": 27,
+          "Column": 5
+         }
+        }
+       },
+       {
+        "vertical_region_decl_stmt": {
+         "vertical_region": {
+          "loc": {
+           "Line": 29,
+           "Column": 5
+          },
+          "ast": {
+           "root": {
+            "block_stmt": {
+             "statements": [
+              {
+               "expr_stmt": {
+                "expr": {
+                 "assignment_expr": {
+                  "left": {
+                   "field_access_expr": {
+                    "name": "lap",
+                    "offset": [
+                     0,
+                     0,
+                     0
+                    ],
+                    "argument_map": [
+                     -1,
+                     -1,
+                     -1
+                    ],
+                    "argument_offset": [
+                     0,
+                     0,
+                     0
+                    ],
+                    "negate_offset": false,
+                    "loc": {
+                     "Line": 30,
+                     "Column": 7
+                    }
+                   }
+                  },
+                  "op": "=",
+                  "right": {
+                   "binary_operator": {
+                    "left": {
+                     "binary_operator": {
+                      "left": {
+                       "binary_operator": {
+                        "left": {
+                         "binary_operator": {
+                          "left": {
+                           "binary_operator": {
+                            "left": {
+                             "field_access_expr": {
+                              "name": "u",
+                              "offset": [
+                               1,
+                               0,
+                               0
+                              ],
+                              "argument_map": [
+                               -1,
+                               -1,
+                               -1
+                              ],
+                              "argument_offset": [
+                               0,
+                               0,
+                               0
+                              ],
+                              "negate_offset": false,
+                              "loc": {
+                               "Line": 30,
+                               "Column": 13
+                              }
+                             }
+                            },
+                            "op": "+",
+                            "right": {
+                             "field_access_expr": {
+                              "name": "u",
+                              "offset": [
+                               -1,
+                               0,
+                               0
+                              ],
+                              "argument_map": [
+                               -1,
+                               -1,
+                               -1
+                              ],
+                              "argument_offset": [
+                               0,
+                               0,
+                               0
+                              ],
+                              "negate_offset": false,
+                              "loc": {
+                               "Line": 30,
+                               "Column": 24
+                              }
+                             }
+                            },
+                            "loc": {
+                             "Line": 30,
+                             "Column": 13
+                            }
+                           }
+                          },
+                          "op": "+",
+                          "right": {
+                           "field_access_expr": {
+                            "name": "u",
+                            "offset": [
+                             0,
+                             1,
+                             0
+                            ],
+                            "argument_map": [
+                             -1,
+                             -1,
+                             -1
+                            ],
+                            "argument_offset": [
+                             0,
+                             0,
+                             0
+                            ],
+                            "negate_offset": false,
+                            "loc": {
+                             "Line": 30,
+                             "Column": 35
+                            }
+                           }
+                          },
+                          "loc": {
+                           "Line": 30,
+                           "Column": 13
+                          }
+                         }
+                        },
+                        "op": "+",
+                        "right": {
+                         "field_access_expr": {
+                          "name": "u",
+                          "offset": [
+                           0,
+                           -1,
+                           0
+                          ],
+                          "argument_map": [
+                           -1,
+                           -1,
+                           -1
+                          ],
+                          "argument_offset": [
+                           0,
+                           0,
+                           0
+                          ],
+                          "negate_offset": false,
+                          "loc": {
+                           "Line": 30,
+                           "Column": 46
+                          }
+                         }
+                        },
+                        "loc": {
+                         "Line": 30,
+                         "Column": 13
+                        }
+                       }
+                      },
+                      "op": "-",
+                      "right": {
+                       "binary_operator": {
+                        "left": {
+                         "literal_access_expr": {
+                          "value": "4",
+                          "type": {
+                           "type_id": "Float"
+                          },
+                          "loc": {
+                           "Line": 30,
+                           "Column": 57
+                          }
+                         }
+                        },
+                        "op": "*",
+                        "right": {
+                         "field_access_expr": {
+                          "name": "u",
+                          "offset": [
+                           0,
+                           0,
+                           0
+                          ],
+                          "argument_map": [
+                           -1,
+                           -1,
+                           -1
+                          ],
+                          "argument_offset": [
+                           0,
+                           0,
+                           0
+                          ],
+                          "negate_offset": false,
+                          "loc": {
+                           "Line": 30,
+                           "Column": 63
+                          }
+                         }
+                        },
+                        "loc": {
+                         "Line": 30,
+                         "Column": 57
+                        }
+                       }
+                      },
+                      "loc": {
+                       "Line": 30,
+                       "Column": 13
+                      }
+                     }
+                    },
+                    "op": "+",
+                    "right": {
+                     "field_access_expr": {
+                      "name": "coeff",
+                      "offset": [
+                       0,
+                       0,
+                       1
+                      ],
+                      "argument_map": [
+                       -1,
+                       -1,
+                       -1
+                      ],
+                      "argument_offset": [
+                       0,
+                       0,
+                       0
+                      ],
+                      "negate_offset": false,
+                      "loc": {
+                       "Line": 30,
+                       "Column": 67
+                      }
+                     }
+                    },
+                    "loc": {
+                     "Line": 30,
+                     "Column": 13
+                    }
+                   }
+                  },
+                  "loc": {
+                   "Line": 30,
+                   "Column": 7
+                  }
+                 }
+                },
+                "loc": {
+                 "Line": 30,
+                 "Column": 7
+                }
+               }
+              },
+              {
+               "expr_stmt": {
+                "expr": {
+                 "assignment_expr": {
+                  "left": {
+                   "field_access_expr": {
+                    "name": "out",
+                    "offset": [
+                     0,
+                     0,
+                     0
+                    ],
+                    "argument_map": [
+                     -1,
+                     -1,
+                     -1
+                    ],
+                    "argument_offset": [
+                     0,
+                     0,
+                     0
+                    ],
+                    "negate_offset": false,
+                    "loc": {
+                     "Line": 31,
+                     "Column": 7
+                    }
+                   }
+                  },
+                  "op": "=",
+                  "right": {
+                   "binary_operator": {
+                    "left": {
+                     "binary_operator": {
+                      "left": {
+                       "binary_operator": {
+                        "left": {
+                         "binary_operator": {
+                          "left": {
+                           "field_access_expr": {
+                            "name": "lap",
+                            "offset": [
+                             1,
+                             0,
+                             0
+                            ],
+                            "argument_map": [
+                             -1,
+                             -1,
+                             -1
+                            ],
+                            "argument_offset": [
+                             0,
+                             0,
+                             0
+                            ],
+                            "negate_offset": false,
+                            "loc": {
+                             "Line": 31,
+                             "Column": 13
+                            }
+                           }
+                          },
+                          "op": "+",
+                          "right": {
+                           "field_access_expr": {
+                            "name": "lap",
+                            "offset": [
+                             -1,
+                             0,
+                             0
+                            ],
+                            "argument_map": [
+                             -1,
+                             -1,
+                             -1
+                            ],
+                            "argument_offset": [
+                             0,
+                             0,
+                             0
+                            ],
+                            "negate_offset": false,
+                            "loc": {
+                             "Line": 31,
+                             "Column": 26
+                            }
+                           }
+                          },
+                          "loc": {
+                           "Line": 31,
+                           "Column": 13
+                          }
+                         }
+                        },
+                        "op": "+",
+                        "right": {
+                         "field_access_expr": {
+                          "name": "lap",
+                          "offset": [
+                           0,
+                           1,
+                           0
+                          ],
+                          "argument_map": [
+                           -1,
+                           -1,
+                           -1
+                          ],
+                          "argument_offset": [
+                           0,
+                           0,
+                           0
+                          ],
+                          "negate_offset": false,
+                          "loc": {
+                           "Line": 31,
+                           "Column": 39
+                          }
+                         }
+                        },
+                        "loc": {
+                         "Line": 31,
+                         "Column": 13
+                        }
+                       }
+                      },
+                      "op": "+",
+                      "right": {
+                       "field_access_expr": {
+                        "name": "lap",
+                        "offset": [
+                         0,
+                         -1,
+                         0
+                        ],
+                        "argument_map": [
+                         -1,
+                         -1,
+                         -1
+                        ],
+                        "argument_offset": [
+                         0,
+                         0,
+                         0
+                        ],
+                        "negate_offset": false,
+                        "loc": {
+                         "Line": 31,
+                         "Column": 52
+                        }
+                       }
+                      },
+                      "loc": {
+                       "Line": 31,
+                       "Column": 13
+                      }
+                     }
+                    },
+                    "op": "-",
+                    "right": {
+                     "binary_operator": {
+                      "left": {
+                       "literal_access_expr": {
+                        "value": "4",
+                        "type": {
+                         "type_id": "Float"
+                        },
+                        "loc": {
+                         "Line": 31,
+                         "Column": 65
+                        }
+                       }
+                      },
+                      "op": "*",
+                      "right": {
+                       "field_access_expr": {
+                        "name": "lap",
+                        "offset": [
+                         0,
+                         0,
+                         0
+                        ],
+                        "argument_map": [
+                         -1,
+                         -1,
+                         -1
+                        ],
+                        "argument_offset": [
+                         0,
+                         0,
+                         0
+                        ],
+                        "negate_offset": false,
+                        "loc": {
+                         "Line": 31,
+                         "Column": 71
+                        }
+                       }
+                      },
+                      "loc": {
+                       "Line": 31,
+                       "Column": 65
+                      }
+                     }
+                    },
+                    "loc": {
+                     "Line": 31,
+                     "Column": 13
+                    }
+                   }
+                  },
+                  "loc": {
+                   "Line": 31,
+                   "Column": 7
+                  }
+                 }
+                },
+                "loc": {
+                 "Line": 31,
+                 "Column": 7
+                }
+               }
+              }
+             ],
+             "loc": {
+              "Line": 29,
+              "Column": 5
+             }
+            }
+           }
+          },
+          "interval": {
+           "lower_offset": 11,
+           "upper_offset": 0,
+           "special_lower_level": "Start",
+           "special_upper_level": "End"
+          },
+          "loop_order": "Forward"
+         },
+         "loc": {
+          "Line": 29,
+          "Column": 5
+         }
+        }
+       }
+      ],
+      "loc": {
+       "Line": -1,
+       "Column": -1
+      }
+     }
+    }
+   },
+   "fields": [
+    {
+     "name": "u",
+     "loc": {
+      "Line": 22,
+      "Column": 11
+     },
+     "is_temporary": false
+    },
+    {
+     "name": "out",
+     "loc": {
+      "Line": 22,
+      "Column": 14
+     },
+     "is_temporary": false
+    },
+    {
+     "name": "coeff",
+     "loc": {
+      "Line": 22,
+      "Column": 19
+     },
+     "is_temporary": false
+    },
+    {
+     "name": "lap",
+     "loc": {
+      "Line": 22,
+      "Column": 26
+     },
+     "is_temporary": false
+    },
+    {
+     "name": "out2",
+     "loc": {
+      "Line": 22,
+      "Column": 31
+     },
+     "is_temporary": false
+    }
+   ]
+  }
+ ],
+ "stencil_functions": [],
+ "global_variables": {
+  "map": {}
+ }
+}

--- a/test/unit-test/dawn/Optimizer/Passes/test_field_access_interval_04.sir
+++ b/test/unit-test/dawn/Optimizer/Passes/test_field_access_interval_04.sir
@@ -1,0 +1,396 @@
+{
+ "filename": "/code/dawn/test/unit-test/dawn/Optimizer/Passes/samples/test_field_access_interval_04.cpp",
+ "stencils": [
+  {
+   "name": "compute_extent_test_stencil",
+   "loc": {
+    "Line": 21,
+    "Column": 8
+   },
+   "ast": {
+    "root": {
+     "block_stmt": {
+      "statements": [
+       {
+        "vertical_region_decl_stmt": {
+         "vertical_region": {
+          "loc": {
+           "Line": 26,
+           "Column": 5
+          },
+          "ast": {
+           "root": {
+            "block_stmt": {
+             "statements": [
+              {
+               "expr_stmt": {
+                "expr": {
+                 "assignment_expr": {
+                  "left": {
+                   "field_access_expr": {
+                    "name": "u",
+                    "offset": [
+                     0,
+                     0,
+                     0
+                    ],
+                    "argument_map": [
+                     -1,
+                     -1,
+                     -1
+                    ],
+                    "argument_offset": [
+                     0,
+                     0,
+                     0
+                    ],
+                    "negate_offset": false,
+                    "loc": {
+                     "Line": 27,
+                     "Column": 7
+                    }
+                   }
+                  },
+                  "op": "=",
+                  "right": {
+                   "field_access_expr": {
+                    "name": "in",
+                    "offset": [
+                     0,
+                     0,
+                     0
+                    ],
+                    "argument_map": [
+                     -1,
+                     -1,
+                     -1
+                    ],
+                    "argument_offset": [
+                     0,
+                     0,
+                     0
+                    ],
+                    "negate_offset": false,
+                    "loc": {
+                     "Line": 27,
+                     "Column": 11
+                    }
+                   }
+                  },
+                  "loc": {
+                   "Line": 27,
+                   "Column": 7
+                  }
+                 }
+                },
+                "loc": {
+                 "Line": 27,
+                 "Column": 7
+                }
+               }
+              }
+             ],
+             "loc": {
+              "Line": 26,
+              "Column": 5
+             }
+            }
+           }
+          },
+          "interval": {
+           "lower_offset": 2,
+           "upper_offset": 3,
+           "special_lower_level": "Start",
+           "special_upper_level": "Start"
+          },
+          "loop_order": "Forward"
+         },
+         "loc": {
+          "Line": 26,
+          "Column": 5
+         }
+        }
+       },
+       {
+        "vertical_region_decl_stmt": {
+         "vertical_region": {
+          "loc": {
+           "Line": 28,
+           "Column": 5
+          },
+          "ast": {
+           "root": {
+            "block_stmt": {
+             "statements": [
+              {
+               "expr_stmt": {
+                "expr": {
+                 "assignment_expr": {
+                  "left": {
+                   "field_access_expr": {
+                    "name": "out1",
+                    "offset": [
+                     0,
+                     0,
+                     0
+                    ],
+                    "argument_map": [
+                     -1,
+                     -1,
+                     -1
+                    ],
+                    "argument_offset": [
+                     0,
+                     0,
+                     0
+                    ],
+                    "negate_offset": false,
+                    "loc": {
+                     "Line": 29,
+                     "Column": 7
+                    }
+                   }
+                  },
+                  "op": "=",
+                  "right": {
+                   "binary_operator": {
+                    "left": {
+                     "field_access_expr": {
+                      "name": "u",
+                      "offset": [
+                       0,
+                       0,
+                       2
+                      ],
+                      "argument_map": [
+                       -1,
+                       -1,
+                       -1
+                      ],
+                      "argument_offset": [
+                       0,
+                       0,
+                       0
+                      ],
+                      "negate_offset": false,
+                      "loc": {
+                       "Line": 29,
+                       "Column": 14
+                      }
+                     }
+                    },
+                    "op": "+",
+                    "right": {
+                     "field_access_expr": {
+                      "name": "u",
+                      "offset": [
+                       0,
+                       0,
+                       1
+                      ],
+                      "argument_map": [
+                       -1,
+                       -1,
+                       -1
+                      ],
+                      "argument_offset": [
+                       0,
+                       0,
+                       0
+                      ],
+                      "negate_offset": false,
+                      "loc": {
+                       "Line": 29,
+                       "Column": 23
+                      }
+                     }
+                    },
+                    "loc": {
+                     "Line": 29,
+                     "Column": 14
+                    }
+                   }
+                  },
+                  "loc": {
+                   "Line": 29,
+                   "Column": 7
+                  }
+                 }
+                },
+                "loc": {
+                 "Line": 29,
+                 "Column": 7
+                }
+               }
+              }
+             ],
+             "loc": {
+              "Line": 28,
+              "Column": 5
+             }
+            }
+           }
+          },
+          "interval": {
+           "lower_offset": 2,
+           "upper_offset": 10,
+           "special_lower_level": "Start",
+           "special_upper_level": "Start"
+          },
+          "loop_order": "Forward"
+         },
+         "loc": {
+          "Line": 28,
+          "Column": 5
+         }
+        }
+       },
+       {
+        "vertical_region_decl_stmt": {
+         "vertical_region": {
+          "loc": {
+           "Line": 30,
+           "Column": 5
+          },
+          "ast": {
+           "root": {
+            "block_stmt": {
+             "statements": [
+              {
+               "expr_stmt": {
+                "expr": {
+                 "assignment_expr": {
+                  "left": {
+                   "field_access_expr": {
+                    "name": "out2",
+                    "offset": [
+                     0,
+                     0,
+                     0
+                    ],
+                    "argument_map": [
+                     -1,
+                     -1,
+                     -1
+                    ],
+                    "argument_offset": [
+                     0,
+                     0,
+                     0
+                    ],
+                    "negate_offset": false,
+                    "loc": {
+                     "Line": 31,
+                     "Column": 7
+                    }
+                   }
+                  },
+                  "op": "=",
+                  "right": {
+                   "field_access_expr": {
+                    "name": "u",
+                    "offset": [
+                     0,
+                     0,
+                     6
+                    ],
+                    "argument_map": [
+                     -1,
+                     -1,
+                     -1
+                    ],
+                    "argument_offset": [
+                     0,
+                     0,
+                     0
+                    ],
+                    "negate_offset": false,
+                    "loc": {
+                     "Line": 31,
+                     "Column": 14
+                    }
+                   }
+                  },
+                  "loc": {
+                   "Line": 31,
+                   "Column": 7
+                  }
+                 }
+                },
+                "loc": {
+                 "Line": 31,
+                 "Column": 7
+                }
+               }
+              }
+             ],
+             "loc": {
+              "Line": 30,
+              "Column": 5
+             }
+            }
+           }
+          },
+          "interval": {
+           "lower_offset": 0,
+           "upper_offset": 8,
+           "special_lower_level": "Start",
+           "special_upper_level": "Start"
+          },
+          "loop_order": "Forward"
+         },
+         "loc": {
+          "Line": 30,
+          "Column": 5
+         }
+        }
+       }
+      ],
+      "loc": {
+       "Line": -1,
+       "Column": -1
+      }
+     }
+    }
+   },
+   "fields": [
+    {
+     "name": "in",
+     "loc": {
+      "Line": 22,
+      "Column": 11
+     },
+     "is_temporary": false
+    },
+    {
+     "name": "out1",
+     "loc": {
+      "Line": 22,
+      "Column": 15
+     },
+     "is_temporary": false
+    },
+    {
+     "name": "out2",
+     "loc": {
+      "Line": 22,
+      "Column": 21
+     },
+     "is_temporary": false
+    },
+    {
+     "name": "u",
+     "loc": {
+      "Line": 24,
+      "Column": 7
+     },
+     "is_temporary": true
+    }
+   ]
+  }
+ ],
+ "stencil_functions": [],
+ "global_variables": {
+  "map": {}
+ }
+}

--- a/test/unit-test/dawn/Optimizer/Passes/test_field_access_interval_05.sir
+++ b/test/unit-test/dawn/Optimizer/Passes/test_field_access_interval_05.sir
@@ -1,0 +1,756 @@
+{
+ "filename": "/code/dawn/test/unit-test/dawn/Optimizer/Passes/samples/test_field_access_interval_05.cpp",
+ "stencils": [
+  {
+   "name": "compute_extent_test_stencil",
+   "loc": {
+    "Line": 29,
+    "Column": 8
+   },
+   "ast": {
+    "root": {
+     "block_stmt": {
+      "statements": [
+       {
+        "vertical_region_decl_stmt": {
+         "vertical_region": {
+          "loc": {
+           "Line": 33,
+           "Column": 5
+          },
+          "ast": {
+           "root": {
+            "block_stmt": {
+             "statements": [
+              {
+               "expr_stmt": {
+                "expr": {
+                 "assignment_expr": {
+                  "left": {
+                   "field_access_expr": {
+                    "name": "out",
+                    "offset": [
+                     0,
+                     0,
+                     0
+                    ],
+                    "argument_map": [
+                     -1,
+                     -1,
+                     -1
+                    ],
+                    "argument_offset": [
+                     0,
+                     0,
+                     0
+                    ],
+                    "negate_offset": false,
+                    "loc": {
+                     "Line": 34,
+                     "Column": 7
+                    }
+                   }
+                  },
+                  "op": "=",
+                  "right": {
+                   "field_access_expr": {
+                    "name": "u",
+                    "offset": [
+                     0,
+                     0,
+                     0
+                    ],
+                    "argument_map": [
+                     -1,
+                     -1,
+                     -1
+                    ],
+                    "argument_offset": [
+                     0,
+                     0,
+                     0
+                    ],
+                    "negate_offset": false,
+                    "loc": {
+                     "Line": 34,
+                     "Column": 13
+                    }
+                   }
+                  },
+                  "loc": {
+                   "Line": 34,
+                   "Column": 7
+                  }
+                 }
+                },
+                "loc": {
+                 "Line": 34,
+                 "Column": 7
+                }
+               }
+              }
+             ],
+             "loc": {
+              "Line": 33,
+              "Column": 5
+             }
+            }
+           }
+          },
+          "interval": {
+           "lower_offset": 0,
+           "upper_offset": 10,
+           "special_lower_level": "Start",
+           "special_upper_level": "Start"
+          },
+          "loop_order": "Forward"
+         },
+         "loc": {
+          "Line": 33,
+          "Column": 5
+         }
+        }
+       },
+       {
+        "vertical_region_decl_stmt": {
+         "vertical_region": {
+          "loc": {
+           "Line": 35,
+           "Column": 5
+          },
+          "ast": {
+           "root": {
+            "block_stmt": {
+             "statements": [
+              {
+               "expr_stmt": {
+                "expr": {
+                 "assignment_expr": {
+                  "left": {
+                   "field_access_expr": {
+                    "name": "lap",
+                    "offset": [
+                     0,
+                     0,
+                     0
+                    ],
+                    "argument_map": [
+                     -1,
+                     -1,
+                     -1
+                    ],
+                    "argument_offset": [
+                     0,
+                     0,
+                     0
+                    ],
+                    "negate_offset": false,
+                    "loc": {
+                     "Line": 36,
+                     "Column": 7
+                    }
+                   }
+                  },
+                  "op": "=",
+                  "right": {
+                   "binary_operator": {
+                    "left": {
+                     "binary_operator": {
+                      "left": {
+                       "binary_operator": {
+                        "left": {
+                         "binary_operator": {
+                          "left": {
+                           "binary_operator": {
+                            "left": {
+                             "field_access_expr": {
+                              "name": "u",
+                              "offset": [
+                               1,
+                               0,
+                               0
+                              ],
+                              "argument_map": [
+                               -1,
+                               -1,
+                               -1
+                              ],
+                              "argument_offset": [
+                               0,
+                               0,
+                               0
+                              ],
+                              "negate_offset": false,
+                              "loc": {
+                               "Line": 36,
+                               "Column": 13
+                              }
+                             }
+                            },
+                            "op": "+",
+                            "right": {
+                             "field_access_expr": {
+                              "name": "u",
+                              "offset": [
+                               -1,
+                               0,
+                               0
+                              ],
+                              "argument_map": [
+                               -1,
+                               -1,
+                               -1
+                              ],
+                              "argument_offset": [
+                               0,
+                               0,
+                               0
+                              ],
+                              "negate_offset": false,
+                              "loc": {
+                               "Line": 36,
+                               "Column": 24
+                              }
+                             }
+                            },
+                            "loc": {
+                             "Line": 36,
+                             "Column": 13
+                            }
+                           }
+                          },
+                          "op": "+",
+                          "right": {
+                           "field_access_expr": {
+                            "name": "u",
+                            "offset": [
+                             0,
+                             1,
+                             0
+                            ],
+                            "argument_map": [
+                             -1,
+                             -1,
+                             -1
+                            ],
+                            "argument_offset": [
+                             0,
+                             0,
+                             0
+                            ],
+                            "negate_offset": false,
+                            "loc": {
+                             "Line": 36,
+                             "Column": 35
+                            }
+                           }
+                          },
+                          "loc": {
+                           "Line": 36,
+                           "Column": 13
+                          }
+                         }
+                        },
+                        "op": "+",
+                        "right": {
+                         "field_access_expr": {
+                          "name": "u",
+                          "offset": [
+                           0,
+                           -1,
+                           0
+                          ],
+                          "argument_map": [
+                           -1,
+                           -1,
+                           -1
+                          ],
+                          "argument_offset": [
+                           0,
+                           0,
+                           0
+                          ],
+                          "negate_offset": false,
+                          "loc": {
+                           "Line": 36,
+                           "Column": 46
+                          }
+                         }
+                        },
+                        "loc": {
+                         "Line": 36,
+                         "Column": 13
+                        }
+                       }
+                      },
+                      "op": "-",
+                      "right": {
+                       "binary_operator": {
+                        "left": {
+                         "literal_access_expr": {
+                          "value": "4",
+                          "type": {
+                           "type_id": "Float"
+                          },
+                          "loc": {
+                           "Line": 36,
+                           "Column": 57
+                          }
+                         }
+                        },
+                        "op": "*",
+                        "right": {
+                         "field_access_expr": {
+                          "name": "u",
+                          "offset": [
+                           0,
+                           0,
+                           0
+                          ],
+                          "argument_map": [
+                           -1,
+                           -1,
+                           -1
+                          ],
+                          "argument_offset": [
+                           0,
+                           0,
+                           0
+                          ],
+                          "negate_offset": false,
+                          "loc": {
+                           "Line": 36,
+                           "Column": 63
+                          }
+                         }
+                        },
+                        "loc": {
+                         "Line": 36,
+                         "Column": 57
+                        }
+                       }
+                      },
+                      "loc": {
+                       "Line": 36,
+                       "Column": 13
+                      }
+                     }
+                    },
+                    "op": "+",
+                    "right": {
+                     "field_access_expr": {
+                      "name": "coeff",
+                      "offset": [
+                       0,
+                       0,
+                       1
+                      ],
+                      "argument_map": [
+                       -1,
+                       -1,
+                       -1
+                      ],
+                      "argument_offset": [
+                       0,
+                       0,
+                       0
+                      ],
+                      "negate_offset": false,
+                      "loc": {
+                       "Line": 36,
+                       "Column": 67
+                      }
+                     }
+                    },
+                    "loc": {
+                     "Line": 36,
+                     "Column": 13
+                    }
+                   }
+                  },
+                  "loc": {
+                   "Line": 36,
+                   "Column": 7
+                  }
+                 }
+                },
+                "loc": {
+                 "Line": 36,
+                 "Column": 7
+                }
+               }
+              },
+              {
+               "expr_stmt": {
+                "expr": {
+                 "assignment_expr": {
+                  "left": {
+                   "field_access_expr": {
+                    "name": "out",
+                    "offset": [
+                     0,
+                     0,
+                     0
+                    ],
+                    "argument_map": [
+                     -1,
+                     -1,
+                     -1
+                    ],
+                    "argument_offset": [
+                     0,
+                     0,
+                     0
+                    ],
+                    "negate_offset": false,
+                    "loc": {
+                     "Line": 37,
+                     "Column": 7
+                    }
+                   }
+                  },
+                  "op": "=",
+                  "right": {
+                   "stencil_fun_call_expr": {
+                    "callee": "func",
+                    "arguments": [
+                     {
+                      "field_access_expr": {
+                       "name": "lap",
+                       "offset": [
+                        0,
+                        0,
+                        0
+                       ],
+                       "argument_map": [
+                        -1,
+                        -1,
+                        -1
+                       ],
+                       "argument_offset": [
+                        0,
+                        0,
+                        0
+                       ],
+                       "negate_offset": false,
+                       "loc": {
+                        "Line": 37,
+                        "Column": 18
+                       }
+                      }
+                     }
+                    ],
+                    "loc": {
+                     "Line": 37,
+                     "Column": 13
+                    }
+                   }
+                  },
+                  "loc": {
+                   "Line": 37,
+                   "Column": 7
+                  }
+                 }
+                },
+                "loc": {
+                 "Line": 37,
+                 "Column": 7
+                }
+               }
+              }
+             ],
+             "loc": {
+              "Line": 35,
+              "Column": 5
+             }
+            }
+           }
+          },
+          "interval": {
+           "lower_offset": 11,
+           "upper_offset": 0,
+           "special_lower_level": "Start",
+           "special_upper_level": "End"
+          },
+          "loop_order": "Forward"
+         },
+         "loc": {
+          "Line": 35,
+          "Column": 5
+         }
+        }
+       }
+      ],
+      "loc": {
+       "Line": -1,
+       "Column": -1
+      }
+     }
+    }
+   },
+   "fields": [
+    {
+     "name": "u",
+     "loc": {
+      "Line": 30,
+      "Column": 11
+     },
+     "is_temporary": false
+    },
+    {
+     "name": "out",
+     "loc": {
+      "Line": 30,
+      "Column": 14
+     },
+     "is_temporary": false
+    },
+    {
+     "name": "coeff",
+     "loc": {
+      "Line": 30,
+      "Column": 19
+     },
+     "is_temporary": false
+    },
+    {
+     "name": "lap",
+     "loc": {
+      "Line": 30,
+      "Column": 26
+     },
+     "is_temporary": false
+    }
+   ]
+  }
+ ],
+ "stencil_functions": [
+  {
+   "name": "func",
+   "loc": {
+    "Line": 21,
+    "Column": 8
+   },
+   "asts": [
+    {
+     "root": {
+      "block_stmt": {
+       "statements": [
+        {
+         "return_stmt": {
+          "expr": {
+           "binary_operator": {
+            "left": {
+             "binary_operator": {
+              "left": {
+               "binary_operator": {
+                "left": {
+                 "binary_operator": {
+                  "left": {
+                   "field_access_expr": {
+                    "name": "lap",
+                    "offset": [
+                     1,
+                     0,
+                     0
+                    ],
+                    "argument_map": [
+                     -1,
+                     -1,
+                     -1
+                    ],
+                    "argument_offset": [
+                     0,
+                     0,
+                     0
+                    ],
+                    "negate_offset": false,
+                    "loc": {
+                     "Line": 25,
+                     "Column": 9
+                    }
+                   }
+                  },
+                  "op": "+",
+                  "right": {
+                   "field_access_expr": {
+                    "name": "lap",
+                    "offset": [
+                     -1,
+                     0,
+                     -1
+                    ],
+                    "argument_map": [
+                     -1,
+                     -1,
+                     -1
+                    ],
+                    "argument_offset": [
+                     0,
+                     0,
+                     0
+                    ],
+                    "negate_offset": false,
+                    "loc": {
+                     "Line": 25,
+                     "Column": 22
+                    }
+                   }
+                  },
+                  "loc": {
+                   "Line": 25,
+                   "Column": 9
+                  }
+                 }
+                },
+                "op": "+",
+                "right": {
+                 "field_access_expr": {
+                  "name": "lap",
+                  "offset": [
+                   0,
+                   1,
+                   0
+                  ],
+                  "argument_map": [
+                   -1,
+                   -1,
+                   -1
+                  ],
+                  "argument_offset": [
+                   0,
+                   0,
+                   0
+                  ],
+                  "negate_offset": false,
+                  "loc": {
+                   "Line": 25,
+                   "Column": 40
+                  }
+                 }
+                },
+                "loc": {
+                 "Line": 25,
+                 "Column": 9
+                }
+               }
+              },
+              "op": "+",
+              "right": {
+               "field_access_expr": {
+                "name": "lap",
+                "offset": [
+                 0,
+                 -1,
+                 0
+                ],
+                "argument_map": [
+                 -1,
+                 -1,
+                 -1
+                ],
+                "argument_offset": [
+                 0,
+                 0,
+                 0
+                ],
+                "negate_offset": false,
+                "loc": {
+                 "Line": 25,
+                 "Column": 53
+                }
+               }
+              },
+              "loc": {
+               "Line": 25,
+               "Column": 9
+              }
+             }
+            },
+            "op": "-",
+            "right": {
+             "binary_operator": {
+              "left": {
+               "literal_access_expr": {
+                "value": "4",
+                "type": {
+                 "type_id": "Float"
+                },
+                "loc": {
+                 "Line": 25,
+                 "Column": 66
+                }
+               }
+              },
+              "op": "*",
+              "right": {
+               "field_access_expr": {
+                "name": "lap",
+                "offset": [
+                 0,
+                 0,
+                 0
+                ],
+                "argument_map": [
+                 -1,
+                 -1,
+                 -1
+                ],
+                "argument_offset": [
+                 0,
+                 0,
+                 0
+                ],
+                "negate_offset": false,
+                "loc": {
+                 "Line": 25,
+                 "Column": 72
+                }
+               }
+              },
+              "loc": {
+               "Line": 25,
+               "Column": 66
+              }
+             }
+            },
+            "loc": {
+             "Line": 25,
+             "Column": 9
+            }
+           }
+          },
+          "loc": {
+           "Line": 25,
+           "Column": 2
+          }
+         }
+        }
+       ],
+       "loc": {
+        "Line": 24,
+        "Column": 16
+       }
+      }
+     }
+    }
+   ],
+   "intervals": [],
+   "arguments": [
+    {
+     "field_value": {
+      "name": "lap",
+      "loc": {
+       "Line": 23,
+       "Column": 11
+      },
+      "is_temporary": false
+     }
+    }
+   ]
+  }
+ ],
+ "global_variables": {
+  "map": {}
+ }
+}

--- a/test/unit-test/dawn/Support/TestSmallVector.cpp
+++ b/test/unit-test/dawn/Support/TestSmallVector.cpp
@@ -1,13 +1,13 @@
 //===--------------------------------------------------------------------------------*- C++ -*-===//
-//                          _                      
-//                         | |                     
-//                       __| | __ ___      ___ ___  
-//                      / _` |/ _` \ \ /\ / / '_  | 
+//                          _
+//                         | |
+//                       __| | __ ___      ___ ___
+//                      / _` |/ _` \ \ /\ / / '_  |
 //                     | (_| | (_| |\ V  V /| | | |
 //                      \__,_|\__,_| \_/\_/ |_| |_| - Compiler Toolchain
 //
 //
-//  This file is distributed under the MIT License (MIT). 
+//  This file is distributed under the MIT License (MIT).
 //  See LICENSE.txt for details.
 //
 //===------------------------------------------------------------------------------------------===//
@@ -129,12 +129,10 @@ private:
   NonCopyable& operator=(const NonCopyable&) = delete;
 };
 
-
 DAWN_ATTRIBUTE_UNUSED void CompileTest() {
   SmallVector<NonCopyable, 0> V;
   V.resize(42);
 }
-
 
 class SmallVectorTestBase : public testing::Test {
 protected:
@@ -184,7 +182,8 @@ protected:
 
 typedef ::testing::Types<SmallVector<Constructable, 0>, SmallVector<Constructable, 1>,
                          SmallVector<Constructable, 2>, SmallVector<Constructable, 4>,
-                         SmallVector<Constructable, 5>> SmallVectorTestTypes;
+                         SmallVector<Constructable, 5>>
+    SmallVectorTestTypes;
 TYPED_TEST_CASE(SmallVectorTest, SmallVectorTestTypes);
 
 // New vector test.
@@ -698,8 +697,8 @@ TYPED_TEST(DualSmallVectorsTest, MoveAssignment) {
 }
 
 struct notassignable {
-  int& x;
-  notassignable(int& x) : x(x) {}
+  int& x_;
+  notassignable(int& x) : x_(x) {}
 };
 
 TEST(SmallVectorCustomTest, NoAssignTest) {
@@ -707,7 +706,7 @@ TEST(SmallVectorCustomTest, NoAssignTest) {
   SmallVector<notassignable, 2> vec;
   vec.push_back(notassignable(x));
   x = 42;
-  EXPECT_EQ(42, vec.pop_back_val().x);
+  EXPECT_EQ(42, vec.pop_back_val().x_);
 }
 
 struct MovedFrom {
@@ -746,31 +745,30 @@ private:
 
 enum EmplaceableState { ES_Emplaced, ES_Moved };
 struct Emplaceable {
-  EmplaceableArg<0> A0;
-  EmplaceableArg<1> A1;
-  EmplaceableArg<2> A2;
-  EmplaceableArg<3> A3;
+  EmplaceableArg<0> A0_;
+  EmplaceableArg<1> A1_;
+  EmplaceableArg<2> A2_;
+  EmplaceableArg<3> A3_;
   EmplaceableState State;
 
   Emplaceable() : State(ES_Emplaced) {}
 
   template <class A0Ty>
-  explicit Emplaceable(A0Ty&& A0)
-      : A0(std::forward<A0Ty>(A0)), State(ES_Emplaced) {}
+  explicit Emplaceable(A0Ty&& A0) : A0_(std::forward<A0Ty>(A0)), State(ES_Emplaced) {}
 
   template <class A0Ty, class A1Ty>
   Emplaceable(A0Ty&& A0, A1Ty&& A1)
-      : A0(std::forward<A0Ty>(A0)), A1(std::forward<A1Ty>(A1)), State(ES_Emplaced) {}
+      : A0_(std::forward<A0Ty>(A0)), A1_(std::forward<A1Ty>(A1)), State(ES_Emplaced) {}
 
   template <class A0Ty, class A1Ty, class A2Ty>
   Emplaceable(A0Ty&& A0, A1Ty&& A1, A2Ty&& A2)
-      : A0(std::forward<A0Ty>(A0)), A1(std::forward<A1Ty>(A1)), A2(std::forward<A2Ty>(A2)),
+      : A0_(std::forward<A0Ty>(A0)), A1_(std::forward<A1Ty>(A1)), A2_(std::forward<A2Ty>(A2)),
         State(ES_Emplaced) {}
 
   template <class A0Ty, class A1Ty, class A2Ty, class A3Ty>
   Emplaceable(A0Ty&& A0, A1Ty&& A1, A2Ty&& A2, A3Ty&& A3)
-      : A0(std::forward<A0Ty>(A0)), A1(std::forward<A1Ty>(A1)), A2(std::forward<A2Ty>(A2)),
-        A3(std::forward<A3Ty>(A3)), State(ES_Emplaced) {}
+      : A0_(std::forward<A0Ty>(A0)), A1_(std::forward<A1Ty>(A1)), A2_(std::forward<A2Ty>(A2)),
+        A3_(std::forward<A3Ty>(A3)), State(ES_Emplaced) {}
 
   Emplaceable(Emplaceable&&) : State(ES_Moved) {}
   Emplaceable& operator=(Emplaceable&&) {
@@ -793,60 +791,60 @@ TEST(SmallVectorTest, EmplaceBack) {
     V.emplace_back();
     EXPECT_TRUE(V.size() == 1);
     EXPECT_TRUE(V.back().State == ES_Emplaced);
-    EXPECT_TRUE(V.back().A0.State == EAS_Defaulted);
-    EXPECT_TRUE(V.back().A1.State == EAS_Defaulted);
-    EXPECT_TRUE(V.back().A2.State == EAS_Defaulted);
-    EXPECT_TRUE(V.back().A3.State == EAS_Defaulted);
+    EXPECT_TRUE(V.back().A0_.State == EAS_Defaulted);
+    EXPECT_TRUE(V.back().A1_.State == EAS_Defaulted);
+    EXPECT_TRUE(V.back().A2_.State == EAS_Defaulted);
+    EXPECT_TRUE(V.back().A3_.State == EAS_Defaulted);
   }
   {
     SmallVector<Emplaceable, 3> V;
     V.emplace_back(std::move(A0));
     EXPECT_TRUE(V.size() == 1);
     EXPECT_TRUE(V.back().State == ES_Emplaced);
-    EXPECT_TRUE(V.back().A0.State == EAS_RValue);
-    EXPECT_TRUE(V.back().A1.State == EAS_Defaulted);
-    EXPECT_TRUE(V.back().A2.State == EAS_Defaulted);
-    EXPECT_TRUE(V.back().A3.State == EAS_Defaulted);
+    EXPECT_TRUE(V.back().A0_.State == EAS_RValue);
+    EXPECT_TRUE(V.back().A1_.State == EAS_Defaulted);
+    EXPECT_TRUE(V.back().A2_.State == EAS_Defaulted);
+    EXPECT_TRUE(V.back().A3_.State == EAS_Defaulted);
   }
   {
     SmallVector<Emplaceable, 3> V;
     V.emplace_back(A0);
     EXPECT_TRUE(V.size() == 1);
     EXPECT_TRUE(V.back().State == ES_Emplaced);
-    EXPECT_TRUE(V.back().A0.State == EAS_LValue);
-    EXPECT_TRUE(V.back().A1.State == EAS_Defaulted);
-    EXPECT_TRUE(V.back().A2.State == EAS_Defaulted);
-    EXPECT_TRUE(V.back().A3.State == EAS_Defaulted);
+    EXPECT_TRUE(V.back().A0_.State == EAS_LValue);
+    EXPECT_TRUE(V.back().A1_.State == EAS_Defaulted);
+    EXPECT_TRUE(V.back().A2_.State == EAS_Defaulted);
+    EXPECT_TRUE(V.back().A3_.State == EAS_Defaulted);
   }
   {
     SmallVector<Emplaceable, 3> V;
     V.emplace_back(A0, A1);
     EXPECT_TRUE(V.size() == 1);
     EXPECT_TRUE(V.back().State == ES_Emplaced);
-    EXPECT_TRUE(V.back().A0.State == EAS_LValue);
-    EXPECT_TRUE(V.back().A1.State == EAS_LValue);
-    EXPECT_TRUE(V.back().A2.State == EAS_Defaulted);
-    EXPECT_TRUE(V.back().A3.State == EAS_Defaulted);
+    EXPECT_TRUE(V.back().A0_.State == EAS_LValue);
+    EXPECT_TRUE(V.back().A1_.State == EAS_LValue);
+    EXPECT_TRUE(V.back().A2_.State == EAS_Defaulted);
+    EXPECT_TRUE(V.back().A3_.State == EAS_Defaulted);
   }
   {
     SmallVector<Emplaceable, 3> V;
     V.emplace_back(std::move(A0), std::move(A1));
     EXPECT_TRUE(V.size() == 1);
     EXPECT_TRUE(V.back().State == ES_Emplaced);
-    EXPECT_TRUE(V.back().A0.State == EAS_RValue);
-    EXPECT_TRUE(V.back().A1.State == EAS_RValue);
-    EXPECT_TRUE(V.back().A2.State == EAS_Defaulted);
-    EXPECT_TRUE(V.back().A3.State == EAS_Defaulted);
+    EXPECT_TRUE(V.back().A0_.State == EAS_RValue);
+    EXPECT_TRUE(V.back().A1_.State == EAS_RValue);
+    EXPECT_TRUE(V.back().A2_.State == EAS_Defaulted);
+    EXPECT_TRUE(V.back().A3_.State == EAS_Defaulted);
   }
   {
     SmallVector<Emplaceable, 3> V;
     V.emplace_back(std::move(A0), A1, std::move(A2), A3);
     EXPECT_TRUE(V.size() == 1);
     EXPECT_TRUE(V.back().State == ES_Emplaced);
-    EXPECT_TRUE(V.back().A0.State == EAS_RValue);
-    EXPECT_TRUE(V.back().A1.State == EAS_LValue);
-    EXPECT_TRUE(V.back().A2.State == EAS_RValue);
-    EXPECT_TRUE(V.back().A3.State == EAS_LValue);
+    EXPECT_TRUE(V.back().A0_.State == EAS_RValue);
+    EXPECT_TRUE(V.back().A1_.State == EAS_LValue);
+    EXPECT_TRUE(V.back().A2_.State == EAS_RValue);
+    EXPECT_TRUE(V.back().A3_.State == EAS_LValue);
   }
   {
     SmallVector<int, 1> V;


### PR DESCRIPTION
Description
=============

Captures the intervals where temporaries are accessed in order to do a proper allocation size of storages in the code generation

Changes: 
* Fix a memory issue with shared_ptr being extracted (OptimizerContext) as raw pointers. When the shared_ptr was out of scope the whole StencilInstantiation was deallocated, while raw pointers still used. 
* Compute the intervals per field being accessed in the Stage::update()
* Unittest the interval computation