### PR TITLE
fix tmptostencil function with fields are versioned

### DIFF
--- a/src/dawn/Optimizer/AccessComputation.cpp
+++ b/src/dawn/Optimizer/AccessComputation.cpp
@@ -445,6 +445,7 @@ public:
 void computeAccesses(StencilInstantiation* instantiation,
                      ArrayRef<std::shared_ptr<StatementAccessesPair>> statementAccessesPairs) {
   for(const auto& statementAccessesPair : statementAccessesPairs) {
+    DAWN_ASSERT(instantiation);
     AccessMapper mapper(instantiation, statementAccessesPair, nullptr);
     statementAccessesPair->getStatement()->ASTStmt->accept(mapper);
   }

--- a/src/dawn/Optimizer/StatementMapper.cpp
+++ b/src/dawn/Optimizer/StatementMapper.cpp
@@ -250,6 +250,7 @@ void StatementMapper::visit(const std::shared_ptr<StencilFunCallExpr>& expr) {
   Scope* candiateScope = getCurrentCandidateScope();
 
   const auto& arguments = candiateScope->FunctionInstantiation->getArguments();
+
   for(std::size_t argIdx = 0; argIdx < arguments.size(); ++argIdx) {
     if(sir::Field* field = dyn_cast<sir::Field>(arguments[argIdx].get())) {
       int AccessID = candiateScope->FunctionInstantiation->getCallerAccessIDOfArgField(argIdx);

--- a/src/dawn/Optimizer/StencilFunctionInstantiation.cpp
+++ b/src/dawn/Optimizer/StencilFunctionInstantiation.cpp
@@ -172,10 +172,12 @@ int StencilFunctionInstantiation::getArgumentIndexFromCallerAccessID(int callerA
 
 const std::string&
 StencilFunctionInstantiation::getOriginalNameFromCallerAccessID(int callerAccessID) const {
-  for(std::size_t argIdx = 0; argIdx < function_->Args.size(); ++argIdx)
-    if(sir::Field* field = dyn_cast<sir::Field>(function_->Args[argIdx].get()))
+  for(std::size_t argIdx = 0; argIdx < function_->Args.size(); ++argIdx) {
+    if(sir::Field* field = dyn_cast<sir::Field>(function_->Args[argIdx].get())) {
       if(getCallerAccessIDOfArgField(argIdx) == callerAccessID)
         return field->Name;
+    }
+  }
   dawn_unreachable("invalid AccessID");
 }
 
@@ -292,6 +294,9 @@ void StencilFunctionInstantiation::setAccessIDOfExpr(const std::shared_ptr<Expr>
 
 void StencilFunctionInstantiation::mapExprToAccessID(const std::shared_ptr<Expr>& expr,
                                                      int accessID) {
+  if(ExprToCallerAccessIDMap_.count(expr)) {
+    DAWN_ASSERT(ExprToCallerAccessIDMap_.at(expr) == accessID);
+  }
   ExprToCallerAccessIDMap_.emplace(expr, accessID);
 }
 


### PR DESCRIPTION
This is a fix of the temporary to stencil function pass for the following case, that was caused due to versioning of the fields 

```
#include "gridtools/clang_dsl.hpp"

using namespace gridtools::clang;

stencil Test04 {
  storage a;
  storage b, c, d;
  var tmp_a, tmp_b;
  void Do() {
    vertical_region(k_start, k_end) {
      tmp_a = a[i + 1] + b;
      tmp_b = c[j - 1] + d;
      c = tmp_a[i - 1] + b;
      d = tmp_b[j + 1] + a;
    }
  }
};
```