### PR TITLE
[outdated] New GT syntax

### DIFF
--- a/src/dawn/CodeGen/GridTools/ASTStencilDesc.cpp
+++ b/src/dawn/CodeGen/GridTools/ASTStencilDesc.cpp
@@ -60,7 +60,7 @@ void ASTStencilDesc::visit(const std::shared_ptr<StencilCallDeclStmt>& stmt) {
   int StencilID = instantiation_->getStencilCallToStencilIDMap().find(stmt)->second;
 
   for(const std::string& stencilName : StencilIDToStencilNameMap_.find(StencilID)->second) {
-    ss_ << std::string(indent_, ' ') << stencilName << ".get_stencil()->run();\n";
+    ss_ << std::string(indent_, ' ') << stencilName << ".get_stencil().run();\n";
   }
 }
 

--- a/src/dawn/CodeGen/GridTools/GTCodeGen.cpp
+++ b/src/dawn/CodeGen/GridTools/GTCodeGen.cpp
@@ -293,7 +293,7 @@ GTCodeGen::generateStencilInstantiation(const StencilInstantiation* stencilInsta
         .addTemplate(Twine("axis_") + StencilName);
 
     // Generate code for members of the stencil
-//    StencilClass.addComment("Members");
+    //    StencilClass.addComment("Members");
     //////////////////////////////////////////////////////////////////////////////////////////////
     //////////////////////////////////////////////////////////////////////////////////////////////
     //////////////////////////////////////////////////////////////////////////////////////////////
@@ -351,8 +351,8 @@ GTCodeGen::generateStencilInstantiation(const StencilInstantiation* stencilInsta
     //    }
     //    StencilClass.addMember("std::shared_ptr< gridtools::stencil<gridtools::notype> >",
     //    "m_stencil");
-//    stencilType = "computation<void>";
-//    StencilClass.addMember(stencilType, "m_stencil");
+    //    stencilType = "computation<void>";
+    //    StencilClass.addMember(stencilType, "m_stencil");
 
     //
     // Generate stencil functions code for stencils instantiated by this stencil
@@ -716,8 +716,10 @@ GTCodeGen::generateStencilInstantiation(const StencilInstantiation* stencilInsta
     //    dtor.commit();
 
     // Generate stencil getter
-    StencilClass.addMemberFunction(stencilType+"&", "get_stencil").addStatement("return m_stencil");
-    StencilClass.addMemberFunction("std::string","get_name").addStatement("return std::string(s_name)");
+    StencilClass.addMemberFunction(stencilType + "&", "get_stencil")
+        .addStatement("return m_stencil");
+    StencilClass.addMemberFunction("std::string", "get_name")
+        .addStatement("return std::string(s_name)");
   }
 
   if(isEmpty) {
@@ -784,7 +786,7 @@ GTCodeGen::generateStencilInstantiation(const StencilInstantiation* stencilInsta
     extents += fieldDimensions[0] ? "i" : "";
     extents += fieldDimensions[1] ? "j" : "";
     extents += fieldDimensions[2] ? "k" : "";
-    extents.pop_back();
+    extents += "_t";
     StencilWrapperConstructorArguments.emplace_back(extents,
                                                     SIRFieldsWithoutTemps[accessorIdx]->Name);
   }

--- a/src/dawn/CodeGen/GridTools/GTCodeGen.cpp
+++ b/src/dawn/CodeGen/GridTools/GTCodeGen.cpp
@@ -305,53 +305,54 @@ GTCodeGen::generateStencilInstantiation(const StencilInstantiation* stencilInsta
     //////////////////////////////////////////////////////////////////////////////////////////////
     //////////////////////////////////////////////////////////////////////////////////////////////
     // Fields
-    std::vector<Stencil::FieldInfo> StencilFields_a = stencil.getFields();
-    std::vector<std::string> StencilGlobalVariables_a = stencil.getGlobalVariables();
-    std::size_t numFields_a = StencilFields_a.size();
-    std::string listOfArguments;
-    int accessorIdx = 0;
-    for(; accessorIdx < numFields_a; ++accessorIdx)
-      if(StencilFields_a[accessorIdx].IsTemporary == false) {
-        Array3i fieldDimensions = StencilFields_a[accessorIdx].Dimensions;
-        std::string extents = "storage_";
-        extents += fieldDimensions[0] ? "i" : "";
-        extents += fieldDimensions[1] ? "j" : "";
-        extents += fieldDimensions[2] ? "k" : "";
+    //    std::vector<Stencil::FieldInfo> StencilFields_a = stencil.getFields();
+    //    std::vector<std::string> StencilGlobalVariables_a = stencil.getGlobalVariables();
+    //    std::size_t numFields_a = StencilFields_a.size();
+    //    std::string listOfArguments;
+    //    int accessorIdx = 0;
+    //    for(; accessorIdx < numFields_a; ++accessorIdx)
+    //      if(StencilFields_a[accessorIdx].IsTemporary == false) {
+    //        Array3i fieldDimensions = StencilFields_a[accessorIdx].Dimensions;
+    //        std::string extents = "storage_";
+    //        extents += fieldDimensions[0] ? "i" : "";
+    //        extents += fieldDimensions[1] ? "j" : "";
+    //        extents += fieldDimensions[2] ? "k" : "";
 
-        //          StencilClass.addComment(extents + " " + StencilFields_a[accessorIdx].Name);
-        extents += "_t";
+    //        //          StencilClass.addComment(extents + " " +
+    //        StencilFields_a[accessorIdx].Name);
+    //        extents += "_t";
 
-        StencilClass.addTypeDef("p_" + StencilFields_a[accessorIdx].Name)
-            .addType(c_gt() + "arg")
-            .addTemplate(Twine(accessorIdx))
-            .addTemplate(extents);
-        listOfArguments += "p_" + StencilFields_a[accessorIdx].Name + ", ";
-      } else {
-        StencilClass.addTypeDef("p_" + StencilFields_a[accessorIdx].Name)
-            .addType(c_gt() + "tmp_arg")
-            .addTemplate(Twine(accessorIdx))
-            .addTemplate("storage_t");
-      }
-    for(; accessorIdx < (numFields_a + StencilGlobalVariables_a.size()); ++accessorIdx) {
-      // Global variables
-      const auto& varname = StencilGlobalVariables_a[accessorIdx - numFields_a];
-      StencilClass.addTypeDef("p_" + StencilGlobalVariables_a[accessorIdx - numFields_a])
-          .addType(c_gt() + "arg")
-          .addTemplate(Twine(accessorIdx))
-          .addTemplate("typename std::decay<decltype(globals::get()." + varname +
-                       ".as_global_parameter())>::type");
-      listOfArguments += "p_" + StencilGlobalVariables_a[accessorIdx - numFields_a] + ", ";
-    }
-    // wittodo: proper calls, read extents
+    //        StencilClass.addTypeDef("p_" + StencilFields_a[accessorIdx].Name)
+    //            .addType(c_gt() + "arg")
+    //            .addTemplate(Twine(accessorIdx))
+    //            .addTemplate(extents);
+    //        listOfArguments += "p_" + StencilFields_a[accessorIdx].Name + ", ";
+    //      } else {
+    //        StencilClass.addTypeDef("p_" + StencilFields_a[accessorIdx].Name)
+    //            .addType(c_gt() + "tmp_arg")
+    //            .addTemplate(Twine(accessorIdx))
+    //            .addTemplate("storage_t");
+    //      }
+    //    for(; accessorIdx < (numFields_a + StencilGlobalVariables_a.size()); ++accessorIdx) {
+    //      // Global variables
+    //      const auto& varname = StencilGlobalVariables_a[accessorIdx - numFields_a];
+    //      StencilClass.addTypeDef("p_" + StencilGlobalVariables_a[accessorIdx - numFields_a])
+    //          .addType(c_gt() + "arg")
+    //          .addTemplate(Twine(accessorIdx))
+    //          .addTemplate("typename std::decay<decltype(globals::get()." + varname +
+    //                       ".as_global_parameter())>::type");
+    //      listOfArguments += "p_" + StencilGlobalVariables_a[accessorIdx - numFields_a] + ", ";
+    //    }
+    //    // wittodo: proper calls, read extents
 
-    if(listOfArguments.size() > 2) {
-      listOfArguments.pop_back();
-      listOfArguments.pop_back();
-    }
-    stencilType = "std::shared_ptr<computation<void, " + listOfArguments + ">>";
-    StencilClass.addMember(stencilType, "m_stencil");
+    //    if(listOfArguments.size() > 2) {
+    //      listOfArguments.pop_back();
+    //      listOfArguments.pop_back();
+    //    }
     //    StencilClass.addMember("std::shared_ptr< gridtools::stencil<gridtools::notype> >",
     //    "m_stencil");
+    stencilType = "computation<void>";
+    StencilClass.addMember(stencilType, "m_stencil");
 
     //
     // Generate stencil functions code for stencils instantiated by this stencil
@@ -518,7 +519,7 @@ GTCodeGen::generateStencilInstantiation(const StencilInstantiation* stencilInsta
           return "";
         }
 
-        accessorIdx = 0;
+        std::size_t accessorIdx = 0;
         for(; accessorIdx < fields.size(); ++accessorIdx) {
           const auto& field = fields[accessorIdx];
           std::string paramName = stencilInstantiation->getNameFromAccessID(field.getAccessID());
@@ -624,34 +625,37 @@ GTCodeGen::generateStencilInstantiation(const StencilInstantiation* stencilInsta
 
     StencilConstructor.startBody();
 
-    // Generate domain
-    //    StencilConstructor.addComment("Domain");
-    //    accessorIdx = 0;
+    // Generate domain StencilConstructor.addComment("Domain");
+    int accessorIdx = 0;
 
-    //    for(; accessorIdx < numFields; ++accessorIdx)
-    //      // Fields
-    //      StencilConstructor.addTypeDef("p_" + StencilFields[accessorIdx].Name)
-    //          .addType(c_gt() + (StencilFields[accessorIdx].IsTemporary ? "tmp_arg" : "arg"))
-    //          .addTemplate(Twine(accessorIdx))
-    //          .addTemplate(StencilFields[accessorIdx].IsTemporary
-    //                           ? "storage_t"
-    //                           : StencilConstructorTemplates[accessorIdx - numTemporaries]);
+    for(; accessorIdx < numFields; ++accessorIdx)
+      // Fields
+      StencilConstructor.addTypeDef("p_" + StencilFields[accessorIdx].Name)
+          .addType(c_gt() + (StencilFields[accessorIdx].IsTemporary ? "tmp_arg" : "arg"))
+          .addTemplate(Twine(accessorIdx))
+          .addTemplate(StencilFields[accessorIdx].IsTemporary
+                           ? "storage_t"
+                           : StencilConstructorTemplates[accessorIdx - numTemporaries]);
 
-    //    for(; accessorIdx < (numFields + StencilGlobalVariables.size()); ++accessorIdx) {
-    //      // Global variables
-    //      const auto& varname = StencilGlobalVariables[accessorIdx - numFields];
-    //      StencilConstructor.addTypeDef("p_" + StencilGlobalVariables[accessorIdx - numFields])
-    //          .addType(c_gt() + "arg")
-    //          .addTemplate(Twine(accessorIdx))
-    //          .addTemplate("typename std::decay<decltype(globals::get()." + varname +
-    //                       ".as_global_parameter())>::type");
-    //    }
+    for(; accessorIdx < (numFields + StencilGlobalVariables.size()); ++accessorIdx) {
+      // Global variables
+      const auto& varname = StencilGlobalVariables[accessorIdx - numFields];
+      StencilConstructor.addTypeDef("p_" + StencilGlobalVariables[accessorIdx - numFields])
+          .addType(c_gt() + "arg")
+          .addTemplate(Twine(accessorIdx))
+          .addTemplate("typename std::decay<decltype(globals::get()." + varname +
+                       ".as_global_parameter())>::type");
+    }
 
-    //    std::vector<std::string> ArglistPlaceholders;
-    //    for(const auto& field : StencilFields)
-    //      ArglistPlaceholders.push_back("p_" + field.Name);
-    //    for(const auto& var : StencilGlobalVariables)
-    //      ArglistPlaceholders.push_back("p_" + var);
+    std::vector<std::string> ArglistPlaceholders;
+    for(const auto& field : StencilFields)
+      ArglistPlaceholders.push_back("p_" + field.Name);
+    for(const auto& var : StencilGlobalVariables)
+      ArglistPlaceholders.push_back("p_" + var);
+
+    StencilConstructor.addTypeDef("domain_arg_list")
+        .addType("boost::mpl::vector")
+        .addTemplates(ArglistPlaceholders);
 
     // Placeholders to map the real storages to the placeholders (no temporaries)
     std::vector<std::string> DomainMapPlaceholders;
@@ -703,9 +707,9 @@ GTCodeGen::generateStencilInstantiation(const StencilInstantiation* stencilInsta
     StencilConstructor.commit();
 
     // Generate destructor
-//    auto dtor = StencilClass.addDestructor();
-//    dtor.addStatement("m_stencil->finalize()");
-//    dtor.commit();
+    //    auto dtor = StencilClass.addDestructor();
+    //    dtor.addStatement("m_stencil->finalize()");
+    //    dtor.commit();
 
     // Generate stencil getter
     StencilClass.addMemberFunction(stencilType, "get_stencil").addStatement("return m_stencil");
@@ -783,16 +787,18 @@ GTCodeGen::generateStencilInstantiation(const StencilInstantiation* stencilInsta
   for(int i = 0; i < SIRFieldsWithoutTemps.size(); ++i)
     StencilWrapperConstructorTemplates.push_back("S" + std::to_string(i + 1));
 
-  auto StencilWrapperConstructor = StencilWrapperClass.addConstructor(); //(RangeToString(", ", "", "")(
-//      StencilWrapperConstructorTemplates, [](const std::string& str) { return "class " + str; }));
+  auto StencilWrapperConstructor =
+      StencilWrapperClass.addConstructor(); //(RangeToString(", ", "", "")(
+  //      StencilWrapperConstructorTemplates, [](const std::string& str) { return "class " + str;
+  //      }));
 
   StencilWrapperConstructor.addArg("const " + c_gtc() + "domain& dom");
-  for(const auto& FieldStorage : StencilWrapperConstructorArguments){
-   StencilWrapperConstructor.addArg(FieldStorage.first+" "+FieldStorage.second);
+  for(const auto& FieldStorage : StencilWrapperConstructorArguments) {
+    StencilWrapperConstructor.addArg(FieldStorage.first + " " + FieldStorage.second);
   }
-//  for(int i = 0; i < SIRFieldsWithoutTemps.size(); ++i)
-//    StencilWrapperConstructor.addArg(StencilWrapperConstructorTemplates[i] + " " +
-//                                     SIRFieldsWithoutTemps[i]->Name);
+  //  for(int i = 0; i < SIRFieldsWithoutTemps.size(); ++i)
+  //    StencilWrapperConstructor.addArg(StencilWrapperConstructorTemplates[i] + " " +
+  //                                     SIRFieldsWithoutTemps[i]->Name);
 
   // Initialize allocated fields
   if(stencilInstantiation->hasAllocatedFields()) {
@@ -819,11 +825,12 @@ GTCodeGen::generateStencilInstantiation(const StencilInstantiation* stencilInsta
             return field.Name;
         }));
 
-//  for(int i = 0; i < SIRFieldsWithoutTemps.size(); ++i)
-//    StencilWrapperConstructor.addStatement(
-//        "static_assert(gridtools::is_data_store<" + StencilWrapperConstructorTemplates[i] +
-//        ">::value, \"argument '" + SIRFieldsWithoutTemps[i]->Name +
-//        "' is not a 'gridtools::data_store' (" + decimalToOrdinal(i + 2) + " argument invalid)\")");
+  //  for(int i = 0; i < SIRFieldsWithoutTemps.size(); ++i)
+  //    StencilWrapperConstructor.addStatement(
+  //        "static_assert(gridtools::is_data_store<" + StencilWrapperConstructorTemplates[i] +
+  //        ">::value, \"argument '" + SIRFieldsWithoutTemps[i]->Name +
+  //        "' is not a 'gridtools::data_store' (" + decimalToOrdinal(i + 2) + " argument
+  //        invalid)\")");
   StencilWrapperConstructor.commit();
 
   // Generate the run method by generate code for the stencil description AST

--- a/src/dawn/CodeGen/GridTools/GTCodeGen.cpp
+++ b/src/dawn/CodeGen/GridTools/GTCodeGen.cpp
@@ -292,68 +292,6 @@ GTCodeGen::generateStencilInstantiation(const StencilInstantiation* stencilInsta
         .addType(c_gt() + "grid")
         .addTemplate(Twine("axis_") + StencilName);
 
-    // Generate code for members of the stencil
-    //    StencilClass.addComment("Members");
-    //////////////////////////////////////////////////////////////////////////////////////////////
-    //////////////////////////////////////////////////////////////////////////////////////////////
-    //////////////////////////////////////////////////////////////////////////////////////////////
-    //////////////////////////////////////////////// wittodo    //////////////////////////////////
-    //////////////////////////////////////////////////////////////////////////////////////////////
-    //////////////////////////////////////////////////////////////////////////////////////////////
-    //////////////////////////////////////////////////////////////////////////////////////////////
-    //////////////////////////////////////////////////////////////////////////////////////////////
-    //////////////////////////////////////////////////////////////////////////////////////////////
-    //////////////////////////////////////////////////////////////////////////////////////////////
-    // Fields
-    //    std::vector<Stencil::FieldInfo> StencilFields_a = stencil.getFields();
-    //    std::vector<std::string> StencilGlobalVariables_a = stencil.getGlobalVariables();
-    //    std::size_t numFields_a = StencilFields_a.size();
-    //    std::string listOfArguments;
-    //    int accessorIdx = 0;
-    //    for(; accessorIdx < numFields_a; ++accessorIdx)
-    //      if(StencilFields_a[accessorIdx].IsTemporary == false) {
-    //        Array3i fieldDimensions = StencilFields_a[accessorIdx].Dimensions;
-    //        std::string extents = "storage_";
-    //        extents += fieldDimensions[0] ? "i" : "";
-    //        extents += fieldDimensions[1] ? "j" : "";
-    //        extents += fieldDimensions[2] ? "k" : "";
-
-    //        //          StencilClass.addComment(extents + " " +
-    //        StencilFields_a[accessorIdx].Name);
-    //        extents += "_t";
-
-    //        StencilClass.addTypeDef("p_" + StencilFields_a[accessorIdx].Name)
-    //            .addType(c_gt() + "arg")
-    //            .addTemplate(Twine(accessorIdx))
-    //            .addTemplate(extents);
-    //        listOfArguments += "p_" + StencilFields_a[accessorIdx].Name + ", ";
-    //      } else {
-    //        StencilClass.addTypeDef("p_" + StencilFields_a[accessorIdx].Name)
-    //            .addType(c_gt() + "tmp_arg")
-    //            .addTemplate(Twine(accessorIdx))
-    //            .addTemplate("storage_t");
-    //      }
-    //    for(; accessorIdx < (numFields_a + StencilGlobalVariables_a.size()); ++accessorIdx) {
-    //      // Global variables
-    //      const auto& varname = StencilGlobalVariables_a[accessorIdx - numFields_a];
-    //      StencilClass.addTypeDef("p_" + StencilGlobalVariables_a[accessorIdx - numFields_a])
-    //          .addType(c_gt() + "arg")
-    //          .addTemplate(Twine(accessorIdx))
-    //          .addTemplate("typename std::decay<decltype(globals::get()." + varname +
-    //                       ".as_global_parameter())>::type");
-    //      listOfArguments += "p_" + StencilGlobalVariables_a[accessorIdx - numFields_a] + ", ";
-    //    }
-    //    // wittodo: proper calls, read extents
-
-    //    if(listOfArguments.size() > 2) {
-    //      listOfArguments.pop_back();
-    //      listOfArguments.pop_back();
-    //    }
-    //    StencilClass.addMember("std::shared_ptr< gridtools::stencil<gridtools::notype> >",
-    //    "m_stencil");
-    //    stencilType = "computation<void>";
-    //    StencilClass.addMember(stencilType, "m_stencil");
-
     //
     // Generate stencil functions code for stencils instantiated by this stencil
     //
@@ -833,12 +771,6 @@ GTCodeGen::generateStencilInstantiation(const StencilInstantiation* stencilInsta
             return field.Name;
         }));
 
-  //  for(int i = 0; i < SIRFieldsWithoutTemps.size(); ++i)
-  //    StencilWrapperConstructor.addStatement(
-  //        "static_assert(gridtools::is_data_store<" + StencilWrapperConstructorTemplates[i] +
-  //        ">::value, \"argument '" + SIRFieldsWithoutTemps[i]->Name +
-  //        "' is not a 'gridtools::data_store' (" + decimalToOrdinal(i + 2) + " argument
-  //        invalid)\")");
   StencilWrapperConstructor.commit();
 
   // Generate the run method by generate code for the stencil description AST
@@ -862,9 +794,7 @@ GTCodeGen::generateStencilInstantiation(const StencilInstantiation* stencilInsta
   // Generate stencil getter
   MemberFunction timing = StencilWrapperClass.addMemberFunction("std::string", "get_meters");
   timing.addArg("int stencilID = -1");
-  //  RunMethod.addStatement();
 
-  //  timing.addStatement("switch(stencilID){\ncase 1: foo;\n case 2: bar;\n}");
   timing.addStatement("std::string retval =\"\";");
   timing.addBlockStatement("switch (stencilID)", [&]() {
     int idx;

--- a/src/dawn/CodeGen/GridTools/GTCodeGen.cpp
+++ b/src/dawn/CodeGen/GridTools/GTCodeGen.cpp
@@ -563,7 +563,7 @@ GTCodeGen::generateStencilInstantiation(const StencilInstantiation* stencilInsta
 
     StencilConstructor.startBody();
 
-    // Generate domain StencilConstructor.addComment("Domain");
+    // Generate domain
     int accessorIdx = 0;
 
     for(; accessorIdx < numFields; ++accessorIdx)
@@ -648,10 +648,6 @@ GTCodeGen::generateStencilInstantiation(const StencilInstantiation* stencilInsta
     stencilType = "computation<void>";
     StencilClass.addMember(stencilType, "m_stencil");
 
-    // Generate destructor
-    //    auto dtor = StencilClass.addDestructor();
-    //    dtor.addStatement("m_stencil->finalize()");
-    //    dtor.commit();
 
     // Generate stencil getter
     StencilClass.addMemberFunction(stencilType + "&", "get_stencil")
@@ -742,9 +738,6 @@ GTCodeGen::generateStencilInstantiation(const StencilInstantiation* stencilInsta
   for(const auto& FieldStorage : StencilWrapperConstructorArguments) {
     StencilWrapperConstructor.addArg(FieldStorage.first + " " + FieldStorage.second);
   }
-  //  for(int i = 0; i < SIRFieldsWithoutTemps.size(); ++i)
-  //    StencilWrapperConstructor.addArg(StencilWrapperConstructorTemplates[i] + " " +
-  //                                     SIRFieldsWithoutTemps[i]->Name);
 
   // Initialize allocated fields
   if(stencilInstantiation->hasAllocatedFields()) {

--- a/src/dawn/CodeGen/GridTools/GTCodeGen.cpp
+++ b/src/dawn/CodeGen/GridTools/GTCodeGen.cpp
@@ -348,7 +348,7 @@ GTCodeGen::generateStencilInstantiation(const StencilInstantiation* stencilInsta
       listOfArguments.pop_back();
       listOfArguments.pop_back();
     }
-    stencilType = "computation<void, " + listOfArguments + ">";
+    stencilType = "std::shared_ptr<computation<void, " + listOfArguments + ">>";
     StencilClass.addMember(stencilType, "m_stencil");
     //    StencilClass.addMember("std::shared_ptr< gridtools::stencil<gridtools::notype> >",
     //    "m_stencil");

--- a/src/dawn/CodeGen/GridTools/GTCodeGen.cpp
+++ b/src/dawn/CodeGen/GridTools/GTCodeGen.cpp
@@ -868,13 +868,13 @@ GTCodeGen::generateStencilInstantiation(const StencilInstantiation* stencilInsta
     int idx;
     for(idx = 0; idx < stencilInstantiation->getStencils().size(); ++idx) {
       timing << "case " << idx << ":\n"
-             << "return m_stencil_" << idx << ".get_stencil()->get_name()+\":\\t\"+"
-             << "m_stencil_" << idx << ".get_stencil()->get_meter();";
+             << "return m_stencil_" << idx << ".get_name()+\":\\t\"+"
+             << "std::to_string(m_stencil_" << idx << ".get_stencil().get_meter());";
     }
-    timing << "case -1 :\n"
+    timing << "case -1 :\n";
     std::string s = RangeToString("\n", "", "")(stencilMembers, [](const std::string& member) {
-      return "retval += " + member + ".get_stencil()->get_name()+\":\\t\"+" + member +
-             ".get_stencil()->get_meter()+\"\\n\";";
+      return "retval += " + member + ".get_name()+\":\\t\"+ std::to_string(" + member +
+             ".get_stencil().get_meter())+\"\\n\";";
     });
     timing << s;
     timing << "return retval;";
@@ -894,7 +894,7 @@ GTCodeGen::generateStencilInstantiation(const StencilInstantiation* stencilInsta
   // Generate name getter
   StencilWrapperClass.addMemberFunction("const char*", "get_name")
       .isConst(true)
-      .addStatement("return s_name");
+      .addStatement("return std::string(s_name)");
 
   StencilWrapperClass.commit();
 

--- a/src/dawn/CodeGen/GridTools/GTCodeGen.cpp
+++ b/src/dawn/CodeGen/GridTools/GTCodeGen.cpp
@@ -703,9 +703,9 @@ GTCodeGen::generateStencilInstantiation(const StencilInstantiation* stencilInsta
     StencilConstructor.commit();
 
     // Generate destructor
-    auto dtor = StencilClass.addDestructor();
-    dtor.addStatement("m_stencil->finalize()");
-    dtor.commit();
+//    auto dtor = StencilClass.addDestructor();
+//    dtor.addStatement("m_stencil->finalize()");
+//    dtor.commit();
 
     // Generate stencil getter
     StencilClass.addMemberFunction(stencilType, "get_stencil").addStatement("return m_stencil");

--- a/src/dawn/CodeGen/GridTools/GTCodeGen.cpp
+++ b/src/dawn/CodeGen/GridTools/GTCodeGen.cpp
@@ -652,8 +652,6 @@ GTCodeGen::generateStencilInstantiation(const StencilInstantiation* stencilInsta
     // Generate stencil getter
     StencilClass.addMemberFunction(stencilType + "&", "get_stencil")
         .addStatement("return m_stencil");
-    StencilClass.addMemberFunction("std::string", "get_name")
-        .addStatement("return std::string(s_name)");
   }
 
   if(isEmpty) {
@@ -784,6 +782,11 @@ GTCodeGen::generateStencilInstantiation(const StencilInstantiation* stencilInsta
 
   RunMethod.commit();
 
+  // Generate name getter
+  StencilWrapperClass.addMemberFunction("std::string", "get_name")
+      .isConst(true)
+      .addStatement("return std::string(s_name)");
+
   // Generate stencil getter
   MemberFunction timing = StencilWrapperClass.addMemberFunction("std::string", "get_meters");
   timing.addArg("int stencilID = -1");
@@ -793,12 +796,12 @@ GTCodeGen::generateStencilInstantiation(const StencilInstantiation* stencilInsta
     int idx;
     for(idx = 0; idx < stencilInstantiation->getStencils().size(); ++idx) {
       timing << "case " << idx << ":\n"
-             << "return m_stencil_" << idx << ".get_name()+\":\\t\"+"
+             << "return get_name() + \"m_stencil_" << idx << ":\\t\"+"
              << "std::to_string(m_stencil_" << idx << ".get_stencil().get_meter());";
     }
     timing << "case -1 :\n";
     std::string s = RangeToString("\n", "", "")(stencilMembers, [](const std::string& member) {
-      return "retval += " + member + ".get_name()+\":\\t\"+ std::to_string(" + member +
+      return "retval += get_name() + \"" + member + ":\\t\"+ std::to_string(" + member +
              ".get_stencil().get_meter())+\"\\n\";";
     });
     timing << s;
@@ -816,10 +819,7 @@ GTCodeGen::generateStencilInstantiation(const StencilInstantiation* stencilInsta
   clearMeters << s;
   clearMeters.commit();
 
-  // Generate name getter
-  StencilWrapperClass.addMemberFunction("const char*", "get_name")
-      .isConst(true)
-      .addStatement("return std::string(s_name)");
+
 
   StencilWrapperClass.commit();
 

--- a/src/dawn/CodeGen/GridTools/GTCodeGen.cpp
+++ b/src/dawn/CodeGen/GridTools/GTCodeGen.cpp
@@ -319,6 +319,7 @@ GTCodeGen::generateStencilInstantiation(const StencilInstantiation* stencilInsta
         extents += fieldDimensions[2] ? "k" : "";
 
         //          StencilClass.addComment(extents + " " + StencilFields_a[accessorIdx].Name);
+        extents += "_t";
 
         StencilClass.addTypeDef("p_" + StencilFields_a[accessorIdx].Name)
             .addType(c_gt() + "arg")

--- a/src/dawn/Optimizer/Stencil.cpp
+++ b/src/dawn/Optimizer/Stencil.cpp
@@ -123,13 +123,15 @@ std::vector<Stencil::FieldInfo> Stencil::getFields(bool withTemporaries) const {
   for(const auto& AccessID : fieldAccessIDs) {
     std::string name = stencilInstantiation_.getNameFromAccessID(AccessID);
     bool isTemporary = stencilInstantiation_.isTemporaryField(AccessID);
+    Array3i specifiedDimension = stencilInstantiation_.getFieldIDFromInitializedDimensionsMap(AccessID);//{{0,0,0}}; //= stencilInstantiation_.
+    // wittodo: read dimension and add to fieldinfo
 
     if(isTemporary) {
       if(withTemporaries) {
-        fields.insert(fields.begin(), FieldInfo{isTemporary, name, AccessID});
+        fields.insert(fields.begin(), FieldInfo{isTemporary, name, AccessID, specifiedDimension});
       }
     } else {
-      fields.emplace_back(FieldInfo{isTemporary, name, AccessID});
+      fields.emplace_back(FieldInfo{isTemporary, name, AccessID, specifiedDimension});
     }
   }
 

--- a/src/dawn/Optimizer/Stencil.cpp
+++ b/src/dawn/Optimizer/Stencil.cpp
@@ -123,8 +123,8 @@ std::vector<Stencil::FieldInfo> Stencil::getFields(bool withTemporaries) const {
   for(const auto& AccessID : fieldAccessIDs) {
     std::string name = stencilInstantiation_.getNameFromAccessID(AccessID);
     bool isTemporary = stencilInstantiation_.isTemporaryField(AccessID);
-    Array3i specifiedDimension = stencilInstantiation_.getFieldIDFromInitializedDimensionsMap(AccessID);//{{0,0,0}}; //= stencilInstantiation_.
-    // wittodo: read dimension and add to fieldinfo
+    Array3i specifiedDimension =
+        stencilInstantiation_.getFieldIDFromInitializedDimensionsMap(AccessID);
 
     if(isTemporary) {
       if(withTemporaries) {

--- a/src/dawn/Optimizer/Stencil.h
+++ b/src/dawn/Optimizer/Stencil.h
@@ -51,6 +51,7 @@ public:
     bool IsTemporary;
     std::string Name;
     int AccessID;
+    Array3i Dimensions;
   };
 
   /// @brief Position of a stage

--- a/src/dawn/Optimizer/StencilInstantiation.cpp
+++ b/src/dawn/Optimizer/StencilInstantiation.cpp
@@ -589,6 +589,7 @@ StencilInstantiation::StencilInstantiation(OptimizerContext* context,
   for(const auto& field : SIRStencil->Fields) {
     int AccessID = nextUID();
     setAccessIDNamePairOfField(AccessID, field->Name, field->IsTemporary);
+    fieldIDToInitializedDimensionsMap_.emplace(AccessID, field->fieldDimensions);
   }
 
   // Process the stencil description of the "main stencil"

--- a/src/dawn/Optimizer/StencilInstantiation.h
+++ b/src/dawn/Optimizer/StencilInstantiation.h
@@ -163,6 +163,9 @@ class StencilInstantiation : NonCopyable {
   /// Set of all the IDs that are locally cached
   std::set<int> CachedVariableSet_;
 
+  /// table from FieldID to an Array of initialized dimensions
+  std::unordered_map<int, Array3i> fieldIDToInitializedDimensionsMap_;
+
 public:
   /// @brief Assemble StencilInstantiation for stencil
   StencilInstantiation(OptimizerContext* context, const std::shared_ptr<sir::Stencil>& SIRStencil,
@@ -561,6 +564,13 @@ public:
       DAWN_ASSERT_MSG(false, "Boundary Condition does not have a matching Extent");
     }
     return BoundaryConditionToExtentsMap_.find(stmt)->second;
+  }
+
+  Array3i getFieldIDFromInitializedDimensionsMap(int FieldID){
+      if(fieldIDToInitializedDimensionsMap_.count(FieldID) == 0){
+          return Array3i{{0,0,0}};
+      }
+      return fieldIDToInitializedDimensionsMap_.find(FieldID)->second;
   }
 
 private:

--- a/src/dawn/Optimizer/StencilInstantiation.h
+++ b/src/dawn/Optimizer/StencilInstantiation.h
@@ -566,11 +566,11 @@ public:
     return BoundaryConditionToExtentsMap_.find(stmt)->second;
   }
 
-  Array3i getFieldIDFromInitializedDimensionsMap(int FieldID){
-      if(fieldIDToInitializedDimensionsMap_.count(FieldID) == 0){
-          return Array3i{{0,0,0}};
-      }
-      return fieldIDToInitializedDimensionsMap_.find(FieldID)->second;
+  Array3i getFieldIDFromInitializedDimensionsMap(int FieldID) {
+    if(fieldIDToInitializedDimensionsMap_.count(FieldID) == 0) {
+      return Array3i{{1, 1, 1}};
+    }
+    return fieldIDToInitializedDimensionsMap_.find(FieldID)->second;
   }
 
 private:


### PR DESCRIPTION
This pull request goes with the one in [GTClang](https://github.com/MeteoSwiss-APN/gtclang/pull/71)

## Technical Description
- The abstract class that we used to store the stencils, `gridtools::stencil<gridtools::notype>`, does no longer exist. We updated the code-generation to incorporate the new interface.
- Since we have the information about the storage-dimensions, we incorporate them into code generation and do no longer need them to be templated.
- A better version for reading the performance meters has been implemented