### PR TITLE
Add reference source option

### DIFF
--- a/src/dawn/Compiler/DawnCompiler.cpp
+++ b/src/dawn/Compiler/DawnCompiler.cpp
@@ -230,10 +230,12 @@ std::unique_ptr<OptimizerContext> DawnCompiler::runOptimizer(std::shared_ptr<SIR
                      << instantiation->getName() << "`";
 
       if(options_->SerializeIIR) {
-        IIRSerializer::serialize(
-            remove_fileextension(instantiation->getMetaData().getFileName(), ".cpp") + "." +
-                std::to_string(i) + ".iir",
-            instantiation, serializationKind);
+        const std::string originalFileName = remove_fileextension(
+            options_->ReferenceSource.empty() ? instantiation->getMetaData().getFileName()
+                                              : options_->ReferenceSource,
+            ".cpp");
+        IIRSerializer::serialize(originalFileName + "." + std::to_string(i) + ".iir", instantiation,
+                                 serializationKind);
         i++;
       }
     }

--- a/src/dawn/Compiler/Options.inc
+++ b/src/dawn/Compiler/Options.inc
@@ -60,5 +60,6 @@ OPT(int, MaxFieldsPerStencil, 40, "max-fields", "",
     "Set the maximum number of fields in any given stencils", "<N>", true, false)
 OPT(bool, MaxCutMSS, false, "max-cut-mss", "",
     "Cuts the given multistages in as many multistages as possible while maintaining legal code", "", false, true)
+OPT(std::string, ReferenceSource, "", "reference-src", "", "Sets the reference DSL .cpp source (of the input SIR) to <file>", "<file>", true, false)
 
 // clang-format on

--- a/src/dawn/Serialization/IIRSerializer.cpp
+++ b/src/dawn/Serialization/IIRSerializer.cpp
@@ -330,7 +330,6 @@ void IIRSerializer::serializeIIR(proto::iir::StencilInstantiation& target,
       protoGlobalToStore.set_type(proto::iir::GlobalValueAndType_TypeKind_Boolean);
       break;
     case sir::Value::Integer:
-      std::cout << "serialize int" << std::endl;
       if(globalToValue.second->has_value()) {
         protoGlobalToStore.set_value(globalToValue.second->getValue<int>());
         valueIsSet = true;
@@ -338,7 +337,6 @@ void IIRSerializer::serializeIIR(proto::iir::StencilInstantiation& target,
       protoGlobalToStore.set_type(proto::iir::GlobalValueAndType_TypeKind_Integer);
       break;
     case sir::Value::Double:
-      std::cout << "serialize double" << std::endl;
       if(globalToValue.second->has_value()) {
         protoGlobalToStore.set_value(globalToValue.second->getValue<double>());
         valueIsSet = true;
@@ -640,14 +638,14 @@ void IIRSerializer::deserializeIIR(std::shared_ptr<iir::StencilInstantiation>& t
       } else {
         // the explicit cast is needed since in this case GlobalToValue.second.value()
         // may hold a double constant because of trailing dot in the IIR (e.g. 12.)
-        value = std::make_shared<sir::Value>((int) GlobalToValue.second.value());
+        value = std::make_shared<sir::Value>((int)GlobalToValue.second.value());
       }
       break;
     case proto::iir::GlobalValueAndType_TypeKind_Double:
       if(GlobalToValue.second.valueisset()) {
         value = std::make_shared<sir::Value>(sir::Value::Double);
       } else {
-        value = std::make_shared<sir::Value>((double) GlobalToValue.second.value());
+        value = std::make_shared<sir::Value>((double)GlobalToValue.second.value());
       }
       break;
     default:


### PR DESCRIPTION
### Techincal Description
To specify the path of the DSL cpp source that was used to generate the IRs. Used while serializing IIR to calculate the path where to store the outputs. Also removing 2 debug printfs.

### Usage
Run dawn with `SerializeIIR` flag on and `ReferenceSource` set to DSL .cpp source. Serialized IIR files will be put in the same directory as the DSL source.