### PR TITLE
sort of generated code

### DIFF
--- a/src/dawn/CodeGen/CodeGen.cpp
+++ b/src/dawn/CodeGen/CodeGen.cpp
@@ -250,26 +250,25 @@ void CodeGen::addTempStorageTypedef(Structure& stencilClass, iir::Stencil const&
       .addType("storage_traits_t::data_store_t< float_type, " + tmpMetadataTypename_ + ">");
 }
 
-void CodeGen::addTmpStorageDeclaration(
-    Structure& stencilClass,
-    IndexRange<const std::unordered_map<int, iir::Stencil::FieldInfo>>& tempFields) const {
+void CodeGen::addTmpStorageDeclaration(Structure& stencilClass,
+                                      const std::vector<std::string>& tempFields) const {
   if(!(tempFields.empty())) {
     stencilClass.addMember(tmpMetadataTypename_, tmpMetadataName_);
 
-    for(auto field : tempFields) {
-      stencilClass.addMember(tmpStorageTypename_, "m_" + (*field).second.Name);
+    for(auto fieldName : tempFields) {
+      stencilClass.addMember(tmpStorageTypename_, "m_" + fieldName);
     }
   }
 }
 
 void CodeGen::addTmpStorageInit(
     MemberFunction& ctr, iir::Stencil const& stencil,
-    IndexRange<const std::unordered_map<int, iir::Stencil::FieldInfo>>& tempFields) const {
+    std::vector<std::string>& tempFields) const {
   if(!(tempFields.empty())) {
     ctr.addInit(tmpMetadataName_ + "(dom_.isize(), dom_.jsize(), dom_.ksize() + 2*" +
                 std::to_string(getVerticalTmpHaloSize(stencil)) + ")");
-    for(auto fieldIt : tempFields) {
-      ctr.addInit("m_" + (*fieldIt).second.Name + "(" + tmpMetadataName_ + ")");
+    for(auto fieldName : tempFields) {
+      ctr.addInit("m_" + fieldName + "(" + tmpMetadataName_ + ")");
     }
   }
 }

--- a/src/dawn/CodeGen/CodeGen.cpp
+++ b/src/dawn/CodeGen/CodeGen.cpp
@@ -175,13 +175,22 @@ CodeGen::computeCodeGenProperties(const iir::StencilInstantiation* stencilInstan
 
     // fields used in the stencil
     const auto& StencilFields = stencil->getFields();
+    std::vector<std::pair<int, iir::Stencil::FieldInfo>> sortedFields;
+    for(auto field : StencilFields) {
+      sortedFields.push_back(field);
+    }
+    std::sort(sortedFields.begin(), sortedFields.end(),
+              [&](std::pair<int, iir::Stencil::FieldInfo> field1,
+                  std::pair<int, iir::Stencil::FieldInfo> field2) {
+                return field1.first < field2.first;
+              });
 
     auto nonTempFields = makeRange(
-        StencilFields,
+        sortedFields,
         std::function<bool(std::pair<int, iir::Stencil::FieldInfo> const&)>([](
             std::pair<int, iir::Stencil::FieldInfo> const& p) { return !p.second.IsTemporary; }));
     auto tempFields = makeRange(
-        StencilFields,
+        sortedFields,
         std::function<bool(std::pair<int, iir::Stencil::FieldInfo> const&)>(
             [](std::pair<int, iir::Stencil::FieldInfo> const& p) { return p.second.IsTemporary; }));
 

--- a/src/dawn/CodeGen/CodeGen.h
+++ b/src/dawn/CodeGen/CodeGen.h
@@ -37,10 +37,10 @@ protected:
   virtual void addTempStorageTypedef(Structure& stencilClass, iir::Stencil const& stencil) const;
   void addTmpStorageDeclaration(
       Structure& stencilClass,
-      IndexRange<const std::unordered_map<int, iir::Stencil::FieldInfo>>& tmpFields) const;
+      const std::vector<std::string>& tmpFields) const;
   virtual void addTmpStorageInit(
       MemberFunction& ctr, const iir::Stencil& stencil,
-      IndexRange<const std::unordered_map<int, iir::Stencil::FieldInfo>>& tempFields) const;
+      std::vector<std::string>& tempFields) const;
   void
   addTmpStorageInitStencilWrapperCtr(MemberFunction& ctr,
                                      const std::vector<std::unique_ptr<iir::Stencil>>& stencils,

--- a/src/dawn/CodeGen/Cuda/CudaCodeGen.h
+++ b/src/dawn/CodeGen/Cuda/CudaCodeGen.h
@@ -54,9 +54,8 @@ private:
 
   void addTempStorageTypedef(Structure& stencilClass, iir::Stencil const& stencil) const override;
 
-  void addTmpStorageInit(MemberFunction& ctr, iir::Stencil const& stencil,
-                         IndexRange<const std::unordered_map<int, iir::Stencil::FieldInfo>>&
-                             tempFields) const override;
+  void addTmpStorageInit(MemberFunction& ctr, const iir::Stencil& stencil,
+                         std::vector<std::string>& tempFields) const override;
 
   void
   generateCudaKernelCode(std::stringstream& ssSW,
@@ -102,16 +101,14 @@ private:
   void generateStencilClassCtr(
       Structure& stencilClass, const iir::Stencil& stencil,
       const sir::GlobalVariableMap& globalsMap,
-      IndexRange<const std::unordered_map<int, iir::Stencil::FieldInfo>>& nonTempFields,
-      IndexRange<const std::unordered_map<int, iir::Stencil::FieldInfo>>& tempFields,
+      std::vector<std::string>& nonTempFields,
+      std::vector<std::string>& tempFields,
       std::shared_ptr<StencilProperties> stencilProperties) const;
 
-  void generateStencilClassMembers(
-      Structure& stencilClass, const iir::Stencil& stencil,
-      const sir::GlobalVariableMap& globalsMap,
-      IndexRange<const std::unordered_map<int, iir::Stencil::FieldInfo>>& nonTempFields,
-      IndexRange<const std::unordered_map<int, iir::Stencil::FieldInfo>>& tempFields,
-      std::shared_ptr<StencilProperties> stencilProperties) const;
+  void generateStencilClassMembers(Structure& stencilClass, const iir::Stencil& stencil,
+                                   const sir::GlobalVariableMap& globalsMap,
+                                   std::vector<std::string>& nonTempFields,
+                                   std::vector<std::string>& tempFields) const;
 
   std::string generateStencilInstantiation(
       const std::shared_ptr<iir::StencilInstantiation>& stencilInstantiation);

--- a/src/dawn/CodeGen/GridTools/GTCodeGen.h
+++ b/src/dawn/CodeGen/GridTools/GTCodeGen.h
@@ -70,7 +70,7 @@ private:
   void buildPlaceholderDefinitions(
       MemberFunction& function,
       const std::shared_ptr<iir::StencilInstantiation>& stencilInstantiation,
-      const std::unordered_map<int, iir::Stencil::FieldInfo>& stencilFields,
+      const std::vector<std::pair<int, iir::Stencil::FieldInfo>>& stencilFields,
       std::vector<std::string> const& stencilGlobalVariables,
       const sir::GlobalVariableMap& globalsMap, const CodeGenProperties& codeGenProperties) const;
 
@@ -112,7 +112,7 @@ private:
   /// code generate sync methods statements for all the fields passed
   void generateSyncStorages(
       MemberFunction& method,
-      const IndexRange<std::unordered_map<int, iir::Stencil::FieldInfo>>& stencilFields) const;
+      const IndexRange<std::vector<std::pair<int, iir::Stencil::FieldInfo>>>& stencilFields) const;
 
   /// construct a string of template parameters for storages
   std::vector<std::string> buildFieldTemplateNames(

--- a/src/dawn/Compiler/DawnCompiler.cpp
+++ b/src/dawn/Compiler/DawnCompiler.cpp
@@ -232,6 +232,7 @@ std::unique_ptr<codegen::TranslationUnit> DawnCompiler::compile(const std::share
                                    "backend options must be : " +
                                        dawn::RangeToString(", ", "", "")(std::vector<std::string>{
                                            "gridtools", "c++-naive", "c++-opt"})));
+    return nullptr;
   }
 
   return CG->generateCode();


### PR DESCRIPTION
## Technical Description
we want the code-generation to be reporducible and therefore need the iterators to be over sorted containers. For this to happen we sort the unordered containers used in the compiler to ordered ones in the code-generation where sorting is based on field-id's.