### PR TITLE
remove debug MSS split and add debug Stage Split

### DIFF
--- a/src/dawn/Compiler/DawnCompiler.cpp
+++ b/src/dawn/Compiler/DawnCompiler.cpp
@@ -143,12 +143,7 @@ std::unique_ptr<OptimizerContext> DawnCompiler::runOptimizer(std::shared_ptr<SIR
   }
 
   using StageSplitStrategy = PassStageSplitter::StageSplittingStrategy;
-  StageSplitStrategy stageSplitStrategy;
-  if(options_->Debug) {
-    stageSplitStrategy = StageSplitStrategy::SS_Debug;
-  } else {
-    stageSplitStrategy = StageSplitStrategy::SS_Optimized;
-  }
+  StageSplitStrategy stageSplitStrategy = StageSplitStrategy::SS_Optimized;
 
   // -max-fields
   int maxFields = options_->MaxFieldsPerStencil;

--- a/src/dawn/Compiler/DawnCompiler.cpp
+++ b/src/dawn/Compiler/DawnCompiler.cpp
@@ -134,12 +134,20 @@ std::unique_ptr<OptimizerContext> DawnCompiler::runOptimizer(std::shared_ptr<SIR
     return nullptr;
   }
 
-  using MultistageSplitStrategy = PassMultiStageSplitter::MulitStageSplittingStrategy;
+  using MultistageSplitStrategy = PassMultiStageSplitter::MultiStageSplittingStrategy;
   MultistageSplitStrategy mssSplitStrategy;
