### PR TITLE
updated asserts

### DIFF
--- a/src/dawn/CodeGen/GridTools/GTCodeGen.cpp
+++ b/src/dawn/CodeGen/GridTools/GTCodeGen.cpp
@@ -784,7 +784,6 @@ void GTCodeGen::generateStencilClasses(
 
     // Add static asserts to check halos against extents
     StencilConstructor.addComment("Check if extents do not exceed the halos");
-    int nonTempFieldId = 0;
     std::map<std::string, iir::Extents> parameterTypeToFullExtentsMap;
     for(const auto& fieldPair : stencilFields) {
       const auto& fieldInfo = fieldPair.second;
@@ -803,7 +802,6 @@ void GTCodeGen::generateStencilClasses(
         } else {
           (*searchIterator).second.merge(ext);
         }
-        ++nonTempFieldId;
       }
     }
 


### PR DESCRIPTION
## Technical Description

Removing gridtools code generation's unnecessary asserts: multiple identical checks for the same storage types and trivial "positive number > 0" or "negative number < 0" checks. 

#### Resolves / Enhances

#197 

#### Example
The following was generated before the fix (trivial because the left-hand side of the comparison is always negative):
`static_assert(((-1) * static_cast<int>(storage_ijk_t::storage_info_t::halo_t::template at<0>()) <= 0) ||
                        (storage_ijk_t::storage_info_t::layout_t::template at<0>() == -1),
                    "Used extents exceed halo limits.");`
Repeated asserts were also generated when multiple storage fields of the same type (`storage_ijk a,b;`) are present:
`static_assert((static_cast<int>(storage_ijk_t::storage_info_t::halo_t::template at<0>()) >= 2) ||
                        (storage_ijk_t::storage_info_t::layout_t::template at<0>() == -1),
                    "Used extents exceed halo limits.");`
`static_assert((static_cast<int>(storage_ijk_t::storage_info_t::halo_t::template at<0>()) >= 2) ||
                        (storage_ijk_t::storage_info_t::layout_t::template at<0>() == -1),
                    "Used extents exceed halo limits.");`

