### PR TITLE
change json dump of -fpass-verbose to produce arrays 

### DIFF
--- a/src/dawn/IIR/MultiStage.cpp
+++ b/src/dawn/IIR/MultiStage.cpp
@@ -423,11 +423,12 @@ json::json MultiStage::jsonDump() const {
   }
   node["Caches"] = cachesJson;
 
-  int cnt = 0;
+  auto stagesArray = json::json::array();
   for(const auto& stage : children_) {
-    node["Stage" + std::to_string(cnt)] = stage->jsonDump(metadata_);
-    cnt++;
+    stagesArray.push_back(stage->jsonDump(metadata_));
   }
+  node["Stages"] = stagesArray;
+
   return node;
 }
 

--- a/src/dawn/IIR/MultiStage.cpp
+++ b/src/dawn/IIR/MultiStage.cpp
@@ -428,7 +428,6 @@ json::json MultiStage::jsonDump() const {
     stagesArray.push_back(stage->jsonDump(metadata_));
   }
   node["Stages"] = stagesArray;
-
   return node;
 }
 

--- a/src/dawn/IIR/Stage.cpp
+++ b/src/dawn/IIR/Stage.cpp
@@ -51,11 +51,11 @@ json::json Stage::jsonDump(const StencilMetaInformation& metaData) const {
   node["Extents"] = ss.str();
   node["RequiresSync"] = derivedInfo_.requiresSync_;
 
-  int cnt = 0;
+  auto doMethodsArray = json::json::array();
   for(const auto& doMethod : children_) {
-    node["DoMethod" + std::to_string(cnt)] = doMethod->jsonDump(metaData);
-    cnt++;
+    doMethodsArray.push_back(doMethod->jsonDump(metaData));
   }
+  node["DoMethods"] = doMethodsArray;
   return node;
 }
 

--- a/src/dawn/IIR/Stencil.cpp
+++ b/src/dawn/IIR/Stencil.cpp
@@ -100,11 +100,11 @@ json::json Stencil::jsonDump() const {
   }
   node["Fields"] = fieldsJson;
 
-  int cnt = 0;
+  auto multiStagesArray = json::json::array();
   for(const auto& child : children_) {
-    node["MultiStage" + std::to_string(cnt)] = child->jsonDump();
-    cnt++;
+    multiStagesArray.push_back(child->jsonDump());
   }
+  node["MultiStages"] = multiStagesArray;
   return node;
 }
 


### PR DESCRIPTION
## Technical Description

Changes -fpass-verbose behavior when dumping json nodes of Stencil, MultiStage or Stage. Instead of outputting dictionaries, it gives arrays of (respectively) MultiStages, Stages and DoMethods.

#### Resolves

#180 

#### Example

```
// RUN: %gtclang% %file% -fpass-verbose

#include "gridtools/clang_dsl.hpp"
using namespace gridtools::clang;

stencil test {
  storage a, b ;
  storage_ij c;
  Do {
    vertical_region(k_start, k_end) {
      c = b[i+2] + a[j-3];
      a = c[i+1];
    }
  }
};
```
Generated log file PassInlining_1_Log.json now looks like:
```
...
"Stencil0": {
      ...
      "MultiStages": [
        {
          "Caches": null,
          "Fields": ...,
          "ID": 38,
          "Loop": "parallel",
          "Stages": [
            {
              "DoMethods": [
                {
                  "Fields": null,
                  "ID": 1,
                  "Stmts":  ...
                }
              ],
              "Extents": "[(0, 0), (0, 0), (0, 0)]",
              "Fields": ...,
              "RequiresSync": false
            },
            {
              "DoMethods": [
                {
                  "Fields": null,
                  "ID": 2,
                  "Stmts": ...,
                  "interval": "{ Start : End-5 }"
                }
              ],
              "Extents": "[(0, 0), (0, 0), (0, 0)]",
              "Fields": ...,
              "RequiresSync": false
            }
          ]
        }
      ]
    }
```
## Testing

To run tests checkout the related PR on gtclang: MeteoSwiss-APN/gtclang#130

## Dependencies

MeteoSwiss-APN/gtclang#130