### PR TITLE
fix inlining

### DIFF
--- a/src/dawn/Optimizer/PassInlining.cpp
+++ b/src/dawn/Optimizer/PassInlining.cpp
@@ -310,6 +310,10 @@ public:
 
   void visit(const std::shared_ptr<VarAccessExpr>& expr) override {
 
+    std::string callerName = instantiation_->getNameFromAccessID(
+        curStencilFunctioninstantiation_->getAccessIDFromExpr(expr));
+    expr->setName(callerName);
+
     instantiation_->mapExprToAccessID(expr,
                                       curStencilFunctioninstantiation_->getAccessIDFromExpr(expr));
     if(expr->isArrayAccess())
@@ -319,6 +323,10 @@ public:
   void visit(const std::shared_ptr<FieldAccessExpr>& expr) override {
     instantiation_->mapExprToAccessID(expr,
                                       curStencilFunctioninstantiation_->getAccessIDFromExpr(expr));
+
+    std::string callerName = instantiation_->getNameFromAccessID(
+        curStencilFunctioninstantiation_->getAccessIDFromExpr(expr));
+    expr->setName(callerName);
 
     // Set the fully evaluated offset as the new offset of the field. Note that this renders the
     // AST of the current stencil function incorrent which is why it needs to be removed!

--- a/src/dawn/SIR/ASTExpr.h
+++ b/src/dawn/SIR/ASTExpr.h
@@ -402,6 +402,8 @@ public:
   const std::string& getName() const { return name_; }
   std::string& getName() { return name_; }
 
+  void setName(std::string name) { name_ = name; }
+
   void setIsExternal(bool external) { isExternal_ = external; }
 
   /// @brief Is the variable externally defined (e.g access to a global)?
@@ -493,6 +495,8 @@ public:
 
   const std::string& getName() const { return name_; }
   std::string& getName() { return name_; }
+
+  void setName(std::string name) { name_ = name; }
 
   const Array3i& getOffset() const { return offset_; }
   Array3i& getOffset() { return offset_; }

--- a/src/dawn/SIR/ASTExpr.h
+++ b/src/dawn/SIR/ASTExpr.h
@@ -400,7 +400,6 @@ public:
   /// @}
 
   const std::string& getName() const { return name_; }
-  std::string& getName() { return name_; }
 
   void setName(std::string name) { name_ = name; }
 
@@ -494,7 +493,6 @@ public:
   void setPureOffset(const Array3i& offset);
 
   const std::string& getName() const { return name_; }
-  std::string& getName() { return name_; }
 
   void setName(std::string name) { name_ = name; }
 


### PR DESCRIPTION
When expr's of a function are inlined in parent scope, the name of the expr should be changed to the caller expr name

Goes together with https://github.com/MeteoSwiss-APN/gtclang/pull/103