-  if(options_->Debug) {
-    mssSplitStrategy = MultistageSplitStrategy::SS_Debug;
+  if(options_->MaxCutMSS) {
+    mssSplitStrategy = MultistageSplitStrategy::SS_MaxCut;
   } else {
     mssSplitStrategy = MultistageSplitStrategy::SS_Optimized;
+  }
+
+  using StageSplitStrategy = PassStageSplitter::StageSplittingStrategy;
+  StageSplitStrategy stageSplitStrategy;
+  if(options_->Debug) {
+    stageSplitStrategy = StageSplitStrategy::SS_Debug;
+  } else {
+    stageSplitStrategy = StageSplitStrategy::SS_Optimized;
   }
 
   // -max-fields
@@ -156,7 +164,7 @@ std::unique_ptr<OptimizerContext> DawnCompiler::runOptimizer(std::shared_ptr<SIR
   optimizer->checkAndPushBack<PassFieldVersioning>();
   optimizer->checkAndPushBack<PassSSA>();
   optimizer->checkAndPushBack<PassMultiStageSplitter>(mssSplitStrategy);
-  optimizer->checkAndPushBack<PassStageSplitter>();
+  optimizer->checkAndPushBack<PassStageSplitter>(stageSplitStrategy);
   optimizer->checkAndPushBack<PassPrintStencilGraph>();
   optimizer->checkAndPushBack<PassTemporaryType>();
   optimizer->checkAndPushBack<PassSetStageName>();

--- a/src/dawn/Compiler/DawnCompiler.cpp
+++ b/src/dawn/Compiler/DawnCompiler.cpp
@@ -142,8 +142,6 @@ std::unique_ptr<OptimizerContext> DawnCompiler::runOptimizer(std::shared_ptr<SIR
     mssSplitStrategy = MultistageSplitStrategy::SS_Optimized;
   }
 
-  using StageSplitStrategy = PassStageSplitter::StageSplittingStrategy;
-  StageSplitStrategy stageSplitStrategy = StageSplitStrategy::SS_Optimized;
 
   // -max-fields
   int maxFields = options_->MaxFieldsPerStencil;
@@ -159,7 +157,7 @@ std::unique_ptr<OptimizerContext> DawnCompiler::runOptimizer(std::shared_ptr<SIR
   optimizer->checkAndPushBack<PassFieldVersioning>();
   optimizer->checkAndPushBack<PassSSA>();
   optimizer->checkAndPushBack<PassMultiStageSplitter>(mssSplitStrategy);
-  optimizer->checkAndPushBack<PassStageSplitter>(stageSplitStrategy);
+  optimizer->checkAndPushBack<PassStageSplitter>();
   optimizer->checkAndPushBack<PassPrintStencilGraph>();
   optimizer->checkAndPushBack<PassTemporaryType>();
   optimizer->checkAndPushBack<PassSetStageName>();

--- a/src/dawn/Compiler/Options.inc
+++ b/src/dawn/Compiler/Options.inc
@@ -105,4 +105,6 @@ OPT(bool, ReportBoundaryConditions, false, "report-bc", "",
     "Report where boundary conditions are inserted", "", false, true)
 OPT(bool, Debug, false, "debug", "",
     "Compile to debug backend", "", false, true)
+OPT(bool, MaxCutMSS, false, "max-cut-mss", "",
+    "Cuts the given multistages in as many multistages as possible while maintaining legal code", "", false, true)
 // clang-format on

--- a/src/dawn/Optimizer/Pass.h
+++ b/src/dawn/Optimizer/Pass.h
@@ -41,10 +41,11 @@ protected:
   /// Name of the passes this pass depends on (empty implies no dependency)
   std::vector<std::string> dependencies_;
   /// Categroy of the pass
-  bool isDebug_ = false;
+  const bool isDebug_;
 
 public:
-  Pass(const std::string& name) : name_(name) {}
+  Pass(const std::string& name) : Pass(name, false) {}
+  Pass(const std::string& name, bool isDebug) : name_(name), isDebug_(isDebug) {}
   virtual ~Pass() {}
 
   /// @brief Run the the Pass

--- a/src/dawn/Optimizer/PassComputeStageExtents.cpp
+++ b/src/dawn/Optimizer/PassComputeStageExtents.cpp
@@ -20,9 +20,8 @@
 
 namespace dawn {
 
-PassComputeStageExtents::PassComputeStageExtents() : Pass("PassComputeStageExtents") {
+PassComputeStageExtents::PassComputeStageExtents() : Pass("PassComputeStageExtents", true) {
   dependencies_.push_back("PassSetStageName");
-  isDebug_ = true;
 }
 
 bool PassComputeStageExtents::run(

--- a/src/dawn/Optimizer/PassFieldVersioning.cpp
+++ b/src/dawn/Optimizer/PassFieldVersioning.cpp
@@ -89,9 +89,7 @@ static void reportRaceCondition(const Statement& statement, StencilInstantiation
 
 } // anonymous namespace
 
-PassFieldVersioning::PassFieldVersioning() : Pass("PassFieldVersioning"), numRenames_(0) {
-  isDebug_ = true;
-}
+PassFieldVersioning::PassFieldVersioning() : Pass("PassFieldVersioning", true), numRenames_(0) {}
 
 bool PassFieldVersioning::run(const std::shared_ptr<StencilInstantiation>& stencilInstantiation) {
   OptimizerContext* context = stencilInstantiation->getOptimizerContext();

--- a/src/dawn/Optimizer/PassInlining.cpp
+++ b/src/dawn/Optimizer/PassInlining.cpp
@@ -460,9 +460,7 @@ tryInlineStencilFunction(PassInlining::InlineStrategyKind strategy,
 } // anonymous namespace
 
 PassInlining::PassInlining(InlineStrategyKind strategy)
-    : Pass("PassInlining"), strategy_(strategy) {
-  isDebug_ = true;
-}
+    : Pass("PassInlining", true), strategy_(strategy) {}
 
 bool PassInlining::run(const std::shared_ptr<StencilInstantiation>& stencilInstantiation) {
   // Nothing to do ...

--- a/src/dawn/Optimizer/PassMultiStageSplitter.cpp
+++ b/src/dawn/Optimizer/PassMultiStageSplitter.cpp
@@ -106,9 +106,6 @@ setDebugLoopContent() {
     for(int stmtIndex = doMethod.getStatementAccessesPairs().size() - 2; stmtIndex >= 0;
         --stmtIndex) {
       DAWN_ASSERT_MSG(false, "Max-Cut for Multistages is not yet implemented");
-      // We split every StmtAccessPair into its own multistage
-      splitterIndices.emplace_front(MultiStage::SplitIndex{stageIndex, stmtIndex, curLoopOrder});
-      numSplit++;
     }
 
     // After splitting all the statements into their own Multistages, we need to ensure that if we

--- a/src/dawn/Optimizer/PassMultiStageSplitter.cpp
+++ b/src/dawn/Optimizer/PassMultiStageSplitter.cpp
@@ -28,9 +28,7 @@
 namespace dawn {
 
 PassMultiStageSplitter::PassMultiStageSplitter(MultiStageSplittingStrategy strategy)
-    : Pass("PassMultiStageSplitter"), strategy_(strategy) {
-  isDebug_ = true;
-}
+    : Pass("PassMultiStageSplitter", true), strategy_(strategy) {}
 namespace {
 
 int checkDependencies(const std::shared_ptr<Stage>& stage, int stmtIdx) {

--- a/src/dawn/Optimizer/PassMultiStageSplitter.h
+++ b/src/dawn/Optimizer/PassMultiStageSplitter.h
@@ -25,18 +25,19 @@ namespace dawn {
 /// @ingroup optimizer
 class PassMultiStageSplitter : public Pass {
 public:
-  /// @brief Inlining strategies
-  enum MulitStageSplittingStrategy {
-    SS_Debug,    ///< Splitting every Statement into it's own Multistage
+  /// @brief Multistage splitting strategies
+  enum MultiStageSplittingStrategy {
+    SS_MaxCut, ///< Splitting the multistage into as many multistages as possible while maintaining
+               /// code legality
     SS_Optimized ///< Optimized splitting of Multistages, only when needed
   };
-  PassMultiStageSplitter(MulitStageSplittingStrategy strategy);
+  PassMultiStageSplitter(MultiStageSplittingStrategy strategy);
 
   /// @brief Pass implementation
   bool run(const std::shared_ptr<StencilInstantiation>& stencilInstantiation) override;
 
 private:
-  MulitStageSplittingStrategy strategy_;
+  MultiStageSplittingStrategy strategy_;
 };
 
 } // namespace dawn

--- a/src/dawn/Optimizer/PassSetStageName.cpp
+++ b/src/dawn/Optimizer/PassSetStageName.cpp
@@ -18,7 +18,7 @@
 
 namespace dawn {
 
-PassSetStageName::PassSetStageName() : Pass("PassSetStageName") { isDebug_ = true; }
+PassSetStageName::PassSetStageName() : Pass("PassSetStageName", true) {}
 
 bool PassSetStageName::run(const std::shared_ptr<StencilInstantiation>& stencilInstantiation) {
   stencilInstantiation->getStageIDToNameMap().clear();

--- a/src/dawn/Optimizer/PassStageSplitter.cpp
+++ b/src/dawn/Optimizer/PassStageSplitter.cpp
@@ -28,100 +28,25 @@
 
 namespace dawn {
 
-PassStageSplitter::PassStageSplitter(StageSplittingStrategy strategy)
-    : Pass("PassStageSplitter"), strategy_(strategy) {
-  isDebug_ = true;
-}
+PassStageSplitter::PassStageSplitter() : Pass("PassStageSplitter") {}
 
-namespace {
-std::function<void(std::list<std::shared_ptr<Stage>>::iterator&, std::deque<int>&,
-                   std::deque<std::shared_ptr<DependencyGraphAccesses>>&,
-                   const std::shared_ptr<StencilInstantiation>&, const Options&, int, int,
-                   const std::string&, const std::string&, int&, std::shared_ptr<MultiStage>&)>
-setOptimizedLoopContent() {
-  return [&](std::list<std::shared_ptr<Stage>>::iterator& stageIt, std::deque<int>& splitterIndices,
-             std::deque<std::shared_ptr<DependencyGraphAccesses>>& graphs,
-             const std::shared_ptr<StencilInstantiation>& stencilInstantiation,
-             const Options& options, int multiStageIndex, int stageIndex,
-             const std::string& passName, const std::string& stencilName, int& numSplit,
-             std::shared_ptr<MultiStage>& multiStage) {
+bool PassStageSplitter::run(const std::shared_ptr<StencilInstantiation>& stencilInstantiation) {
+  OptimizerContext* context = stencilInstantiation->getOptimizerContext();
 
-    Stage& stage = (**stageIt);
-    DoMethod& doMethod = stage.getSingleDoMethod();
+  int numSplit = 0;
+  std::deque<int> splitterIndices;
+  std::deque<std::shared_ptr<DependencyGraphAccesses>> graphs;
 
-    splitterIndices.clear();
-    graphs.clear();
+  // Iterate over all stages in all multistages of all stencils
+  for(auto& stencil : stencilInstantiation->getStencils()) {
 
-    std::shared_ptr<DependencyGraphAccesses> newGraph, oldGraph;
-    newGraph = std::make_shared<DependencyGraphAccesses>(stencilInstantiation.get());
+    int multiStageIndex = 0;
+    int linearStageIndex = 0;
+    for(auto& multiStage : stencil->getMultiStages()) {
 
-    // Build the Dependency graph (bottom to top)
-    for(int stmtIndex = doMethod.getStatementAccessesPairs().size() - 1; stmtIndex >= 0;
-        --stmtIndex) {
-      auto& stmtAccessesPair = doMethod.getStatementAccessesPairs()[stmtIndex];
-
-      newGraph->insertStatementAccessesPair(stmtAccessesPair);
-
-      // If we have a horizontal read-before-write conflict, we record the current index for
-      // splitting
-      if(hasHorizontalReadBeforeWriteConflict(newGraph.get())) {
-
-        if(options.DumpSplitGraphs)
-          oldGraph->toDot(
-              format("stmt_hd_ms%i_s%i_%02i.dot", multiStageIndex, stageIndex, numSplit));
-
-        // Set the splitter index and assign the *old* graph as the stage dependency graph
-        splitterIndices.push_front(stmtIndex);
-        graphs.push_front(std::move(oldGraph));
-
-        if(options.ReportPassStageSplit)
-          std::cout << "\nPASS: " << passName /*getName()*/ << ": "
-                    << stencilName /*stencilInstantiation->getName()*/
-                    << ": split:"
-                    << stmtAccessesPair->getStatement()->ASTStmt->getSourceLocation().Line << "\n";
-
-        // Clear the new graph an process the current statements again
-        newGraph->clear();
-        newGraph->insertStatementAccessesPair(stmtAccessesPair);
-
-        numSplit++;
-      }
-
-      oldGraph = newGraph->clone();
-    }
-
-    if(options.DumpSplitGraphs)
-      newGraph->toDot(format("stmt_hd_ms%i_s%i_%02i.dot", multiStageIndex, stageIndex, numSplit));
-
-    graphs.push_front(newGraph);
-
-    // Perform the spliting of the stages and insert the stages *before* the stage we processed.
-    // Note that the "old" stage will be erased (it was consumed in split(...) anyway)
-    if(!splitterIndices.empty()) {
-      auto newStages = stage.split(splitterIndices, &graphs);
-      stageIt = multiStage->getStages().erase(stageIt);
-      multiStage->getStages().insert(stageIt, std::make_move_iterator(newStages.begin()),
-                                     std::make_move_iterator(newStages.end()));
-    } else {
-      DAWN_ASSERT(graphs.size() == 1);
-      doMethod.setDependencyGraph(graphs.back());
-      stage.update();
-      ++stageIt;
-    }
-  };
-}
-std::function<void(std::list<std::shared_ptr<Stage>>::iterator&, std::deque<int>&,
-                   std::deque<std::shared_ptr<DependencyGraphAccesses>>&,
-                   const std::shared_ptr<StencilInstantiation>&, const Options&, int, int,
-                   const std::string&, const std::string&, int&, std::shared_ptr<MultiStage>&)>
-setDebugLoopContent() {
-
-  return
-      [&](std::list<std::shared_ptr<Stage>>::iterator& stageIt, std::deque<int>& splitterIndices,
-          std::deque<std::shared_ptr<DependencyGraphAccesses>>& graphs,
-          const std::shared_ptr<StencilInstantiation>& stencilInstantiation, const Options& options,
-          int multiStageIndex, int stageIndex, const std::string& passName,
-          const std::string& stencilName, int& numSplit, std::shared_ptr<MultiStage>& multiStage) {
+      int stageIndex = 0;
+      for(auto stageIt = multiStage->getStages().begin(); stageIt != multiStage->getStages().end();
+          ++stageIndex, ++linearStageIndex) {
         Stage& stage = (**stageIt);
         DoMethod& doMethod = stage.getSingleDoMethod();
 
@@ -132,24 +57,43 @@ setDebugLoopContent() {
         newGraph = std::make_shared<DependencyGraphAccesses>(stencilInstantiation.get());
 
         // Build the Dependency graph (bottom to top)
-        for(int stmtIndex = doMethod.getStatementAccessesPairs().size() - 2; stmtIndex >= 0;
+        for(int stmtIndex = doMethod.getStatementAccessesPairs().size() - 1; stmtIndex >= 0;
             --stmtIndex) {
           auto& stmtAccessesPair = doMethod.getStatementAccessesPairs()[stmtIndex];
 
           newGraph->insertStatementAccessesPair(stmtAccessesPair);
 
-          // Set the splitter index and assign the *old* graph as the stage dependency graph
-          splitterIndices.push_front(stmtIndex);
-          graphs.push_front(std::move(oldGraph));
+          // If we have a horizontal read-before-write conflict, we record the current index for
+          // splitting
+          if(hasHorizontalReadBeforeWriteConflict(newGraph.get())) {
 
-          // Clear the new graph an process the current statements again
-          newGraph->clear();
-          newGraph->insertStatementAccessesPair(stmtAccessesPair);
+            if(context->getOptions().DumpSplitGraphs)
+              oldGraph->toDot(
+                  format("stmt_hd_ms%i_s%i_%02i.dot", multiStageIndex, stageIndex, numSplit));
 
-          numSplit++;
+            // Set the splitter index and assign the *old* graph as the stage dependency graph
+            splitterIndices.push_front(stmtIndex);
+            graphs.push_front(std::move(oldGraph));
+
+            if(context->getOptions().ReportPassStageSplit)
+              std::cout << "\nPASS: " << getName() << ": " << stencilInstantiation->getName()
+                        << ": split:"
+                        << stmtAccessesPair->getStatement()->ASTStmt->getSourceLocation().Line
+                        << "\n";
+
+            // Clear the new graph an process the current statements again
+            newGraph->clear();
+            newGraph->insertStatementAccessesPair(stmtAccessesPair);
+
+            numSplit++;
+          }
 
           oldGraph = newGraph->clone();
         }
+
+        if(context->getOptions().DumpSplitGraphs)
+          newGraph->toDot(
+              format("stmt_hd_ms%i_s%i_%02i.dot", multiStageIndex, stageIndex, numSplit));
 
         graphs.push_front(newGraph);
 
@@ -166,45 +110,6 @@ setDebugLoopContent() {
           stage.update();
           ++stageIt;
         }
-
-      };
-}
-} // anonymous namespace
-
-bool PassStageSplitter::run(const std::shared_ptr<StencilInstantiation>& stencilInstantiation) {
-  OptimizerContext* context = stencilInstantiation->getOptimizerContext();
-
-  int numSplit = 0;
-  std::deque<int> splitterIndices;
-  std::deque<std::shared_ptr<DependencyGraphAccesses>> graphs;
-
-  std::function<void(std::list<std::shared_ptr<Stage>>::iterator&, std::deque<int>&,
-                     std::deque<std::shared_ptr<DependencyGraphAccesses>>&,
-                     const std::shared_ptr<StencilInstantiation>&, const Options&, int, int,
-                     const std::string&, const std::string&, int&, std::shared_ptr<MultiStage>&)>
-      stageSplittingAlgorithm;
-
-  if(strategy_ == StageSplittingStrategy::SS_Optimized) {
-    stageSplittingAlgorithm = setOptimizedLoopContent();
-  } else {
-    DAWN_ASSERT_MSG(
-        false, "Debug splitting strategy for stages is not supported by the extent computation");
-    stageSplittingAlgorithm = setDebugLoopContent();
-  }
-
-  // Iterate over all stages in all multistages of all stencils
-  for(auto& stencil : stencilInstantiation->getStencils()) {
-
-    int multiStageIndex = 0;
-    int linearStageIndex = 0;
-    for(auto& multiStage : stencil->getMultiStages()) {
-
-      int stageIndex = 0;
-      for(auto stageIt = multiStage->getStages().begin(); stageIt != multiStage->getStages().end();
-          ++stageIndex, ++linearStageIndex) {
-        stageSplittingAlgorithm(stageIt, splitterIndices, graphs, stencilInstantiation,
-                                context->getOptions(), multiStageIndex, stageIndex, getName(),
-                                stencilInstantiation->getName(), numSplit, multiStage);
       }
 
       multiStageIndex += 1;

--- a/src/dawn/Optimizer/PassStageSplitter.cpp
+++ b/src/dawn/Optimizer/PassStageSplitter.cpp
@@ -28,7 +28,7 @@
 
 namespace dawn {
 
-PassStageSplitter::PassStageSplitter() : Pass("PassStageSplitter") { isDebug_ = true; }
+PassStageSplitter::PassStageSplitter() : Pass("PassStageSplitter", true) {}
 
 bool PassStageSplitter::run(const std::shared_ptr<StencilInstantiation>& stencilInstantiation) {
   OptimizerContext* context = stencilInstantiation->getOptimizerContext();

--- a/src/dawn/Optimizer/PassStageSplitter.cpp
+++ b/src/dawn/Optimizer/PassStageSplitter.cpp
@@ -28,7 +28,7 @@
 
 namespace dawn {
 
-PassStageSplitter::PassStageSplitter() : Pass("PassStageSplitter") {}
+PassStageSplitter::PassStageSplitter() : Pass("PassStageSplitter") { isDebug_ = true; }
 
 bool PassStageSplitter::run(const std::shared_ptr<StencilInstantiation>& stencilInstantiation) {
   OptimizerContext* context = stencilInstantiation->getOptimizerContext();

--- a/src/dawn/Optimizer/PassStageSplitter.cpp
+++ b/src/dawn/Optimizer/PassStageSplitter.cpp
@@ -28,25 +28,100 @@
 
 namespace dawn {
 
-PassStageSplitter::PassStageSplitter() : Pass("PassStageSplitter") {}
+PassStageSplitter::PassStageSplitter(StageSplittingStrategy strategy)
+    : Pass("PassStageSplitter"), strategy_(strategy) {
+  isDebug_ = true;
+}
 
-bool PassStageSplitter::run(const std::shared_ptr<StencilInstantiation>& stencilInstantiation) {
-  OptimizerContext* context = stencilInstantiation->getOptimizerContext();
+namespace {
+std::function<void(std::list<std::shared_ptr<Stage>>::iterator&, std::deque<int>&,
+                   std::deque<std::shared_ptr<DependencyGraphAccesses>>&,
+                   const std::shared_ptr<StencilInstantiation>&, const Options&, int, int,
+                   const std::string&, const std::string&, int&, std::shared_ptr<MultiStage>&)>
+setOptimizedLoopContent() {
+  return [&](std::list<std::shared_ptr<Stage>>::iterator& stageIt, std::deque<int>& splitterIndices,
+             std::deque<std::shared_ptr<DependencyGraphAccesses>>& graphs,
+             const std::shared_ptr<StencilInstantiation>& stencilInstantiation,
+             const Options& options, int multiStageIndex, int stageIndex,
+             const std::string& passName, const std::string& stencilName, int& numSplit,
+             std::shared_ptr<MultiStage>& multiStage) {
 
-  int numSplit = 0;
-  std::deque<int> splitterIndices;
-  std::deque<std::shared_ptr<DependencyGraphAccesses>> graphs;
+    Stage& stage = (**stageIt);
+    DoMethod& doMethod = stage.getSingleDoMethod();
 
-  // Iterate over all stages in all multistages of all stencils
-  for(auto& stencil : stencilInstantiation->getStencils()) {
+    splitterIndices.clear();
+    graphs.clear();
 
-    int multiStageIndex = 0;
-    int linearStageIndex = 0;
-    for(auto& multiStage : stencil->getMultiStages()) {
+    std::shared_ptr<DependencyGraphAccesses> newGraph, oldGraph;
+    newGraph = std::make_shared<DependencyGraphAccesses>(stencilInstantiation.get());
 
-      int stageIndex = 0;
-      for(auto stageIt = multiStage->getStages().begin(); stageIt != multiStage->getStages().end();
-          ++stageIndex, ++linearStageIndex) {
+    // Build the Dependency graph (bottom to top)
+    for(int stmtIndex = doMethod.getStatementAccessesPairs().size() - 1; stmtIndex >= 0;
+        --stmtIndex) {
+      auto& stmtAccessesPair = doMethod.getStatementAccessesPairs()[stmtIndex];
+
+      newGraph->insertStatementAccessesPair(stmtAccessesPair);
+
+      // If we have a horizontal read-before-write conflict, we record the current index for
+      // splitting
+      if(hasHorizontalReadBeforeWriteConflict(newGraph.get())) {
+
+        if(options.DumpSplitGraphs)
+          oldGraph->toDot(
+              format("stmt_hd_ms%i_s%i_%02i.dot", multiStageIndex, stageIndex, numSplit));
+
+        // Set the splitter index and assign the *old* graph as the stage dependency graph
+        splitterIndices.push_front(stmtIndex);
+        graphs.push_front(std::move(oldGraph));
+
+        if(options.ReportPassStageSplit)
+          std::cout << "\nPASS: " << passName /*getName()*/ << ": "
+                    << stencilName /*stencilInstantiation->getName()*/
+                    << ": split:"
+                    << stmtAccessesPair->getStatement()->ASTStmt->getSourceLocation().Line << "\n";
+
+        // Clear the new graph an process the current statements again
+        newGraph->clear();
+        newGraph->insertStatementAccessesPair(stmtAccessesPair);
+
+        numSplit++;
+      }
+
+      oldGraph = newGraph->clone();
+    }
+
+    if(options.DumpSplitGraphs)
+      newGraph->toDot(format("stmt_hd_ms%i_s%i_%02i.dot", multiStageIndex, stageIndex, numSplit));
+
+    graphs.push_front(newGraph);
+
+    // Perform the spliting of the stages and insert the stages *before* the stage we processed.
+    // Note that the "old" stage will be erased (it was consumed in split(...) anyway)
+    if(!splitterIndices.empty()) {
+      auto newStages = stage.split(splitterIndices, &graphs);
+      stageIt = multiStage->getStages().erase(stageIt);
+      multiStage->getStages().insert(stageIt, std::make_move_iterator(newStages.begin()),
+                                     std::make_move_iterator(newStages.end()));
+    } else {
+      DAWN_ASSERT(graphs.size() == 1);
+      doMethod.setDependencyGraph(graphs.back());
+      stage.update();
+      ++stageIt;
+    }
+  };
+}
+std::function<void(std::list<std::shared_ptr<Stage>>::iterator&, std::deque<int>&,
+                   std::deque<std::shared_ptr<DependencyGraphAccesses>>&,
+                   const std::shared_ptr<StencilInstantiation>&, const Options&, int, int,
+                   const std::string&, const std::string&, int&, std::shared_ptr<MultiStage>&)>
+setDebugLoopContent() {
+
+  return
+      [&](std::list<std::shared_ptr<Stage>>::iterator& stageIt, std::deque<int>& splitterIndices,
+          std::deque<std::shared_ptr<DependencyGraphAccesses>>& graphs,
+          const std::shared_ptr<StencilInstantiation>& stencilInstantiation, const Options& options,
+          int multiStageIndex, int stageIndex, const std::string& passName,
+          const std::string& stencilName, int& numSplit, std::shared_ptr<MultiStage>& multiStage) {
         Stage& stage = (**stageIt);
         DoMethod& doMethod = stage.getSingleDoMethod();
 
@@ -57,43 +132,24 @@ bool PassStageSplitter::run(const std::shared_ptr<StencilInstantiation>& stencil
         newGraph = std::make_shared<DependencyGraphAccesses>(stencilInstantiation.get());
 
         // Build the Dependency graph (bottom to top)
-        for(int stmtIndex = doMethod.getStatementAccessesPairs().size() - 1; stmtIndex >= 0;
+        for(int stmtIndex = doMethod.getStatementAccessesPairs().size() - 2; stmtIndex >= 0;
             --stmtIndex) {
           auto& stmtAccessesPair = doMethod.getStatementAccessesPairs()[stmtIndex];
 
           newGraph->insertStatementAccessesPair(stmtAccessesPair);
 
-          // If we have a horizontal read-before-write conflict, we record the current index for
-          // splitting
-          if(hasHorizontalReadBeforeWriteConflict(newGraph.get())) {
+          // Set the splitter index and assign the *old* graph as the stage dependency graph
+          splitterIndices.push_front(stmtIndex);
+          graphs.push_front(std::move(oldGraph));
 
-            if(context->getOptions().DumpSplitGraphs)
-              oldGraph->toDot(
-                  format("stmt_hd_ms%i_s%i_%02i.dot", multiStageIndex, stageIndex, numSplit));
+          // Clear the new graph an process the current statements again
+          newGraph->clear();
+          newGraph->insertStatementAccessesPair(stmtAccessesPair);
 
-            // Set the splitter index and assign the *old* graph as the stage dependency graph
-            splitterIndices.push_front(stmtIndex);
-            graphs.push_front(std::move(oldGraph));
-
-            if(context->getOptions().ReportPassStageSplit)
-              std::cout << "\nPASS: " << getName() << ": " << stencilInstantiation->getName()
-                        << ": split:"
-                        << stmtAccessesPair->getStatement()->ASTStmt->getSourceLocation().Line
-                        << "\n";
-
-            // Clear the new graph an process the current statements again
-            newGraph->clear();
-            newGraph->insertStatementAccessesPair(stmtAccessesPair);
-
-            numSplit++;
-          }
+          numSplit++;
 
           oldGraph = newGraph->clone();
         }
-
-        if(context->getOptions().DumpSplitGraphs)
-          newGraph->toDot(
-              format("stmt_hd_ms%i_s%i_%02i.dot", multiStageIndex, stageIndex, numSplit));
 
         graphs.push_front(newGraph);
 
@@ -110,6 +166,43 @@ bool PassStageSplitter::run(const std::shared_ptr<StencilInstantiation>& stencil
           stage.update();
           ++stageIt;
         }
+
+      };
+}
+} // anonymous namespace
+
+bool PassStageSplitter::run(const std::shared_ptr<StencilInstantiation>& stencilInstantiation) {
+  OptimizerContext* context = stencilInstantiation->getOptimizerContext();
+
+  int numSplit = 0;
+  std::deque<int> splitterIndices;
+  std::deque<std::shared_ptr<DependencyGraphAccesses>> graphs;
+
+  std::function<void(std::list<std::shared_ptr<Stage>>::iterator&, std::deque<int>&,
+                     std::deque<std::shared_ptr<DependencyGraphAccesses>>&,
+                     const std::shared_ptr<StencilInstantiation>&, const Options&, int, int,
+                     const std::string&, const std::string&, int&, std::shared_ptr<MultiStage>&)>
+      stageSplittingAlgorithm;
+
+  if(strategy_ == StageSplittingStrategy::SS_Optimized) {
+    stageSplittingAlgorithm = setOptimizedLoopContent();
+  } else {
+    stageSplittingAlgorithm = setDebugLoopContent();
+  }
+
+  // Iterate over all stages in all multistages of all stencils
+  for(auto& stencil : stencilInstantiation->getStencils()) {
+
+    int multiStageIndex = 0;
+    int linearStageIndex = 0;
+    for(auto& multiStage : stencil->getMultiStages()) {
+
+      int stageIndex = 0;
+      for(auto stageIt = multiStage->getStages().begin(); stageIt != multiStage->getStages().end();
+          ++stageIndex, ++linearStageIndex) {
+        stageSplittingAlgorithm(stageIt, splitterIndices, graphs, stencilInstantiation,
+                                context->getOptions(), multiStageIndex, stageIndex, getName(),
+                                stencilInstantiation->getName(), numSplit, multiStage);
       }
 
       multiStageIndex += 1;

--- a/src/dawn/Optimizer/PassStageSplitter.cpp
+++ b/src/dawn/Optimizer/PassStageSplitter.cpp
@@ -187,6 +187,8 @@ bool PassStageSplitter::run(const std::shared_ptr<StencilInstantiation>& stencil
   if(strategy_ == StageSplittingStrategy::SS_Optimized) {
     stageSplittingAlgorithm = setOptimizedLoopContent();
   } else {
+    DAWN_ASSERT_MSG(
+        false, "Debug splitting strategy for stages is not supported by the extent computation");
     stageSplittingAlgorithm = setDebugLoopContent();
   }
 

--- a/src/dawn/Optimizer/PassStageSplitter.h
+++ b/src/dawn/Optimizer/PassStageSplitter.h
@@ -28,10 +28,18 @@ namespace dawn {
 /// This pass is not necessary to create legal code and is hence not in the debug-group
 class PassStageSplitter : public Pass {
 public:
-  PassStageSplitter();
+  /// @brief Multistage splitting strategies
+  enum StageSplittingStrategy {
+    SS_Debug,    ///< Splitting every Statement into its own Stage
+    SS_Optimized ///< Optimized splitting of Stages, only when needed
+  };
+  PassStageSplitter(StageSplittingStrategy strategy);
 
   /// @brief Pass implementation
   bool run(const std::shared_ptr<StencilInstantiation>& stencilInstantiation) override;
+
+private:
+  StageSplittingStrategy strategy_;
 };
 
 } // namespace dawn

--- a/src/dawn/Optimizer/PassStageSplitter.h
+++ b/src/dawn/Optimizer/PassStageSplitter.h
@@ -32,7 +32,6 @@ public:
 
   /// @brief Pass implementation
   bool run(const std::shared_ptr<StencilInstantiation>& stencilInstantiation) override;
-
 };
 
 } // namespace dawn

--- a/src/dawn/Optimizer/PassStageSplitter.h
+++ b/src/dawn/Optimizer/PassStageSplitter.h
@@ -28,18 +28,11 @@ namespace dawn {
 /// This pass is not necessary to create legal code and is hence not in the debug-group
 class PassStageSplitter : public Pass {
 public:
-  /// @brief Multistage splitting strategies
-  enum StageSplittingStrategy {
-    SS_Debug,    ///< Splitting every Statement into its own Stage
-    SS_Optimized ///< Optimized splitting of Stages, only when needed
-  };
-  PassStageSplitter(StageSplittingStrategy strategy);
+  PassStageSplitter();
 
   /// @brief Pass implementation
   bool run(const std::shared_ptr<StencilInstantiation>& stencilInstantiation) override;
 
-private:
-  StageSplittingStrategy strategy_;
 };
 
 } // namespace dawn

--- a/src/dawn/Optimizer/PassTemporaryFirstAccess.cpp
+++ b/src/dawn/Optimizer/PassTemporaryFirstAccess.cpp
@@ -63,9 +63,7 @@ public:
 
 } // anonymous namespace
 
-PassTemporaryFirstAccess::PassTemporaryFirstAccess() : Pass("PassTemporaryFirstAccess") {
-  isDebug_ = true;
-}
+PassTemporaryFirstAccess::PassTemporaryFirstAccess() : Pass("PassTemporaryFirstAccess", true) {}
 
 bool PassTemporaryFirstAccess::run(
     const std::shared_ptr<StencilInstantiation>& stencilInstantiation) {

--- a/src/dawn/Optimizer/PassTemporaryType.cpp
+++ b/src/dawn/Optimizer/PassTemporaryType.cpp
@@ -86,7 +86,7 @@ struct Temporary {
 
 } // anonymous namespace
 
-PassTemporaryType::PassTemporaryType() : Pass("PassTemporaryType") { isDebug_ = true; }
+PassTemporaryType::PassTemporaryType() : Pass("PassTemporaryType", true) {}
 
 bool PassTemporaryType::run(const std::shared_ptr<StencilInstantiation>& instantiation) {
   OptimizerContext* context = instantiation->getOptimizerContext();


### PR DESCRIPTION
## Technical Description

Since our current syntax allows for iterative stencils in the form of 
```
vertical_region(k_start+1, k_end){
  var a = computation();
  var b = a[k-1] * computation();
  a = a / b;
}
```
we are not able to split every statement into a separate multistage since in the second iteration of the k-loop at line two we rely on the third line of this loop to be executed on the first k-level.

Therefore the suggested debugging backend is not a valid option. We moved the splitting of each statement to the stage-level. This relies on the multistage-splitter to be a mandatory, working piece to generate legal code. The option of having a separate algorithm that checks how many cuts we can maximally do in a given multistage without making the code illegal is though after but not yet finalized