### PR TITLE
Add default value to globals

### DIFF
--- a/src/dawn/SIR/SIR.cpp
+++ b/src/dawn/SIR/SIR.cpp
@@ -618,22 +618,22 @@ const char* sir::Value::typeToString(sir::Value::TypeKind type) {
 sir::Value::Value(TypeKind type) : isConstexpr_(false) {
   switch(type) {
   case Boolean:
-    valueImpl_ = make_unique<ValueImpl<bool>>();
+    valueImpl_ = make_unique<ValueImpl<decay_t<bool>>>(false);
     break;
   case Integer:
-    valueImpl_ = make_unique<ValueImpl<int>>();
+    valueImpl_ = make_unique<ValueImpl<decay_t<int>>>(0);
     break;
   case Double:
-    valueImpl_ = make_unique<ValueImpl<double>>();
+    valueImpl_ = make_unique<ValueImpl<decay_t<double>>>(0.0);
     break;
   case String:
-    valueImpl_ = make_unique<ValueImpl<std::string>>();
+    valueImpl_ = make_unique<ValueImpl<decay_t<std::string>>>("");
     break;
   }
 }
 
 BuiltinTypeID sir::Value::typeToBuiltinTypeID(sir::Value::TypeKind type) {
-  switch(type) {  
+  switch(type) {
   case Boolean:
     return BuiltinTypeID::Boolean;
   case Integer:


### PR DESCRIPTION
### Description
Since type is not explicitly serialized for globals, this makes it always known.

### Example
```
globals {
  bool ltur;
  double zdtr = 0.8;
  ...
}
```
becomes, in SIR:
```
"global_variables": {
   "ltur": {
    "is_constexpr": false,
    "boolean_value": false
   },
   "zdtr": {
    "is_constexpr": false,
    "double_value": 0.8
   }, ...
```