### PR TITLE
Fix python examples

### DIFF
--- a/examples/python/copy_stencil.py
+++ b/examples/python/copy_stencil.py
@@ -1,14 +1,30 @@
+#!/usr/bin/python3
+# -*- coding: utf-8 -*-
+# ===-----------------------------------------------------------------------------*- Python -*-===##
+#                          _
+#                         | |
+#                       __| | __ ___      ___ ___
+#                      / _` |/ _` \ \ /\ / / '_  |
+#                     | (_| | (_| |\ V  V /| | | |
+#                      \__,_|\__,_| \_/\_/ |_| |_| - Compiler Toolchain
+#
+#
+#  This file is distributed under the MIT License (MIT).
+#  See LICENSE.txt for details.
+#
+# ===------------------------------------------------------------------------------------------===##
+
 """Copy stencil HIR generator
 
 This program creates the HIR corresponding to a copy stencil using the Python API of the HIR.
 The copy stencil is a hello world for stencil computations.
-The code is meant as an example for high-level DSLs that could generate HIR from their own 
-internal IR. 
-The program contains two parts: 
+The code is meant as an example for high-level DSLs that could generate HIR from their own
+internal IR.
+The program contains two parts:
     1. construct the HIR of the example
     2. pass the HIR to the dawn compiler in order to run all optimizer passes and code generation.
-       In this example the compiler is configured with the CUDA backend, therefore will code generate
-       an optimized CUDA implementation.
+       In this example the compiler is configured with the CUDA backend, therefore will code
+       generate an optimized CUDA implementation.
 
 """
 
@@ -43,7 +59,8 @@ def create_vertical_region_stmt() -> VerticalRegionDeclStmt:
         ]
     )
 
-    vertical_region_stmt = make_vertical_region_decl_stmt(body_ast, interval, VerticalRegion.Forward)
+    vertical_region_stmt = make_vertical_region_decl_stmt(
+        body_ast, interval, VerticalRegion.Forward)
     return vertical_region_stmt
 
 
@@ -65,11 +82,12 @@ parser.add_option("-v", "--verbose",
 
 # Print the SIR to stdout only in verbose mode
 if options.verbose:
-    T = textwrap.TextWrapper(initial_indent=' ' * 1, width=120, subsequent_indent=' ' * 1)
+    T = textwrap.TextWrapper(
+        initial_indent=' ' * 1, width=120, subsequent_indent=' ' * 1)
     des = sir_printer.SIRPrinter()
 
     for stencil in hir.stencils:
-        des.visitStencil(stencil)
+        des.visit_stencil(stencil)
 
 # serialize the hir to pass it to the compiler
 hirstr = hir.SerializeToString()
@@ -79,6 +97,8 @@ options = dawn.dawnOptionsCreate()
 # we set the backend of the compiler to cuda
 backend = dawn.dawnOptionsEntryCreateString("cuda".encode('utf-8'))
 dawn.dawnOptionsSet(options, "Backend".encode('utf-8'), backend)
+# true = dawn.dawnOptionsEntryCreateInteger(1)
+# dawn.dawnOptionsSet(options, "SerializeIIR".encode('utf-8'), true)
 
 # call the compiler that generates a translation unit
 tu = dawn.dawnCompile(hirstr, len(hirstr), options)
@@ -88,7 +108,8 @@ b_stencilName = stencilname.encode('utf-8')
 code = dawn.dawnTranslationUnitGetStencil(tu, b_stencilName)
 
 # write to file
-f = open(os.path.dirname(os.path.realpath(__file__)) + "/data/copy_stencil.cpp", "w")
+f = open(os.path.dirname(os.path.realpath(__file__))
+         + "/data/copy_stencil.cpp", "w")
 f.write(ctypes.c_char_p(code).value.decode("utf-8"))
 
 f.close()

--- a/examples/python/hori_diff.py
+++ b/examples/python/hori_diff.py
@@ -125,7 +125,7 @@ if options.verbose:
     des = sir_printer.SIRPrinter()
 
     for stencil in hir.stencils:
-        des.visitStencil(stencil)
+        des.visit_stencil(stencil)
 
 # serialize the hir to pass it to the compiler
 hirstr = hir.SerializeToString()

--- a/examples/python/hori_diff.py
+++ b/examples/python/hori_diff.py
@@ -1,3 +1,18 @@
+#!/usr/bin/python3
+# -*- coding: utf-8 -*-
+# ===-----------------------------------------------------------------------------*- Python -*-===##
+#                          _
+#                         | |
+#                       __| | __ ___      ___ ___
+#                      / _` |/ _` \ \ /\ / / '_  |
+#                     | (_| | (_| |\ V  V /| | | |
+#                      \__,_|\__,_| \_/\_/ |_| |_| - Compiler Toolchain
+#
+#
+#  This file is distributed under the MIT License (MIT).
+#  See LICENSE.txt for details.
+#
+# ===------------------------------------------------------------------------------------------===##
 """Horizontal diffusion stencil HIR generator
 
 This program creates the HIR corresponding to an horizontal diffusion stencil using the Python API of the HIR.

--- a/examples/python/tridiagonal_solve.py
+++ b/examples/python/tridiagonal_solve.py
@@ -160,7 +160,7 @@ if options.verbose:
     des = sir_printer.SIRPrinter()
 
     for stencil in hir.stencils:
-        des.visitStencil(stencil)
+        des.visit_stencil(stencil)
 
 # serialize the hir to pass it to the compiler
 hirstr = hir.SerializeToString()

--- a/examples/python/tridiagonal_solve.py
+++ b/examples/python/tridiagonal_solve.py
@@ -1,11 +1,26 @@
+#!/usr/bin/python3
+# -*- coding: utf-8 -*-
+# ===-----------------------------------------------------------------------------*- Python -*-===##
+#                          _
+#                         | |
+#                       __| | __ ___      ___ ___
+#                      / _` |/ _` \ \ /\ / / '_  |
+#                     | (_| | (_| |\ V  V /| | | |
+#                      \__,_|\__,_| \_/\_/ |_| |_| - Compiler Toolchain
+#
+#
+#  This file is distributed under the MIT License (MIT).
+#  See LICENSE.txt for details.
+#
+# ===------------------------------------------------------------------------------------------===##
 """Tridiagonal solve computation HIR generator
 
 This program creates the HIR corresponding to a tridiagonal solve computation using the Python API of the HIR.
-The tridiagonal solve is a basic example that contains vertical data dependencies that need to be resolved 
-by the compiler passes. 
-The code is meant as an example for high-level DSLs that could generate HIR from their own 
-internal IR. 
-The program contains two parts: 
+The tridiagonal solve is a basic example that contains vertical data dependencies that need to be resolved
+by the compiler passes.
+The code is meant as an example for high-level DSLs that could generate HIR from their own
+internal IR.
+The program contains two parts:
     1. construct the HIR of the example
     2. pass the HIR to the dawn compiler in order to run all optimizer passes and code generation.
        In this example the compiler is configured with the CUDA backend, therefore will code generate
@@ -45,7 +60,8 @@ def create_vertical_region_stmt1() -> VerticalRegionDeclStmt:
         ]
     )
 
