### PR TITLE
Fix fieldversioning

### DIFF
--- a/src/dawn/IIR/FieldAccessMetadata.cpp
+++ b/src/dawn/IIR/FieldAccessMetadata.cpp
@@ -50,7 +50,7 @@ json::json VariableVersions::jsonDump() const {
   }
   node["versions"] = versionMap;
   json::json versionID;
-  for(const int id : versionIDs_) {
+  for(const int id : getVersionIDs()) {
     versionID.push_back(id);
   }
   node["versionIDs"] = versionID;
@@ -64,8 +64,11 @@ void FieldAccessMetadata::clone(const FieldAccessMetadata& origin) {
   TemporaryFieldAccessIDSet_ = origin.TemporaryFieldAccessIDSet_;
   AllocatedFieldAccessIDSet_ = origin.AllocatedFieldAccessIDSet_;
   GlobalVariableAccessIDSet_ = origin.GlobalVariableAccessIDSet_;
-  for(auto id : origin.variableVersions_.getVersionIDs()) {
-    variableVersions_.insert(id, origin.variableVersions_.getVersions(id));
+  for(auto idToVersionsPair : origin.variableVersions_.getvariableVersionsMap()) {
+    int originalID = idToVersionsPair.first;
+    for(auto versionID : *idToVersionsPair.second) {
+      variableVersions_.insertIDPair(originalID, versionID);
+    }
   }
   accessIDType_ = origin.accessIDType_;
 }

--- a/src/dawn/IIR/FieldAccessMetadata.h
+++ b/src/dawn/IIR/FieldAccessMetadata.h
@@ -17,7 +17,6 @@
 
 #include "boost/variant.hpp"
 #include "dawn/Support/Assert.h"
-#include "dawn/Support/Assert.h"
 #include "dawn/Support/Json.h"
 #include <set>
 #include <unordered_map>

--- a/src/dawn/IIR/FieldAccessMetadata.h
+++ b/src/dawn/IIR/FieldAccessMetadata.h
@@ -125,25 +125,6 @@ public:
   }
 
   json::json jsonDump() const;
-
-  // now that we only have getters and setters this should always be in a consistent state.
-  // Should we remove this enirely, have it here as a safety valve if one wants to mess with the
-  // versioning and needs a clean update or have this as part of the update-level step for the
-  // top-most level holding the metadata?
-  // I personally think option 1 should be desired as this is (hopefully) never necessary but I've
-  // put it here if the reviewers think this would be helpful
-  void recomputeDerivedInfo() {
-    derivedInfo_.versionIDs_.clear();
-    derivedInfo_.versionToOriginalVersionMap_.clear();
-    for(auto IDToVersionsPair : variableVersionsMap_) {
-      int originalID = IDToVersionsPair.first;
-      std::shared_ptr<std::vector<int>> listOfVersions = IDToVersionsPair.second;
-      for(auto versionID : *listOfVersions) {
-        derivedInfo_.versionIDs_.insert(versionID);
-        derivedInfo_.versionToOriginalVersionMap_[versionID] = originalID;
-      }
-    }
-  }
 };
 
 enum class FieldAccessType {

--- a/src/dawn/IIR/StencilMetaInformation.cpp
+++ b/src/dawn/IIR/StencilMetaInformation.cpp
@@ -438,7 +438,7 @@ int StencilMetaInformation::insertTmpField(FieldAccessType type, const std::stri
 void StencilMetaInformation::removeAccessID(int AccessID) {
   AccessIDToNameMap_.directEraseKey(AccessID);
 
-  // we can only remove field or local variables (i.e. we can not remove niether globals nor
+  // we can only remove field or local variables (i.e. we can not remove neither globals nor
   // literals
   DAWN_ASSERT(isAccessType(FieldAccessType::FAT_Field, AccessID) ||
               isAccessType(FieldAccessType::FAT_LocalVariable, AccessID));
@@ -465,7 +465,7 @@ void StencilMetaInformation::removeAccessID(int AccessID) {
   }
   fieldAccessMetadata_.accessIDType_.erase(AccessID);
 
-  if(fieldAccessMetadata_.variableVersions_.hasVariableMultipleVersions(AccessID)) {
+  if(fieldAccessMetadata_.variableVersions_.variableHasMultipleVersions(AccessID)) {
     auto versions = fieldAccessMetadata_.variableVersions_.getVersions(AccessID);
     versions->erase(std::remove_if(versions->begin(), versions->end(),
                                    [&](int AID) { return AID == AccessID; }),
@@ -477,11 +477,6 @@ StencilMetaInformation::StencilMetaInformation(const sir::GlobalVariableMap& glo
   for(const auto& global : globalVariables) {
     insertAccessOfType(iir::FieldAccessType::FAT_GlobalVariable, global.first);
   }
-}
-
-void StencilMetaInformation::insertVersions(const int accessID,
-                                            std::shared_ptr<std::vector<int>> versionsID) {
-  fieldAccessMetadata_.variableVersions_.insert(accessID, versionsID);
 }
 
 std::shared_ptr<std::vector<int>> StencilMetaInformation::getVersionsOf(const int accessID) const {

--- a/src/dawn/IIR/StencilMetaInformation.h
+++ b/src/dawn/IIR/StencilMetaInformation.h
@@ -242,8 +242,8 @@ public:
 
   const FieldAccessMetadata& getFieldAccessMetadata() const { return fieldAccessMetadata_; }
 
-  void insertFieldVersionIDPair(const int originalAccessID, const int versionedAccessID){
-      fieldAccessMetadata_.variableVersions_.insertIDPair(originalAccessID, versionedAccessID);
+  void insertFieldVersionIDPair(const int originalAccessID, const int versionedAccessID) {
+    fieldAccessMetadata_.variableVersions_.insertIDPair(originalAccessID, versionedAccessID);
   }
 
   bool variableHasMultipleVersions(const int accessID) const {

--- a/src/dawn/IIR/StencilMetaInformation.h
+++ b/src/dawn/IIR/StencilMetaInformation.h
@@ -66,7 +66,7 @@ public:
   /// @brief Check whether the `AccessID` corresponds to a multi-versioned field
   bool isMultiVersionedField(int AccessID) const {
     return isAccessType(FieldAccessType::FAT_Field, AccessID) &&
-           fieldAccessMetadata_.variableVersions_.hasVariableMultipleVersions(AccessID);
+           fieldAccessMetadata_.variableVersions_.variableHasMultipleVersions(AccessID);
   }
 
   int getOriginalVersionOfAccessID(const int accessID) const {
@@ -242,10 +242,12 @@ public:
 
   const FieldAccessMetadata& getFieldAccessMetadata() const { return fieldAccessMetadata_; }
 
-  void insertVersions(const int accessID, std::shared_ptr<std::vector<int>> versionsID);
+  void insertFieldVersionIDPair(const int originalAccessID, const int versionedAccessID){
+      fieldAccessMetadata_.variableVersions_.insertIDPair(originalAccessID, versionedAccessID);
+  }
 
-  bool hasVariableMultipleVersions(const int accessID) const {
-    return fieldAccessMetadata_.variableVersions_.hasVariableMultipleVersions(accessID);
+  bool variableHasMultipleVersions(const int accessID) const {
+    return fieldAccessMetadata_.variableVersions_.variableHasMultipleVersions(accessID);
   }
 
   std::shared_ptr<std::vector<int>> getVersionsOf(const int accessID) const;

--- a/src/dawn/Serialization/IIRSerializer.cpp
+++ b/src/dawn/Serialization/IIRSerializer.cpp
@@ -260,7 +260,7 @@ void IIRSerializer::serializeMetaData(proto::iir::StencilInstantiation& target,
   auto protoVariableVersions = protoMetaData->mutable_versionedfields();
   auto& protoVariableVersionMap = *protoVariableVersions->mutable_variableversionmap();
   auto variableVersions = metaData.fieldAccessMetadata_.variableVersions_;
-  for(auto& IDtoVectorOfVersionsPair : variableVersions.variableVersionsMap_) {
+  for(const auto& IDtoVectorOfVersionsPair : variableVersions.getvariableVersionsMap()) {
     proto::iir::AllVersionedFields protoFieldVersions;
     for(int id : *(IDtoVectorOfVersionsPair.second)) {
       protoFieldVersions.add_allids(id);
@@ -535,14 +535,9 @@ void IIRSerializer::deserializeMetaData(std::shared_ptr<iir::StencilInstantiatio
   }
 
   for(auto variableVersionMap : protoMetaData.versionedfields().variableversionmap()) {
-    std::shared_ptr<std::vector<int>> versions = std::make_shared<std::vector<int>>();
     for(auto versionedID : variableVersionMap.second.allids()) {
-      versions->push_back(versionedID);
-      metadata.fieldAccessMetadata_.variableVersions_.versionIDs_.insert(versionedID);
-      metadata.fieldAccessMetadata_.variableVersions_.versionToOriginalVersionMap_.emplace(
-          versionedID, variableVersionMap.first);
+      metadata.insertFieldVersionIDPair(variableVersionMap.first, versionedID);
     }
-    metadata.fieldAccessMetadata_.variableVersions_.insert(variableVersionMap.first, versions);
   }
 
   for(auto IDToCall : protoMetaData.idtostencilcall()) {

--- a/test/unit-test/dawn/IIR/TestIIRSerializer.cpp
+++ b/test/unit-test/dawn/IIR/TestIIRSerializer.cpp
@@ -253,11 +253,9 @@ TEST_F(IIRSerializerTest, SimpleDataStructures) {
                                                           712, "field4");
   IIR_EXPECT_EQ(serializeAndDeserializeRef(), referenceInstantiaton);
 
-  auto refvec = std::make_shared<std::vector<int>>();
-  refvec->push_back(6);
-  refvec->push_back(7);
-  refvec->push_back(8);
-  referenceInstantiaton->getMetaData().insertVersions(5, refvec);
+  referenceInstantiaton->getMetaData().insertFieldVersionIDPair(5, 6);
+  referenceInstantiaton->getMetaData().insertFieldVersionIDPair(5, 7);
+  referenceInstantiaton->getMetaData().insertFieldVersionIDPair(5, 8);
   IIR_EXPECT_EQ(serializeAndDeserializeRef(), referenceInstantiaton);
 
   referenceInstantiaton->getMetaData().setFileName("fileName");


### PR DESCRIPTION
## Technical Description

- Field-Versioning had a very odd way of storing things that made the fix of https://github.com/MeteoSwiss-APN/dawn/issues/121 impossible
- This was already looked at in  https://github.com/MeteoSwiss-APN/dawn/pull/187 but is now reworked here

## Dependencies
- This changes the indexing to be 0-based instead of 1-based and therefore need to go with https://github.com/MeteoSwiss-APN/gtclang/pull/134

## Testing
Since the indexing changes to be 0 based instead of 1 based, we need to adapt some reference files and the testing is in https://github.com/MeteoSwiss-APN/gtclang/pull/134