### PR TITLE
Fix tests in clang-gridtools due to issue_199

### DIFF
--- a/src/dawn/IIR/StencilMetaInformation.cpp
+++ b/src/dawn/IIR/StencilMetaInformation.cpp
@@ -309,7 +309,7 @@ void StencilMetaInformation::insertAccessOfType(FieldAccessType type, int Access
   } else if(type == FieldAccessType::FAT_LocalVariable) {
     // local variables are not stored
   } else if(type == FieldAccessType::FAT_Literal) {
-    DAWN_ASSERT(!fieldAccessMetadata_.LiteralAccessIDToNameMap_.count(AccessID));
+    DAWN_ASSERT(AccessID < 0);
     fieldAccessMetadata_.LiteralAccessIDToNameMap_.emplace(AccessID, name);
   }
 }

--- a/src/dawn/Optimizer/OptimizerContext.cpp
+++ b/src/dawn/Optimizer/OptimizerContext.cpp
@@ -537,7 +537,7 @@ public:
             scope_.top()->controlFlowDescriptor_.getStatements().back()->ASTStmt, expr, newExpr);
 
         int AccessID = instantiation_->nextUID();
-        metadata_.insertAccessOfType(iir::FieldAccessType::FAT_Literal, AccessID,
+        metadata_.insertAccessOfType(iir::FieldAccessType::FAT_Literal, -AccessID,
                                      newExpr->getValue());
         metadata_.insertExprToAccessID(newExpr, AccessID);
 

--- a/src/dawn/Optimizer/StatementMapper.cpp
+++ b/src/dawn/Optimizer/StatementMapper.cpp
@@ -328,7 +328,9 @@ void StatementMapper::visit(const std::shared_ptr<iir::VarAccessExpr>& expr) {
       iir::replaceOldExprWithNewExprInStmt(
           (*(scope_.top()->doMethod_.childrenRBegin()))->getStatement()->ASTStmt, expr, newExpr);
 
-      int AccessID = instantiation_->nextUID();
+      //if a global is replaced by its value it becomes a de-facto literal negate access id
+      int AccessID = -instantiation_->nextUID();
+
       metadata_.insertAccessOfType(iir::FieldAccessType::FAT_Literal, AccessID,
                                    newExpr->getValue());
       metadata_.insertExprToAccessID(newExpr, AccessID);

--- a/test/unit-test/dawn/IIR/TestIIRSerializer.cpp
+++ b/test/unit-test/dawn/IIR/TestIIRSerializer.cpp
@@ -219,7 +219,7 @@ TEST_F(IIRSerializerTest, SimpleDataStructures) {
       std::make_shared<iir::ExprStmt>(std::make_shared<iir::NOPExpr>()), 10);
   IIR_EXPECT_EQ(serializeAndDeserializeRef(), referenceInstantiaton);
 
-  referenceInstantiaton->getMetaData().insertAccessOfType(iir::FieldAccessType::FAT_Literal, 5,
+  referenceInstantiaton->getMetaData().insertAccessOfType(iir::FieldAccessType::FAT_Literal, -5,
                                                           "test");
   IIR_EXPECT_EQ(serializeAndDeserializeRef(), referenceInstantiaton);
 


### PR DESCRIPTION
## Technical Description

Some edge cases in the clang-gridtools test suite were not correctly handled by the changes introduced due to the fix to issue_199 (`DoubleSidedMap` and general `StencilMetaData` clean up). `AccessID` s to literals are now always strictly negative, no matter the context (e.g. even if the literal is in fact a global which was overwritten by a config file). A test was adapted accordingly.

## Dependencies

This PR is independent. 