### PR TITLE
Fix cuda backend

### DIFF
--- a/src/dawn/CodeGen/Cuda/CudaCodeGen.cpp
+++ b/src/dawn/CodeGen/Cuda/CudaCodeGen.cpp
@@ -543,7 +543,7 @@ void CudaCodeGen::generateTmpIndexInit(
 }
 
 int CudaCodeGen::paddedBoundary(int value) {
-  return value <= 1 ? 1 : value <= 2 ? 2 : value <= 4 ? 4 : 8;
+  return std::abs(value) <= 1 ? 1 : std::abs(value) <= 2 ? 2 : std::abs(value) <= 4 ? 4 : 8;
 }
 void CudaCodeGen::generateAllCudaKernels(
     std::stringstream& ssSW,

--- a/src/dawn/CodeGen/Cuda/CudaCodeGen.cpp
+++ b/src/dawn/CodeGen/Cuda/CudaCodeGen.cpp
@@ -376,8 +376,8 @@ void CudaCodeGen::generateCudaKernelCode(
           // block
           std::string step = intervalDiffToString(kmin, "ksize - 1");
           if(firstInterval) {
-            step = "max(" + step + "," + CodeGeneratorHelper::generateStrideName(2, index.second) +
-                   " * blockIdx.z * " + std::to_string(blockSize[2]) + ")";
+            step = "max(" + step + "," + " blockIdx.z * " + std::to_string(blockSize[2]) + ") * " +
+                   CodeGeneratorHelper::generateStrideName(2, index.second);
 
             cudaKernel.addComment("jump iterators to match the intersection of beginning of next "
                                   "interval and the parallel execution block ");

--- a/src/dawn/CodeGen/Cuda/CudaCodeGen.h
+++ b/src/dawn/CodeGen/Cuda/CudaCodeGen.h
@@ -154,7 +154,8 @@ private:
   std::string generateStencilInstantiation(
       const std::shared_ptr<iir::StencilInstantiation>& stencilInstantiation);
   static int paddedBoundary(int value);
-  bool requiresSync(const iir::Stage& stage, const std::unique_ptr<iir::MultiStage>& ms) const;
+  bool intervalRequiresSync(const iir::Interval& interval, const iir::Stage& stage,
+                            const std::unique_ptr<iir::MultiStage>& ms) const;
 };
 } // namespace cuda
 } // namespace codegen

--- a/src/dawn/CodeGen/Cuda/CudaCodeGen.h
+++ b/src/dawn/CodeGen/Cuda/CudaCodeGen.h
@@ -154,6 +154,9 @@ private:
   std::string generateStencilInstantiation(
       const std::shared_ptr<iir::StencilInstantiation>& stencilInstantiation);
   static int paddedBoundary(int value);
+  /// @brief returns true if the stage is the last stage of an interval loop execution
+  /// which requires synchronization due to usage of 2D ij caches (which are re-written at the next
+  /// k-loop iteration)
   bool intervalRequiresSync(const iir::Interval& interval, const iir::Stage& stage,
                             const std::unique_ptr<iir::MultiStage>& ms) const;
 };

--- a/src/dawn/Optimizer/PassSetSyncStage.cpp
+++ b/src/dawn/Optimizer/PassSetSyncStage.cpp
@@ -35,16 +35,6 @@ bool PassSetSyncStage::requiresSync(const iir::Stage& stage,
     return false;
   }
   DAWN_ASSERT(!ms->getChildren().empty());
-  // if the stage is the last stage, it will require a sync (to ensure we sync before the write of a
-  // previous stage at the next k level), but only if the stencil is not pure vertical
-  if(stageId == ms->getChildren().back()->getStageID()) {
-    for(const auto& st : ms->getChildren()) {
-      if(!st->getExtents().isPointwise()) {
-        return true;
-      }
-    }
-    return false;
-  }
 
   for(const auto& field : stage.getFields()) {
     const int accessID = field.second.getAccessID();


### PR DESCRIPTION
Fix that adds a synchronization after the last stage, if caches are used after the last stage that was synchronized. This is to avoid overwrite buffer of IJ Caches at the next K iteration