### PR TITLE
Update clang format

### DIFF
--- a/cmake/Addclang-format.cmake
+++ b/cmake/Addclang-format.cmake
@@ -12,7 +12,7 @@
 ##
 ##===------------------------------------------------------------------------------------------===##
 
-find_package(clang-format EXACT 3.8)
+find_package(clang-format EXACT 6.0)
 
 yoda_export_package(
   NAME clang-format

--- a/src/dawn/CodeGen/CXXNaive/ASTStencilBody.h
+++ b/src/dawn/CodeGen/CXXNaive/ASTStencilBody.h
@@ -27,7 +27,7 @@ namespace dawn {
 namespace iir {
 class StencilFunctionInstantiation;
 class StencilMetaInformation;
-}
+} // namespace iir
 
 namespace codegen {
 namespace cxxnaive {

--- a/src/dawn/CodeGen/CXXNaive/ASTStencilFunctionParamVisitor.cpp
+++ b/src/dawn/CodeGen/CXXNaive/ASTStencilFunctionParamVisitor.cpp
@@ -12,13 +12,12 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
-#include "dawn/SIR/AST.h"
 #include "dawn/CodeGen/CXXNaive/ASTStencilFunctionParamVisitor.h"
-#include "dawn/CodeGen/CXXUtil.h"
 #include "dawn/CodeGen/CXXUtil.h"
 #include "dawn/IIR/StencilFunctionInstantiation.h"
 #include "dawn/IIR/StencilInstantiation.h"
 #include "dawn/Optimizer/OptimizerContext.h"
+#include "dawn/SIR/AST.h"
 #include "dawn/Support/Unreachable.h"
 
 namespace dawn {
@@ -62,10 +61,9 @@ void ASTStencilFunctionParamVisitor::visit(const std::shared_ptr<StencilFunCallE
 
 void ASTStencilFunctionParamVisitor::visit(const std::shared_ptr<FieldAccessExpr>& expr) {
 
-  std::string fieldName = (currentFunction_)
-                              ? currentFunction_->getOriginalNameFromCallerAccessID(
-                                    currentFunction_->getAccessIDFromExpr(expr))
-                              : getName(expr);
+  std::string fieldName = (currentFunction_) ? currentFunction_->getOriginalNameFromCallerAccessID(
+                                                   currentFunction_->getAccessIDFromExpr(expr))
+                                             : getName(expr);
 
   ss_ << ",param_wrapper<decltype(" << fieldName << ")>(" << fieldName << ","
       << "std::array<int, 3>{" << RangeToString(", ", "", "")(expr->getOffset())

--- a/src/dawn/CodeGen/CXXNaive/ASTStencilFunctionParamVisitor.h
+++ b/src/dawn/CodeGen/CXXNaive/ASTStencilFunctionParamVisitor.h
@@ -25,7 +25,7 @@ namespace dawn {
 namespace iir {
 class StencilFunctionInstantiation;
 class StencilMetaInformation;
-}
+} // namespace iir
 
 namespace codegen {
 namespace cxxnaive {

--- a/src/dawn/CodeGen/CXXNaive/CXXNaiveCodeGen.cpp
+++ b/src/dawn/CodeGen/CXXNaive/CXXNaiveCodeGen.cpp
@@ -268,9 +268,10 @@ void CXXNaiveCodeGen::generateStencilClasses(
     const auto stencilFields = orderMap(stencil.getFields());
 
     auto nonTempFields = makeRange(
-        stencilFields,
-        std::function<bool(std::pair<int, iir::Stencil::FieldInfo> const&)>([](
-            std::pair<int, iir::Stencil::FieldInfo> const& p) { return !p.second.IsTemporary; }));
+        stencilFields, std::function<bool(std::pair<int, iir::Stencil::FieldInfo> const&)>(
+                           [](std::pair<int, iir::Stencil::FieldInfo> const& p) {
+                             return !p.second.IsTemporary;
+                           }));
     auto tempFields = makeRange(
         stencilFields,
         std::function<bool(std::pair<int, iir::Stencil::FieldInfo> const&)>(
@@ -283,8 +284,9 @@ void CXXNaiveCodeGen::generateStencilClasses(
                   [cnt]() mutable { return "StorageType" + std::to_string(cnt++); });
 
     Structure StencilClass = stencilWrapperClass.addStruct(
-        stencilName, RangeToString(", ", "", "")(
-                         StencilTemplates, [](const std::string& str) { return "class " + str; }),
+        stencilName,
+        RangeToString(", ", "", "")(StencilTemplates,
+                                    [](const std::string& str) { return "class " + str; }),
         "sbase");
 
     ASTStencilBody stencilBodyCXXVisitor(stencilInstantiation->getMetaData(),
@@ -397,7 +399,6 @@ void CXXNaiveCodeGen::generateStencilClasses(
                     makeIJLoop(stage.getExtents()[0], "m_dom", "i"), [&]() {
                       StencilRunMethod.addBlockStatement(
                           makeIJLoop(stage.getExtents()[1], "m_dom", "j"), [&]() {
-
                             // Generate Do-Method
                             for(const auto& doMethodPtr : stage.getChildren()) {
                               const iir::DoMethod& doMethod = *doMethodPtr;
@@ -409,7 +410,6 @@ void CXXNaiveCodeGen::generateStencilClasses(
                                 StencilRunMethod << stencilBodyCXXVisitor.getCodeAndResetStream();
                               }
                             }
-
                           });
                     });
               }

--- a/src/dawn/CodeGen/CXXUtil.h
+++ b/src/dawn/CodeGen/CXXUtil.h
@@ -674,7 +674,7 @@ auto c_gt = []() { return Twine("gridtools::"); };
 auto c_gtc = []() { return Twine("gridtools::clang::"); };
 auto c_gt_enum = []() { return Twine("gridtools::enumtype::"); };
 
-} // namesapce codegen
+} // namespace codegen
 
 } // namespace dawn
 

--- a/src/dawn/CodeGen/CodeGen.cpp
+++ b/src/dawn/CodeGen/CodeGen.cpp
@@ -188,9 +188,10 @@ CodeGen::computeCodeGenProperties(const iir::StencilInstantiation* stencilInstan
     const auto& StencilFields = stencil->getFields();
 
     auto nonTempFields = makeRange(
-        StencilFields,
-        std::function<bool(std::pair<int, iir::Stencil::FieldInfo> const&)>([](
-            std::pair<int, iir::Stencil::FieldInfo> const& p) { return !p.second.IsTemporary; }));
+        StencilFields, std::function<bool(std::pair<int, iir::Stencil::FieldInfo> const&)>(
+                           [](std::pair<int, iir::Stencil::FieldInfo> const& p) {
+                             return !p.second.IsTemporary;
+                           }));
     auto tempFields = makeRange(
         StencilFields,
         std::function<bool(std::pair<int, iir::Stencil::FieldInfo> const&)>(

--- a/src/dawn/CodeGen/CodeGen.h
+++ b/src/dawn/CodeGen/CodeGen.h
@@ -47,9 +47,9 @@ protected:
   void addTmpStorageDeclaration(
       Structure& stencilClass,
       IndexRange<const std::map<int, iir::Stencil::FieldInfo>>& tmpFields) const;
-  virtual void addTmpStorageInit(
-      MemberFunction& ctr, const iir::Stencil& stencil,
-      IndexRange<const std::map<int, iir::Stencil::FieldInfo>>& tempFields) const;
+  virtual void
+  addTmpStorageInit(MemberFunction& ctr, const iir::Stencil& stencil,
+                    IndexRange<const std::map<int, iir::Stencil::FieldInfo>>& tempFields) const;
   void
   addTmpStorageInitStencilWrapperCtr(MemberFunction& ctr,
                                      const std::vector<std::unique_ptr<iir::Stencil>>& stencils,

--- a/src/dawn/CodeGen/Cuda/ASTStencilFunctionParamVisitor.cpp
+++ b/src/dawn/CodeGen/Cuda/ASTStencilFunctionParamVisitor.cpp
@@ -12,13 +12,12 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
-#include "dawn/SIR/AST.h"
-#include "dawn/CodeGen/CXXUtil.h"
-#include "dawn/CodeGen/CXXUtil.h"
 #include "dawn/CodeGen/Cuda/ASTStencilFunctionParamVisitor.h"
+#include "dawn/CodeGen/CXXUtil.h"
 #include "dawn/IIR/StencilFunctionInstantiation.h"
 #include "dawn/IIR/StencilInstantiation.h"
 #include "dawn/Optimizer/OptimizerContext.h"
+#include "dawn/SIR/AST.h"
 #include "dawn/Support/Unreachable.h"
 
 namespace dawn {
@@ -63,10 +62,9 @@ void ASTStencilFunctionParamVisitor::visit(const std::shared_ptr<StencilFunCallE
 
 void ASTStencilFunctionParamVisitor::visit(const std::shared_ptr<FieldAccessExpr>& expr) {
 
-  std::string fieldName = (currentFunction_)
-                              ? currentFunction_->getOriginalNameFromCallerAccessID(
-                                    currentFunction_->getAccessIDFromExpr(expr))
-                              : getName(expr);
+  std::string fieldName = (currentFunction_) ? currentFunction_->getOriginalNameFromCallerAccessID(
+                                                   currentFunction_->getAccessIDFromExpr(expr))
+                                             : getName(expr);
 
   ss_ << ",param_wrapper<decltype(" << fieldName << ")>(" << fieldName << ","
       << "std::array<int, 3>{" << RangeToString(", ", "", "")(expr->getOffset())

--- a/src/dawn/CodeGen/Cuda/ASTStencilFunctionParamVisitor.h
+++ b/src/dawn/CodeGen/Cuda/ASTStencilFunctionParamVisitor.h
@@ -25,7 +25,7 @@ namespace dawn {
 namespace iir {
 class StencilFunctionInstantiation;
 class StencilMetaInformation;
-}
+} // namespace iir
 
 namespace codegen {
 namespace cuda {

--- a/src/dawn/CodeGen/Cuda/CacheProperties.h
+++ b/src/dawn/CodeGen/Cuda/CacheProperties.h
@@ -23,7 +23,7 @@ namespace dawn {
 namespace iir {
 class StencilInstantiation;
 class MultiStage;
-}
+} // namespace iir
 
 namespace codegen {
 namespace cuda {

--- a/src/dawn/CodeGen/Cuda/CodeGeneratorHelper.cpp
+++ b/src/dawn/CodeGen/Cuda/CodeGeneratorHelper.cpp
@@ -130,9 +130,8 @@ bool CodeGeneratorHelper::hasAccessIDMemAccess(const int accessID,
   return false;
 }
 
-bool CodeGeneratorHelper::useTemporaries(
-    const std::unique_ptr<iir::Stencil>& stencil,
-    const iir::StencilMetaInformation& metadata) {
+bool CodeGeneratorHelper::useTemporaries(const std::unique_ptr<iir::Stencil>& stencil,
+                                         const iir::StencilMetaInformation& metadata) {
 
   const auto& fields = stencil->getFields();
   const bool containsMemTemporary =
@@ -157,8 +156,9 @@ void CodeGeneratorHelper::generateFieldAccessDeref(
   DAWN_ASSERT(fieldIndexMap.count(accessID) || isTemporary);
   const auto& field = ms->getField(accessID);
   bool useTmpIndex = isTemporary && useTemporaries(ms->getParent(), metadata);
-  std::string index = useTmpIndex ? "idx_tmp" : "idx" + CodeGeneratorHelper::indexIteratorName(
-                                                            fieldIndexMap.at(accessID));
+  std::string index =
+      useTmpIndex ? "idx_tmp"
+                  : "idx" + CodeGeneratorHelper::indexIteratorName(fieldIndexMap.at(accessID));
 
   // temporaries have all 3 dimensions
   Array3i iter = isTemporary ? Array3i{1, 1, 1} : fieldIndexMap.at(accessID);

--- a/src/dawn/CodeGen/Cuda/CodeGeneratorHelper.h
+++ b/src/dawn/CodeGen/Cuda/CodeGeneratorHelper.h
@@ -28,7 +28,7 @@ class StencilInstantiation;
 class Stencil;
 class StencilMetaInformation;
 class Field;
-}
+} // namespace iir
 namespace codegen {
 namespace cuda {
 

--- a/src/dawn/CodeGen/Cuda/CudaCodeGen.h
+++ b/src/dawn/CodeGen/Cuda/CudaCodeGen.h
@@ -54,9 +54,9 @@ private:
 
   void addTempStorageTypedef(Structure& stencilClass, iir::Stencil const& stencil) const override;
 
-  void addTmpStorageInit(MemberFunction& ctr, iir::Stencil const& stencil,
-                         IndexRange<const std::map<int, iir::Stencil::FieldInfo>>&
-                             tempFields) const override;
+  void addTmpStorageInit(
+      MemberFunction& ctr, iir::Stencil const& stencil,
+      IndexRange<const std::map<int, iir::Stencil::FieldInfo>>& tempFields) const override;
 
   void
   generateCudaKernelCode(std::stringstream& ssSW,
@@ -99,12 +99,12 @@ private:
   generateStencilWrapperPublicMemberFunctions(Class& stencilWrapperClass,
                                               const CodeGenProperties& codeGenProperties) const;
 
-  void generateStencilClassCtr(
-      Structure& stencilClass, const iir::Stencil& stencil,
-      const sir::GlobalVariableMap& globalsMap,
-      IndexRange<const std::map<int, iir::Stencil::FieldInfo>>& nonTempFields,
-      IndexRange<const std::map<int, iir::Stencil::FieldInfo>>& tempFields,
-      std::shared_ptr<StencilProperties> stencilProperties) const;
+  void
+  generateStencilClassCtr(Structure& stencilClass, const iir::Stencil& stencil,
+                          const sir::GlobalVariableMap& globalsMap,
+                          IndexRange<const std::map<int, iir::Stencil::FieldInfo>>& nonTempFields,
+                          IndexRange<const std::map<int, iir::Stencil::FieldInfo>>& tempFields,
+                          std::shared_ptr<StencilProperties> stencilProperties) const;
 
   void generateStencilClassMembers(
       Structure& stencilClass, const iir::Stencil& stencil,

--- a/src/dawn/CodeGen/Cuda/MSCodeGen.cpp
+++ b/src/dawn/CodeGen/Cuda/MSCodeGen.cpp
@@ -136,9 +136,10 @@ void MSCodeGen::generateKCacheFillStatement(MemberFunction& cudaKernel,
   CodeGeneratorHelper::generateFieldAccessDeref(ss, ms_, stencilInstantiation_->getMetaData(),
                                                 kcacheProp.accessID_, fieldIndexMap,
                                                 Array3i{0, 0, klev});
-  cudaKernel.addStatement(kcacheProp.name_ + "[" + std::to_string(cacheProperties_.getKCacheIndex(
-                                                       kcacheProp.accessID_, klev)) +
-                          "] =" + ss.str());
+  cudaKernel.addStatement(
+      kcacheProp.name_ + "[" +
+      std::to_string(cacheProperties_.getKCacheIndex(kcacheProp.accessID_, klev)) +
+      "] =" + ss.str());
 }
 
 iir::MultiInterval
@@ -515,11 +516,11 @@ void MSCodeGen::generateKCacheFlushBlockStatement(
     std::string intervalKBegin = kBegin("dom", ms_->getLoopOrder(), cacheInterval);
 
     if(ms_->getLoopOrder() == iir::LoopOrderKind::LK_Backward) {
-      pred << "if( " + intervalKBegin + " - " + currentKLevel + " >= " +
-                  std::to_string(std::abs(kcacheTailExtent)) + ")";
+      pred << "if( " + intervalKBegin + " - " + currentKLevel +
+                  " >= " + std::to_string(std::abs(kcacheTailExtent)) + ")";
     } else {
-      pred << "if( " + currentKLevel + " - " + intervalKBegin + " >= " +
-                  std::to_string(std::abs(kcacheTailExtent)) + ")";
+      pred << "if( " + currentKLevel + " - " + intervalKBegin +
+                  " >= " + std::to_string(std::abs(kcacheTailExtent)) + ")";
     }
     cudaKernel.addBlockStatement(pred.str(), [&]() {
       generateKCacheFlushStatement(cudaKernel, fieldIndexMap, kcacheProp.accessID_,
@@ -672,12 +673,12 @@ void MSCodeGen::generateCudaKernelCode() {
   // fields used in the stencil
   const auto fields = orderMap(ms_->getFields());
 
-  auto nonTempFields =
-      makeRange(fields, std::function<bool(std::pair<int, iir::Field> const&)>([&](
-                            std::pair<int, iir::Field> const& p) {
-                  return !metadata_.isAccessType(iir::FieldAccessType::FAT_StencilTemporary,
-                                                 p.second.getAccessID());
-                }));
+  auto nonTempFields = makeRange(fields, std::function<bool(std::pair<int, iir::Field> const&)>(
+                                             [&](std::pair<int, iir::Field> const& p) {
+                                               return !metadata_.isAccessType(
+                                                   iir::FieldAccessType::FAT_StencilTemporary,
+                                                   p.second.getAccessID());
+                                             }));
   // all the temp fields that are non local cache, and therefore will require the infrastructure
   // of
   // tmp storages (allocation, iterators, etc)
@@ -989,7 +990,6 @@ void MSCodeGen::generateCudaKernelCode() {
 
     // for each interval, we generate naive nested loops
     cudaKernel.addBlockStatement(makeKLoop("dom", interval, solveKLoopInParallel_), [&]() {
-
       if(!solveKLoopInParallel_) {
         generateFillKCaches(cudaKernel, interval, fieldIndexMap);
       }
@@ -1013,9 +1013,9 @@ void MSCodeGen::generateCudaKernelCode() {
 
         cudaKernel.addBlockStatement(
             "if(iblock >= " + std::to_string(extent[0].Minus) + " && iblock <= block_size_i -1 + " +
-                std::to_string(extent[0].Plus) + " && jblock >= " +
-                std::to_string(extent[1].Minus) + " && jblock <= block_size_j -1 + " +
-                std::to_string(extent[1].Plus) + ")",
+                std::to_string(extent[0].Plus) +
+                " && jblock >= " + std::to_string(extent[1].Minus) +
+                " && jblock <= block_size_j -1 + " + std::to_string(extent[1].Plus) + ")",
             [&]() {
               // Generate Do-Method
               for(const auto& doMethodPtr : stage.getChildren()) {

--- a/src/dawn/CodeGen/GridTools/GTCodeGen.h
+++ b/src/dawn/CodeGen/GridTools/GTCodeGen.h
@@ -30,7 +30,7 @@ namespace iir {
 class StencilInstantiation;
 class Stage;
 class Stencil;
-}
+} // namespace iir
 
 namespace codegen {
 namespace gt {
@@ -67,7 +67,8 @@ private:
   //  std::string generateGlobals(const std::shared_ptr<SIR>& Sir);
   std::string cacheWindowToString(const iir::Cache::window& cacheWindow);
 
-  void buildPlaceholderDefinitions(MemberFunction& function,
+  void buildPlaceholderDefinitions(
+      MemberFunction& function,
       const std::shared_ptr<iir::StencilInstantiation>& stencilInstantiation,
       const std::map<int, iir::Stencil::FieldInfo>& stencilFields,
       const sir::GlobalVariableMap& globalsMap, const CodeGenProperties& codeGenProperties) const;

--- a/src/dawn/CodeGen/StencilFunctionAsBCGenerator.cpp
+++ b/src/dawn/CodeGen/StencilFunctionAsBCGenerator.cpp
@@ -104,5 +104,5 @@ void BCGenerator::generate(const std::shared_ptr<BoundaryConditionDeclStmt>& stm
   ss_ << makeView;
   ss_ << bcapply;
 }
-}
-}
+} // namespace codegen
+} // namespace dawn

--- a/src/dawn/CodeGen/StencilFunctionAsBCGenerator.h
+++ b/src/dawn/CodeGen/StencilFunctionAsBCGenerator.h
@@ -23,7 +23,7 @@ namespace dawn {
 namespace iir {
 class StencilInstantiation;
 class StencilMetaInformation;
-}
+} // namespace iir
 namespace sir {
 struct StencilFunction;
 }

--- a/src/dawn/IIR/ControlFlowDescriptor.h
+++ b/src/dawn/IIR/ControlFlowDescriptor.h
@@ -48,7 +48,7 @@ public:
   void removeStencilCalls(const std::set<int>& emptyStencilIDs,
                           iir::StencilMetaInformation& metadata);
 };
-}
-}
+} // namespace iir
+} // namespace dawn
 
 #endif

--- a/src/dawn/IIR/FieldAccessExtents.h
+++ b/src/dawn/IIR/FieldAccessExtents.h
@@ -29,8 +29,8 @@ public:
   /// @{
   FieldAccessExtents(boost::optional<Extents> const& readExtents,
                      boost::optional<Extents> const& writeExtents)
-      : readAccessExtents_(readExtents), writeAccessExtents_(writeExtents),
-        totalExtents_{0, 0, 0, 0, 0, 0} {
+      : readAccessExtents_(readExtents),
+        writeAccessExtents_(writeExtents), totalExtents_{0, 0, 0, 0, 0, 0} {
     updateTotalExtents();
   }
 

--- a/src/dawn/IIR/FieldAccessMetadata.h
+++ b/src/dawn/IIR/FieldAccessMetadata.h
@@ -159,7 +159,7 @@ struct is_mapp_impl<
     : std::true_type {
   void t() { T::kk(); }
 };
-}
+} // namespace impl
 
 template <FieldAccessType TFieldAccessType>
 struct TypeOfAccessContainer;

--- a/src/dawn/IIR/IIRNodeIterator.h
+++ b/src/dawn/IIR/IIRNodeIterator.h
@@ -190,6 +190,6 @@ struct iterator_traits<dawn::iir::IIRNodeIterator<RootNode, LeafNode>> {
   using iterator_category =
       typename iterator_traits<typename LeafNode::ChildIterator>::iterator_category;
 };
-}
+} // namespace std
 
 #endif

--- a/src/dawn/IIR/Interval.h
+++ b/src/dawn/IIR/Interval.h
@@ -57,8 +57,8 @@ public:
       : lower_{lowerLevel, lowerOffset}, upper_{upperLevel, upperOffset} {}
 
   Interval(const sir::Interval& interval)
-      : lower_{interval.LowerLevel, interval.LowerOffset},
-        upper_{interval.UpperLevel, interval.UpperOffset} {}
+      : lower_{interval.LowerLevel, interval.LowerOffset}, upper_{interval.UpperLevel,
+                                                                  interval.UpperOffset} {}
 
   Interval(const Interval&) = default;
   Interval(Interval&&) = default;

--- a/src/dawn/IIR/StencilFunctionInstantiation.cpp
+++ b/src/dawn/IIR/StencilFunctionInstantiation.cpp
@@ -511,7 +511,6 @@ void StencilFunctionInstantiation::update() {
     // as the caller fields have the *initial* extent (e.g in `avg(u(i+1))` u has an initial extent
     // of [1, 0, 0])
     auto computeAccesses = [&](std::vector<Field>& fields, bool callerAccesses) {
-
       // Index to speedup lookup into fields map
       std::unordered_map<int, std::vector<Field>::iterator> AccessIDToFieldMap;
       for(auto it = fields.begin(), end = fields.end(); it != end; ++it)

--- a/src/dawn/Optimizer/AccessComputation.h
+++ b/src/dawn/Optimizer/AccessComputation.h
@@ -25,7 +25,7 @@ namespace iir {
 class StatementAccessesPair;
 class StencilInstantiation;
 class StencilFunctionInstantiation;
-}
+} // namespace iir
 
 /// @name Access computation routines
 /// @ingroup optimizer

--- a/src/dawn/Optimizer/OptimizerContext.cpp
+++ b/src/dawn/Optimizer/OptimizerContext.cpp
@@ -564,7 +564,7 @@ public:
 
   void visit(const std::shared_ptr<FieldAccessExpr>& expr) override {}
 };
-} // namespace anonymous
+} // namespace
 
 OptimizerContext::OptimizerContext(DiagnosticsEngine& diagnostics, Options& options,
                                    const std::shared_ptr<SIR>& SIR)

--- a/src/dawn/Optimizer/PassFieldVersioning.h
+++ b/src/dawn/Optimizer/PassFieldVersioning.h
@@ -24,7 +24,7 @@ namespace iir {
 class Stencil;
 class DependencyGraphAccesses;
 class DoMethod;
-}
+} // namespace iir
 
 /// @brief This pass resolves potential race condition by introducing double buffering i.e
 /// versioning of fields
@@ -32,6 +32,8 @@ class DoMethod;
 /// @see fixRaceCondition
 /// @ingroup optimizer
 class PassFieldVersioning : public Pass {
+
+private:
   int numRenames_;
 
 public:

--- a/src/dawn/Optimizer/PassMultiStageSplitter.cpp
+++ b/src/dawn/Optimizer/PassMultiStageSplitter.cpp
@@ -47,7 +47,6 @@ multiStageSplitterOptimized() {
           std::deque<iir::MultiStage::SplitIndex>& splitterIndices, int stageIndex,
           int multiStageIndex, int& numSplit, const std::string& StencilName,
           const std::string& PassName, const Options& options) {
-
         iir::Stage& stage = (**stageIt);
         iir::DoMethod& doMethod = stage.getSingleDoMethod();
 

--- a/src/dawn/Optimizer/PassMultiStageSplitter.h
+++ b/src/dawn/Optimizer/PassMultiStageSplitter.h
@@ -29,7 +29,7 @@ public:
   enum MultiStageSplittingStrategy {
     SS_MaxCut, ///< Splitting the multistage into as many multistages as possible while maintaining
                /// code legality
-    SS_Optimized   ///< Optimized splitting of Multistages, only when needed
+    SS_Optimized ///< Optimized splitting of Multistages, only when needed
   };
   PassMultiStageSplitter(MultiStageSplittingStrategy strategy);
 

--- a/src/dawn/Optimizer/PassSetBoundaryCondition.cpp
+++ b/src/dawn/Optimizer/PassSetBoundaryCondition.cpp
@@ -59,7 +59,7 @@ static iir::Extents analyzeStencilExtents(const std::unique_ptr<iir::Stencil>& s
 }
 
 enum FieldType { FT_NotOriginal = -1 };
-}
+} // namespace
 ///
 /// @brief The VisitStencilCalls class traverses the StencilDescAST to determine an order of the
 /// stencil calls. This is required to properly evaluate boundary conditions
@@ -156,7 +156,6 @@ bool PassSetBoundaryCondition::run(
     } else {
       return (int)FieldType::FT_NotOriginal;
     }
-
   };
 
   std::unordered_map<int, iir::Extents> dirtyFields;
@@ -185,7 +184,6 @@ bool PassSetBoundaryCondition::run(
   }
 
   auto calculateHaloExtents = [&](std::string fieldname) {
-
     iir::Extents fullExtent{0, 0, 0, 0, 0, 0};
     // Did we already apply a BoundaryCondition for this field?
     // This is the first time we apply a BC to this field, we traverse all stencils that were

--- a/src/dawn/Optimizer/PassSetCaches.cpp
+++ b/src/dawn/Optimizer/PassSetCaches.cpp
@@ -245,8 +245,9 @@ bool PassSetCaches::run(const std::shared_ptr<iir::StencilInstantiation>& instan
 
           // Determine if we need to fill the cache by analyzing the current multi-stage
           CacheCandidate cacheCandidate = computeCacheCandidateForMS(
-              field, metadata.isAccessType(iir::FieldAccessType::FAT_StencilTemporary,
-                                           field.getAccessID()),
+              field,
+              metadata.isAccessType(iir::FieldAccessType::FAT_StencilTemporary,
+                                    field.getAccessID()),
               ms);
 
           if(!metadata.isAccessType(iir::FieldAccessType::FAT_StencilTemporary,
@@ -270,8 +271,9 @@ bool PassSetCaches::run(const std::shared_ptr<iir::StencilInstantiation>& instan
               const iir::Field& fieldInNextMS = nextMSfields.find(field.getAccessID())->second;
 
               CacheCandidate policyMS2 = computeCacheCandidateForMS(
-                  fieldInNextMS, metadata.isAccessType(iir::FieldAccessType::FAT_StencilTemporary,
-                                                       fieldInNextMS.getAccessID()),
+                  fieldInNextMS,
+                  metadata.isAccessType(iir::FieldAccessType::FAT_StencilTemporary,
+                                        fieldInNextMS.getAccessID()),
                   nextMS);
               // if the interval of the two cache candidate do not overlap, there is no data
               // dependency, therefore we skip it

--- a/src/dawn/Optimizer/PassSetCaches.h
+++ b/src/dawn/Optimizer/PassSetCaches.h
@@ -15,11 +15,11 @@
 #ifndef DAWN_OPTIMIZER_PASSSETMULTISTAGECACHES_H
 #define DAWN_OPTIMIZER_PASSSETMULTISTAGECACHES_H
 
-#include "dawn/IIR/Stencil.h"
-#include "dawn/IIR/Interval.h"
-#include "dawn/Optimizer/Pass.h"
-#include "dawn/IIR/Stage.h"
 #include "dawn/IIR/Cache.h"
+#include "dawn/IIR/Interval.h"
+#include "dawn/IIR/Stage.h"
+#include "dawn/IIR/Stencil.h"
+#include "dawn/Optimizer/Pass.h"
 
 namespace dawn {
 

--- a/src/dawn/Optimizer/PassSetStageGraph.cpp
+++ b/src/dawn/Optimizer/PassSetStageGraph.cpp
@@ -14,8 +14,8 @@
 
 #include "dawn/Optimizer/PassSetStageGraph.h"
 #include "dawn/IIR/DependencyGraphStage.h"
-#include "dawn/Optimizer/OptimizerContext.h"
 #include "dawn/IIR/StencilInstantiation.h"
+#include "dawn/Optimizer/OptimizerContext.h"
 #include "dawn/Support/STLExtras.h"
 
 namespace dawn {

--- a/src/dawn/Optimizer/PassSetStageName.cpp
+++ b/src/dawn/Optimizer/PassSetStageName.cpp
@@ -13,8 +13,8 @@
 //===------------------------------------------------------------------------------------------===//
 
 #include "dawn/Optimizer/PassSetStageName.h"
-#include "dawn/Optimizer/OptimizerContext.h"
 #include "dawn/IIR/StencilInstantiation.h"
+#include "dawn/Optimizer/OptimizerContext.h"
 
 namespace dawn {
 

--- a/src/dawn/Optimizer/PassTemporaryToStencilFunction.h
+++ b/src/dawn/Optimizer/PassTemporaryToStencilFunction.h
@@ -25,7 +25,7 @@ namespace dawn {
 namespace iir {
 class Stencil;
 class DoMethod;
-}
+} // namespace iir
 
 struct SkipIDs {
   std::unordered_map<int, std::set<int>> accessIDs;

--- a/src/dawn/Optimizer/Renaming.h
+++ b/src/dawn/Optimizer/Renaming.h
@@ -26,7 +26,7 @@ class StatementAccessesPair;
 class StencilFunctionInstantiation;
 class StencilInstantiation;
 class StencilMetaInformation;
-}
+} // namespace iir
 
 /// @name Renaming routines
 /// @ingroup optimizer

--- a/src/dawn/Optimizer/ReorderStrategy.h
+++ b/src/dawn/Optimizer/ReorderStrategy.h
@@ -23,7 +23,7 @@ namespace iir {
 class Stencil;
 class StencilInstantiation;
 class DependencyGraphStage;
-}
+} // namespace iir
 
 /// @brief Abstract class for various reodering strategies
 /// @ingroup optimizer

--- a/src/dawn/Optimizer/Replacing.h
+++ b/src/dawn/Optimizer/Replacing.h
@@ -28,7 +28,7 @@ class Stencil;
 class StatementAccessesPair;
 class StencilInstantiation;
 class StencilMetaInformation;
-}
+} // namespace iir
 
 /// @name Replacing routines
 /// @ingroup optimizer

--- a/src/dawn/Optimizer/StatementMapper.cpp
+++ b/src/dawn/Optimizer/StatementMapper.cpp
@@ -401,4 +401,4 @@ void StatementMapper::visit(const std::shared_ptr<FieldAccessExpr>& expr) {
     candiateScope->ArgumentIndex += 1;
   }
 }
-}
+} // namespace dawn

--- a/src/dawn/SIR/ASTExpr.cpp
+++ b/src/dawn/SIR/ASTExpr.cpp
@@ -67,8 +67,9 @@ BinaryOperator::BinaryOperator(const std::shared_ptr<Expr>& left, std::string op
     : Expr(EK_BinaryOperator, loc), operands_{left, right}, op_(std::move(op)) {}
 
 BinaryOperator::BinaryOperator(const BinaryOperator& expr)
-    : Expr(EK_BinaryOperator, expr.getSourceLocation()),
-      operands_{expr.getLeft()->clone(), expr.getRight()->clone()}, op_(expr.getOp()) {}
+    : Expr(EK_BinaryOperator, expr.getSourceLocation()), operands_{expr.getLeft()->clone(),
+                                                                   expr.getRight()->clone()},
+      op_(expr.getOp()) {}
 
 BinaryOperator& BinaryOperator::operator=(BinaryOperator expr) {
   assign(expr);
@@ -166,8 +167,9 @@ TernaryOperator::TernaryOperator(const std::shared_ptr<Expr>& cond,
     : Expr(EK_TernaryOperator, loc), operands_{cond, left, right} {}
 
 TernaryOperator::TernaryOperator(const TernaryOperator& expr)
-    : Expr(EK_TernaryOperator, expr.getSourceLocation()),
-      operands_{expr.getCondition()->clone(), expr.getLeft()->clone(), expr.getRight()->clone()} {}
+    : Expr(EK_TernaryOperator, expr.getSourceLocation()), operands_{expr.getCondition()->clone(),
+                                                                    expr.getLeft()->clone(),
+                                                                    expr.getRight()->clone()} {}
 
 TernaryOperator& TernaryOperator::operator=(TernaryOperator expr) {
   assign(expr);

--- a/src/dawn/SIR/ASTStmt.cpp
+++ b/src/dawn/SIR/ASTStmt.cpp
@@ -281,9 +281,11 @@ IfStmt::IfStmt(const std::shared_ptr<Stmt>& condStmt, const std::shared_ptr<Stmt
     : Stmt(SK_IfStmt, loc), subStmts_{condStmt, thenStmt, elseStmt} {}
 
 IfStmt::IfStmt(const IfStmt& stmt)
-    : Stmt(SK_IfStmt, stmt.getSourceLocation()),
-      subStmts_{stmt.getCondStmt()->clone(), stmt.getThenStmt()->clone(),
-                stmt.hasElse() ? stmt.getElseStmt()->clone() : nullptr} {}
+    : Stmt(SK_IfStmt, stmt.getSourceLocation()), subStmts_{stmt.getCondStmt()->clone(),
+                                                           stmt.getThenStmt()->clone(),
+                                                           stmt.hasElse()
+                                                               ? stmt.getElseStmt()->clone()
+                                                               : nullptr} {}
 
 IfStmt& IfStmt::operator=(IfStmt stmt) {
   assign(stmt);

--- a/src/dawn/SIR/ASTStmt.h
+++ b/src/dawn/SIR/ASTStmt.h
@@ -30,7 +30,7 @@ namespace sir {
 struct VerticalRegion;
 struct StencilCall;
 struct Field;
-}
+} // namespace sir
 
 class ASTVisitor;
 class Expr;

--- a/src/dawn/SIR/ASTStringifier.cpp
+++ b/src/dawn/SIR/ASTStringifier.cpp
@@ -249,7 +249,7 @@ public:
   std::string toString() const { return ss_.str(); }
 };
 
-} // namespace anonymous
+} // namespace
 
 std::string ASTStringifer::toString(const AST& ast, int initialIndent, bool newLines) {
   StringVisitor strVisitor(initialIndent, newLines);

--- a/src/dawn/SIR/ASTUtil.cpp
+++ b/src/dawn/SIR/ASTUtil.cpp
@@ -12,8 +12,8 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
-#include "dawn/SIR/AST.h"
 #include "dawn/SIR/ASTUtil.h"
+#include "dawn/SIR/AST.h"
 #include "dawn/SIR/ASTVisitor.h"
 #include "dawn/SIR/Statement.h"
 #include "dawn/Support/StringSwitch.h"

--- a/src/dawn/SIR/ASTVisitor.cpp
+++ b/src/dawn/SIR/ASTVisitor.cpp
@@ -13,8 +13,8 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
-#include "dawn/SIR/AST.h"
 #include "dawn/SIR/ASTVisitor.h"
+#include "dawn/SIR/AST.h"
 #include "dawn/SIR/SIR.h"
 
 namespace dawn {

--- a/src/dawn/SIR/SIR.cpp
+++ b/src/dawn/SIR/SIR.cpp
@@ -259,9 +259,8 @@ sir::CompareResult sir::Stencil::comparison(const sir::Stencil& rhs) const {
                                       Name, rhs.Name),
                          false};
 
-  if(!Fields.empty() &&
-     !std::equal(Fields.begin(), Fields.end(), rhs.Fields.begin(),
-                 pointeeComparisonWithOutput<Field>)) {
+  if(!Fields.empty() && !std::equal(Fields.begin(), Fields.end(), rhs.Fields.begin(),
+                                    pointeeComparisonWithOutput<Field>)) {
     std::string output = "[Stencil mismatch] Fields do not match\n";
     for(int i = 0; i < Fields.size(); ++i) {
       auto comp = pointeeComparisonWithOutput(Fields[i], rhs.Fields[i]);
@@ -335,9 +334,8 @@ sir::CompareResult sir::StencilFunction::comparison(const sir::StencilFunction& 
   }
 
   // Intervals
-  if(!Intervals.empty() &&
-     !std::equal(Intervals.begin(), Intervals.end(), rhs.Intervals.begin(),
-                 pointeeComparison<sir::Interval>)) {
+  if(!Intervals.empty() && !std::equal(Intervals.begin(), Intervals.end(), rhs.Intervals.begin(),
+                                       pointeeComparison<sir::Interval>)) {
     std::string output = "[StencilFunction mismatch] Intervals do not match\n";
     for(int i = 0; i < Intervals.size(); ++i) {
       auto comp = pointeeComparisonWithOutput(Intervals[i], rhs.Intervals[i]);

--- a/src/dawn/SIR/SIRSerializer.cpp
+++ b/src/dawn/SIR/SIRSerializer.cpp
@@ -12,11 +12,11 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
-#include "dawn/SIR/SIR.h"
+#include "dawn/SIR/SIRSerializer.h"
 #include "dawn/SIR/AST.h"
 #include "dawn/SIR/ASTVisitor.h"
+#include "dawn/SIR/SIR.h"
 #include "dawn/SIR/SIR.pb.h"
-#include "dawn/SIR/SIRSerializer.h"
 #include "dawn/Serialization/ASTSerializer.h"
 #include "dawn/Support/Format.h"
 #include "dawn/Support/Logging.h"

--- a/src/dawn/Serialization/ASTSerializer.h
+++ b/src/dawn/Serialization/ASTSerializer.h
@@ -17,9 +17,9 @@
 
 #include "dawn/IIR/StatementAccessesPair.h"
 #include "dawn/IIR/StencilInstantiation.h"
-#include "dawn/SIR/statements.pb.h"
 #include "dawn/SIR/ASTVisitor.h"
 #include "dawn/SIR/SIR.h"
+#include "dawn/SIR/statements.pb.h"
 #include <stack>
 
 using namespace dawn;

--- a/src/dawn/Serialization/SIRSerializer.cpp
+++ b/src/dawn/Serialization/SIRSerializer.cpp
@@ -12,11 +12,11 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
-#include "dawn/SIR/SIR.h"
+#include "dawn/Serialization/SIRSerializer.h"
 #include "dawn/SIR/AST.h"
 #include "dawn/SIR/ASTVisitor.h"
+#include "dawn/SIR/SIR.h"
 #include "dawn/SIR/SIR.pb.h"
-#include "dawn/Serialization/SIRSerializer.h"
 #include "dawn/Serialization/ASTSerializer.h"
 #include "dawn/Support/Format.h"
 #include "dawn/Support/Logging.h"

--- a/src/dawn/Support/Assert.h
+++ b/src/dawn/Support/Assert.h
@@ -36,8 +36,9 @@ extern void assertionFailedMsg(char const* expr, char const* msg, char const* fu
 /// @brief Assert macro
 /// @ingroup support
 #define DAWN_ASSERT(expr)                                                                          \
-  (DAWN_BUILTIN_LIKELY(!!(expr)) ? ((void)0) : dawn::assertionFailed(#expr, DAWN_CURRENT_FUNCTION, \
-                                                                     __FILE__, __LINE__))
+  (DAWN_BUILTIN_LIKELY(!!(expr))                                                                   \
+       ? ((void)0)                                                                                 \
+       : dawn::assertionFailed(#expr, DAWN_CURRENT_FUNCTION, __FILE__, __LINE__))
 
 /// @macro DAWN_ASSERT_MSG
 /// @brief Assert macro with additional message

--- a/src/dawn/Support/SmallVector.h
+++ b/src/dawn/Support/SmallVector.h
@@ -107,14 +107,14 @@ public:
   typedef const T* const_pointer;
 
   // forward iterator creation methods.
-  inline iterator begin() { return (iterator) this->BeginX; }
-  inline const_iterator begin() const { return (const_iterator) this->BeginX; }
-  inline iterator end() { return (iterator) this->EndX; }
-  inline const_iterator end() const { return (const_iterator) this->EndX; }
+  inline iterator begin() { return (iterator)this->BeginX; }
+  inline const_iterator begin() const { return (const_iterator)this->BeginX; }
+  inline iterator end() { return (iterator)this->EndX; }
+  inline const_iterator end() const { return (const_iterator)this->EndX; }
 
 protected:
-  iterator capacity_ptr() { return (iterator) this->CapacityX; }
-  const_iterator capacity_ptr() const { return (const_iterator) this->CapacityX; }
+  iterator capacity_ptr() { return (iterator)this->CapacityX; }
+  const_iterator capacity_ptr() const { return (const_iterator)this->CapacityX; }
 
 public:
   // reverse iterator creation methods.


### PR DESCRIPTION
## Technical Description

Update to clang-format 6.0 and a reformatting of the repo

#### Resolves / Enhances

Formatting inconsistencies that cropped up.

## Dependencies

This PR is independent, but the same update happens in GTClang and clang-gridtools https://github.com/MeteoSwiss-APN/gtclang/pull/141 and https://github.com/MeteoSwiss-APN/clang-gridtools/pull/120/files

## Upgrade locally
```
sudo apt-get install clang-format-6.0
sudo update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-6.0 1
```


