### PR TITLE
Codegen sort

### DIFF
--- a/src/dawn/CodeGen/CXXNaive/CXXNaiveCodeGen.cpp
+++ b/src/dawn/CodeGen/CXXNaive/CXXNaiveCodeGen.cpp
@@ -159,7 +159,7 @@ void CXXNaiveCodeGen::generateStencilWrapperCtr(
     if(stencil.isEmpty())
       continue;
 
-    const auto& StencilFields = stencil.getFields();
+    const auto& StencilFields = orderMap(stencil.getFields());
 
     const std::string stencilName =
         codeGenProperties.getStencilName(StencilContext::SC_Stencil, stencil.getStencilID());
@@ -258,7 +258,7 @@ void CXXNaiveCodeGen::generateStencilClasses(
       continue;
 
     // fields used in the stencil
-    const auto& StencilFields = stencil.getFields();
+    const auto& StencilFields = orderMap(stencil.getFields());
 
     auto nonTempFields = makeRange(
         StencilFields,

--- a/src/dawn/CodeGen/CXXNaive/CXXNaiveCodeGen.cpp
+++ b/src/dawn/CodeGen/CXXNaive/CXXNaiveCodeGen.cpp
@@ -159,7 +159,7 @@ void CXXNaiveCodeGen::generateStencilWrapperCtr(
     if(stencil.isEmpty())
       continue;
 
-    const auto& StencilFields = orderMap(stencil.getFields());
+    const auto stencilFields = orderMap(stencil.getFields());
 
     const std::string stencilName =
         codeGenProperties.getStencilName(StencilContext::SC_Stencil, stencil.getStencilID());
@@ -167,7 +167,7 @@ void CXXNaiveCodeGen::generateStencilWrapperCtr(
     std::string initCtr = "m_" + stencilName + "(new " + stencilName;
 
     int i = 0;
-    for(const auto& fieldInfoPair : StencilFields) {
+    for(const auto& fieldInfoPair : stencilFields) {
       const auto& fieldInfo = fieldInfoPair.second;
       if(fieldInfo.IsTemporary)
         continue;
@@ -182,7 +182,7 @@ void CXXNaiveCodeGen::generateStencilWrapperCtr(
     if(!globalsMap.empty()) {
       initCtr += ",m_globals";
     }
-    for(const auto& fieldInfoPair : StencilFields) {
+    for(const auto& fieldInfoPair : stencilFields) {
       const auto& fieldInfo = fieldInfoPair.second;
       if(fieldInfo.IsTemporary)
         continue;
@@ -258,14 +258,14 @@ void CXXNaiveCodeGen::generateStencilClasses(
       continue;
 
     // fields used in the stencil
-    const auto& StencilFields = orderMap(stencil.getFields());
+    const auto stencilFields = orderMap(stencil.getFields());
 
     auto nonTempFields = makeRange(
-        StencilFields,
+        stencilFields,
         std::function<bool(std::pair<int, iir::Stencil::FieldInfo> const&)>([](
             std::pair<int, iir::Stencil::FieldInfo> const& p) { return !p.second.IsTemporary; }));
     auto tempFields = makeRange(
-        StencilFields,
+        stencilFields,
         std::function<bool(std::pair<int, iir::Stencil::FieldInfo> const&)>(
             [](std::pair<int, iir::Stencil::FieldInfo> const& p) { return p.second.IsTemporary; }));
 

--- a/src/dawn/CodeGen/CodeGen.cpp
+++ b/src/dawn/CodeGen/CodeGen.cpp
@@ -250,9 +250,8 @@ void CodeGen::addTempStorageTypedef(Structure& stencilClass, iir::Stencil const&
       .addType("storage_traits_t::data_store_t< float_type, " + tmpMetadataTypename_ + ">");
 }
 
-void CodeGen::addTmpStorageDeclaration(
-    Structure& stencilClass,
-    IndexRange<const std::unordered_map<int, iir::Stencil::FieldInfo>>& tempFields) const {
+void CodeGen::addTmpStorageDeclaration(Structure& stencilClass,
+    IndexRange<const std::map<int, iir::Stencil::FieldInfo> > &tempFields) const {
   if(!(tempFields.empty())) {
     stencilClass.addMember(tmpMetadataTypename_, tmpMetadataName_);
 
@@ -262,9 +261,8 @@ void CodeGen::addTmpStorageDeclaration(
   }
 }
 
-void CodeGen::addTmpStorageInit(
-    MemberFunction& ctr, iir::Stencil const& stencil,
-    IndexRange<const std::unordered_map<int, iir::Stencil::FieldInfo>>& tempFields) const {
+void CodeGen::addTmpStorageInit(MemberFunction& ctr, iir::Stencil const& stencil,
+    IndexRange<const std::map<int, iir::Stencil::FieldInfo> > &tempFields) const {
   if(!(tempFields.empty())) {
     ctr.addInit(tmpMetadataName_ + "(dom_.isize(), dom_.jsize(), dom_.ksize() + 2*" +
                 std::to_string(getVerticalTmpHaloSize(stencil)) + ")");

--- a/src/dawn/CodeGen/CodeGen.h
+++ b/src/dawn/CodeGen/CodeGen.h
@@ -26,7 +26,7 @@ namespace dawn {
 namespace codegen {
 
 template <typename Key, typename Value>
-std::map<Key, Value> orderMap(const std::unordered_map<Key, Value>& umap) {
+extern std::map<Key, Value> orderMap(const std::unordered_map<Key, Value>& umap) {
   std::map<Key, Value> m;
   for(const auto& f : umap)
     m.insert(f);

--- a/src/dawn/CodeGen/CodeGen.h
+++ b/src/dawn/CodeGen/CodeGen.h
@@ -25,6 +25,15 @@
 namespace dawn {
 namespace codegen {
 
+template <typename Key, typename Value>
+std::map<Key, Value> orderMap(const std::unordered_map<Key, Value>& umap) {
+  std::map<Key, Value> m;
+  for(const auto& f : umap)
+    m.insert(f);
+
+  return m;
+}
+
 /// @brief Interface of the backend code generation
 /// @ingroup codegen
 class CodeGen {
@@ -37,10 +46,10 @@ protected:
   virtual void addTempStorageTypedef(Structure& stencilClass, iir::Stencil const& stencil) const;
   void addTmpStorageDeclaration(
       Structure& stencilClass,
-      IndexRange<const std::unordered_map<int, iir::Stencil::FieldInfo>>& tmpFields) const;
+      IndexRange<const std::map<int, iir::Stencil::FieldInfo>>& tmpFields) const;
   virtual void addTmpStorageInit(
       MemberFunction& ctr, const iir::Stencil& stencil,
-      IndexRange<const std::unordered_map<int, iir::Stencil::FieldInfo>>& tempFields) const;
+      IndexRange<const std::map<int, iir::Stencil::FieldInfo>>& tempFields) const;
   void
   addTmpStorageInitStencilWrapperCtr(MemberFunction& ctr,
                                      const std::vector<std::unique_ptr<iir::Stencil>>& stencils,

--- a/src/dawn/CodeGen/Cuda/CodeGeneratorHelper.cpp
+++ b/src/dawn/CodeGen/Cuda/CodeGeneratorHelper.cpp
@@ -50,9 +50,8 @@ std::string CodeGeneratorHelper::buildCudaKernelName(
          "_ms" + std::to_string(ms->getID()) + "_kernel";
 }
 
-std::vector<std::string> CodeGeneratorHelper::generateStrideArguments(
-    const IndexRange<const std::unordered_map<int, iir::Field>>& nonTempFields,
-    const IndexRange<const std::unordered_map<int, iir::Field>>& tempFields,
+std::vector<std::string> CodeGeneratorHelper::generateStrideArguments(const IndexRange<const std::map<int, iir::Field> > &nonTempFields,
+    const IndexRange<const std::map<int, iir::Field> > &tempFields,
     const std::shared_ptr<iir::StencilInstantiation>& stencilInstantiation,
     const std::unique_ptr<iir::MultiStage>& ms, CodeGeneratorHelper::FunctionArgType funArg) {
 

--- a/src/dawn/CodeGen/Cuda/CodeGeneratorHelper.h
+++ b/src/dawn/CodeGen/Cuda/CodeGeneratorHelper.h
@@ -20,6 +20,7 @@
 #include "dawn/Support/Array.h"
 #include "dawn/Support/IndexRange.h"
 #include <string>
+#include <map>
 
 namespace dawn {
 namespace codegen {
@@ -59,8 +60,8 @@ public:
   static iir::Extents computeTempMaxWriteExtent(iir::Stencil const& stencil);
 
   static std::vector<std::string> generateStrideArguments(
-      const IndexRange<const std::unordered_map<int, iir::Field>>& nonTempFields,
-      const IndexRange<const std::unordered_map<int, iir::Field>>& tempFields,
+      const IndexRange<const std::map<int, iir::Field>>& nonTempFields,
+      const IndexRange<const std::map<int, iir::Field>>& tempFields,
       const std::shared_ptr<iir::StencilInstantiation>& stencilInstantiation,
       const std::unique_ptr<iir::MultiStage>& ms, CodeGeneratorHelper::FunctionArgType funArg);
 

--- a/src/dawn/CodeGen/Cuda/CudaCodeGen.cpp
+++ b/src/dawn/CodeGen/Cuda/CudaCodeGen.cpp
@@ -171,7 +171,7 @@ void CudaCodeGen::generateStencilClasses(
       continue;
 
     // fields used in the stencil
-    const auto& StencilFields = stencil.getFields();
+    const auto& StencilFields = orderMap(stencil.getFields());
 
     auto nonTempFields = makeRange(
         StencilFields,
@@ -229,10 +229,9 @@ void CudaCodeGen::generateStencilClasses(
   }
 }
 
-void CudaCodeGen::generateStencilClassMembers(
-    Structure& stencilClass, const iir::Stencil& stencil, const sir::GlobalVariableMap& globalsMap,
-    IndexRange<const std::unordered_map<int, iir::Stencil::FieldInfo>>& nonTempFields,
-    IndexRange<const std::unordered_map<int, iir::Stencil::FieldInfo>>& tempFields,
+void CudaCodeGen::generateStencilClassMembers(Structure& stencilClass, const iir::Stencil& stencil, const sir::GlobalVariableMap& globalsMap,
+    IndexRange<const std::map<int, iir::Stencil::FieldInfo> > &nonTempFields,
+    IndexRange<const std::map<int, iir::Stencil::FieldInfo> > &tempFields,
     std::shared_ptr<StencilProperties> stencilProperties) const {
 
   auto& paramNameToType = stencilProperties->paramNameToType_;
@@ -256,10 +255,9 @@ void CudaCodeGen::generateStencilClassMembers(
   stencilClass.addComment("temporary storage declarations");
   addTmpStorageDeclaration(stencilClass, tempFields);
 }
-void CudaCodeGen::generateStencilClassCtr(
-    Structure& stencilClass, const iir::Stencil& stencil, const sir::GlobalVariableMap& globalsMap,
-    IndexRange<const std::unordered_map<int, iir::Stencil::FieldInfo>>& nonTempFields,
-    IndexRange<const std::unordered_map<int, iir::Stencil::FieldInfo>>& tempFields,
+void CudaCodeGen::generateStencilClassCtr(Structure& stencilClass, const iir::Stencil& stencil, const sir::GlobalVariableMap& globalsMap,
+    IndexRange<const std::map<int, iir::Stencil::FieldInfo> > &nonTempFields,
+    IndexRange<const std::map<int, iir::Stencil::FieldInfo> > &tempFields,
     std::shared_ptr<StencilProperties> stencilProperties) const {
 
   auto stencilClassCtr = stencilClass.addConstructor();
@@ -316,7 +314,7 @@ void CudaCodeGen::generateStencilWrapperCtr(
     if(stencil.isEmpty())
       continue;
 
-    const auto& StencilFields = stencil.getFields();
+    const auto& StencilFields = orderMap(stencil.getFields());
 
     const std::string stencilName =
         codeGenProperties.getStencilName(StencilContext::SC_Stencil, stencil.getStencilID());
@@ -460,7 +458,7 @@ void CudaCodeGen::generateStencilRunMethod(
     const iir::MultiStage& multiStage = *multiStagePtr;
     bool solveKLoopInParallel_ = CodeGeneratorHelper::solveKLoopInParallel(multiStagePtr);
 
-    const auto& fields = multiStage.getFields();
+    const auto& fields = orderMap(multiStage.getFields());
 
     auto nonTempFields =
         makeRange(fields, std::function<bool(std::pair<int, iir::Field> const&)>([&](
@@ -617,7 +615,7 @@ void CudaCodeGen::addTempStorageTypedef(Structure& stencilClass,
 
 void CudaCodeGen::addTmpStorageInit(
     MemberFunction& ctr, iir::Stencil const& stencil,
-    IndexRange<const std::unordered_map<int, iir::Stencil::FieldInfo>>& tempFields) const {
+    IndexRange<const std::map<int, iir::Stencil::FieldInfo>>& tempFields) const {
   auto maxExtents = CodeGeneratorHelper::computeTempMaxWriteExtent(stencil);
 
   const auto blockSize = stencil.getParent()->getBlockSize();

--- a/src/dawn/CodeGen/Cuda/CudaCodeGen.cpp
+++ b/src/dawn/CodeGen/Cuda/CudaCodeGen.cpp
@@ -171,14 +171,14 @@ void CudaCodeGen::generateStencilClasses(
       continue;
 
     // fields used in the stencil
-    const auto& StencilFields = orderMap(stencil.getFields());
+    const auto stencilFields = orderMap(stencil.getFields());
 
     auto nonTempFields = makeRange(
-        StencilFields,
+        stencilFields,
         std::function<bool(std::pair<int, iir::Stencil::FieldInfo> const&)>([](
             std::pair<int, iir::Stencil::FieldInfo> const& p) { return !p.second.IsTemporary; }));
     auto tempFields = makeRange(
-        StencilFields,
+        stencilFields,
         std::function<bool(std::pair<int, iir::Stencil::FieldInfo> const&)>(
             [](std::pair<int, iir::Stencil::FieldInfo> const& p) { return p.second.IsTemporary; }));
 
@@ -314,7 +314,7 @@ void CudaCodeGen::generateStencilWrapperCtr(
     if(stencil.isEmpty())
       continue;
 
-    const auto& StencilFields = orderMap(stencil.getFields());
+    const auto stencilFields = orderMap(stencil.getFields());
 
     const std::string stencilName =
         codeGenProperties.getStencilName(StencilContext::SC_Stencil, stencil.getStencilID());
@@ -326,7 +326,7 @@ void CudaCodeGen::generateStencilWrapperCtr(
       initCtr += ",m_globals";
     }
 
-    for(const auto& fieldInfoPair : StencilFields) {
+    for(const auto& fieldInfoPair : stencilFields) {
       const auto& fieldInfo = fieldInfoPair.second;
       if(fieldInfo.IsTemporary)
         continue;
@@ -458,7 +458,7 @@ void CudaCodeGen::generateStencilRunMethod(
     const iir::MultiStage& multiStage = *multiStagePtr;
     bool solveKLoopInParallel_ = CodeGeneratorHelper::solveKLoopInParallel(multiStagePtr);
 
-    const auto& fields = orderMap(multiStage.getFields());
+    const auto fields = orderMap(multiStage.getFields());
 
     auto nonTempFields =
         makeRange(fields, std::function<bool(std::pair<int, iir::Field> const&)>([&](

--- a/src/dawn/CodeGen/Cuda/CudaCodeGen.h
+++ b/src/dawn/CodeGen/Cuda/CudaCodeGen.h
@@ -55,7 +55,7 @@ private:
   void addTempStorageTypedef(Structure& stencilClass, iir::Stencil const& stencil) const override;
 
   void addTmpStorageInit(MemberFunction& ctr, iir::Stencil const& stencil,
-                         IndexRange<const std::unordered_map<int, iir::Stencil::FieldInfo>>&
+                         IndexRange<const std::map<int, iir::Stencil::FieldInfo>>&
                              tempFields) const override;
 
   void
@@ -102,15 +102,15 @@ private:
   void generateStencilClassCtr(
       Structure& stencilClass, const iir::Stencil& stencil,
       const sir::GlobalVariableMap& globalsMap,
-      IndexRange<const std::unordered_map<int, iir::Stencil::FieldInfo>>& nonTempFields,
-      IndexRange<const std::unordered_map<int, iir::Stencil::FieldInfo>>& tempFields,
+      IndexRange<const std::map<int, iir::Stencil::FieldInfo>>& nonTempFields,
+      IndexRange<const std::map<int, iir::Stencil::FieldInfo>>& tempFields,
       std::shared_ptr<StencilProperties> stencilProperties) const;
 
   void generateStencilClassMembers(
       Structure& stencilClass, const iir::Stencil& stencil,
       const sir::GlobalVariableMap& globalsMap,
-      IndexRange<const std::unordered_map<int, iir::Stencil::FieldInfo>>& nonTempFields,
-      IndexRange<const std::unordered_map<int, iir::Stencil::FieldInfo>>& tempFields,
+      IndexRange<const std::map<int, iir::Stencil::FieldInfo>>& nonTempFields,
+      IndexRange<const std::map<int, iir::Stencil::FieldInfo>>& tempFields,
       std::shared_ptr<StencilProperties> stencilProperties) const;
 
   std::string generateStencilInstantiation(

--- a/src/dawn/CodeGen/Cuda/MSCodeGen.cpp
+++ b/src/dawn/CodeGen/Cuda/MSCodeGen.cpp
@@ -18,6 +18,7 @@
 #include "dawn/CodeGen/Cuda/CodeGeneratorHelper.h"
 #include "dawn/IIR/IIRNodeIterator.h"
 #include "dawn/Support/IndexRange.h"
+#include "dawn/CodeGen/CodeGen.h"
 #include <functional>
 #include <numeric>
 
@@ -595,7 +596,7 @@ void MSCodeGen::generateCudaKernelCode() {
   }
 
   // fields used in the stencil
-  const auto& fields = ms_->getFields();
+  const auto& fields = orderMap(ms_->getFields());
 
   auto nonTempFields =
       makeRange(fields, std::function<bool(std::pair<int, iir::Field> const&)>([&](

--- a/src/dawn/CodeGen/Cuda/MSCodeGen.cpp
+++ b/src/dawn/CodeGen/Cuda/MSCodeGen.cpp
@@ -596,7 +596,7 @@ void MSCodeGen::generateCudaKernelCode() {
   }
 
   // fields used in the stencil
-  const auto& fields = orderMap(ms_->getFields());
+  const auto fields = orderMap(ms_->getFields());
 
   auto nonTempFields =
       makeRange(fields, std::function<bool(std::pair<int, iir::Field> const&)>([&](

--- a/src/dawn/CodeGen/GridTools/GTCodeGen.cpp
+++ b/src/dawn/CodeGen/GridTools/GTCodeGen.cpp
@@ -252,7 +252,7 @@ void GTCodeGen::generateStencilWrapperRun(
 
   for(const auto& stencil : stencils) {
 
-    const auto& fields = orderMap(stencil->getFields());
+    const auto fields = orderMap(stencil->getFields());
     std::vector<iir::Stencil::FieldInfo> nonTempFields;
 
     for(const auto& field : fields) {
@@ -318,7 +318,7 @@ void GTCodeGen::generateStencilWrapperCtr(
 
   // Initialize stencils
   for(const auto& stencil : stencils) {
-    const auto& fields = orderMap(stencil->getFields());
+    const auto fields = orderMap(stencil->getFields());
 
     std::vector<iir::Stencil::FieldInfo> nonTempFields;
 
@@ -405,10 +405,10 @@ void GTCodeGen::generateStencilClasses(
     std::string stencilType;
     const iir::Stencil& stencil = *stencils[stencilIdx];
 
-    const auto& StencilFields = orderMap(stencil.getFields());
+    const auto stencilFields = orderMap(stencil.getFields());
 
     auto nonTempFields = makeRange(
-        StencilFields,
+        stencilFields,
         std::function<bool(std::pair<int, iir::Stencil::FieldInfo> const&)>([](
             std::pair<int, iir::Stencil::FieldInfo> const& f) { return !f.second.IsTemporary; }));
     if(stencil.isEmpty()) {
@@ -648,7 +648,7 @@ void GTCodeGen::generateStencilClasses(
         ssMS << extents[0].Minus << ", " << extents[0].Plus << ", " << extents[1].Minus << ", "
              << extents[1].Plus << "> >(";
 
-        const auto& fields = orderMap(stage.getFields());
+        const auto fields = orderMap(stage.getFields());
 
         // Field declaration
         std::vector<std::string> arglist;
@@ -745,8 +745,7 @@ void GTCodeGen::generateStencilClasses(
     //
     // Generate constructor/destructor and methods of the stencil
     //
-    std::vector<std::string> StencilGlobalVariables = stencil.getGlobalVariables();
-    std::size_t numFields = StencilFields.size();
+    std::size_t numFields = stencilFields.size();
 
     mplContainerMaxSize_ = std::max(mplContainerMaxSize_, numFields);
 
@@ -774,7 +773,7 @@ void GTCodeGen::generateStencilClasses(
     // Add static asserts to check halos against extents
     StencilConstructor.addComment("Check if extents do not exceed the halos");
     int nonTempFieldId = 0;
-    for(const auto& fieldPair : StencilFields) {
+    for(const auto& fieldPair : stencilFields) {
       const auto& fieldInfo = fieldPair.second;
       if(!fieldInfo.IsTemporary) {
         auto const& ext = fieldInfo.field.getExtentsRB();
@@ -811,11 +810,11 @@ void GTCodeGen::generateStencilClasses(
     }
 
     // Generate domain
-    buildPlaceholderDefinitions(StencilConstructor, stencilInstantiation, StencilFields, globalsMap,
+    buildPlaceholderDefinitions(StencilConstructor, stencilInstantiation, stencilFields, globalsMap,
                                 codeGenProperties);
 
     std::vector<std::string> ArglistPlaceholders;
-    for(const auto& field : StencilFields)
+    for(const auto& field : stencilFields)
       ArglistPlaceholders.push_back("p_" + field.second.Name);
     if(!globalsMap.empty()) {
       ArglistPlaceholders.push_back("p_globals");

--- a/src/dawn/CodeGen/GridTools/GTCodeGen.h
+++ b/src/dawn/CodeGen/GridTools/GTCodeGen.h
@@ -67,11 +67,9 @@ private:
   //  std::string generateGlobals(const std::shared_ptr<SIR>& Sir);
   std::string cacheWindowToString(const iir::Cache::window& cacheWindow);
 
-  void buildPlaceholderDefinitions(
-      MemberFunction& function,
+  void buildPlaceholderDefinitions(MemberFunction& function,
       const std::shared_ptr<iir::StencilInstantiation>& stencilInstantiation,
-      const std::unordered_map<int, iir::Stencil::FieldInfo>& stencilFields,
-      std::vector<std::string> const& stencilGlobalVariables,
+      const std::map<int, iir::Stencil::FieldInfo>& stencilFields,
       const sir::GlobalVariableMap& globalsMap, const CodeGenProperties& codeGenProperties) const;
 
   std::string getFieldName(std::shared_ptr<sir::Field> const& f) const { return f->Name; }
@@ -112,7 +110,7 @@ private:
   /// code generate sync methods statements for all the fields passed
   void generateSyncStorages(
       MemberFunction& method,
-      const IndexRange<std::unordered_map<int, iir::Stencil::FieldInfo>>& stencilFields) const;
+      const IndexRange<const std::map<int, iir::Stencil::FieldInfo>>& stencilFields) const;
 
   /// construct a string of template parameters for storages
   std::vector<std::string> buildFieldTemplateNames(


### PR DESCRIPTION
## Technical Description
we want the code-generation to be reporducible and therefore need the iterators to be over sorted containers. For this to happen we sort the unordered containers used in the compiler to ordered ones in the code-generation where sorting is based on field-id's.