### PR TITLE
Fix json dump access by index bug

### DIFF
--- a/src/dawn/IIR/MultiStage.cpp
+++ b/src/dawn/IIR/MultiStage.cpp
@@ -419,7 +419,7 @@ json::json MultiStage::jsonDump() const {
 
   json::json cachesJson;
   for(const auto& cache : derivedInfo_.caches_) {
-    cachesJson[cache.first] = cache.second.jsonDump();
+    cachesJson[std::to_string(cache.first)] = cache.second.jsonDump();
   }
   node["Caches"] = cachesJson;
 

--- a/src/dawn/IIR/StencilMetaInformation.cpp
+++ b/src/dawn/IIR/StencilMetaInformation.cpp
@@ -516,7 +516,6 @@ json::json StencilMetaInformation::jsonDump() const {
 
   json::json accessIdToTypeJson;
   for(const auto& p : fieldAccessMetadata_.accessIDType_) {
-    std::cout << std::to_string(p.first) << " : " << toString(p.second) << std::endl;
     accessIdToTypeJson[std::to_string(p.first)] = toString(p.second);
   }
   json::json tmpAccessIDsJson;

--- a/src/dawn/IIR/StencilMetaInformation.cpp
+++ b/src/dawn/IIR/StencilMetaInformation.cpp
@@ -516,7 +516,8 @@ json::json StencilMetaInformation::jsonDump() const {
 
   json::json accessIdToTypeJson;
   for(const auto& p : fieldAccessMetadata_.accessIDType_) {
-    accessIdToTypeJson[p.first] = toString(p.second);
+    std::cout << std::to_string(p.first) << " : " << toString(p.second) << std::endl;
+    accessIdToTypeJson[std::to_string(p.first)] = toString(p.second);
   }
   json::json tmpAccessIDsJson;
   for(const auto& id : fieldAccessMetadata_.TemporaryFieldAccessIDSet_) {


### PR DESCRIPTION
## Technical Description

Changes insertions into json object of the form `jsonObj[integerVar]` (which force the json object to be an array without `integerVar` necessarily being a valid array index) into `jsonObj[std::to_string(integerVar)]`.

#### Example

Crash when compiling the following code with ` -fpass-verbose`:
```
#include "gridtools/clang_dsl.hpp"
using namespace gridtools::clang;

globals {
  bool x = false;
};

stencil_function sum {
  offset off;
  storage data;

  Do { return data[off] + data; }
};

stencil test {

  storage b,c,d;
  var z, a;

  Do {
    vertical_region(k_end, k_end) {
      if(x == 0) {
        a = 0;
        z = a * b;
        const double e = d * (c * sum(i + 1, z));
      }
    }
  }
};
```

