### PR TITLE
Fix pytests

### DIFF
--- a/bundle/CMakeLists.txt
+++ b/bundle/CMakeLists.txt
@@ -72,6 +72,7 @@ include("thirdparty/DawnAddBoost")
 
 option(DAWN_BUNDLE_PYTHON "Build and install the Python module interface to HIR" OFF)
 option(DAWN_BUNDLE_JAVA "Build and install the java interface to HIR" OFF)
+option(DAWN_PYTHON_EXAMPLES "Build the python examples of generating HIR" OFF)
 
 if( DAWN_BUNDLE_PYTHON )
   if(NOT DEFINED PYTHON_EXECUTABLE)
@@ -79,7 +80,7 @@ if( DAWN_BUNDLE_PYTHON )
   endif()
 endif()
 
-set(dawn_cmake_args -DProtobuf_DIR=${Protobuf_DIR} -DBOOST_ROOT=${BOOST_ROOT} -DDAWN_PYTHON=${DAWN_BUNDLE_PYTHON} -DDAWN_EXAMPLES=ON -DDAWN_JAVA=${DAWN_BUNDLE_JAVA})
+set(dawn_cmake_args -DProtobuf_DIR=${Protobuf_DIR} -DBOOST_ROOT=${BOOST_ROOT} -DDAWN_PYTHON=${DAWN_BUNDLE_PYTHON} -DDAWN_EXAMPLES=${DAWN_PYTHON_EXAMPLES} -DDAWN_JAVA=${DAWN_BUNDLE_JAVA})
 
 yoda_find_package(
   PACKAGE dawn

--- a/bundle/CMakeLists.txt
+++ b/bundle/CMakeLists.txt
@@ -66,8 +66,6 @@ yoda_add_target_clean_all(
 
 include("thirdparty/DawnAddProtobuf")
 
-install(DIRECTORY ${PROTOBUF_PYTHON_INSTALL}/google DESTINATION ${CMAKE_INSTALL_PREFIX}/python)
-
 include("thirdparty/DawnAddBoost")
 
 option(DAWN_BUNDLE_PYTHON "Build and install the Python module interface to HIR" OFF)
@@ -111,5 +109,6 @@ install(
 )
 
 if(DAWN_BUNDLE_PYTHON)
+  install(DIRECTORY ${PROTOBUF_PYTHON_INSTALL}/google DESTINATION ${CMAKE_INSTALL_PREFIX}/python)
   install (SCRIPT "${CMAKE_SOURCE_DIR}/PostInstall.cmake")
 endif(DAWN_BUNDLE_PYTHON)

--- a/scripts/jenkins/build.sh
+++ b/scripts/jenkins/build.sh
@@ -18,7 +18,7 @@ if [ -z ${PROTOBUFDIR+x} ]; then
  echo "PROTOBUFDIF needs to be set in the machine env"
 fi
 
-cmake -DDAWN_BUNDLE_PYTHON=ON -DDAWN_BUNDLE_JAVA=ON -DCMAKE_BUILD_TYPE=${build_type} -DBOOST_ROOT=${BOOST_DIR}  \
+cmake -DDAWN_BUNDLE_PYTHON=ON -DDAWN_BUNDLE_JAVA=ON -DDAWN_PYTHON_EXAMPLES=ON -DCMAKE_BUILD_TYPE=${build_type} -DBOOST_ROOT=${BOOST_DIR}  \
         -DProtobuf_DIR=${PROTOBUFDIR} ../
 make -j2
 

--- a/scripts/jenkins/build.sh
+++ b/scripts/jenkins/build.sh
@@ -20,7 +20,7 @@ fi
 
 cmake -DDAWN_BUNDLE_PYTHON=ON -DDAWN_BUNDLE_JAVA=ON -DDAWN_PYTHON_EXAMPLES=ON -DCMAKE_BUILD_TYPE=${build_type} -DBOOST_ROOT=${BOOST_DIR}  \
         -DProtobuf_DIR=${PROTOBUFDIR} ../
-make -j2
+make -j2 install
 
 # Run unittests
 ctest -VV -C ${build_type} --output-on-failure --force-new-ctest-process  


### PR DESCRIPTION
## Technical Description

Changes the default behavior of the bundle to not run the python examples as the default is not to install the required python modules.

#### Resolves

This should fix the currently broken master builds of jenkins.
If the bundle downloads dawn, the default flags are off for python-bindings but on for python tests. So the (post)-install step fails. 

#### Example

http://jenkins-mch.cscs.ch/view/PASCHA/job/gtclang/

## Testing

The pipeline test does not work here since it works with a dawn that is installed on a previous step. So a "maunal" launch of the pipeline https://github.com/MeteoSwiss-APN/gtclang/pull/146

## Dependencies

This PR is indepdent


