### PR TITLE
Fixes dash filling bug

### DIFF
--- a/src/dawn/Optimizer/PassDataLocalityMetric.cpp
+++ b/src/dawn/Optimizer/PassDataLocalityMetric.cpp
@@ -312,8 +312,9 @@ bool PassDataLocalityMetric::run(
 
   if(context->getOptions().ReportDataLocalityMetric) {
     std::string title = " DataLocality - " + stencilInstantiation->getName() + " ";
-    std::cout << std::string((51 - title.size()) / 2, '-') << title
-              << std::string((51 - title.size() + 1) / 2, '-') << "\n";
+    const int paddingLength = std::max(int(TERMINAL_CHAR_WIDTH - title.size()), 0);
+    std::cout << std::string((paddingLength) / 2, '-') << title
+              << std::string((paddingLength + 1) / 2, '-') << "\n";
 
     std::size_t perStencilNumReads = 0, perStencilNumWrites = 0;
 

--- a/src/dawn/Optimizer/PassDataLocalityMetric.h
+++ b/src/dawn/Optimizer/PassDataLocalityMetric.h
@@ -33,6 +33,10 @@ struct ReadWriteAccumulator {
 ///
 /// This pass is not necessary to create legal code and is hence not in the debug-group
 class PassDataLocalityMetric : public Pass {
+
+private:
+  static const int TERMINAL_CHAR_WIDTH = 70;
+
 public:
   PassDataLocalityMetric();
 


### PR DESCRIPTION
## Technical Description

When `ReportDataLocalityMetric` is on, PassDataLocalityMetric run method was trying to create a padding string filled with '-' possibly giving a negative number as fill size. Fixed by imposing that the fill size must be non-negative.

#### Example

Bug was happening for long stencil names such as: HorizontalDiffusionColdPoolTPCopyStencil


