### PR TITLE
Fix Serializer -> Optimizer dependency

### DIFF
--- a/src/dawn/Serialization/IIRSerializer.cpp
+++ b/src/dawn/Serialization/IIRSerializer.cpp
@@ -17,8 +17,6 @@
 #include "dawn/IIR/MultiStage.h"
 #include "dawn/IIR/StatementAccessesPair.h"
 #include "dawn/IIR/StencilInstantiation.h"
-#include "dawn/Optimizer/PassComputeStageExtents.h"
-#include "dawn/Optimizer/PassInlining.h"
 #include "dawn/SIR/ASTVisitor.h"
 #include "dawn/SIR/SIR.h"
 #include "dawn/Serialization/ASTSerializer.h"
@@ -434,8 +432,6 @@ std::string
 IIRSerializer::serializeImpl(const std::shared_ptr<iir::StencilInstantiation>& instantiation,
                              dawn::IIRSerializer::SerializationKind kind) {
   GOOGLE_PROTOBUF_VERIFY_VERSION;
-  // Before Serialization we need to ensure there are no stencilfunctions present. This is why we
-  // inline everything here.
   /////////////////////////////// WITTODO //////////////////////////////////////////////////////////
   //==------------------------------------------------------------------------------------------==//
   // After we have the merge of carlos' new inliner that distinguishes between full inlining (as


### PR DESCRIPTION
## Technical Description

We remove all the backwards dependencies from the Seriaizer to the Optimizer. This is part of cleaning up all unwanted (circular) dependencies between modules

####  Enhances

Now Serializer is independent of Optimizer

## Dependencies

This PR is independent


