### PR TITLE
move gcc to 5.4

### DIFF
--- a/scripts/jenkins/env_kesch.sh
+++ b/scripts/jenkins/env_kesch.sh
@@ -5,9 +5,6 @@ module load PE/17.06
 module load git
 module load /users/jenkins/easybuild/kesch/modules/all/cmake/3.12.4
 module load python/3.6.2-gmvolf-17.02
-module unload gcc
-module load gcc/6.1.0
-
 
 export CXX=`which g++`
 export CC=`which gcc`


### PR DESCRIPTION
Using the latest gcc (6) was bad idea, since many other software is built (like clang) using the default 5.4