### PR TITLE
Nodeiteator cleanup

### DIFF
--- a/src/dawn/IIR/IIRNodeIterator.h
+++ b/src/dawn/IIR/IIRNodeIterator.h
@@ -24,7 +24,6 @@
 namespace dawn {
 namespace iir {
 
-
 template <typename RootIIRNode, typename LeafNode>
 class IIRNodeIterator {
   template <class A, class B>
@@ -58,14 +57,15 @@ public:
     }
   }
 
-
   bool isVoidIter() const {
     if(voidIter_)
       return true;
     return restIterator_.isVoidIter();
   }
+
 private:
   IIRNodeIterator() = default;
+
 public:
   IIRNodeIterator(IIRNodeIterator&&) = default;
   IIRNodeIterator(const IIRNodeIterator&) = default;
@@ -134,16 +134,16 @@ public:
       return true;
     return iterator_ == end_;
   }
-private:
-  IIRNodeIterator() = default;
 };
 
 template <typename LeafNode>
 class IIRNodeIterator<LeafNode, LeafNode> {
   template <class A, class B>
   friend class IIRNodeIterator;
+
 private:
   IIRNodeIterator() = default;
+
 public:
   IIRNodeIterator(const LeafNode* root) {}
   IIRNodeIterator(IIRNodeIterator&&) = default;
@@ -179,8 +179,6 @@ public:
     it.setToEnd();
     return it;
   }
-private:
-  IIRNodeIterator() = default;
 };
 
 } // namespace iir

--- a/src/dawn/IIR/IIRNodeIterator.h
+++ b/src/dawn/IIR/IIRNodeIterator.h
@@ -26,6 +26,8 @@ namespace iir {
 
 template <typename RootIIRNode, typename LeafNode>
 class IIRNodeIterator {
+  template <class A, class B>
+  friend class IIRNodeIterator;
 
   typename RootIIRNode::ChildConstIterator iterator_;
   typename RootIIRNode::ChildConstIterator end_;
@@ -60,7 +62,6 @@ public:
       return true;
     return restIterator_.isVoidIter();
   }
-  IIRNodeIterator() = default;
   IIRNodeIterator(IIRNodeIterator&&) = default;
   IIRNodeIterator(const IIRNodeIterator&) = default;
   IIRNodeIterator& operator=(IIRNodeIterator&&) = default;
@@ -128,12 +129,15 @@ public:
       return true;
     return iterator_ == end_;
   }
+private:
+  IIRNodeIterator() = default;
 };
 
 template <typename LeafNode>
 class IIRNodeIterator<LeafNode, LeafNode> {
+  template <class A, class B>
+  friend class IIRNodeIterator;
 public:
-  IIRNodeIterator() = default;
   IIRNodeIterator(const LeafNode* root) {}
   IIRNodeIterator(IIRNodeIterator&&) = default;
   IIRNodeIterator(const IIRNodeIterator&) = default;
@@ -168,6 +172,8 @@ public:
     it.setToEnd();
     return it;
   }
+private:
+  IIRNodeIterator() = default;
 };
 
 } // namespace iir


### PR DESCRIPTION
## Technical Description

There was a default constructor setting it's const-ptr to a nullptr and should therefore never be used. This makes them private. (Solution by @Stagno)

#### Resolves / Enhances

Cleanup of the node iterator class.

## Dependencies

This PR is independent

