### PR TITLE
Fix dependencies

### DIFF
--- a/bundle/CMakeLists.txt
+++ b/bundle/CMakeLists.txt
@@ -39,7 +39,7 @@ include(DawnCloneRepository)
 
 set(DAWN_YODA_GIT_URL "https:///github.com/Meteoswiss-APN/yoda.git"
     CACHE PATH "URL of the dawn git repository to clone")
-set(DAWN_YODA_GIT_BRANCH "1.0.0" CACHE STRING "Branch of the dawn git repository to clone")
+set(DAWN_YODA_GIT_BRANCH "1.0.1" CACHE STRING "Branch of the dawn git repository to clone")
 dawn_clone_repository(NAME yoda URL ${DAWN_YODA_GIT_URL} BRANCH ${DAWN_YODA_GIT_BRANCH} SOURCE_DIR DAWN_YODA_SOURCE_DIR )
 #
 list(APPEND CMAKE_MODULE_PATH "${DAWN_YODA_SOURCE_DIR}/cmake")

--- a/src/dawn-c/CMakeLists.txt
+++ b/src/dawn-c/CMakeLists.txt
@@ -24,7 +24,6 @@ yoda_add_library(
           TranslationUnit.cpp
           TranslationUnit.h
           Types.h
-          
           util/Allocate.h
           util/CompilerWrapper.h          
           util/OptionsWrapper.cpp
@@ -38,16 +37,15 @@ yoda_combine_libraries(
   NAME DawnC
   OBJECTS DawnCObjects
           DawnSupportObjects
-          DawnSIRObjects
           DawnCompilerObjects
           DawnIIRObjects
           DawnOptimizerObjects
           DawnCodeGenObjects
-          DawnSerializerObjects
   INSTALL_DESTINATION ${DAWN_INSTALL_LIB_DIR}
   VERSION ${DAWN_VERSION}
-  DEPENDS ${DAWN_EXTERNAL_LIBRARIES}
+  DEPENDS ${DAWN_EXTERNAL_LIBRARIES} DawnSIRStatic DawnSerializerStatic
+  EXPORT_GROUP DawnTargets
 )
 
 # Export the targets
-install(EXPORT DawnCTargets NAMESPACE Dawn:: DESTINATION ${DAWN_INSTALL_CMAKE_DIR})
+install(EXPORT DawnTargets NAMESPACE Dawn:: DESTINATION ${DAWN_INSTALL_CMAKE_DIR})

--- a/src/dawn/CMakeLists.txt
+++ b/src/dawn/CMakeLists.txt
@@ -32,7 +32,7 @@ yoda_combine_libraries(
           DawnCodeGenObjects
   INSTALL_DESTINATION ${DAWN_INSTALL_LIB_DIR}
   VERSION ${DAWN_VERSION}
-  DEPENDS ${DAWN_EXTERNAL_LIBRARIES} DawnSIRStatic DawnSerializerStatic DawnIIRStatic
+  DEPENDS ${DAWN_EXTERNAL_LIBRARIES} DawnSerializerStatic
 )
 
 target_include_directories(DawnShared SYSTEM INTERFACE ${Boost_INCLUDE_DIRS})

--- a/src/dawn/CMakeLists.txt
+++ b/src/dawn/CMakeLists.txt
@@ -12,7 +12,6 @@
 ##
 ##===------------------------------------------------------------------------------------------===##
 
-set(sir_proto_include_dirs "")
 add_subdirectory(Support)
 add_subdirectory(SIR)
 add_subdirectory(Compiler)

--- a/src/dawn/CMakeLists.txt
+++ b/src/dawn/CMakeLists.txt
@@ -12,6 +12,7 @@
 ##
 ##===------------------------------------------------------------------------------------------===##
 
+set(sir_proto_include_dirs "")
 add_subdirectory(Support)
 add_subdirectory(SIR)
 add_subdirectory(Compiler)
@@ -26,15 +27,12 @@ include(yodaCombineLibraries)
 yoda_combine_libraries(
   NAME Dawn
   OBJECTS DawnSupportObjects
-          DawnSIRObjects
           DawnCompilerObjects
-          DawnIIRObjects
           DawnOptimizerObjects
           DawnCodeGenObjects
-	  DawnSerializerObjects
   INSTALL_DESTINATION ${DAWN_INSTALL_LIB_DIR}
   VERSION ${DAWN_VERSION}
-  DEPENDS ${DAWN_EXTERNAL_LIBRARIES}
+  DEPENDS ${DAWN_EXTERNAL_LIBRARIES} DawnSIRStatic DawnSerializerStatic DawnIIRStatic
 )
 
 target_include_directories(DawnShared SYSTEM INTERFACE ${Boost_INCLUDE_DIRS})

--- a/src/dawn/Compiler/CMakeLists.txt
+++ b/src/dawn/Compiler/CMakeLists.txt
@@ -26,6 +26,5 @@ yoda_add_library(
   OBJECT
 )
 
-#to propagate the dependencies from IIR to here (where the serializer is used) needs this linking
-#target_link_libraries(DawnCompilerObjects $<TARGET_OBJECTS:DawnIIRObjects>)
-target_include_directories(DawnCompilerObjects PUBLIC $<TARGET_PROPERTY:DawnIIRStatic,INCLUDE_DIRECTORIES>)
+target_include_directories(DawnCompilerObjects PUBLIC $<TARGET_PROPERTY:DawnSIRStatic,INCLUDE_DIRECTORIES>)
+

--- a/src/dawn/Compiler/CMakeLists.txt
+++ b/src/dawn/Compiler/CMakeLists.txt
@@ -27,4 +27,5 @@ yoda_add_library(
 )
 
 #to propagate the dependencies from IIR to here (where the serializer is used) needs this linking
-target_link_libraries(DawnCompilerObjects DawnIIRObjects)
+#target_link_libraries(DawnCompilerObjects $<TARGET_OBJECTS:DawnIIRObjects>)
+target_include_directories(DawnCompilerObjects PUBLIC $<TARGET_PROPERTY:DawnIIRStatic,INCLUDE_DIRECTORIES>)

--- a/src/dawn/IIR/CMakeLists.txt
+++ b/src/dawn/IIR/CMakeLists.txt
@@ -90,6 +90,7 @@ yoda_combine_libraries(
   NAME DawnIIR
   OBJECTS DawnIIRObjects
   INSTALL_DESTINATION ${DAWN_INSTALL_LIB_DIR}
+  DEPENDS DawnSIRStatic
   VERSION ${DAWN_VERSION}
   EXPORT_GROUP DawnTargets
 )

--- a/src/dawn/IIR/CMakeLists.txt
+++ b/src/dawn/IIR/CMakeLists.txt
@@ -78,13 +78,11 @@ yoda_add_library(
   OBJECT
 )
 
+target_include_directories(DawnIIRObjects PUBLIC $<TARGET_PROPERTY:DawnSIRStatic,INCLUDE_DIRECTORIES>)
+target_include_directories(DawnIIRObjects SYSTEM PUBLIC ${Boost_INCLUDE_DIR} ${iir_proto_include_dirs})
+
 add_custom_target(IIR_Proto_Generated ALL DEPENDS ${iir_proto_cpp_files})
 add_dependencies(IIR_Proto_Generated SIR_Proto_Generated)
-
-target_include_directories(DawnIIRObjects SYSTEM PUBLIC ${Boost_INCLUDE_DIR} ${iir_proto_include_dirs})
-# we need to pass the include directories from SIR to here since protobuf is just including the
-# header without any path
-target_include_directories(DawnIIRObjects PUBLIC $<TARGET_PROPERTY:DawnSIRStatic,INCLUDE_DIRECTORIES>)
 
 yoda_combine_libraries(
   NAME DawnIIR
@@ -94,6 +92,4 @@ yoda_combine_libraries(
   VERSION ${DAWN_VERSION}
   EXPORT_GROUP DawnTargets
 )
-
-target_include_directories(DawnIIRStatic PUBLIC $<TARGET_PROPERTY:DawnSIRStatic,INCLUDE_DIRECTORIES>)
 

--- a/src/dawn/IIR/CMakeLists.txt
+++ b/src/dawn/IIR/CMakeLists.txt
@@ -84,4 +84,15 @@ add_dependencies(IIR_Proto_Generated SIR_Proto_Generated)
 target_include_directories(DawnIIRObjects SYSTEM PUBLIC ${Boost_INCLUDE_DIR} ${iir_proto_include_dirs})
 # we need to pass the include directories from SIR to here since protobuf is just including the
 # header without any path
-target_include_directories(DawnIIRObjects PUBLIC $<TARGET_PROPERTY:DawnSIRObjects,INCLUDE_DIRECTORIES>)
+target_include_directories(DawnIIRObjects PUBLIC $<TARGET_PROPERTY:DawnSIRStatic,INCLUDE_DIRECTORIES>)
+
+yoda_combine_libraries(
+  NAME DawnIIR
+  OBJECTS DawnIIRObjects
+  INSTALL_DESTINATION ${DAWN_INSTALL_LIB_DIR}
+  VERSION ${DAWN_VERSION}
+  EXPORT_GROUP DawnTargets
+)
+
+target_include_directories(DawnIIRStatic PUBLIC $<TARGET_PROPERTY:DawnSIRStatic,INCLUDE_DIRECTORIES>)
+

--- a/src/dawn/Optimizer/CMakeLists.txt
+++ b/src/dawn/Optimizer/CMakeLists.txt
@@ -84,3 +84,13 @@ yoda_add_library(
 )
 
 target_include_directories(DawnOptimizerObjects SYSTEM PUBLIC ${Boost_INCLUDE_DIR})
+
+yoda_combine_libraries(
+  NAME DawnOptimizer
+  OBJECTS DawnOptimizerObjects
+  DEPENDS DawnSupportStatic
+  INSTALL_DESTINATION ${DAWN_INSTALL_LIB_DIR}
+  VERSION ${DAWN_VERSION}
+  EXPORT_GROUP DawnTargets
+)
+

--- a/src/dawn/SIR/CMakeLists.txt
+++ b/src/dawn/SIR/CMakeLists.txt
@@ -44,8 +44,21 @@ yoda_add_library(
           ${sir_proto_cpp_files}
   OBJECT
 )
+
+yoda_combine_libraries(
+  NAME DawnSIR
+  OBJECTS DawnSIRObjects
+  INSTALL_DESTINATION ${DAWN_INSTALL_LIB_DIR}
+  VERSION ${DAWN_VERSION}
+  EXPORT_GROUP DawnTargets
+)
+
+message("KKK ${sir_proto_cpp_files} ${sir_proto_include_dirs}")
+message("KKK ${sir_proto_include_dirs}")
+
 # only include proto since protobuf uses relative path "statements.proto" -> export to dependent
-target_include_directories(DawnSIRObjects PUBLIC ${sir_proto_include_dirs})
+#target_include_directories(DawnSIRStatic INTERFACE $<BUILD_INTERFACE:dawn/SIR $<INSTALL_INTERFACE:include/>)
+target_include_directories(DawnSIRStatic PUBLIC $<BUILD_INTERFACE:${sir_proto_include_dirs}> $<INSTALL_INTERFACE:include/>)
 
 add_custom_target(SIR_Proto_Generated ALL DEPENDS ${sir_proto_cpp_files})
 

--- a/src/dawn/SIR/CMakeLists.txt
+++ b/src/dawn/SIR/CMakeLists.txt
@@ -54,11 +54,7 @@ yoda_combine_libraries(
   EXPORT_GROUP DawnTargets
 )
 
-message("KKK ${sir_proto_cpp_files} ${sir_proto_include_dirs}")
-message("KKK ${sir_proto_include_dirs}")
-
 # only include proto since protobuf uses relative path "statements.proto" -> export to dependent
-#target_include_directories(DawnSIRStatic INTERFACE $<BUILD_INTERFACE:dawn/SIR $<INSTALL_INTERFACE:include/>)
 target_include_directories(DawnSIRStatic PUBLIC $<BUILD_INTERFACE:${sir_proto_include_dirs}> $<INSTALL_INTERFACE:include/>)
 
 add_custom_target(SIR_Proto_Generated ALL DEPENDS ${sir_proto_cpp_files})

--- a/src/dawn/SIR/CMakeLists.txt
+++ b/src/dawn/SIR/CMakeLists.txt
@@ -49,6 +49,7 @@ yoda_combine_libraries(
   NAME DawnSIR
   OBJECTS DawnSIRObjects
   INSTALL_DESTINATION ${DAWN_INSTALL_LIB_DIR}
+  DEPENDS DawnSupportStatic protobuf::libprotobuf
   VERSION ${DAWN_VERSION}
   EXPORT_GROUP DawnTargets
 )

--- a/src/dawn/Serialization/CMakeLists.txt
+++ b/src/dawn/Serialization/CMakeLists.txt
@@ -26,17 +26,16 @@ yoda_add_library(
 yoda_combine_libraries(
   NAME DawnSerializer
   OBJECTS DawnSerializerObjects
-  DEPENDS DawnSIRStatic
+  DEPENDS DawnIIRStatic DawnOptimizerStatic
   INSTALL_DESTINATION ${DAWN_INSTALL_LIB_DIR}
   VERSION ${DAWN_VERSION}
   EXPORT_GROUP DawnTargets
 )
 
-add_dependencies(DawnSerializerStatic IIR_Proto_Generated)
+add_dependencies(DawnSerializerObjects IIR_Proto_Generated)
 message("OOO ${sir_proto_include_dirs}")
 message("KKKKKK ${sir_proto_include_dirs}")
 target_include_directories(DawnSerializerObjects PUBLIC $<TARGET_PROPERTY:DawnIIRStatic,INCLUDE_DIRECTORIES>)
-target_include_directories(DawnSerializerStatic PUBLIC $<TARGET_PROPERTY:DawnIIRStatic,INCLUDE_DIRECTORIES>)
 
 
 #target_include_directories(DawnSerializerObjects PUBLIC ${sir_proto_include_dirs})

--- a/src/dawn/Serialization/CMakeLists.txt
+++ b/src/dawn/Serialization/CMakeLists.txt
@@ -23,5 +23,22 @@ yoda_add_library(
   OBJECT
 )
 
-add_dependencies(DawnSerializerObjects IIR_Proto_Generated)
-target_include_directories(DawnSerializerObjects PUBLIC $<TARGET_PROPERTY:DawnSIRObjects,INCLUDE_DIRECTORIES>)
+yoda_combine_libraries(
+  NAME DawnSerializer
+  OBJECTS DawnSerializerObjects
+  DEPENDS DawnSIRStatic
+  INSTALL_DESTINATION ${DAWN_INSTALL_LIB_DIR}
+  VERSION ${DAWN_VERSION}
+  EXPORT_GROUP DawnTargets
+)
+
+add_dependencies(DawnSerializerStatic IIR_Proto_Generated)
+message("OOO ${sir_proto_include_dirs}")
+message("KKKKKK ${sir_proto_include_dirs}")
+target_include_directories(DawnSerializerObjects PUBLIC $<TARGET_PROPERTY:DawnIIRStatic,INCLUDE_DIRECTORIES>)
+target_include_directories(DawnSerializerStatic PUBLIC $<TARGET_PROPERTY:DawnIIRStatic,INCLUDE_DIRECTORIES>)
+
+
+#target_include_directories(DawnSerializerObjects PUBLIC ${sir_proto_include_dirs})
+install(EXPORT DawnTargets NAMESPACE Dawn:: DESTINATION ${DAWN_INSTALL_CMAKE_DIR})
+

--- a/src/dawn/Serialization/CMakeLists.txt
+++ b/src/dawn/Serialization/CMakeLists.txt
@@ -33,8 +33,6 @@ yoda_combine_libraries(
 )
 
 add_dependencies(DawnSerializerObjects IIR_Proto_Generated)
-message("OOO ${sir_proto_include_dirs}")
-message("KKKKKK ${sir_proto_include_dirs}")
 target_include_directories(DawnSerializerObjects PUBLIC $<TARGET_PROPERTY:DawnIIRStatic,INCLUDE_DIRECTORIES>)
 
 

--- a/src/dawn/Support/CMakeLists.txt
+++ b/src/dawn/Support/CMakeLists.txt
@@ -64,3 +64,12 @@ yoda_add_library(
           ../Dawn.h
   OBJECT
 )
+
+yoda_combine_libraries(
+  NAME DawnSupport
+  OBJECTS DawnSupportObjects
+  INSTALL_DESTINATION ${DAWN_INSTALL_LIB_DIR}
+  VERSION ${DAWN_VERSION}
+  EXPORT_GROUP DawnTargets
+)
+

--- a/test/unit-test/CMakeLists.txt
+++ b/test/unit-test/CMakeLists.txt
@@ -33,7 +33,7 @@ macro(dawn_add_unittest_impl)
   yoda_add_unittest(
     NAME ${ARG_NAME}
     SOURCES ${ARG_SOURCES}
-    DEPENDS DawnUnittestStatic DawnStatic DawnCStatic DawnSerializerStatic DawnSIRStatic DawnIIRStatic ${DAWN_EXTERNAL_LIBRARIES} gtest
+    DEPENDS DawnUnittestStatic DawnCStatic DawnStatic  ${DAWN_EXTERNAL_LIBRARIES} gtest
     OUTPUT_DIR ${CMAKE_BINARY_DIR}/bin/unittest
     GTEST_ARGS --gtest_color=yes
   )

--- a/test/unit-test/CMakeLists.txt
+++ b/test/unit-test/CMakeLists.txt
@@ -33,7 +33,7 @@ macro(dawn_add_unittest_impl)
   yoda_add_unittest(
     NAME ${ARG_NAME}
     SOURCES ${ARG_SOURCES}
-    DEPENDS DawnUnittestStatic DawnStatic DawnCStatic ${DAWN_EXTERNAL_LIBRARIES} gtest
+    DEPENDS DawnUnittestStatic DawnStatic DawnCStatic DawnSerializerStatic DawnSIRStatic DawnIIRStatic ${DAWN_EXTERNAL_LIBRARIES} gtest
     OUTPUT_DIR ${CMAKE_BINARY_DIR}/bin/unittest
     GTEST_ARGS --gtest_color=yes
   )


### PR DESCRIPTION
The dependencies with proto files didnt work in my system with a newer cmake. 
It seems to be related to the propagation with the dependencies on objects targets. 
Here I moved the affected libraries to static libraries rather than objects