### PR TITLE
Fix stage merge

### DIFF
--- a/src/dawn/IIR/Stage.cpp
+++ b/src/dawn/IIR/Stage.cpp
@@ -109,6 +109,7 @@ std::vector<Interval> Stage::getIntervals() const {
 }
 
 Interval Stage::getEnclosingInterval() const {
+  DAWN_ASSERT_MSG(getChildren().size() > 0, "Stage does not contain any children");
   Interval interval = getChildren().front()->getInterval();
   for(const auto& doMethod : getChildren())
     interval.merge(doMethod->getInterval());

--- a/src/dawn/Optimizer/PassStageMerger.cpp
+++ b/src/dawn/Optimizer/PassStageMerger.cpp
@@ -48,6 +48,7 @@ bool PassStageMerger::run(const std::shared_ptr<iir::StencilInstantiation>& sten
 
   for(const auto& stencilPtr : stencilInstantiation->getStencils()) {
     iir::Stencil& stencil = *stencilPtr;
+    auto stencilAxis = stencil.getAxis(false);
 
     // Do we need to run the analysis for thist stencil?
     const std::shared_ptr<iir::DependencyGraphStage>& stageDAG = stencil.getStageDependencyGraph();
@@ -74,7 +75,7 @@ bool PassStageMerger::run(const std::shared_ptr<iir::StencilInstantiation>& sten
         bool updateFields = false;
 
         // If our Do-Methods already spans the entire axis, we don't want to destroy that property
-        bool MergeDoMethodsOfStage = curStage.getEnclosingInterval() != stencil.getAxis(false);
+        bool MergeDoMethodsOfStage = curStage.getEnclosingInterval() != stencilAxis;
         if(!MergeDoMethodsOfStage && !MergeDoMethodsOfStencil) {
           continue;
         }


### PR DESCRIPTION
## Technical Description

Moves the axis computation to the stencil-level so we're not computing illegal states

#### Resolves

Issue with the integration-tests when both dawn and gtclang are used in debug mode

#### Example

https://github.com/MeteoSwiss-APN/gtclang/blob/master/test/integration-test/CodeGen/intervals_stencil.cpp

## Dependencies

This PR is independent 


