### PR TITLE
removal of the semicolons where needed

### DIFF
--- a/src/dawn/CodeGen/CXXNaive/CXXNaiveCodeGen.cpp
+++ b/src/dawn/CodeGen/CXXNaive/CXXNaiveCodeGen.cpp
@@ -108,11 +108,7 @@ std::string CXXNaiveCodeGen::generateStencilInstantiation(
 
   cxxnaiveNamespace.commit();
 
-  // Remove trailing ';' as this is retained by Clang's Rewriter
-  std::string str = ssSW.str();
-  str[str.size() - 2] = ' ';
-
-  return str;
+  return ssSW.str();
 }
 
 void CXXNaiveCodeGen::generateStencilWrapperRun(

--- a/src/dawn/CodeGen/Cuda/CudaCodeGen.cpp
+++ b/src/dawn/CodeGen/Cuda/CudaCodeGen.cpp
@@ -117,11 +117,7 @@ std::string CudaCodeGen::generateStencilInstantiation(
 
   cudaNamespace.commit();
 
-  // Remove trailing ';' as this is retained by Clang's Rewriter
-  std::string str = ssSW.str();
-  str[str.size() - 2] = ' ';
-
-  return str;
+  return ssSW.str();
 }
 
 void CudaCodeGen::generateStencilWrapperPublicMemberFunctions(

--- a/src/dawn/CodeGen/GridTools/GTCodeGen.cpp
+++ b/src/dawn/CodeGen/GridTools/GTCodeGen.cpp
@@ -207,11 +207,7 @@ std::string GTCodeGen::generateStencilInstantiation(
 
   gridtoolsNamespace.commit();
 
-  // Remove trailing ';' as this is retained by Clang's Rewriter
-  std::string str = ssSW.str();
-  str[str.size() - 2] = ' ';
-
-  return str;
+  return ssSW.str();
 }
 
 void GTCodeGen::generateStencilWrapperPublicMemberFunctions(


### PR DESCRIPTION
Since we're now namespacing the generated code, this method of removing trailing semicolons does no longer work