### PR TITLE
Fix iir optimizer dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,7 +24,7 @@ bundle/CMakeFiles/*
 # Ignore gh-pages folder
 gh-pages*
 
-#ignore vscodes
+# Ignore IDEs
 .idea
 .vscode/
 **/compile_commands.json

--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,6 @@
 *~
 *.user
 *.project
-.idea
 
 # Build directories
 build*/
@@ -24,3 +23,9 @@ bundle/CMakeFiles/*
 
 # Ignore gh-pages folder
 gh-pages*
+
+#ignore vscodes
+.idea
+.vscode/
+**/compile_commands.json
+.clangd/

--- a/src/dawn/CodeGen/CMakeLists.txt
+++ b/src/dawn/CodeGen/CMakeLists.txt
@@ -42,7 +42,7 @@ yoda_add_library(
           Cuda/ASTStencilFunctionParamVisitor.cpp
           Cuda/ASTStencilFunctionParamVisitor.h
           Cuda/MSCodeGen.cpp
-          Cuda/MSCodeGen.hpp
+          Cuda/MSCodeGen.h
           GridTools/ASTStencilBody.cpp
           GridTools/ASTStencilBody.h
           GridTools/ASTStencilDesc.cpp

--- a/src/dawn/CodeGen/CXXNaive/ASTStencilBody.cpp
+++ b/src/dawn/CodeGen/CXXNaive/ASTStencilBody.cpp
@@ -16,7 +16,6 @@
 #include "dawn/CodeGen/CXXNaive/ASTStencilFunctionParamVisitor.h"
 #include "dawn/CodeGen/CXXUtil.h"
 #include "dawn/IIR/StencilFunctionInstantiation.h"
-#include "dawn/Optimizer/OptimizerContext.h"
 #include "dawn/SIR/AST.h"
 #include "dawn/Support/Unreachable.h"
 

--- a/src/dawn/CodeGen/CXXNaive/ASTStencilFunctionParamVisitor.cpp
+++ b/src/dawn/CodeGen/CXXNaive/ASTStencilFunctionParamVisitor.cpp
@@ -16,7 +16,6 @@
 #include "dawn/CodeGen/CXXUtil.h"
 #include "dawn/IIR/StencilFunctionInstantiation.h"
 #include "dawn/IIR/StencilInstantiation.h"
-#include "dawn/Optimizer/OptimizerContext.h"
 #include "dawn/SIR/AST.h"
 #include "dawn/Support/Unreachable.h"
 

--- a/src/dawn/CodeGen/CXXNaive/CXXNaiveCodeGen.cpp
+++ b/src/dawn/CodeGen/CXXNaive/CXXNaiveCodeGen.cpp
@@ -557,8 +557,8 @@ std::unique_ptr<TranslationUnit> CXXNaiveCodeGen::generateCode() {
   CodeGen::addMplIfdefs(ppDefines, 30);
   DAWN_LOG(INFO) << "Done generating code";
 
-  return make_unique<TranslationUnit>(context_.begin()->second->getMetaData().getFileName(),
-                                      std::move(ppDefines), std::move(stencils),
+  std::string filename = generateFileName(context_);
+  return make_unique<TranslationUnit>(filename, std::move(ppDefines), std::move(stencils),
                                       std::move(globals));
 }
 

--- a/src/dawn/CodeGen/CXXNaive/CXXNaiveCodeGen.cpp
+++ b/src/dawn/CodeGen/CXXNaive/CXXNaiveCodeGen.cpp
@@ -540,11 +540,7 @@ std::unique_ptr<TranslationUnit> CXXNaiveCodeGen::generateCode() {
     stencils.emplace(nameStencilCtxPair.first, std::move(code));
   }
 
-  std::string globals = "";
-  if(context.size() > 0) {
-    const auto& globalsMap = context.begin()->second->getIIR()->getGlobalVariableMap();
-    globals = generateGlobals(globalsMap, "cxxnaive");
-  }
+  std::string globals = generateGlobals(context, "cxxnaive");
 
   std::vector<std::string> ppDefines;
   auto makeDefine = [](std::string define, int value) {

--- a/src/dawn/CodeGen/CXXNaive/CXXNaiveCodeGen.h
+++ b/src/dawn/CodeGen/CXXNaive/CXXNaiveCodeGen.h
@@ -37,8 +37,7 @@ namespace cxxnaive {
 class CXXNaiveCodeGen : public CodeGen {
 public:
   ///@brief constructor
-  CXXNaiveCodeGen(std::map<std::string, std::shared_ptr<iir::StencilInstantiation>>& ctx,
-                  DiagnosticsEngine& engine, int maxHaloPoint);
+  CXXNaiveCodeGen(stencilInstantiationContext& ctx, DiagnosticsEngine& engine, int maxHaloPoint);
   virtual ~CXXNaiveCodeGen();
   virtual std::unique_ptr<TranslationUnit> generateCode() override;
 

--- a/src/dawn/CodeGen/CXXNaive/CXXNaiveCodeGen.h
+++ b/src/dawn/CodeGen/CXXNaive/CXXNaiveCodeGen.h
@@ -29,8 +29,6 @@ namespace iir {
 class StencilInstantiation;
 }
 
-class OptimizerContext;
-
 namespace codegen {
 namespace cxxnaive {
 
@@ -39,7 +37,8 @@ namespace cxxnaive {
 class CXXNaiveCodeGen : public CodeGen {
 public:
   ///@brief constructor
-  CXXNaiveCodeGen(OptimizerContext* context);
+  CXXNaiveCodeGen(std::map<std::string, std::shared_ptr<iir::StencilInstantiation>>& ctx,
+                  DiagnosticsEngine& engine, int maxHaloPoint);
   virtual ~CXXNaiveCodeGen();
   virtual std::unique_ptr<TranslationUnit> generateCode() override;
 

--- a/src/dawn/CodeGen/CodeGen.cpp
+++ b/src/dawn/CodeGen/CodeGen.cpp
@@ -28,10 +28,9 @@ size_t CodeGen::getVerticalTmpHaloSizeForMultipleStencils(
              : 0;
 }
 
-std::string CodeGen::generateGlobals(std::shared_ptr<SIR> const& sir,
+std::string CodeGen::generateGlobals(const sir::GlobalVariableMap& globalsMap,
                                      std::string namespace_) const {
 
-  const auto& globalsMap = *(sir->GlobalVariableMap);
   if(globalsMap.empty())
     return "";
 
@@ -139,8 +138,7 @@ void CodeGen::generateBCHeaders(std::vector<std::string>& ppDefines) const {
         return res || si.second->getMetaData().hasBC();
       };
 
-  if(std::accumulate(context_->getStencilInstantiationMap().begin(),
-                     context_->getStencilInstantiationMap().end(), false, hasBCFold)) {
+  if(std::accumulate(context.begin(), context.end(), false, hasBCFold)) {
     ppDefines.push_back("#include <gridtools/boundary-conditions/boundary.hpp>\n");
   }
 }
@@ -324,8 +322,7 @@ void CodeGen::generateBCFieldMembers(
   }
 }
 
-void CodeGen::addMplIfdefs(std::vector<std::string>& ppDefines, int mplContainerMaxSize,
-                           int MaxHaloPoints) const {
+void CodeGen::addMplIfdefs(std::vector<std::string>& ppDefines, int mplContainerMaxSize) const {
   auto makeIfNotDefined = [](std::string define, int value) {
     return "#ifndef " + define + "\n #define " + define + " " + std::to_string(value) + "\n#endif";
   };
@@ -335,7 +332,8 @@ void CodeGen::addMplIfdefs(std::vector<std::string>& ppDefines, int mplContainer
 
   ppDefines.push_back(makeIfNotDefined("BOOST_RESULT_OF_USE_TR1", 1));
   ppDefines.push_back(makeIfNotDefined("BOOST_NO_CXX11_DECLTYPE", 1));
-  ppDefines.push_back(makeIfNotDefined("GRIDTOOLS_CLANG_HALO_EXTEND", MaxHaloPoints));
+  ppDefines.push_back(
+      makeIfNotDefined("GRIDTOOLS_CLANG_HALO_EXTEND", codeGenOptions.MaxHaloPoints));
   ppDefines.push_back(makeIfNotDefined("BOOST_PP_VARIADICS", 1));
   ppDefines.push_back(makeIfNotDefined("BOOST_FUSION_DONT_USE_PREPROCESSED_FILES", 1));
   ppDefines.push_back(makeIfNotDefined("BOOST_MPL_CFG_NO_PREPROCESSED_HEADERS", 1));

--- a/src/dawn/CodeGen/CodeGen.cpp
+++ b/src/dawn/CodeGen/CodeGen.cpp
@@ -353,5 +353,12 @@ void CodeGen::addMplIfdefs(std::vector<std::string>& ppDefines, int mplContainer
       makeIfNotDefinedString("BOOST_MPL_LIMIT_VECTOR_SIZE", "GT_VECTOR_LIMIT_SIZE"));
 }
 
+std::string CodeGen::generateFileName(const stencilInstantiationContext& context) const {
+  if(context.size() > 0) {
+    return context_.begin()->second->getMetaData().getFileName();
+  }
+  return "";
+}
+
 } // namespace codegen
 } // namespace dawn

--- a/src/dawn/CodeGen/CodeGen.cpp
+++ b/src/dawn/CodeGen/CodeGen.cpp
@@ -28,9 +28,7 @@ size_t CodeGen::getVerticalTmpHaloSizeForMultipleStencils(
              : 0;
 }
 
-std::string
-CodeGen::generateGlobals(std::map<std::string, std::shared_ptr<iir::StencilInstantiation>>& context,
-                         std::string namespace_) {
+std::string CodeGen::generateGlobals(stencilInstantiationContext& context, std::string namespace_) {
   if(context.size() > 0) {
     const auto& globalsMap = context.begin()->second->getIIR()->getGlobalVariableMap();
     return generateGlobals(globalsMap, namespace_);
@@ -147,7 +145,7 @@ void CodeGen::generateBCHeaders(std::vector<std::string>& ppDefines) const {
         return res || si.second->getMetaData().hasBC();
       };
 
-  if(std::accumulate(context.begin(), context.end(), false, hasBCFold)) {
+  if(std::accumulate(context_.begin(), context_.end(), false, hasBCFold)) {
     ppDefines.push_back("#include <gridtools/boundary-conditions/boundary.hpp>\n");
   }
 }

--- a/src/dawn/CodeGen/CodeGen.cpp
+++ b/src/dawn/CodeGen/CodeGen.cpp
@@ -28,6 +28,15 @@ size_t CodeGen::getVerticalTmpHaloSizeForMultipleStencils(
              : 0;
 }
 
+std::string
+CodeGen::generateGlobals(std::map<std::string, std::shared_ptr<iir::StencilInstantiation>>& context,
+                         std::string namespace_) {
+  if(context.size() > 0) {
+    const auto& globalsMap = context.begin()->second->getIIR()->getGlobalVariableMap();
+    return generateGlobals(globalsMap, namespace_);
+  }
+  return "";
+}
 std::string CodeGen::generateGlobals(const sir::GlobalVariableMap& globalsMap,
                                      std::string namespace_) const {
 

--- a/src/dawn/CodeGen/CodeGen.h
+++ b/src/dawn/CodeGen/CodeGen.h
@@ -98,6 +98,9 @@ public:
                                   Class& stencilWrapperClass,
                                   const sir::GlobalVariableMap& globalsMap,
                                   const CodeGenProperties& codeGenProperties) const;
+  virtual std::string
+  generateGlobals(std::map<std::string, std::shared_ptr<iir::StencilInstantiation>>& context,
+                  std::string namespace_);
   virtual std::string generateGlobals(const sir::GlobalVariableMap& globalsMaps,
                                       std::string namespace_) const;
   void generateBCHeaders(std::vector<std::string>& ppDefines) const;

--- a/src/dawn/CodeGen/CodeGen.h
+++ b/src/dawn/CodeGen/CodeGen.h
@@ -103,6 +103,8 @@ public:
   virtual std::string generateGlobals(const sir::GlobalVariableMap& globalsMaps,
                                       std::string namespace_) const;
   void generateBCHeaders(std::vector<std::string>& ppDefines) const;
+
+  std::string generateFileName(const stencilInstantiationContext& context) const;
 };
 
 } // namespace codegen

--- a/src/dawn/CodeGen/CodeGen.h
+++ b/src/dawn/CodeGen/CodeGen.h
@@ -34,12 +34,14 @@ extern std::map<Key, Value> orderMap(const std::unordered_map<Key, Value>& umap)
 
   return m;
 }
+using stencilInstantiationContext =
+    std::map<std::string, std::shared_ptr<iir::StencilInstantiation>>;
 
 /// @brief Interface of the backend code generation
 /// @ingroup codegen
 class CodeGen {
 protected:
-  std::map<std::string, std::shared_ptr<iir::StencilInstantiation>>& context;
+  stencilInstantiationContext context_;
   DiagnosticsEngine& diagEngine;
   struct codeGenOption {
     int MaxHaloPoints;
@@ -75,9 +77,8 @@ protected:
   const std::string bigWrapperMetadata_ = "m_meta_data";
 
 public:
-  CodeGen(std::map<std::string, std::shared_ptr<iir::StencilInstantiation>>& ctx,
-          DiagnosticsEngine& engine, int maxHaloPoints)
-      : context(ctx), diagEngine(engine), codeGenOptions{maxHaloPoints} {};
+  CodeGen(stencilInstantiationContext& ctx, DiagnosticsEngine& engine, int maxHaloPoints)
+      : context_(ctx), diagEngine(engine), codeGenOptions{maxHaloPoints} {};
   virtual ~CodeGen() {}
 
   /// @brief Generate code
@@ -98,9 +99,7 @@ public:
                                   Class& stencilWrapperClass,
                                   const sir::GlobalVariableMap& globalsMap,
                                   const CodeGenProperties& codeGenProperties) const;
-  virtual std::string
-  generateGlobals(std::map<std::string, std::shared_ptr<iir::StencilInstantiation>>& context,
-                  std::string namespace_);
+  virtual std::string generateGlobals(stencilInstantiationContext& context, std::string namespace_);
   virtual std::string generateGlobals(const sir::GlobalVariableMap& globalsMaps,
                                       std::string namespace_) const;
   void generateBCHeaders(std::vector<std::string>& ppDefines) const;

--- a/src/dawn/CodeGen/CodeGen.h
+++ b/src/dawn/CodeGen/CodeGen.h
@@ -18,7 +18,8 @@
 #include "dawn/CodeGen/CXXUtil.h"
 #include "dawn/CodeGen/CodeGenProperties.h"
 #include "dawn/CodeGen/TranslationUnit.h"
-#include "dawn/Optimizer/OptimizerContext.h"
+#include "dawn/IIR/StencilInstantiation.h"
+#include "dawn/Support/DiagnosticsEngine.h"
 #include "dawn/Support/IndexRange.h"
 #include <memory>
 
@@ -38,7 +39,11 @@ extern std::map<Key, Value> orderMap(const std::unordered_map<Key, Value>& umap)
 /// @ingroup codegen
 class CodeGen {
 protected:
-  OptimizerContext* context_;
+  std::map<std::string, std::shared_ptr<iir::StencilInstantiation>>& context;
+  DiagnosticsEngine& diagEngine;
+  struct codeGenOption {
+    int MaxHaloPoints;
+  } codeGenOptions;
 
   static size_t getVerticalTmpHaloSize(iir::Stencil const& stencil);
   size_t getVerticalTmpHaloSizeForMultipleStencils(
@@ -61,8 +66,7 @@ protected:
                               const std::shared_ptr<iir::StencilInstantiation> stencilInstantiation,
                               const CodeGenProperties& codeGenProperties) const;
 
-  void addMplIfdefs(std::vector<std::string>& ppDefines, int mplContainerMaxSize,
-                    int MaxHaloPoints) const;
+  void addMplIfdefs(std::vector<std::string>& ppDefines, int mplContainerMaxSize) const;
 
   const std::string tmpStorageTypename_ = "tmp_storage_t";
   const std::string tmpMetadataTypename_ = "tmp_meta_data_t";
@@ -71,14 +75,13 @@ protected:
   const std::string bigWrapperMetadata_ = "m_meta_data";
 
 public:
-  CodeGen(OptimizerContext* context) : context_(context){};
+  CodeGen(std::map<std::string, std::shared_ptr<iir::StencilInstantiation>>& ctx,
+          DiagnosticsEngine& engine, int maxHaloPoints)
+      : context(ctx), diagEngine(engine), codeGenOptions{maxHaloPoints} {};
   virtual ~CodeGen() {}
 
   /// @brief Generate code
   virtual std::unique_ptr<TranslationUnit> generateCode() = 0;
-
-  /// @brief Get the optimizer context
-  const OptimizerContext* getOptimizerContext() const { return context_; }
 
   static std::string getStorageType(const sir::Field& field);
   static std::string getStorageType(const iir::Stencil::FieldInfo& field);
@@ -95,7 +98,7 @@ public:
                                   Class& stencilWrapperClass,
                                   const sir::GlobalVariableMap& globalsMap,
                                   const CodeGenProperties& codeGenProperties) const;
-  virtual std::string generateGlobals(std::shared_ptr<SIR> const& sir,
+  virtual std::string generateGlobals(const sir::GlobalVariableMap& globalsMaps,
                                       std::string namespace_) const;
   void generateBCHeaders(std::vector<std::string>& ppDefines) const;
 };

--- a/src/dawn/CodeGen/Cuda/ASTStencilBody.cpp
+++ b/src/dawn/CodeGen/Cuda/ASTStencilBody.cpp
@@ -16,7 +16,6 @@
 #include "dawn/CodeGen/CXXUtil.h"
 #include "dawn/CodeGen/Cuda/ASTStencilFunctionParamVisitor.h"
 #include "dawn/IIR/StencilFunctionInstantiation.h"
-#include "dawn/Optimizer/OptimizerContext.h"
 #include "dawn/SIR/AST.h"
 #include "dawn/Support/Unreachable.h"
 #include <string>

--- a/src/dawn/CodeGen/Cuda/ASTStencilFunctionParamVisitor.cpp
+++ b/src/dawn/CodeGen/Cuda/ASTStencilFunctionParamVisitor.cpp
@@ -16,7 +16,6 @@
 #include "dawn/CodeGen/CXXUtil.h"
 #include "dawn/IIR/StencilFunctionInstantiation.h"
 #include "dawn/IIR/StencilInstantiation.h"
-#include "dawn/Optimizer/OptimizerContext.h"
 #include "dawn/SIR/AST.h"
 #include "dawn/Support/Unreachable.h"
 

--- a/src/dawn/CodeGen/Cuda/CudaCodeGen.cpp
+++ b/src/dawn/CodeGen/Cuda/CudaCodeGen.cpp
@@ -35,9 +35,8 @@ namespace dawn {
 namespace codegen {
 namespace cuda {
 
-CudaCodeGen::CudaCodeGen(std::map<std::string, std::shared_ptr<iir::StencilInstantiation>>& ctx,
-                         DiagnosticsEngine& engine, int maxHaloPoints, int nsms, int maxBlocksPerSM,
-                         std::string domainSize)
+CudaCodeGen::CudaCodeGen(stencilInstantiationContext& ctx, DiagnosticsEngine& engine,
+                         int maxHaloPoints, int nsms, int maxBlocksPerSM, std::string domainSize)
     : CodeGen(ctx, engine, maxHaloPoints), codeGenOptions{nsms, maxBlocksPerSM, domainSize} {}
 
 CudaCodeGen::~CudaCodeGen() {}
@@ -665,7 +664,7 @@ std::unique_ptr<TranslationUnit> CudaCodeGen::generateCode() {
 
   // Generate code for StencilInstantiations
   std::map<std::string, std::string> stencils;
-  for(const auto& nameStencilCtxPair : context) {
+  for(const auto& nameStencilCtxPair : context_) {
     std::shared_ptr<iir::StencilInstantiation> origSI = nameStencilCtxPair.second;
     // TODO the clone seems to be broken
     //    std::shared_ptr<iir::StencilInstantiation> stencilInstantiation = origSI->clone();
@@ -677,7 +676,7 @@ std::unique_ptr<TranslationUnit> CudaCodeGen::generateCode() {
     stencils.emplace(nameStencilCtxPair.first, std::move(code));
   }
 
-  std::string globals = generateGlobals(context, "cuda");
+  std::string globals = generateGlobals(context_, "cuda");
 
   std::vector<std::string> ppDefines;
   auto makeDefine = [](std::string define, int value) {
@@ -700,7 +699,7 @@ std::unique_ptr<TranslationUnit> CudaCodeGen::generateCode() {
   DAWN_LOG(INFO) << "Done generating code";
 
   // TODO missing the BC
-  return make_unique<TranslationUnit>(context.begin()->second->getMetaData().getFileName(),
+  return make_unique<TranslationUnit>(context_.begin()->second->getMetaData().getFileName(),
                                       std::move(ppDefines), std::move(stencils),
                                       std::move(globals));
 }

--- a/src/dawn/CodeGen/Cuda/CudaCodeGen.cpp
+++ b/src/dawn/CodeGen/Cuda/CudaCodeGen.cpp
@@ -19,7 +19,7 @@
 #include "dawn/CodeGen/Cuda/ASTStencilDesc.h"
 #include "dawn/CodeGen/Cuda/CacheProperties.h"
 #include "dawn/CodeGen/Cuda/CodeGeneratorHelper.h"
-#include "dawn/CodeGen/Cuda/MSCodeGen.hpp"
+#include "dawn/CodeGen/Cuda/MSCodeGen.h"
 #include "dawn/IIR/IIRNodeIterator.h"
 #include "dawn/IIR/StencilInstantiation.h"
 #include "dawn/SIR/SIR.h"
@@ -677,11 +677,7 @@ std::unique_ptr<TranslationUnit> CudaCodeGen::generateCode() {
     stencils.emplace(nameStencilCtxPair.first, std::move(code));
   }
 
-  std::string globals = "";
-  if(context.size() > 0) {
-    const auto& globalsMap = context.begin()->second->getIIR()->getGlobalVariableMap();
-    globals = generateGlobals(globalsMap, "cuda");
-  }
+  std::string globals = generateGlobals(context, "cuda");
 
   std::vector<std::string> ppDefines;
   auto makeDefine = [](std::string define, int value) {

--- a/src/dawn/CodeGen/Cuda/CudaCodeGen.cpp
+++ b/src/dawn/CodeGen/Cuda/CudaCodeGen.cpp
@@ -698,9 +698,9 @@ std::unique_ptr<TranslationUnit> CudaCodeGen::generateCode() {
 
   DAWN_LOG(INFO) << "Done generating code";
 
+  std::string filename = generateFileName(context_);
   // TODO missing the BC
-  return make_unique<TranslationUnit>(context_.begin()->second->getMetaData().getFileName(),
-                                      std::move(ppDefines), std::move(stencils),
+  return make_unique<TranslationUnit>(filename, std::move(ppDefines), std::move(stencils),
                                       std::move(globals));
 }
 

--- a/src/dawn/CodeGen/Cuda/CudaCodeGen.h
+++ b/src/dawn/CodeGen/Cuda/CudaCodeGen.h
@@ -30,8 +30,6 @@ namespace iir {
 class StencilInstantiation;
 }
 
-class OptimizerContext;
-
 namespace codegen {
 namespace cuda {
 
@@ -43,9 +41,17 @@ class CudaCodeGen : public CodeGen {
 
 public:
   ///@brief constructor
-  CudaCodeGen(OptimizerContext* context);
+  CudaCodeGen(std::map<std::string, std::shared_ptr<iir::StencilInstantiation>>& ctx,
+              DiagnosticsEngine& engine, int maxHaloPoints, int nsms, int maxBlocksPerSM,
+              std::string domainSize);
   virtual ~CudaCodeGen();
   virtual std::unique_ptr<TranslationUnit> generateCode() override;
+
+  struct CudaCodeGenOptions {
+    int nsms;
+    int maxBlocksPerSM;
+    std::string domainSize;
+  };
 
 private:
   static std::string
@@ -115,6 +121,8 @@ private:
 
   std::string generateStencilInstantiation(
       const std::shared_ptr<iir::StencilInstantiation>& stencilInstantiation);
+
+  CudaCodeGenOptions codeGenOptions;
 };
 } // namespace cuda
 } // namespace codegen

--- a/src/dawn/CodeGen/Cuda/CudaCodeGen.h
+++ b/src/dawn/CodeGen/Cuda/CudaCodeGen.h
@@ -41,9 +41,8 @@ class CudaCodeGen : public CodeGen {
 
 public:
   ///@brief constructor
-  CudaCodeGen(std::map<std::string, std::shared_ptr<iir::StencilInstantiation>>& ctx,
-              DiagnosticsEngine& engine, int maxHaloPoints, int nsms, int maxBlocksPerSM,
-              std::string domainSize);
+  CudaCodeGen(stencilInstantiationContext& ctx, DiagnosticsEngine& engine, int maxHaloPoints,
+              int nsms, int maxBlocksPerSM, std::string domainSize);
   virtual ~CudaCodeGen();
   virtual std::unique_ptr<TranslationUnit> generateCode() override;
 

--- a/src/dawn/CodeGen/Cuda/MSCodeGen.cpp
+++ b/src/dawn/CodeGen/Cuda/MSCodeGen.cpp
@@ -12,7 +12,7 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
-#include "dawn/CodeGen/Cuda/MSCodeGen.hpp"
+#include "dawn/CodeGen/Cuda/MSCodeGen.h"
 #include "dawn/CodeGen/CXXUtil.h"
 #include "dawn/CodeGen/CodeGen.h"
 #include "dawn/CodeGen/Cuda/ASTStencilBody.h"
@@ -28,7 +28,7 @@ namespace cuda {
 MSCodeGen::MSCodeGen(std::stringstream& ss, const std::unique_ptr<iir::MultiStage>& ms,
                      const std::shared_ptr<iir::StencilInstantiation>& stencilInstantiation,
                      const CacheProperties& cacheProperties,
-                     CudaCodeGen::CudaCodeGenOptions& options)
+                     CudaCodeGen::CudaCodeGenOptions options)
     : ss_(ss), ms_(ms), stencilInstantiation_(stencilInstantiation),
       metadata_(stencilInstantiation->getMetaData()), cacheProperties_(cacheProperties),
       useCodeGenTemporaries_(CodeGeneratorHelper::useTemporaries(

--- a/src/dawn/CodeGen/Cuda/MSCodeGen.h
+++ b/src/dawn/CodeGen/Cuda/MSCodeGen.h
@@ -55,12 +55,12 @@ private:
   std::string cudaKernelName_;
   Array3ui blockSize_;
   const bool solveKLoopInParallel_;
-  CudaCodeGen::CudaCodeGenOptions& options_;
+  CudaCodeGen::CudaCodeGenOptions options_;
 
 public:
   MSCodeGen(std::stringstream& ss, const std::unique_ptr<iir::MultiStage>& ms,
             const std::shared_ptr<iir::StencilInstantiation>& stencilInstantiation,
-            const CacheProperties& cacheProperties, CudaCodeGen::CudaCodeGenOptions& options);
+            const CacheProperties& cacheProperties, CudaCodeGen::CudaCodeGenOptions options);
 
   void generateCudaKernelCode();
 

--- a/src/dawn/CodeGen/Cuda/MSCodeGen.hpp
+++ b/src/dawn/CodeGen/Cuda/MSCodeGen.hpp
@@ -20,6 +20,7 @@
 #include "dawn/CodeGen/CXXUtil.h"
 #include "dawn/CodeGen/Cuda/CacheProperties.h"
 #include "dawn/CodeGen/Cuda/CodeGeneratorHelper.h"
+#include "dawn/CodeGen/Cuda/CudaCodeGen.h"
 #include "dawn/IIR/MultiStage.h"
 #include "dawn/Support/IndexRange.h"
 
@@ -54,11 +55,12 @@ private:
   std::string cudaKernelName_;
   Array3ui blockSize_;
   const bool solveKLoopInParallel_;
+  CudaCodeGen::CudaCodeGenOptions& options_;
 
 public:
   MSCodeGen(std::stringstream& ss, const std::unique_ptr<iir::MultiStage>& ms,
             const std::shared_ptr<iir::StencilInstantiation>& stencilInstantiation,
-            const CacheProperties& cacheProperties);
+            const CacheProperties& cacheProperties, CudaCodeGen::CudaCodeGenOptions& options);
 
   void generateCudaKernelCode();
 

--- a/src/dawn/CodeGen/GridTools/ASTStencilBody.cpp
+++ b/src/dawn/CodeGen/GridTools/ASTStencilBody.cpp
@@ -16,7 +16,6 @@
 #include "dawn/CodeGen/CXXUtil.h"
 #include "dawn/IIR/StencilFunctionInstantiation.h"
 #include "dawn/IIR/StencilInstantiation.h"
-#include "dawn/Optimizer/OptimizerContext.h"
 #include "dawn/SIR/AST.h"
 #include "dawn/Support/Unreachable.h"
 

--- a/src/dawn/CodeGen/GridTools/GTCodeGen.cpp
+++ b/src/dawn/CodeGen/GridTools/GTCodeGen.cpp
@@ -964,8 +964,8 @@ std::unique_ptr<TranslationUnit> GTCodeGen::generateCode() {
 
   DAWN_LOG(INFO) << "Done generating code";
 
-  return make_unique<TranslationUnit>(context_.begin()->second->getMetaData().getFileName(),
-                                      std::move(ppDefines), std::move(stencils),
+  std::string filename = generateFileName(context_);
+  return make_unique<TranslationUnit>(filename, std::move(ppDefines), std::move(stencils),
                                       std::move(globals));
 }
 

--- a/src/dawn/CodeGen/GridTools/GTCodeGen.cpp
+++ b/src/dawn/CodeGen/GridTools/GTCodeGen.cpp
@@ -34,8 +34,8 @@ namespace dawn {
 namespace codegen {
 namespace gt {
 
-GTCodeGen::GTCodeGen(std::map<std::string, std::shared_ptr<iir::StencilInstantiation>>& ctx,
-                     DiagnosticsEngine& engine, bool useParallelEP, int maxHaloPoints)
+GTCodeGen::GTCodeGen(stencilInstantiationContext& ctx, DiagnosticsEngine& engine,
+                     bool useParallelEP, int maxHaloPoints)
     : CodeGen(ctx, engine, maxHaloPoints),
       mplContainerMaxSize_(20), codeGenOptions_{useParallelEP} {}
 
@@ -928,7 +928,7 @@ std::unique_ptr<TranslationUnit> GTCodeGen::generateCode() {
 
   // Generate StencilInstantiations
   std::map<std::string, std::string> stencils;
-  for(const auto& nameStencilCtxPair : context) {
+  for(const auto& nameStencilCtxPair : context_) {
     std::string code = generateStencilInstantiation(nameStencilCtxPair.second);
 
     if(code.empty())
@@ -937,7 +937,7 @@ std::unique_ptr<TranslationUnit> GTCodeGen::generateCode() {
   }
 
   // Generate globals
-  std::string globals = generateGlobals(context, "gridtools");
+  std::string globals = generateGlobals(context_, "gridtools");
 
   // If we need more than 20 elements in boost::mpl containers, we need to increment to the
   // nearest multiple of ten
@@ -964,7 +964,7 @@ std::unique_ptr<TranslationUnit> GTCodeGen::generateCode() {
 
   DAWN_LOG(INFO) << "Done generating code";
 
-  return make_unique<TranslationUnit>(context.begin()->second->getMetaData().getFileName(),
+  return make_unique<TranslationUnit>(context_.begin()->second->getMetaData().getFileName(),
                                       std::move(ppDefines), std::move(stencils),
                                       std::move(globals));
 }

--- a/src/dawn/CodeGen/GridTools/GTCodeGen.cpp
+++ b/src/dawn/CodeGen/GridTools/GTCodeGen.cpp
@@ -20,9 +20,9 @@
 #include "dawn/IIR/StatementAccessesPair.h"
 #include "dawn/IIR/StencilFunctionInstantiation.h"
 #include "dawn/IIR/StencilInstantiation.h"
-#include "dawn/Optimizer/OptimizerContext.h"
 #include "dawn/SIR/SIR.h"
 #include "dawn/Support/Assert.h"
+#include "dawn/Support/DiagnosticsEngine.h"
 #include "dawn/Support/Logging.h"
 #include "dawn/Support/StringUtil.h"
 #include <boost/optional.hpp>
@@ -34,7 +34,10 @@ namespace dawn {
 namespace codegen {
 namespace gt {
 
-GTCodeGen::GTCodeGen(OptimizerContext* context) : CodeGen(context), mplContainerMaxSize_(20) {}
+GTCodeGen::GTCodeGen(std::map<std::string, std::shared_ptr<iir::StencilInstantiation>>& ctx,
+                     DiagnosticsEngine& engine, bool useParallelEP, int maxHaloPoints)
+    : CodeGen(ctx, engine, maxHaloPoints), mplContainerMaxSize_(20), useParallelEP_(useParallelEP) {
+}
 
 GTCodeGen::~GTCodeGen() {}
 
@@ -428,7 +431,7 @@ void GTCodeGen::generateStencilClasses(
                               stencilInstantiation->getMetaData().getStencilLocation());
       diag << "empty stencil '" << stencilInstantiation->getName()
            << "', this would result in invalid gridtools code";
-      context_->getDiagnostics().report(diag);
+      diagEngine.report(diag);
       return;
     }
 
@@ -510,7 +513,7 @@ void GTCodeGen::generateStencilClasses(
           DiagnosticsBuilder diag(DiagnosticsKind::Error, stencilFun->getStencilFunction()->Loc);
           diag << "no storages referenced in stencil function '" << stencilFun->getName()
                << "', this would result in invalid gridtools code";
-          context_->getDiagnostics().report(diag);
+          diagEngine.report(diag);
           return;
         }
 
@@ -599,8 +602,7 @@ void GTCodeGen::generateStencilClasses(
 
       // Generate `make_multistage`
       ssMS << "gridtools::make_multistage(gridtools::enumtype::execute<gridtools::enumtype::";
-      if(!context_->getOptions().UseParallelEP &&
-         multiStage.getLoopOrder() == iir::LoopOrderKind::LK_Parallel)
+      if(!useParallelEP_ && multiStage.getLoopOrder() == iir::LoopOrderKind::LK_Parallel)
         ssMS << iir::LoopOrderKind::LK_Forward << " /*parallel*/ ";
       else
         ssMS << multiStage.getLoopOrder();
@@ -669,7 +671,7 @@ void GTCodeGen::generateStencilClasses(
                                   stencilInstantiation->getMetaData().getStencilLocation());
           diag << "no storages referenced in stencil '" << stencilInstantiation->getName()
                << "', this would result in invalid gridtools code";
-          context_->getDiagnostics().report(diag);
+          diagEngine.report(diag);
         }
 
         std::size_t accessorIdx = 0;
@@ -925,7 +927,7 @@ std::unique_ptr<TranslationUnit> GTCodeGen::generateCode() {
 
   // Generate StencilInstantiations
   std::map<std::string, std::string> stencils;
-  for(const auto& nameStencilCtxPair : context_->getStencilInstantiationMap()) {
+  for(const auto& nameStencilCtxPair : context) {
     std::string code = generateStencilInstantiation(nameStencilCtxPair.second);
 
     if(code.empty())
@@ -934,10 +936,14 @@ std::unique_ptr<TranslationUnit> GTCodeGen::generateCode() {
   }
 
   // Generate globals
-  std::string globals = generateGlobals(context_->getSIR(), "gridtools");
+  std::string globals = "";
+  if(context.size() > 0) {
+    const auto& globalsMap = context.begin()->second->getIIR()->getGlobalVariableMap();
+    globals = generateGlobals(globalsMap, "gridtools");
+  }
 
-  // If we need more than 20 elements in boost::mpl containers, we need to increment to the nearest
-  // multiple of ten
+  // If we need more than 20 elements in boost::mpl containers, we need to increment to the
+  // nearest multiple of ten
   // http://www.boost.org/doc/libs/1_61_0/libs/mpl/doc/refmanual/limit-vector-size.html
   if(mplContainerMaxSize_ > 20) {
     mplContainerMaxSize_ += (10 - mplContainerMaxSize_ % 10);
@@ -955,14 +961,15 @@ std::unique_ptr<TranslationUnit> GTCodeGen::generateCode() {
   ppDefines.push_back(makeDefine("GRIDTOOLS_CLANG_GENERATED", 1));
   ppDefines.push_back("#define GRIDTOOLS_CLANG_BACKEND_T GT");
 
-  CodeGen::addMplIfdefs(ppDefines, mplContainerMaxSize_, context_->getOptions().MaxHaloPoints);
+  CodeGen::addMplIfdefs(ppDefines, mplContainerMaxSize_);
 
   generateBCHeaders(ppDefines);
 
   DAWN_LOG(INFO) << "Done generating code";
 
-  return make_unique<TranslationUnit>(context_->getSIR()->Filename, std::move(ppDefines),
-                                      std::move(stencils), std::move(globals));
+  return make_unique<TranslationUnit>(context.begin()->second->getMetaData().getFileName(),
+                                      std::move(ppDefines), std::move(stencils),
+                                      std::move(globals));
 }
 
 std::vector<std::string> GTCodeGen::buildFieldTemplateNames(

--- a/src/dawn/CodeGen/GridTools/GTCodeGen.h
+++ b/src/dawn/CodeGen/GridTools/GTCodeGen.h
@@ -120,7 +120,9 @@ private:
   std::size_t mplContainerMaxSize_;
 
   /// Use the parallel keyword for mulistages
-  bool useParallelEP_;
+  struct GTCodeGenOptions {
+    bool useParallelEP_;
+  } codeGenOptions_;
 };
 
 } // namespace gt

--- a/src/dawn/CodeGen/GridTools/GTCodeGen.h
+++ b/src/dawn/CodeGen/GridTools/GTCodeGen.h
@@ -37,8 +37,8 @@ namespace gt {
 /// @ingroup gt
 class GTCodeGen : public CodeGen {
 public:
-  GTCodeGen(std::map<std::string, std::shared_ptr<iir::StencilInstantiation>>& ctx,
-            DiagnosticsEngine& engine, bool useParallelEP, int maxHaloPoints);
+  GTCodeGen(stencilInstantiationContext& ctx, DiagnosticsEngine& engine, bool useParallelEP,
+            int maxHaloPoints);
   virtual ~GTCodeGen();
 
   virtual std::unique_ptr<TranslationUnit> generateCode() override;

--- a/src/dawn/CodeGen/GridTools/GTCodeGen.h
+++ b/src/dawn/CodeGen/GridTools/GTCodeGen.h
@@ -24,8 +24,6 @@
 
 namespace dawn {
 
-class OptimizerContext;
-
 namespace iir {
 class StencilInstantiation;
 class Stage;
@@ -39,7 +37,8 @@ namespace gt {
 /// @ingroup gt
 class GTCodeGen : public CodeGen {
 public:
-  GTCodeGen(OptimizerContext* context);
+  GTCodeGen(std::map<std::string, std::shared_ptr<iir::StencilInstantiation>>& ctx,
+            DiagnosticsEngine& engine, bool useParallelEP, int maxHaloPoints);
   virtual ~GTCodeGen();
 
   virtual std::unique_ptr<TranslationUnit> generateCode() override;
@@ -119,6 +118,9 @@ private:
 
   /// Maximum needed vector size of boost::fusion containers
   std::size_t mplContainerMaxSize_;
+
+  /// Use the parallel keyword for mulistages
+  bool useParallelEP_;
 };
 
 } // namespace gt

--- a/src/dawn/Compiler/CMakeLists.txt
+++ b/src/dawn/Compiler/CMakeLists.txt
@@ -16,11 +16,6 @@ yoda_add_library(
   NAME DawnCompiler
   SOURCES DawnCompiler.h
           DawnCompiler.cpp
-          DiagnosticsEngine.cpp
-          DiagnosticsEngine.h
-          DiagnosticsMessage.h
-          DiagnosticsQueue.cpp
-          DiagnosticsQueue.h
           Options.h
           Options.inc
   OBJECT

--- a/src/dawn/Compiler/DawnCompiler.cpp
+++ b/src/dawn/Compiler/DawnCompiler.cpp
@@ -163,8 +163,7 @@ std::unique_ptr<OptimizerContext> DawnCompiler::runOptimizer(std::shared_ptr<SIR
   PassManager& passManager = optimizer->getPassManager();
 
   // Setup pass interface
-  optimizer->checkAndPushBack<PassInlining>(true,
-                                            PassInlining::InlineStrategyKind::IK_InlineProcedures);
+  optimizer->checkAndPushBack<PassInlining>(true, PassInlining::InlineStrategy::InlineProcedures);
   // This pass is currently broken and needs to be redesigned before it can be enabled
   //  optimizer->checkAndPushBack<PassTemporaryFirstAccss>();
   optimizer->checkAndPushBack<PassFieldVersioning>();
@@ -182,7 +181,7 @@ std::unique_ptr<OptimizerContext> DawnCompiler::runOptimizer(std::shared_ptr<SIR
   optimizer->checkAndPushBack<PassTemporaryMerger>();
   optimizer->checkAndPushBack<PassInlining>(
       (getOptions().InlineSF || getOptions().PassTmpToFunction),
-      PassInlining::InlineStrategyKind::IK_ComputationsOnTheFly);
+      PassInlining::InlineStrategy::ComputationsOnTheFly);
   optimizer->checkAndPushBack<PassTemporaryToStencilFunction>();
   optimizer->checkAndPushBack<PassSetNonTempCaches>();
   optimizer->checkAndPushBack<PassSetCaches>();
@@ -191,10 +190,11 @@ std::unique_ptr<OptimizerContext> DawnCompiler::runOptimizer(std::shared_ptr<SIR
   optimizer->checkAndPushBack<PassSetBlockSize>();
   optimizer->checkAndPushBack<PassDataLocalityMetric>();
   optimizer->checkAndPushBack<PassSetSyncStage>();
-  // If we want to generate cuda code or serialize the iir we inline all function calls
-  optimizer->checkAndPushBack<PassInlining>(
-      getOptions().Backend == "cuda" || getOptions().SerializeIIR,
-      PassInlining::InlineStrategyKind::IK_ComputationsOnTheFly);
+  // Since both cuda code generation as well as serialization do not support stencil-functions, we
+  // need to inline here as the last step
+  optimizer->checkAndPushBack<PassInlining>(getOptions().Backend == "cuda" ||
+                                                getOptions().SerializeIIR,
+                                            PassInlining::InlineStrategy::ComputationsOnTheFly);
 
   DAWN_LOG(INFO) << "All the passes ran with the current command line arugments:";
   for(const auto& a : passManager.getPasses()) {

--- a/src/dawn/Compiler/DawnCompiler.h
+++ b/src/dawn/Compiler/DawnCompiler.h
@@ -16,9 +16,9 @@
 #define DAWN_COMPILER_DAWNCOMPILER_H
 
 #include "dawn/CodeGen/TranslationUnit.h"
-#include "dawn/Compiler/DiagnosticsEngine.h"
 #include "dawn/Compiler/Options.h"
 #include "dawn/Optimizer/OptimizerContext.h"
+#include "dawn/Support/DiagnosticsEngine.h"
 #include "dawn/Support/NonCopyable.h"
 #include <memory>
 

--- a/src/dawn/IIR/DependencyGraphAccesses.h
+++ b/src/dawn/IIR/DependencyGraphAccesses.h
@@ -15,9 +15,9 @@
 #ifndef DAWN_IIR_DEPENDENCYGRAPHACCESSES_H
 #define DAWN_IIR_DEPENDENCYGRAPHACCESSES_H
 
-#include "dawn/Compiler/DiagnosticsEngine.h"
 #include "dawn/IIR/DependencyGraph.h"
 #include "dawn/IIR/Extents.h"
+#include "dawn/Support/DiagnosticsEngine.h"
 #include "dawn/Support/TypeTraits.h"
 #include <set>
 #include <unordered_map>

--- a/src/dawn/Optimizer/OptimizerContext.h
+++ b/src/dawn/Optimizer/OptimizerContext.h
@@ -15,9 +15,9 @@
 #ifndef DAWN_OPTIMIZER_OPTIMIZERCONTEXT_H
 #define DAWN_OPTIMIZER_OPTIMIZERCONTEXT_H
 
-#include "dawn/Compiler/DiagnosticsEngine.h"
 #include "dawn/Compiler/Options.h"
 #include "dawn/Optimizer/PassManager.h"
+#include "dawn/Support/DiagnosticsEngine.h"
 #include "dawn/Support/NonCopyable.h"
 #include <map>
 #include <memory>

--- a/src/dawn/Optimizer/PassInlining.cpp
+++ b/src/dawn/Optimizer/PassInlining.cpp
@@ -35,7 +35,7 @@ namespace {
 class Inliner;
 
 static std::pair<bool, std::shared_ptr<Inliner>> tryInlineStencilFunction(
-    PassInlining::InlineStrategyKind strategy,
+    PassInlining::InlineStrategy strategy,
     const std::shared_ptr<iir::StencilFunctionInstantiation>& stencilFunctioninstantiation,
     const std::unique_ptr<iir::StatementAccessesPair>& oldStmt,
     std::vector<std::unique_ptr<iir::StatementAccessesPair>>& newStmts, int AccessIDOfCaller,
@@ -43,7 +43,7 @@ static std::pair<bool, std::shared_ptr<Inliner>> tryInlineStencilFunction(
 
 /// @brief Perform the inlining of a stencil-function
 class Inliner : public ASTVisitor {
-  PassInlining::InlineStrategyKind strategy_;
+  PassInlining::InlineStrategy strategy_;
   const std::shared_ptr<iir::StencilFunctionInstantiation>& curStencilFunctioninstantiation_;
   const std::shared_ptr<iir::StencilInstantiation>& instantiation_;
   iir::StencilMetaInformation& metadata_;
@@ -79,7 +79,7 @@ class Inliner : public ASTVisitor {
   std::stack<const std::unique_ptr<iir::StatementAccessesPair>*> currentStmtAccessesPair_;
 
 public:
-  Inliner(PassInlining::InlineStrategyKind strategy,
+  Inliner(PassInlining::InlineStrategy strategy,
           const std::shared_ptr<iir::StencilFunctionInstantiation>& stencilFunctioninstantiation,
           const std::unique_ptr<iir::StatementAccessesPair>& oldStmtAccessesPair,
           std::vector<std::unique_ptr<iir::StatementAccessesPair>>& newStmtAccessesPairs,
@@ -349,7 +349,7 @@ public:
 
 /// @brief Detect inline candidates
 class DetectInlineCandiates : public ASTVisitorForwarding {
-  PassInlining::InlineStrategyKind strategy_;
+  PassInlining::InlineStrategy strategy_;
   const std::shared_ptr<iir::StencilInstantiation>& instantiation_;
 
   /// The statement we are currently analyzing
@@ -378,7 +378,7 @@ class DetectInlineCandiates : public ASTVisitorForwarding {
 public:
   using Base = ASTVisitorForwarding;
 
-  DetectInlineCandiates(PassInlining::InlineStrategyKind strategy,
+  DetectInlineCandiates(PassInlining::InlineStrategy strategy,
                         const std::shared_ptr<iir::StencilInstantiation>& instantiation)
       : strategy_(strategy), instantiation_(instantiation), inlineCandiatesFound_(false) {}
 
@@ -486,7 +486,7 @@ public:
 /// @returns `true` if the stencil-function was inlined, `false` otherwise (the corresponding
 /// `Inliner` instance (or NULL) is returned as well)
 static std::pair<bool, std::shared_ptr<Inliner>> tryInlineStencilFunction(
-    PassInlining::InlineStrategyKind strategy,
+    PassInlining::InlineStrategy strategy,
     const std::shared_ptr<iir::StencilFunctionInstantiation>& stencilFunc,
     const std::unique_ptr<iir::StatementAccessesPair>& oldStmtAccessesPair,
     std::vector<std::unique_ptr<iir::StatementAccessesPair>>& newStmtAccessesPairs,
@@ -494,8 +494,7 @@ static std::pair<bool, std::shared_ptr<Inliner>> tryInlineStencilFunction(
 
   // Function which do not return a value are *always* inlined. Function which do return a value
   // are only inlined if we favor precomputations.
-  if(!stencilFunc->hasReturn() ||
-     strategy == PassInlining::InlineStrategyKind::IK_ComputationsOnTheFly) {
+  if(!stencilFunc->hasReturn() || strategy == PassInlining::InlineStrategy::ComputationsOnTheFly) {
     auto inliner =
         std::make_shared<Inliner>(strategy, stencilFunc, oldStmtAccessesPair, newStmtAccessesPairs,
                                   AccessIDOfCaller, stencilInstantiation);
@@ -507,7 +506,7 @@ static std::pair<bool, std::shared_ptr<Inliner>> tryInlineStencilFunction(
 
 } // anonymous namespace
 
-PassInlining::PassInlining(bool activate, InlineStrategyKind strategy)
+PassInlining::PassInlining(bool activate, InlineStrategy strategy)
     : Pass("PassInlining", true), activate_(activate), strategy_(strategy) {}
 
 bool PassInlining::run(const std::shared_ptr<iir::StencilInstantiation>& stencilInstantiation) {

--- a/src/dawn/Optimizer/PassInlining.cpp
+++ b/src/dawn/Optimizer/PassInlining.cpp
@@ -494,7 +494,8 @@ static std::pair<bool, std::shared_ptr<Inliner>> tryInlineStencilFunction(
 
   // Function which do not return a value are *always* inlined. Function which do return a value
   // are only inlined if we favor precomputations.
-  if(!stencilFunc->hasReturn() || strategy == PassInlining::IK_ComputationsOnTheFly) {
+  if(!stencilFunc->hasReturn() ||
+     strategy == PassInlining::InlineStrategyKind::IK_ComputationsOnTheFly) {
     auto inliner =
         std::make_shared<Inliner>(strategy, stencilFunc, oldStmtAccessesPair, newStmtAccessesPairs,
                                   AccessIDOfCaller, stencilInstantiation);
@@ -511,10 +512,10 @@ PassInlining::PassInlining(bool activate, InlineStrategyKind strategy)
 
 bool PassInlining::run(const std::shared_ptr<iir::StencilInstantiation>& stencilInstantiation) {
 
-  DetectInlineCandiates inliner(strategy_, stencilInstantiation);
-
   if(!activate_)
     return true;
+
+  DetectInlineCandiates inliner(strategy_, stencilInstantiation);
 
   // Iterate all statements (top -> bottom)
   for(const auto& stagePtr : iterateIIROver<iir::Stage>(*(stencilInstantiation->getIIR()))) {

--- a/src/dawn/Optimizer/PassInlining.h
+++ b/src/dawn/Optimizer/PassInlining.h
@@ -34,7 +34,7 @@ namespace dawn {
 class PassInlining : public Pass {
 public:
   /// @brief Inlining strategies
-  enum InlineStrategyKind {
+  enum class InlineStrategyKind {
     IK_InlineProcedures,    ///< Inline functions with no return
     IK_ComputationsOnTheFly ///< Inline stencil functions as computations on the fly
   };

--- a/src/dawn/Optimizer/PassInlining.h
+++ b/src/dawn/Optimizer/PassInlining.h
@@ -34,19 +34,19 @@ namespace dawn {
 class PassInlining : public Pass {
 public:
   /// @brief Inlining strategies
-  enum class InlineStrategyKind {
-    IK_InlineProcedures,    ///< Inline functions with no return
-    IK_ComputationsOnTheFly ///< Inline stencil functions as computations on the fly
+  enum class InlineStrategy {
+    InlineProcedures,    ///< Inline functions with no return
+    ComputationsOnTheFly ///< Inline stencil functions as computations on the fly
   };
 
-  PassInlining(bool activate, InlineStrategyKind strategy);
+  PassInlining(bool activate, InlineStrategy strategy);
 
   /// @brief Pass implementation
   bool run(const std::shared_ptr<iir::StencilInstantiation>& stencilInstantiation) override;
 
 private:
   bool activate_;
-  InlineStrategyKind strategy_;
+  InlineStrategy strategy_;
 };
 
 } // namespace dawn

--- a/src/dawn/Serialization/ASTSerializer.h
+++ b/src/dawn/Serialization/ASTSerializer.h
@@ -17,7 +17,6 @@
 
 #include "dawn/IIR/StatementAccessesPair.h"
 #include "dawn/IIR/StencilInstantiation.h"
-#include "dawn/SIR/SIR/statements.pb.h"
 #include "dawn/SIR/ASTVisitor.h"
 #include "dawn/SIR/SIR.h"
 #include "dawn/SIR/SIR/statements.pb.h"

--- a/src/dawn/Serialization/IIRSerializer.cpp
+++ b/src/dawn/Serialization/IIRSerializer.cpp
@@ -463,9 +463,6 @@ IIRSerializer::serializeImpl(const std::shared_ptr<iir::StencilInstantiation>& i
   // out = 0.5*(u[i+1, j+1] + u[i-1, j+1]) - 0.5*(u[i+1] + u[i-1])
   //==------------------------------------------------------------------------------------------==//
 
-  PassInlining inliner(true, PassInlining::IK_ComputationsOnTheFly);
-  inliner.run(instantiation);
-
   using namespace dawn::proto::iir;
   proto::iir::StencilInstantiation protoStencilInstantiation;
   serializeMetaData(protoStencilInstantiation, instantiation->getMetaData());

--- a/src/dawn/Support/CMakeLists.txt
+++ b/src/dawn/Support/CMakeLists.txt
@@ -25,6 +25,11 @@ yoda_add_library(
           Casting.h
           Compiler.h
           Config.h.cmake
+          DiagnosticsEngine.cpp
+          DiagnosticsEngine.h
+          DiagnosticsMessage.h
+          DiagnosticsQueue.cpp
+          DiagnosticsQueue.h
           DoubleSidedMap.h
           EditDistance.h
           FileUtil.cpp

--- a/src/dawn/Support/DiagnosticsEngine.cpp
+++ b/src/dawn/Support/DiagnosticsEngine.cpp
@@ -12,7 +12,7 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
-#include "dawn/Compiler/DiagnosticsEngine.h"
+#include "dawn/Support/DiagnosticsEngine.h"
 
 namespace dawn {
 

--- a/src/dawn/Support/DiagnosticsEngine.h
+++ b/src/dawn/Support/DiagnosticsEngine.h
@@ -12,11 +12,11 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
-#ifndef DAWN_COMPILER_DIAGNOSTICSENGINE_H
-#define DAWN_COMPILER_DIAGNOSTICSENGINE_H
+#ifndef DAWN_SUPPORT_DIAGNOSTICSENGINE_H
+#define DAWN_SUPPORT_DIAGNOSTICSENGINE_H
 
-#include "dawn/Compiler/DiagnosticsMessage.h"
-#include "dawn/Compiler/DiagnosticsQueue.h"
+#include "dawn/Support/DiagnosticsMessage.h"
+#include "dawn/Support/DiagnosticsQueue.h"
 #include "dawn/Support/NonCopyable.h"
 
 namespace dawn {

--- a/src/dawn/Support/DiagnosticsMessage.h
+++ b/src/dawn/Support/DiagnosticsMessage.h
@@ -12,8 +12,8 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
-#ifndef DAWN_COMPILER_DIAGNOSTICMESSAGE_H
-#define DAWN_COMPILER_DIAGNOSTICMESSAGE_H
+#ifndef DAWN_SUPPORT_DIAGNOSTICMESSAGE_H
+#define DAWN_SUPPORT_DIAGNOSTICMESSAGE_H
 
 #include "dawn/Support/SourceLocation.h"
 #include <sstream>

--- a/src/dawn/Support/DiagnosticsQueue.cpp
+++ b/src/dawn/Support/DiagnosticsQueue.cpp
@@ -12,7 +12,7 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
-#include "dawn/Compiler/DiagnosticsQueue.h"
+#include "dawn/Support/DiagnosticsQueue.h"
 #include "dawn/Support/STLExtras.h"
 
 namespace dawn {

--- a/src/dawn/Support/DiagnosticsQueue.h
+++ b/src/dawn/Support/DiagnosticsQueue.h
@@ -12,10 +12,10 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
-#ifndef DAWN_COMPILER_DIAGNOSTICQUEUE_H
-#define DAWN_COMPILER_DIAGNOSTICQUEUE_H
+#ifndef DAWN_SUPPORT_DIAGNOSTICQUEUE_H
+#define DAWN_SUPPORT_DIAGNOSTICQUEUE_H
 
-#include "dawn/Compiler/DiagnosticsMessage.h"
+#include "dawn/Support/DiagnosticsMessage.h"
 #include "dawn/Support/NonCopyable.h"
 #include <memory>
 #include <vector>

--- a/test/unit-test/dawn/IIR/TestIIRSerializer.cpp
+++ b/test/unit-test/dawn/IIR/TestIIRSerializer.cpp
@@ -12,13 +12,13 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
-#include "dawn/Compiler/DiagnosticsEngine.h"
 #include "dawn/Compiler/Options.h"
 #include "dawn/IIR/IIR.h"
 #include "dawn/IIR/StatementAccessesPair.h"
 #include "dawn/IIR/StencilInstantiation.h"
 #include "dawn/Optimizer/OptimizerContext.h"
 #include "dawn/Serialization/IIRSerializer.h"
+#include "dawn/Support/DiagnosticsEngine.h"
 #include <gtest/gtest.h>
 
 using namespace dawn;

--- a/test/unit-test/dawn/Optimizer/Passes/TestTemporaryToFunction.cpp
+++ b/test/unit-test/dawn/Optimizer/Passes/TestTemporaryToFunction.cpp
@@ -59,7 +59,9 @@ protected:
 
     // Generate code
     std::unique_ptr<codegen::CodeGen> CG;
-    CG = make_unique<codegen::gt::GTCodeGen>(optimizer.get());
+    CG = make_unique<codegen::gt::GTCodeGen>(
+        optimizer->getStencilInstantiationMap(), optimizer->getDiagnostics(),
+        optimizer->getOptions().UseParallelEP, optimizer->getOptions().MaxHaloPoints);
     auto translationUnit = CG->generateCode();
 
     if(optimizer->getDiagnostics().hasDiags()) {


### PR DESCRIPTION
## Technical Description

We remove all the backwards dependencies from Code-Gen to the Optimizer. This is part of cleaning up all unwanted (circular) dependencies between modules

####  Enhances

Now Code-Gen is indepdendent of OptimizerContext

## Testing

See https://github.com/MeteoSwiss-APN/gtclang/pull/148

## Dependencies

This requires the changes in GTClang seen in https://github.com/MeteoSwiss-APN/gtclang/pull/148


