### PR TITLE
fix vertical extents

### DIFF
--- a/src/dawn/IIR/Extents.cpp
+++ b/src/dawn/IIR/Extents.cpp
@@ -14,8 +14,8 @@
 
 #include "dawn/IIR/Extents.h"
 #include "dawn/Support/Assert.h"
-#include "dawn/Support/Unreachable.h"
 #include "dawn/Support/StringUtil.h"
+#include "dawn/Support/Unreachable.h"
 #include <iostream>
 
 namespace dawn {
@@ -65,7 +65,7 @@ void Extents::merge(const Array3i& offset) {
   DAWN_ASSERT(extents_.size() == offset.size());
 
   for(std::size_t i = 0; i < extents_.size(); ++i)
-    extents_[i].merge(offset[i] >= 0 ? Extent{0, offset[i]} : Extent{offset[i], 0});
+    extents_[i].merge(Extent{offset[i], offset[i]});
 }
 
 void Extents::add(const Extents& other) {

--- a/test/unit-test/dawn/IIR/TestExtent.cpp
+++ b/test/unit-test/dawn/IIR/TestExtent.cpp
@@ -61,7 +61,7 @@ TEST(ExtentsTest, Merge3) {
   Extents extents({-1, 1, 0});
   extents.merge({-2, 0, 0});
 
-  EXPECT_TRUE((extents[0] == Extent{-2, 0}));
+  EXPECT_TRUE((extents[0] == Extent{-2, -1}));
   EXPECT_TRUE((extents[1] == Extent{0, 1}));
   EXPECT_TRUE((extents[2] == Extent{0, 0}));
 }


### PR DESCRIPTION
This is the typical problem, that when we compute the extents of accesses, and it is computed from an offset [k+2], the resulting extent is Extent{0,2}, instead of Extent[2,2]