### PR TITLE
Sync cxxnaive storages

### DIFF
--- a/src/dawn/CodeGen/CXXNaive/CXXNaiveCodeGen.h
+++ b/src/dawn/CodeGen/CXXNaive/CXXNaiveCodeGen.h
@@ -16,6 +16,7 @@
 #define DAWN_CODEGEN_CXXNAIVE_CXXNAIVECODEGEN_H
 
 #include "dawn/CodeGen/CodeGen.h"
+#include "dawn/CodeGen/CodeGenProperties.h"
 #include "dawn/Optimizer/Interval.h"
 #include "dawn/Support/IndexRange.h"
 #include <set>
@@ -40,6 +41,8 @@ public:
   virtual std::unique_ptr<TranslationUnit> generateCode() override;
 
 private:
+  void syncArgStorages(MemberFunction& method, const StencilInstantiation* stencilInstantiation,
+                       CodeGenProperties const& codeGenProperties);
   std::string generateStencilInstantiation(const StencilInstantiation* stencilInstantiation);
   std::string generateGlobals(const std::shared_ptr<SIR>& sir);
 };

--- a/src/dawn/CodeGen/CXXNaive/CXXNaiveCodeGen.h
+++ b/src/dawn/CodeGen/CXXNaive/CXXNaiveCodeGen.h
@@ -41,8 +41,6 @@ public:
   virtual std::unique_ptr<TranslationUnit> generateCode() override;
 
 private:
-  void syncArgStorages(MemberFunction& method, const StencilInstantiation* stencilInstantiation,
-                       CodeGenProperties const& codeGenProperties);
   std::string generateStencilInstantiation(const StencilInstantiation* stencilInstantiation);
   std::string generateGlobals(const std::shared_ptr<SIR>& sir);
 };


### PR DESCRIPTION
Technical Description
==================

considering that the naive backend is for debugging, 
here we automatically add `.sync()` calls to all argument storages before and after each call to a run. 
This largely simplifies all the benchmarking files we have in order project, since explicit sync is not needed anymore