-    vertical_region_stmt = make_vertical_region_decl_stmt(body_ast, interval, VerticalRegion.Forward)
+    vertical_region_stmt = make_vertical_region_decl_stmt(
+        body_ast, interval, VerticalRegion.Forward)
     return vertical_region_stmt
 
 
@@ -106,7 +122,8 @@ def create_vertical_region_stmt2() -> VerticalRegionDeclStmt:
         ]
     )
 
-    vertical_region_stmt = make_vertical_region_decl_stmt(body_ast, interval, VerticalRegion.Forward)
+    vertical_region_stmt = make_vertical_region_decl_stmt(
+        body_ast, interval, VerticalRegion.Forward)
     return vertical_region_stmt
 
 
@@ -130,7 +147,8 @@ def create_vertical_region_stmt3() -> VerticalRegionDeclStmt:
         ]
     )
 
-    vertical_region_stmt = make_vertical_region_decl_stmt(body_ast, interval, VerticalRegion.Backward)
+    vertical_region_stmt = make_vertical_region_decl_stmt(
+        body_ast, interval, VerticalRegion.Backward)
     return vertical_region_stmt
 
 
@@ -156,7 +174,8 @@ hir = make_sir("tridiagonal_solve.cpp", [
 
 # Print the SIR to stdout only in verbose mode
 if options.verbose:
-    T = textwrap.TextWrapper(initial_indent=' ' * 1, width=120, subsequent_indent=' ' * 1)
+    T = textwrap.TextWrapper(
+        initial_indent=' ' * 1, width=120, subsequent_indent=' ' * 1)
     des = sir_printer.SIRPrinter()
 
     for stencil in hir.stencils:
@@ -179,7 +198,8 @@ b_stencilName = stencilname.encode('utf-8')
 code = dawn.dawnTranslationUnitGetStencil(tu, b_stencilName)
 
 # write to file
-f = open(os.path.dirname(os.path.realpath(__file__)) + "/data/tridiagonal_solve.cpp", "w")
+f = open(os.path.dirname(os.path.realpath(__file__))
+         + "/data/tridiagonal_solve.cpp", "w")
 f.write(ctypes.c_char_p(code).value.decode("utf-8"))
 
 f.close()


### PR DESCRIPTION
## Technical Description

The verbose mode of the python examples is broken due to renaming

#### Resolves / Enhances

makes the verbose mode of the example works (baused on Joerg's feedback)

#### Example

```
cd dawn/bundle/install/examples/python
export PYTHONPATH=dawn/bundle/install/python
python3.7 copy_stencil.py -v
```

## Dependencies

This PR is independent


