### PR TITLE
Add diagnostic error for unsupported Read-before-Write conflict inside if block

### DIFF
--- a/src/dawn/Optimizer/PassStageSplitter.cpp
+++ b/src/dawn/Optimizer/PassStageSplitter.cpp
@@ -28,8 +28,6 @@
 
 namespace dawn {
 
-namespace {
-
 static void reportDataDependencyInsideConditionalBlock(
     const std::shared_ptr<Statement>& statement,
     const std::shared_ptr<iir::StencilInstantiation>& instantiation) {
@@ -38,8 +36,6 @@ static void reportDataDependencyInsideConditionalBlock(
   diag << "Read-before-Write conflict inside conditional block is not supported.";
   instantiation->getOptimizerContext()->getDiagnostics().report(diag);
 }
-
-} // anonymous namespace
 
 PassStageSplitter::PassStageSplitter() : Pass("PassStageSplitter", true) {}
 


### PR DESCRIPTION
## Technical Description

Since, for now, the stage splitting inside an if block doesn't work, this code adds a check for cases in which this would happen, reports a diagnostic message and returns error.
Also the `oldGraph` uninitialized pointer bug is fixed here. However the code that dumps dependency graphs for each split should be refactored in a different PR.

#### Enhances

#190 

#### Example
```
#include "gridtools/clang_dsl.hpp"
using namespace gridtools::clang;

globals {
  bool x = false;
};

stencil_function sum {
  offset off;
  storage data;

  Do { return data[off] + data; }
};

stencil test {

  storage b,c,d;
  var z, a;

  Do {
    vertical_region(k_end, k_end) {
      if(x == 0) {
        z = a * b;
        const double e = d * (c * sum(i + 1, z));
      }
    }
  }
};
```
