### PR TITLE
Metadata fix fv

### DIFF
--- a/src/dawn/IIR/StencilInstantiation.cpp
+++ b/src/dawn/IIR/StencilInstantiation.cpp
@@ -188,7 +188,7 @@ int StencilInstantiation::createVersionAndRename(int AccessID, Stencil* stencil,
   if(isField(AccessID)) {
     if(metadata_.variableVersions_.hasMultipleVariableVersions(AccessID)) {
       // Field is already multi-versioned, append a new version
-      auto versions = metadata_.variableVersions_.getVersions(AccessID);
+      const auto versions = metadata_.variableVersions_.getVersions(AccessID);
 
       // Set the second to last field to be a temporary (only the first and the last field will be
       // real storages, all other versions will be temporaries)
@@ -204,10 +204,28 @@ int StencilInstantiation::createVersionAndRename(int AccessID, Stencil* stencil,
                                  false);
       IIR_->getAllocatedFieldAccessIDSet().insert(newAccessID);
 
-      versions->push_back(newAccessID);
+      // and register in field-versioning
       metadata_.variableVersions_.insertIDPair(originalID, newAccessID);
-//      metadata_.variableVersions_.insert(newAccessID, versions);
 
+    } else if(metadata_.variableVersions_.isAccessIDAVersion(AccessID)) {
+      int originalID = metadata_.variableVersions_.getOriginalVersionOfAccessID(AccessID);
+      const std::string& originalName = getFieldNameFromAccessID(originalID);
+
+      const auto versions = metadata_.variableVersions_.getVersions(originalID);
+
+      // Set the second to last field to be a temporary (only the first and the last field will be
+      // real storages, all other versions will be temporaries)
+      int lastAccessID = versions->back();
+      metadata_.TemporaryFieldAccessIDSet_.insert(lastAccessID);
+      IIR_->getAllocatedFieldAccessIDSet().erase(lastAccessID);
+
+      // Register the new field
+      setAccessIDNamePairOfField(newAccessID, originalName + "_" + std::to_string(versions->size()),
+                                 false);
+      IIR_->getAllocatedFieldAccessIDSet().insert(newAccessID);
+
+      // and register in field-versioning
+      metadata_.variableVersions_.insertIDPair(originalID, newAccessID);
     } else {
       const std::string& originalName = getFieldNameFromAccessID(AccessID);
 
@@ -216,36 +234,36 @@ int StencilInstantiation::createVersionAndRename(int AccessID, Stencil* stencil,
       auto versionsVecPtr = std::make_shared<std::vector<int>>();
       *versionsVecPtr = {AccessID, newAccessID};
 
-      setAccessIDNamePairOfField(newAccessID, originalName + "_1", false);
+      // Register the new field
+      setAccessIDNamePairOfField(newAccessID, originalName + "_0", false);
       IIR_->getAllocatedFieldAccessIDSet().insert(newAccessID);
 
-      metadata_.variableVersions_.insert(AccessID, versionsVecPtr);
-      metadata_.variableVersions_.insert(newAccessID, versionsVecPtr);
+      // and register in field-versioning
+      metadata_.variableVersions_.insertIDPair(AccessID, newAccessID);
     }
   } else {
-      ////////////////// WITTODO: FIX THIS
     if(metadata_.variableVersions_.hasMultipleVariableVersions(AccessID)) {
       // Variable is already multi-versioned, append a new version
-      auto versions = metadata_.variableVersions_.getVersions(AccessID);
-
-      // The variable with version 0 contains the original name
-      const std::string& originalName = getFieldNameFromAccessID(versions->front());
+      int originalID = metadata_.variableVersions_.getOriginalVersionOfAccessID(AccessID);
+      const std::string& originalName = getFieldNameFromAccessID(originalID);
 
       // Register the new variable
-      setAccessIDNamePair(newAccessID, originalName + "_" + std::to_string(versions->size()));
-      versions->push_back(newAccessID);
-      metadata_.variableVersions_.insert(newAccessID, versions);
+      setAccessIDNamePair(
+          newAccessID,
+          originalName + "_" +
+              std::to_string(metadata_.variableVersions_.getVersions(originalID)->size()));
+
+      // and register in field-versioning
+      metadata_.variableVersions_.insertIDPair(AccessID, newAccessID);
 
     } else {
       const std::string& originalName = getFieldNameFromAccessID(AccessID);
 
-      // Register the new *and* old variable as being multi-versioned
-      auto versionsVecPtr = std::make_shared<std::vector<int>>();
-      *versionsVecPtr = {AccessID, newAccessID};
+      // Register the new variable
+      setAccessIDNamePair(newAccessID, originalName + "_0");
 
-      setAccessIDNamePair(newAccessID, originalName + "_1");
-      metadata_.variableVersions_.insert(AccessID, versionsVecPtr);
-      metadata_.variableVersions_.insert(newAccessID, versionsVecPtr);
+      // and register in field-versioning
+      metadata_.variableVersions_.insertIDPair(AccessID, newAccessID);
     }
   }
 

--- a/src/dawn/IIR/StencilInstantiation.cpp
+++ b/src/dawn/IIR/StencilInstantiation.cpp
@@ -93,12 +93,6 @@ void StencilInstantiation::removeAccessID(int AccessID) {
   metadata_.TemporaryFieldAccessIDSet_.erase(AccessID);
 
   metadata_.variableVersions_.removeID(AccessID);
-  //  if(metadata_.variableVersions_.hasVariableMultipleVersions(AccessID)) {
-  //    auto versions = metadata_.variableVersions_.getVersions(AccessID);
-  //    versions->erase(std::remove_if(versions->begin(), versions->end(),
-  //                                   [&](int AID) { return AID == AccessID; }),
-  //                    versions->end());
-  //  }
 }
 
 const std::string StencilInstantiation::getName() const { return metadata_.stencilName_; }
@@ -173,12 +167,6 @@ const sir::Value& StencilInstantiation::getGlobalVariableValue(const std::string
   DAWN_ASSERT(it != metadata_.globalVariableMap_.end());
   return *it->second;
 }
-
-// ArrayRef<int> StencilInstantiation::getFieldVersions(int AccessID) const {
-//  return metadata_.variableVersions_.hasMultipleVariableVersions(AccessID)
-//             ? ArrayRef<int>(*(metadata_.variableVersions_.getVersions(AccessID)))
-//             : ArrayRef<int>{};
-//}
 
 int StencilInstantiation::createVersionAndRename(int AccessID, Stencil* stencil, int curStageIdx,
                                                  int curStmtIdx, std::shared_ptr<Expr>& expr,

--- a/src/dawn/IIR/StencilInstantiation.h
+++ b/src/dawn/IIR/StencilInstantiation.h
@@ -142,17 +142,17 @@ public:
 
   /// @brief Check whether the `AccessID` corresponds to a multi-versioned field
   inline bool isMultiVersionedField(int AccessID) const {
-    return isField(AccessID) && metadata_.variableVersions_.hasVariableMultipleVersions(AccessID);
+    return isField(AccessID) && metadata_.variableVersions_.hasMultipleVariableVersions(AccessID);
   }
 
   /// @brief Check whether the `AccessID` corresponds to a multi-versioned variable
   inline bool isMultiVersionedVariable(int AccessID) const {
     return isVariable(AccessID) &&
-           metadata_.variableVersions_.hasVariableMultipleVersions(AccessID);
+           metadata_.variableVersions_.hasMultipleVariableVersions(AccessID);
   }
 
   /// @brief Get a list of all field AccessIDs of this multi-versioned field
-  ArrayRef<int> getFieldVersions(int AccessID) const;
+//  ArrayRef<int> getFieldVersions(int AccessID) const;
 
   enum RenameDirection {
     RD_Above, ///< Rename all fields above the current statement

--- a/src/dawn/IIR/StencilInstantiation.h
+++ b/src/dawn/IIR/StencilInstantiation.h
@@ -152,7 +152,7 @@ public:
   }
 
   /// @brief Get a list of all field AccessIDs of this multi-versioned field
-//  ArrayRef<int> getFieldVersions(int AccessID) const;
+  //  ArrayRef<int> getFieldVersions(int AccessID) const;
 
   enum RenameDirection {
     RD_Above, ///< Rename all fields above the current statement

--- a/src/dawn/IIR/StencilInstantiation.h
+++ b/src/dawn/IIR/StencilInstantiation.h
@@ -151,9 +151,6 @@ public:
            metadata_.variableVersions_.hasMultipleVariableVersions(AccessID);
   }
 
-  /// @brief Get a list of all field AccessIDs of this multi-versioned field
-  //  ArrayRef<int> getFieldVersions(int AccessID) const;
-
   enum RenameDirection {
     RD_Above, ///< Rename all fields above the current statement
     RD_Below  ///< Rename all fields below the current statement

--- a/src/dawn/IIR/StencilMetaInformation.cpp
+++ b/src/dawn/IIR/StencilMetaInformation.cpp
@@ -56,8 +56,12 @@ void StencilMetaInformation::clone(const StencilMetaInformation& origin) {
   apiFieldIDs_ = origin.apiFieldIDs_;
   TemporaryFieldAccessIDSet_ = origin.TemporaryFieldAccessIDSet_;
   GlobalVariableAccessIDSet_ = origin.GlobalVariableAccessIDSet_;
-  for(auto id : origin.variableVersions_.getVersionIDs()) {
-    variableVersions_.insert(id, origin.variableVersions_.getVersions(id));
+
+  for(auto idToVersionsPair : origin.variableVersions_.getvariableVersionsMap()) {
+    int originalID = idToVersionsPair.first;
+    for(auto versionID : *idToVersionsPair.second) {
+      variableVersions_.insertIDPair(originalID, versionID);
+    }
   }
   for(auto statement : origin.stencilDescStatements_) {
     stencilDescStatements_.emplace_back(statement->clone());
@@ -107,7 +111,7 @@ json::json StencilMetaInformation::VariableVersions::jsonDump() const {
   }
   node["versions"] = versionMap;
   json::json versionID;
-  for(const int id : versionIDs_) {
+  for(const int id : getVersionIDs()) {
     versionID.push_back(id);
   }
   node["versionIDs"] = versionID;

--- a/src/dawn/Serialization/IIRSerializer.cpp
+++ b/src/dawn/Serialization/IIRSerializer.cpp
@@ -264,10 +264,11 @@ void IIRSerializer::serializeMetaData(proto::iir::StencilInstantiation& target,
   auto protoVariableVersions = protoMetaData->mutable_versionedfields();
   auto& protoVariableVersionMap = *protoVariableVersions->mutable_variableversionmap();
   auto variableVersions = metaData.variableVersions_;
-  for(auto& IDtoVectorOfVersionsPair : variableVersions.variableVersionsMap_) {
+  for(const auto& IDtoVectorOfVersionsPair : variableVersions.getvariableVersionsMap()) {
     proto::iir::AllVersionedFields protoFieldVersions;
     for(int id : *(IDtoVectorOfVersionsPair.second)) {
       protoFieldVersions.add_allids(id);
+      //////////////// WITTODO: Check this
     }
     protoVariableVersionMap.insert({IDtoVectorOfVersionsPair.first, protoFieldVersions});
   }
@@ -533,10 +534,11 @@ void IIRSerializer::deserializeMetaData(std::shared_ptr<iir::StencilInstantiatio
   for(auto variableVersionMap : protoMetaData.versionedfields().variableversionmap()) {
     std::shared_ptr<std::vector<int>> versions = std::make_shared<std::vector<int>>();
     for(auto versionedID : variableVersionMap.second.allids()) {
-      versions->push_back(versionedID);
-      metadata.variableVersions_.versionIDs_.insert(versionedID);
-      metadata.variableVersions_.versionToOriginalVersionMap_.emplace(versionedID,
-                                                                      variableVersionMap.first);
+        /// WITTODO: check this
+//      versions->push_back(versionedID);
+//      metadata.variableVersions_.versionIDs_.insert(versionedID);
+//      metadata.variableVersions_.versionToOriginalVersionMap_.emplace(versionedID,
+//                                                                      variableVersionMap.first);
     }
     metadata.variableVersions_.insert(variableVersionMap.first, versions);
   }

--- a/src/dawn/Serialization/IIRSerializer.cpp
+++ b/src/dawn/Serialization/IIRSerializer.cpp
@@ -211,10 +211,10 @@ static void computeInitialDerivedInfo(const std::shared_ptr<iir::StencilInstanti
         {StencilCallToIDPair.second, StencilCallToIDPair.first});
   }
 
-  for(const auto& leaf : iterateIIROver<iir::StatementAccessesPair>(*target->getIIR())){
+  for(const auto& leaf : iterateIIROver<iir::StatementAccessesPair>(*target->getIIR())) {
     leaf->update(iir::NodeUpdateType::level);
   }
-  for(const auto& leaf : iterateIIROver<iir::DoMethod>(*target->getIIR())){
+  for(const auto& leaf : iterateIIROver<iir::DoMethod>(*target->getIIR())) {
     leaf->update(iir::NodeUpdateType::levelAndTreeAbove);
   }
 }
@@ -268,7 +268,6 @@ void IIRSerializer::serializeMetaData(proto::iir::StencilInstantiation& target,
     proto::iir::AllVersionedFields protoFieldVersions;
     for(int id : *(IDtoVectorOfVersionsPair.second)) {
       protoFieldVersions.add_allids(id);
-      //////////////// WITTODO: Check this
     }
     protoVariableVersionMap.insert({IDtoVectorOfVersionsPair.first, protoFieldVersions});
   }
@@ -532,15 +531,9 @@ void IIRSerializer::deserializeMetaData(std::shared_ptr<iir::StencilInstantiatio
   }
 
   for(auto variableVersionMap : protoMetaData.versionedfields().variableversionmap()) {
-    std::shared_ptr<std::vector<int>> versions = std::make_shared<std::vector<int>>();
     for(auto versionedID : variableVersionMap.second.allids()) {
-        /// WITTODO: check this
-//      versions->push_back(versionedID);
-//      metadata.variableVersions_.versionIDs_.insert(versionedID);
-//      metadata.variableVersions_.versionToOriginalVersionMap_.emplace(versionedID,
-//                                                                      variableVersionMap.first);
+      metadata.variableVersions_.insertIDPair(variableVersionMap.first, versionedID);
     }
-    metadata.variableVersions_.insert(variableVersionMap.first, versions);
   }
 
   for(auto stencilDescStmt : protoMetaData.stencildescstatements()) {

--- a/test/unit-test/dawn/IIR/TestIIRSerializer.cpp
+++ b/test/unit-test/dawn/IIR/TestIIRSerializer.cpp
@@ -15,8 +15,8 @@
 #include "dawn/Compiler/DiagnosticsEngine.h"
 #include "dawn/Compiler/Options.h"
 #include "dawn/IIR/IIR.h"
-#include "dawn/Serialization/IIRSerializer.h"
 #include "dawn/Optimizer/OptimizerContext.h"
+#include "dawn/Serialization/IIRSerializer.h"
 #include <gtest/gtest.h>
 
 using namespace dawn;
@@ -230,11 +230,9 @@ TEST_F(IIRSerializerTest, SimpleDataStructures) {
   referenceInstantiaton->getMetaData().GlobalVariableAccessIDSet_.emplace(712);
   IIR_EXPECT_EQ(serializeAndDeserializeRef(), referenceInstantiaton);
 
-  auto refvec = std::make_shared<std::vector<int>>();
-  refvec->push_back(6);
-  refvec->push_back(7);
-  refvec->push_back(8);
-  referenceInstantiaton->getMetaData().variableVersions_.insert(5, refvec);
+  referenceInstantiaton->getMetaData().variableVersions_.insertIDPair(5, 6);
+  referenceInstantiaton->getMetaData().variableVersions_.insertIDPair(5, 7);
+  referenceInstantiaton->getMetaData().variableVersions_.insertIDPair(5, 8);
   IIR_EXPECT_EQ(serializeAndDeserializeRef(), referenceInstantiaton);
 
   referenceInstantiaton->getMetaData().fileName_ = "fileName";
@@ -296,16 +294,16 @@ TEST_F(IIRSerializerTest, IIRTests) {
       make_unique<iir::DoMethod>(iir::Interval(1, 5, 0, 1), *referenceInstantiaton));
   IIR_EXPECT_EQ(serializeAndDeserializeRef(), referenceInstantiaton);
 
-    auto& IIRDoMethod = (IIRStage)->getChild(0);
-    auto expr = std::make_shared<VarAccessExpr>("name");
-    auto stmt = std::make_shared<ExprStmt>(expr);
-    stmt->setID(22);
-    auto statement = std::make_shared<Statement>(stmt, nullptr);
-    auto stmtAccessPair = make_unique<iir::StatementAccessesPair>(statement);
-    std::shared_ptr<iir::Accesses> callerAccesses = std::make_shared<iir::Accesses>();
-    stmtAccessPair->setCallerAccesses(callerAccesses);
+  auto& IIRDoMethod = (IIRStage)->getChild(0);
+  auto expr = std::make_shared<VarAccessExpr>("name");
+  auto stmt = std::make_shared<ExprStmt>(expr);
+  stmt->setID(22);
+  auto statement = std::make_shared<Statement>(stmt, nullptr);
+  auto stmtAccessPair = make_unique<iir::StatementAccessesPair>(statement);
+  std::shared_ptr<iir::Accesses> callerAccesses = std::make_shared<iir::Accesses>();
+  stmtAccessPair->setCallerAccesses(callerAccesses);
 
-    (IIRDoMethod)->insertChild(std::move(stmtAccessPair));
+  (IIRDoMethod)->insertChild(std::move(stmtAccessPair));
 }
 
 } // anonymous namespace


### PR DESCRIPTION
## Technical Description

- Field-Versioning had a very odd way of storing things that made the fix of https://github.com/MeteoSwiss-APN/dawn/issues/121 impossible
- In order to 
- Accesses to field versioning were sub-optimally handled, there was too much public access given

## Dependencies
- This changes the indexing to be 0-based instead of 1-based and therefore need to go with https://github.com/MeteoSwiss-APN/gtclang/pull/122
