### PR TITLE
Global constexpr

### DIFF
--- a/src/dawn/CodeGen/CodeGen.cpp
+++ b/src/dawn/CodeGen/CodeGen.cpp
@@ -43,6 +43,9 @@ std::string CodeGen::generateGlobals(std::shared_ptr<SIR> const& sir,
 
   for(const auto& globalsPair : globalsMap) {
     sir::Value& value = *globalsPair.second;
+    if(value.isConstexpr()) {
+      continue;
+    }
     std::string Name = globalsPair.first;
     std::string Type = sir::Value::typeToString(value.getType());
 
@@ -51,6 +54,9 @@ std::string CodeGen::generateGlobals(std::shared_ptr<SIR> const& sir,
   auto ctr = GlobalsStruct.addConstructor();
   for(const auto& globalsPair : globalsMap) {
     sir::Value& value = *globalsPair.second;
+    if(value.isConstexpr()) {
+      continue;
+    }
     std::string Name = globalsPair.first;
     if(!value.empty()) {
       ctr.addInit(Name + "(" + value.toString() + ")");
@@ -74,6 +80,9 @@ void CodeGen::generateGlobalsAPI(const iir::StencilInstantiation& stencilInstant
 
   for(const auto& globalProp : globalsMap) {
     auto globalValue = globalProp.second;
+    if(globalValue->isConstexpr()) {
+      continue;
+    }
     auto getter = stencilWrapperClass.addMemberFunction(
         sir::Value::typeToString(globalValue->getType()), "get_" + globalProp.first);
     getter.finishArgs();

--- a/src/dawn/CodeGen/GridTools/GTCodeGen.cpp
+++ b/src/dawn/CodeGen/GridTools/GTCodeGen.cpp
@@ -149,6 +149,9 @@ void GTCodeGen::generateGlobalsAPI(const iir::StencilInstantiation& stencilInsta
 
   for(const auto& globalProp : globalsMap) {
     auto globalValue = globalProp.second;
+    if(globalValue->isConstexpr()) {
+      continue;
+    }
     auto getter = stencilWrapperClass.addMemberFunction(
         sir::Value::typeToString(globalValue->getType()), "get_" + globalProp.first);
     getter.finishArgs();

--- a/src/dawn/Optimizer/PassTemporaryToStencilFunction.cpp
+++ b/src/dawn/Optimizer/PassTemporaryToStencilFunction.cpp
@@ -358,8 +358,13 @@ public:
       }
     }
 
+    auto asir = std::make_shared<SIR>();
+    for(const auto& sf : instantiation_->getStencilFunctions()) {
+      asir->StencilFunctions.push_back(sf);
+    }
+
     // recompute the list of <statement, accesses> pairs
-    StatementMapper statementMapper(nullptr, instantiation_.get(), stackTrace_,
+    StatementMapper statementMapper(asir, instantiation_.get(), stackTrace_,
                                     *(cloneStencilFun->getDoMethod()), interval_, fieldsMap,
                                     cloneStencilFun);
 


### PR DESCRIPTION
It avoids generating member of globals if they are constexpr declared. 
Performance improvements in CUDA backend