### PR TITLE
Addition of Field-Dimensions

### DIFF
--- a/src/dawn/SIR/SIR.h
+++ b/src/dawn/SIR/SIR.h
@@ -159,9 +159,10 @@ struct StencilFunctionArg {
 /// @ingroup sir
 struct Field : public StencilFunctionArg {
   Field(const std::string& name, SourceLocation loc = SourceLocation())
-      : StencilFunctionArg{name, AK_Field, loc}, IsTemporary(false) {}
+      : StencilFunctionArg{name, AK_Field, loc}, IsTemporary(false), fieldDimensions({{0, 0, 0}}) {}
 
   bool IsTemporary;
+  Array3i fieldDimensions;
 
   static bool classof(const StencilFunctionArg* arg) { return arg->Kind == AK_Field; }
   bool operator==(const Field& rhs) const { return comparison(rhs); }

--- a/src/dawn/SIR/SIR.proto
+++ b/src/dawn/SIR/SIR.proto
@@ -35,6 +35,7 @@ message Field {
   string name = 1;        // Name of the field
   SourceLocation loc = 2; // Source location
   bool is_temporary = 3;  // Is the field a temporary?
+  repeated int32 field_dimensions = 4; // Legal dimension of the field initialized by the user
 }
 
 // @brief Directional argument of a StencilFunction

--- a/src/dawn/SIR/SIRSerializer.cpp
+++ b/src/dawn/SIR/SIRSerializer.cpp
@@ -129,7 +129,7 @@ static void setInterval(sir::proto::Interval* intervalProto, const sir::Interval
 static void setField(sir::proto::Field* fieldProto, const sir::Field* field) {
   fieldProto->set_name(field->Name);
   fieldProto->set_is_temporary(field->IsTemporary);
-  for(const auto& initializedDimension : field->fieldDimensions){
+  for(const auto& initializedDimension : field->fieldDimensions) {
     fieldProto->add_field_dimensions(initializedDimension);
   }
   setLocation(fieldProto->mutable_loc(), field->Loc);
@@ -601,15 +601,15 @@ static std::shared_ptr<sir::Field> makeField(const sir::proto::Field& fieldProto
   auto field = std::make_shared<sir::Field>(fieldProto.name(), makeLocation(fieldProto));
   field->IsTemporary = fieldProto.is_temporary();
   if(!fieldProto.field_dimensions().empty()) {
-      auto throwException = [&fieldProto](const char* member) {
-        throw std::runtime_error(format("Field::%s (loc %s) exceeds 3 dimensions", member,
-                                        makeLocation(fieldProto)));
-      };
+    auto throwException = [&fieldProto](const char* member) {
+      throw std::runtime_error(
+          format("Field::%s (loc %s) exceeds 3 dimensions", member, makeLocation(fieldProto)));
+    };
     if(fieldProto.field_dimensions().size() > 3)
       throwException("field_dimensions");
 
-    for(int i = 0; i < fieldProto.field_dimensions().size(); ++i)
-      field->fieldDimensions[i] = fieldProto.field_dimensions()[i];
+    std::copy(fieldProto.field_dimensions().begin(), fieldProto.field_dimensions().end(),
+              field->fieldDimensions.begin());
   }
   return field;
 }
@@ -779,8 +779,7 @@ static std::shared_ptr<Expr> makeExpr(const sir::proto::Expr& expressionProto) {
       if(exprProto.offset().size() > 3)
         throwException("offset");
 
-      for(int i = 0; i < exprProto.offset().size(); ++i)
-        offset[i] = exprProto.offset()[i];
+      std::copy(exprProto.offset().begin(), exprProto.offset().end(), offset.begin());
     }
 
     Array3i argumentOffset{{0, 0, 0}};
@@ -788,8 +787,8 @@ static std::shared_ptr<Expr> makeExpr(const sir::proto::Expr& expressionProto) {
       if(exprProto.argument_offset().size() > 3)
         throwException("argument_offset");
 
-      for(int i = 0; i < exprProto.argument_offset().size(); ++i)
-        argumentOffset[i] = exprProto.argument_offset()[i];
+      std::copy(exprProto.argument_offset().begin(), exprProto.argument_offset().end(),
+                argumentOffset.begin());
     }
 
     Array3i argumentMap{{-1, -1, -1}};
@@ -797,8 +796,8 @@ static std::shared_ptr<Expr> makeExpr(const sir::proto::Expr& expressionProto) {
       if(exprProto.argument_map().size() > 3)
         throwException("argument_map");
 
-      for(int i = 0; i < exprProto.argument_map().size(); ++i)
-        argumentMap[i] = exprProto.argument_map()[i];
+      std::copy(exprProto.argument_map().begin(), exprProto.argument_map().end(),
+                argumentMap.begin());
     }
 
     return std::make_shared<FieldAccessExpr>(name, offset, argumentMap, argumentOffset,

--- a/test/unit-test/dawn/SIR/TestSIRSerializer.cpp
+++ b/test/unit-test/dawn/SIR/TestSIRSerializer.cpp
@@ -63,6 +63,13 @@ TEST_P(StencilTest, Fields) {
   SIR_EXCPECT_EQ(sirRef, serializeAndDeserializeRef());
 }
 
+TEST_P(StencilTest, FieldsWithAttributes) {
+  sirRef->Stencils[0]->Fields.emplace_back(std::make_shared<sir::Field>("foo"));
+  sirRef->Stencils[0]->Fields[0]->IsTemporary = true;
+  sirRef->Stencils[0]->Fields[0]->fieldDimensions = {{1, 1, 0}};
+  SIR_EXCPECT_EQ(sirRef, serializeAndDeserializeRef());
+}
+
 TEST_P(StencilTest, AST) {
   sirRef->Stencils[0]->StencilDescAst =
       std::make_shared<AST>(std::make_shared<BlockStmt>(std::vector<std::shared_ptr<Stmt>>{


### PR DESCRIPTION
(this goes with a PR in [GTClang](https://github.com/MeteoSwiss-APN/gtclang/pull/69))

## Technical Description

This allows the user to specify the dimensionality of fields that are passed as input. Allowed inputs are:
```
storage
storage_i
storage_j
storage_k
storage_ij
storage_ik
storage_jk
storage_ijk
```
where the first and the last are the same

With this feature we gain two things:

* More error-checks are possible.
Currently you can pass a `storage_j_t` to the stencil and call it with i and k offsets. This can be prevented now if the user specifies the dimensionality of storages used.
* In the near future, there will be a Gridtools update that prohibits the notype-stencils that we currenly use.
In order for our setup to work, we need type information at the time of code-generation.