### PR TITLE
Migrate to c++17

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,7 +63,7 @@ include(DawnDefinitions)
 include(DawnMacros)
 
 # Set C++ standard
-yoda_set_cxx_standard(c++11)
+yoda_set_cxx_standard(c++17)
 
 # Set C++ flags
 dawn_set_cxx_flags()

--- a/src/dawn-c/Compiler.cpp
+++ b/src/dawn-c/Compiler.cpp
@@ -77,7 +77,7 @@ dawnTranslationUnit_t* dawnCompile(const char* SIR, size_t size, const dawnOptio
         dawn::SIRSerializer::deserializeFromString(sirStr, dawn::SIRSerializer::SK_Byte);
 
     // Prepare options
-    std::unique_ptr<dawn::Options> compileOptions = dawn::make_unique<dawn::Options>();
+    std::unique_ptr<dawn::Options> compileOptions = std::make_unique<dawn::Options>();
     if(options)
       toConstOptionsWrapper(options)->setDawnOptions(compileOptions.get());
 

--- a/src/dawn/CodeGen/CXXNaive/CXXNaiveCodeGen.cpp
+++ b/src/dawn/CodeGen/CXXNaive/CXXNaiveCodeGen.cpp
@@ -560,7 +560,7 @@ std::unique_ptr<TranslationUnit> CXXNaiveCodeGen::generateCode() {
   DAWN_LOG(INFO) << "Done generating code";
 
   std::string filename = generateFileName(context_);
-  return make_unique<TranslationUnit>(filename, std::move(ppDefines), std::move(stencils),
+  return std::make_unique<TranslationUnit>(filename, std::move(ppDefines), std::move(stencils),
                                       std::move(globals));
 }
 

--- a/src/dawn/CodeGen/Cuda/CudaCodeGen.cpp
+++ b/src/dawn/CodeGen/Cuda/CudaCodeGen.cpp
@@ -702,7 +702,7 @@ std::unique_ptr<TranslationUnit> CudaCodeGen::generateCode() {
 
   std::string filename = generateFileName(context_);
   // TODO missing the BC
-  return make_unique<TranslationUnit>(filename, std::move(ppDefines), std::move(stencils),
+  return std::make_unique<TranslationUnit>(filename, std::move(ppDefines), std::move(stencils),
                                       std::move(globals));
 }
 

--- a/src/dawn/CodeGen/GridTools/GTCodeGen.cpp
+++ b/src/dawn/CodeGen/GridTools/GTCodeGen.cpp
@@ -967,7 +967,7 @@ std::unique_ptr<TranslationUnit> GTCodeGen::generateCode() {
   DAWN_LOG(INFO) << "Done generating code";
 
   std::string filename = generateFileName(context_);
-  return make_unique<TranslationUnit>(filename, std::move(ppDefines), std::move(stencils),
+  return std::make_unique<TranslationUnit>(filename, std::move(ppDefines), std::move(stencils),
                                       std::move(globals));
 }
 

--- a/src/dawn/Compiler/DawnCompiler.cpp
+++ b/src/dawn/Compiler/DawnCompiler.cpp
@@ -125,8 +125,8 @@ createOptimizerOptionsFromAllOptions(const Options& options) {
   return retval;
 }
 
-DawnCompiler::DawnCompiler(Options* options) : diagnostics_(make_unique<DiagnosticsEngine>()) {
-  options_ = options ? make_unique<Options>(*options) : make_unique<Options>();
+DawnCompiler::DawnCompiler(Options* options) : diagnostics_(std::make_unique<DiagnosticsEngine>()) {
+  options_ = options ? std::make_unique<Options>(*options) : std::make_unique<Options>();
 }
 
 std::unique_ptr<OptimizerContext> DawnCompiler::runOptimizer(std::shared_ptr<SIR> const& SIR) {
@@ -174,7 +174,7 @@ std::unique_ptr<OptimizerContext> DawnCompiler::runOptimizer(std::shared_ptr<SIR
   std::unique_ptr<OptimizerContext> optimizer;
 
   if(options_->DeserializeIIR == "") {
-    optimizer = make_unique<OptimizerContext>(getDiagnostics(), optimizerOptions, SIR);
+    optimizer = std::make_unique<OptimizerContext>(getDiagnostics(), optimizerOptions, SIR);
     optimizer->fillIIR();
 
     // Setup pass interface
@@ -240,7 +240,7 @@ std::unique_ptr<OptimizerContext> DawnCompiler::runOptimizer(std::shared_ptr<SIR
       }
     }
   } else {
-    optimizer = make_unique<OptimizerContext>(getDiagnostics(), optimizerOptions, nullptr);
+    optimizer = std::make_unique<OptimizerContext>(getDiagnostics(), optimizerOptions, nullptr);
     auto instantiation =
         IIRSerializer::deserialize(options_->DeserializeIIR, optimizer.get(), serializationKind);
     optimizer->restoreIIR("<restored>", instantiation);
@@ -274,13 +274,13 @@ std::unique_ptr<codegen::TranslationUnit> DawnCompiler::compile(const std::share
   std::unique_ptr<codegen::CodeGen> CG;
 
   if(options_->Backend == "gt" || options_->Backend == "gridtools") {
-    CG = make_unique<codegen::gt::GTCodeGen>(optimizer->getStencilInstantiationMap(), *diagnostics_,
+    CG = std::make_unique<codegen::gt::GTCodeGen>(optimizer->getStencilInstantiationMap(), *diagnostics_,
                                              options_->UseParallelEP, options_->MaxHaloPoints);
   } else if(options_->Backend == "c++-naive") {
-    CG = make_unique<codegen::cxxnaive::CXXNaiveCodeGen>(optimizer->getStencilInstantiationMap(),
+    CG = std::make_unique<codegen::cxxnaive::CXXNaiveCodeGen>(optimizer->getStencilInstantiationMap(),
                                                          *diagnostics_, options_->MaxHaloPoints);
   } else if(options_->Backend == "cuda") {
-    CG = make_unique<codegen::cuda::CudaCodeGen>(
+    CG = std::make_unique<codegen::cuda::CudaCodeGen>(
         optimizer->getStencilInstantiationMap(), *diagnostics_, options_->MaxHaloPoints,
         options_->nsms, options_->maxBlocksPerSM, options_->domain_size);
   } else if(options_->Backend == "c++-opt") {

--- a/src/dawn/IIR/DoMethod.cpp
+++ b/src/dawn/IIR/DoMethod.cpp
@@ -35,7 +35,7 @@ DoMethod::DoMethod(Interval interval, const StencilMetaInformation& metaData)
     : interval_(interval), id_(IndexGenerator::Instance().getIndex()), metaData_(metaData) {}
 
 std::unique_ptr<DoMethod> DoMethod::clone() const {
-  auto cloneMS = make_unique<DoMethod>(interval_, metaData_);
+  auto cloneMS = std::make_unique<DoMethod>(interval_, metaData_);
 
   cloneMS->setID(id_);
   cloneMS->setDependencyGraph(derivedInfo_.dependencyGraph_);

--- a/src/dawn/IIR/IIR.cpp
+++ b/src/dawn/IIR/IIR.cpp
@@ -27,7 +27,7 @@ namespace dawn {
 namespace iir {
 
 std::unique_ptr<IIR> IIR::clone() const {
-  auto cloneIIR = make_unique<IIR>(globalVariableMap_, stencilFunctions_);
+  auto cloneIIR = std::make_unique<IIR>(globalVariableMap_, stencilFunctions_);
   clone(cloneIIR);
   return cloneIIR;
 }

--- a/src/dawn/IIR/MultiStage.cpp
+++ b/src/dawn/IIR/MultiStage.cpp
@@ -32,7 +32,7 @@ MultiStage::MultiStage(StencilMetaInformation& metadata, LoopOrderKind loopOrder
     : metadata_(metadata), loopOrder_(loopOrder), id_(UIDGenerator::getInstance()->get()) {}
 
 std::unique_ptr<MultiStage> MultiStage::clone() const {
-  auto cloneMS = make_unique<MultiStage>(metadata_, loopOrder_);
+  auto cloneMS = std::make_unique<MultiStage>(metadata_, loopOrder_);
 
   cloneMS->id_ = id_;
   cloneMS->derivedInfo_ = derivedInfo_;
@@ -51,7 +51,7 @@ MultiStage::split(std::deque<MultiStage::SplitIndex>& splitterIndices,
   auto curStageIt = children_.begin();
   std::deque<int> curStageSplitterIndices;
 
-  newMultiStages.push_back(make_unique<MultiStage>(metadata_, lastLoopOrder));
+  newMultiStages.push_back(std::make_unique<MultiStage>(metadata_, lastLoopOrder));
 
   for(std::size_t i = 0; i < splitterIndices.size(); ++i) {
     SplitIndex& splitIndex = splitterIndices[i];
@@ -59,7 +59,7 @@ MultiStage::split(std::deque<MultiStage::SplitIndex>& splitterIndices,
     if(splitIndex.StageIndex == curStageIndex) {
 
       curStageSplitterIndices.push_back(splitIndex.StmtIndex);
-      newMultiStages.push_back(make_unique<MultiStage>(metadata_, splitIndex.LowerLoopOrder));
+      newMultiStages.push_back(std::make_unique<MultiStage>(metadata_, splitIndex.LowerLoopOrder));
       lastLoopOrder = splitIndex.LowerLoopOrder;
     }
 
@@ -82,7 +82,7 @@ MultiStage::split(std::deque<MultiStage::SplitIndex>& splitterIndices,
       }
 
       if(i != (splitterIndices.size() - 1))
-        newMultiStages.push_back(make_unique<MultiStage>(metadata_, lastLoopOrder));
+        newMultiStages.push_back(std::make_unique<MultiStage>(metadata_, lastLoopOrder));
 
       // Handle the next stage
       curStageIndex++;

--- a/src/dawn/IIR/Stage.cpp
+++ b/src/dawn/IIR/Stage.cpp
@@ -35,7 +35,7 @@ Stage::Stage(const StencilMetaInformation& metaData, int StageID)
 
 Stage::Stage(const StencilMetaInformation& metaData, int StageID, const Interval& interval)
     : metaData_(metaData), StageID_(StageID) {
-  insertChild(make_unique<DoMethod>(interval, metaData));
+  insertChild(std::make_unique<DoMethod>(interval, metaData));
 }
 
 json::json Stage::jsonDump(const StencilMetaInformation& metaData) const {
@@ -60,7 +60,7 @@ json::json Stage::jsonDump(const StencilMetaInformation& metaData) const {
 
 std::unique_ptr<Stage> Stage::clone() const {
 
-  auto cloneStage = make_unique<Stage>(metaData_, StageID_);
+  auto cloneStage = std::make_unique<Stage>(metaData_, StageID_);
 
   cloneStage->derivedInfo_ = derivedInfo_;
 
@@ -299,7 +299,7 @@ Stage::split(std::deque<int>& splitterIndices,
     DoMethod::StatementAccessesIterator nextSplitterIndex =
         std::next(thisDoMethod.childrenBegin(), splitterIndices[i] + 1);
 
-    newStages.push_back(make_unique<Stage>(metaData_, UIDGenerator::getInstance()->get(),
+    newStages.push_back(std::make_unique<Stage>(metaData_, UIDGenerator::getInstance()->get(),
                                            thisDoMethod.getInterval()));
     Stage& newStage = *newStages.back();
     DoMethod& doMethod = newStage.getSingleDoMethod();

--- a/src/dawn/IIR/StatementAccessesPair.cpp
+++ b/src/dawn/IIR/StatementAccessesPair.cpp
@@ -67,7 +67,7 @@ StatementAccessesPair::StatementAccessesPair(const std::shared_ptr<Statement>& s
     : statement_(statement), callerAccesses_(nullptr), calleeAccesses_(nullptr) {}
 
 std::unique_ptr<StatementAccessesPair> StatementAccessesPair::clone() const {
-  auto cloneSAP = make_unique<StatementAccessesPair>(statement_);
+  auto cloneSAP = std::make_unique<StatementAccessesPair>(statement_);
 
   if(callerAccesses_) {
     cloneSAP->callerAccesses_ = std::make_shared<Accesses>(*callerAccesses_);

--- a/src/dawn/IIR/Stencil.cpp
+++ b/src/dawn/IIR/Stencil.cpp
@@ -174,7 +174,7 @@ std::unordered_set<Interval> Stencil::getIntervals() const {
 }
 
 std::unique_ptr<Stencil> Stencil::clone() const {
-  auto cloneStencil = make_unique<Stencil>(metadata_, stencilAttributes_, StencilID_);
+  auto cloneStencil = std::make_unique<Stencil>(metadata_, stencilAttributes_, StencilID_);
 
   cloneStencil->derivedInfo_ = derivedInfo_;
   cloneStencil->cloneChildrenFrom(*this);

--- a/src/dawn/IIR/StencilFunctionInstantiation.cpp
+++ b/src/dawn/IIR/StencilFunctionInstantiation.cpp
@@ -35,7 +35,7 @@ StencilFunctionInstantiation::StencilFunctionInstantiation(
     const Interval& interval, bool isNested)
     : stencilInstantiation_(context), metadata_(context->getMetaData()), expr_(expr),
       function_(function), ast_(ast), interval_(interval), hasReturn_(false), isNested_(isNested),
-      doMethod_(make_unique<DoMethod>(interval, context->getMetaData())) {
+      doMethod_(std::make_unique<DoMethod>(interval, context->getMetaData())) {
   DAWN_ASSERT(context);
   DAWN_ASSERT(function);
 }

--- a/src/dawn/IIR/StencilInstantiation.cpp
+++ b/src/dawn/IIR/StencilInstantiation.cpp
@@ -45,7 +45,7 @@ namespace iir {
 StencilInstantiation::StencilInstantiation(
     sir::GlobalVariableMap const& globalVariables,
     std::vector<std::shared_ptr<sir::StencilFunction>> const& stencilFunctions)
-    : metadata_(globalVariables), IIR_(make_unique<IIR>(globalVariables, stencilFunctions)) {}
+    : metadata_(globalVariables), IIR_(std::make_unique<IIR>(globalVariables, stencilFunctions)) {}
 
 StencilMetaInformation& StencilInstantiation::getMetaData() { return metadata_; }
 
@@ -58,7 +58,7 @@ std::shared_ptr<StencilInstantiation> StencilInstantiation::clone() const {
   stencilInstantiation->metadata_.clone(metadata_);
 
   stencilInstantiation->IIR_ =
-      make_unique<iir::IIR>(stencilInstantiation->getIIR()->getGlobalVariableMap(),
+      std::make_unique<iir::IIR>(stencilInstantiation->getIIR()->getGlobalVariableMap(),
                             stencilInstantiation->getIIR()->getStencilFunctions());
   IIR_->clone(stencilInstantiation->IIR_);
 

--- a/src/dawn/Optimizer/AccessComputation.cpp
+++ b/src/dawn/Optimizer/AccessComputation.cpp
@@ -77,7 +77,7 @@ public:
                std::shared_ptr<iir::StencilFunctionInstantiation> stencilFun = nullptr)
       : metadata_(metadata), stencilFun_(stencilFun) {
     curStatementAccessPairStack_.push_back(
-        make_unique<CurrentStatementAccessPair>(stmtAccessesPair));
+        std::make_unique<CurrentStatementAccessPair>(stmtAccessesPair));
   }
 
   /// @brief Get the stencil function instantiation from the `StencilFunCallExpr`
@@ -264,7 +264,7 @@ public:
       const auto& curStmt = curStatementAccessPairStack_.back();
       DAWN_ASSERT(curStmt->Pair->hasBlockStatements());
 
-      auto curBlockStmt = make_unique<CurrentStatementAccessPair>(
+      auto curBlockStmt = std::make_unique<CurrentStatementAccessPair>(
           curStmt->Pair->getBlockStatements()[curStmt->ChildIndex]);
 
       curStatementAccessPairStack_.push_back(std::move(curBlockStmt));
@@ -341,7 +341,7 @@ public:
 
     // Compute the accesses of the stencil function
     stencilFunCalls_.push(
-        make_unique<StencilFunctionCallScope>(getStencilFunctionInstantiation(expr)));
+        std::make_unique<StencilFunctionCallScope>(getStencilFunctionInstantiation(expr)));
 
     std::shared_ptr<iir::StencilFunctionInstantiation> curStencilFunCall =
         stencilFunCalls_.top()->FunctionInstantiation;

--- a/src/dawn/Optimizer/OptimizerContext.cpp
+++ b/src/dawn/Optimizer/OptimizerContext.cpp
@@ -123,7 +123,7 @@ public:
   void makeNewStencil() {
     int StencilID = instantiation_->nextUID();
     instantiation_->getIIR()->insertChild(
-        make_unique<Stencil>(metadata_, sirStencil_->Attributes, StencilID),
+        std::make_unique<Stencil>(metadata_, sirStencil_->Attributes, StencilID),
         instantiation_->getIIR());
     // We create a paceholder stencil-call for CodeGen to know wehere we need to insert calls to
     // this stencil
@@ -355,12 +355,12 @@ public:
     std::shared_ptr<iir::AST> ast = cloneAST ? verticalRegion->Ast->clone() : verticalRegion->Ast;
 
     // Create the new multi-stage
-    std::unique_ptr<MultiStage> multiStage = make_unique<MultiStage>(
+    std::unique_ptr<MultiStage> multiStage = std::make_unique<MultiStage>(
         metadata_, verticalRegion->LoopOrder == sir::VerticalRegion::LK_Forward
                        ? LoopOrderKind::LK_Forward
                        : LoopOrderKind::LK_Backward);
     std::unique_ptr<Stage> stage =
-        make_unique<Stage>(metadata_, instantiation_->nextUID(), interval);
+        std::make_unique<Stage>(metadata_, instantiation_->nextUID(), interval);
 
     DAWN_LOG(INFO) << "Processing vertical region at " << verticalRegion->Loc;
 

--- a/src/dawn/Optimizer/OptimizerContext.h
+++ b/src/dawn/Optimizer/OptimizerContext.h
@@ -96,7 +96,7 @@ public:
   /// @brief Create a new pass at the end of the pass list
   template <class T, typename... Args>
   void checkAndPushBack(Args&&... args) {
-    std::unique_ptr<T> pass = make_unique<T>(*this, std::forward<Args>(args)...);
+    std::unique_ptr<T> pass = std::make_unique<T>(*this, std::forward<Args>(args)...);
     if(compareOptionsToPassFlags<T>(pass)) {
       passManager_.getPasses().push_back(std::move(pass));
     }

--- a/src/dawn/Optimizer/PassFieldVersioning.cpp
+++ b/src/dawn/Optimizer/PassFieldVersioning.cpp
@@ -170,10 +170,10 @@ PassFieldVersioning::RCKind PassFieldVersioning::fixRaceCondition(
   int numRenames = 0;
 
   // Vector of strongly connected components with atleast one stencil access
-  auto stencilSCCs = make_unique<std::vector<std::set<int>>>();
+  auto stencilSCCs = std::make_unique<std::vector<std::set<int>>>();
 
   // Find all strongly connected components in the graph ...
-  auto SCCs = make_unique<std::vector<std::set<int>>>();
+  auto SCCs = std::make_unique<std::vector<std::set<int>>>();
   graph->findStronglyConnectedComponents(*SCCs);
 
   // ... and add those which have atleast one stencil access

--- a/src/dawn/Optimizer/PassInlining.cpp
+++ b/src/dawn/Optimizer/PassInlining.cpp
@@ -105,7 +105,7 @@ public:
     if(scopeDepth_ == 1) {
       // The top-level block statement is collapsed thus we only insert at 1. Note that this works
       // because all AST have a block statement as root node.
-      newStmtAccessesPairs_.emplace_back(make_unique<iir::StatementAccessesPair>(
+      newStmtAccessesPairs_.emplace_back(std::make_unique<iir::StatementAccessesPair>(
           std::make_shared<Statement>(stmt, oldStmtAccessesPair_->getStatement()->StackTrace)));
 
       currentStmtAccessesPair_.push(&(newStmtAccessesPairs_.back()));
@@ -113,7 +113,7 @@ public:
     } else if(scopeDepth_ > 1) {
       // We are inside a nested block statement, we add the stmt as a child of the parent statement
       (*currentStmtAccessesPair_.top())
-          ->insertBlockStatement(make_unique<iir::StatementAccessesPair>(
+          ->insertBlockStatement(std::make_unique<iir::StatementAccessesPair>(
               std::make_shared<Statement>(stmt, oldStmtAccessesPair_->getStatement()->StackTrace)));
 
       const std::unique_ptr<iir::StatementAccessesPair>& lp =
@@ -282,7 +282,7 @@ public:
         // back -> swap with our statement -> replace the expr in our statement and evict the empty
         // statement)
         newStmtAccessesPairs_.emplace_back(
-            make_unique<iir::StatementAccessesPair>(std::make_shared<Statement>(nullptr, nullptr)));
+            std::make_unique<iir::StatementAccessesPair>(std::make_shared<Statement>(nullptr, nullptr)));
         std::iter_swap(newStmtAccessesPairs_.begin() + stmtIdxOfFunc,
                        std::prev(newStmtAccessesPairs_.end()));
 

--- a/src/dawn/Optimizer/PassManager.h
+++ b/src/dawn/Optimizer/PassManager.h
@@ -37,13 +37,13 @@ public:
   /// @brief Create a new pass at the end of the pass list
   template <class T, typename... Args>
   void pushBackPass(Args&&... args) {
-    return passes_.emplace_back(make_unique<T>(std::forward<Args>(args)...));
+    return passes_.emplace_back(std::make_unique<T>(std::forward<Args>(args)...));
   };
 
   /// @brief Create a new pass at the start of the pass list
   template <class T, typename... Args>
   void pushFrontPass(Args&&... args) {
-    return passes_.emplace_front(make_unique<T>(std::forward<Args>(args)...));
+    return passes_.emplace_front(std::make_unique<T>(std::forward<Args>(args)...));
   };
 
   /// @brief Run all passes on the `instantiation`

--- a/src/dawn/Optimizer/PassSetNonTempCaches.cpp
+++ b/src/dawn/Optimizer/PassSetNonTempCaches.cpp
@@ -193,9 +193,9 @@ private:
                                                     const std::vector<int>& assigneeIDs) {
     // Add the cache Flush stage
     std::unique_ptr<iir::Stage> assignmentStage =
-        make_unique<iir::Stage>(instantiation_->getMetaData(), instantiation_->nextUID(), interval);
+        std::make_unique<iir::Stage>(instantiation_->getMetaData(), instantiation_->nextUID(), interval);
     iir::Stage::DoMethodSmartPtr_t domethod =
-        make_unique<iir::DoMethod>(interval, instantiation_->getMetaData());
+        std::make_unique<iir::DoMethod>(interval, instantiation_->getMetaData());
     domethod->clearChildren();
 
     for(int i = 0; i < assignmentIDs.size(); ++i) {
@@ -227,7 +227,7 @@ private:
         std::make_shared<iir::AssignmentExpr>(fa_assignment, fa_assignee, "=");
     auto expAssignment = std::make_shared<iir::ExprStmt>(assignmentExpression);
     auto assignmentStatement = std::make_shared<Statement>(expAssignment, nullptr);
-    auto pair = make_unique<iir::StatementAccessesPair>(assignmentStatement);
+    auto pair = std::make_unique<iir::StatementAccessesPair>(assignmentStatement);
     auto newAccess = std::make_shared<iir::Accesses>();
     newAccess->addWriteExtent(assignmentID, iir::Extents(Array3i{{0, 0, 0}}));
     newAccess->addReadExtent(assigneeID, iir::Extents(Array3i{{0, 0, 0}}));

--- a/src/dawn/Optimizer/PassStageReordering.cpp
+++ b/src/dawn/Optimizer/PassStageReordering.cpp
@@ -43,10 +43,10 @@ bool PassStageReordering::run(
     std::unique_ptr<ReorderStrategy> strategy;
     switch(strategy_) {
     case ReorderStrategy::RK_Greedy:
-      strategy = make_unique<ReoderStrategyGreedy>();
+      strategy = std::make_unique<ReoderStrategyGreedy>();
       break;
     case ReorderStrategy::RK_Partitioning:
-      strategy = make_unique<ReoderStrategyPartitioning>();
+      strategy = std::make_unique<ReoderStrategyPartitioning>();
       break;
     default:
       dawn_unreachable("invalid reorder strategy");

--- a/src/dawn/Optimizer/PassStencilSplitter.cpp
+++ b/src/dawn/Optimizer/PassStencilSplitter.cpp
@@ -67,7 +67,7 @@ bool PassStencilSplitter::run(
     if(stencil.getFields().size() > MaxFieldPerStencil) {
       rerunPassSetStageGraph = true;
 
-      newStencils.emplace_back(make_unique<iir::Stencil>(stencilInstantiation->getMetaData(),
+      newStencils.emplace_back(std::make_unique<iir::Stencil>(stencilInstantiation->getMetaData(),
                                                          stencil.getStencilAttributes(),
                                                          stencilInstantiation->nextUID()));
       const std::unique_ptr<iir::Stencil>& newStencil = newStencils.back();
@@ -80,7 +80,7 @@ bool PassStencilSplitter::run(
 
         // Create an empty multi-stage in the current stencil with the same parameter as
         // `multiStage`
-        newStencil->insertChild(make_unique<iir::MultiStage>(stencilInstantiation->getMetaData(),
+        newStencil->insertChild(std::make_unique<iir::MultiStage>(stencilInstantiation->getMetaData(),
                                                              multiStage.getLoopOrder()));
 
         for(const auto& stagePtr : multiStage.getChildren()) {
@@ -97,7 +97,7 @@ bool PassStencilSplitter::run(
 
           } else {
             // Make a new stencil
-            newStencils.emplace_back(make_unique<iir::Stencil>(stencilInstantiation->getMetaData(),
+            newStencils.emplace_back(std::make_unique<iir::Stencil>(stencilInstantiation->getMetaData(),
                                                                stencil.getStencilAttributes(),
                                                                stencilInstantiation->nextUID()));
             const std::unique_ptr<iir::Stencil>& newStencil2 = newStencils.back();
@@ -105,7 +105,7 @@ bool PassStencilSplitter::run(
             fieldsInNewStencil.clear();
 
             // Re-create the current multi-stage in the `newStencil` and insert the stage
-            newStencil2->insertChild(make_unique<iir::MultiStage>(
+            newStencil2->insertChild(std::make_unique<iir::MultiStage>(
                 stencilInstantiation->getMetaData(), multiStage.getLoopOrder()));
             newStencil2->getChildren().back()->insertChild(stagePtr->clone());
           }

--- a/src/dawn/Optimizer/ReorderStrategyGreedy.cpp
+++ b/src/dawn/Optimizer/ReorderStrategyGreedy.cpp
@@ -91,7 +91,7 @@ ReoderStrategyGreedy::reorder(iir::StencilInstantiation* instantiation,
   iir::DependencyGraphStage& stageDAG = *stencil.getStageDependencyGraph();
 
   auto& metadata = instantiation->getMetaData();
-  std::unique_ptr<iir::Stencil> newStencil = make_unique<iir::Stencil>(
+  std::unique_ptr<iir::Stencil> newStencil = std::make_unique<iir::Stencil>(
       metadata, stencil.getStencilAttributes(), stencilPtr->getStencilID());
 
   newStencil->setStageDependencyGraph(stencil.getStageDependencyGraph());
@@ -101,7 +101,7 @@ ReoderStrategyGreedy::reorder(iir::StencilInstantiation* instantiation,
   const int maxBoundaryExtent = context.getOptions().MaxHaloPoints;
 
   auto pushBackNewMultiStage = [&](iir::LoopOrderKind loopOrder) -> void {
-    newStencil->insertChild(make_unique<iir::MultiStage>(metadata, loopOrder));
+    newStencil->insertChild(std::make_unique<iir::MultiStage>(metadata, loopOrder));
     newNumMultiStages++;
   };
 

--- a/src/dawn/Optimizer/StatementMapper.cpp
+++ b/src/dawn/Optimizer/StatementMapper.cpp
@@ -42,13 +42,13 @@ void StatementMapper::appendNewStatementAccessesPair(const std::shared_ptr<iir::
     // The top-level block statement is collapsed thus we only insert at 1. Note that this works
     // because all AST have a block statement as root node.
     scope_.top()->doMethod_.insertChild(
-        make_unique<iir::StatementAccessesPair>(std::make_shared<Statement>(stmt, stackTrace_)));
+        std::make_unique<iir::StatementAccessesPair>(std::make_shared<Statement>(stmt, stackTrace_)));
     scope_.top()->CurentStmtAccessesPair.push(&(*(scope_.top()->doMethod_.childrenRBegin())));
 
   } else if(scope_.top()->ScopeDepth > 1) {
     // We are inside a nested block statement, we add the stmt as a child of the parent statement
     (*scope_.top()->CurentStmtAccessesPair.top())
-        ->insertBlockStatement(make_unique<iir::StatementAccessesPair>(
+        ->insertBlockStatement(std::make_unique<iir::StatementAccessesPair>(
             std::make_shared<Statement>(stmt, stackTrace_)));
 
     const std::unique_ptr<iir::StatementAccessesPair>& lp =

--- a/src/dawn/SIR/SIR.cpp
+++ b/src/dawn/SIR/SIR.cpp
@@ -618,16 +618,16 @@ const char* sir::Value::typeToString(sir::Value::TypeKind type) {
 sir::Value::Value(TypeKind type) : isConstexpr_(false) {
   switch(type) {
   case Boolean:
-    valueImpl_ = make_unique<ValueImpl<decay_t<bool>>>(false);
+    valueImpl_ = std::make_unique<ValueImpl<std::decay_t<bool>>>(false);
     break;
   case Integer:
-    valueImpl_ = make_unique<ValueImpl<decay_t<int>>>(0);
+    valueImpl_ = std::make_unique<ValueImpl<std::decay_t<int>>>(0);
     break;
   case Double:
-    valueImpl_ = make_unique<ValueImpl<decay_t<double>>>(0.0);
+    valueImpl_ = std::make_unique<ValueImpl<std::decay_t<double>>>(0.0);
     break;
   case String:
-    valueImpl_ = make_unique<ValueImpl<decay_t<std::string>>>("");
+    valueImpl_ = std::make_unique<ValueImpl<std::decay_t<std::string>>>("");
     break;
   }
 }

--- a/src/dawn/SIR/SIR.h
+++ b/src/dawn/SIR/SIR.h
@@ -282,12 +282,12 @@ struct Value : NonCopyable {
 
   template <class T>
   explicit Value(T&& value) : isConstexpr_(false) {
-    valueImpl_= make_unique<ValueImpl<decay_t<T>>>(std::forward<T>(value));
+    valueImpl_= std::make_unique<ValueImpl<std::decay_t<T>>>(std::forward<T>(value));
   }
 
   template <class T>
   explicit Value(T value, bool isConstexpr) : isConstexpr_(isConstexpr) {
-    valueImpl_= make_unique<ValueImpl<decay_t<T>>>(std::forward<T>(value));
+    valueImpl_= std::make_unique<ValueImpl<std::decay_t<T>>>(std::forward<T>(value));
   }
 
   explicit Value(TypeKind type);

--- a/src/dawn/Serialization/IIRSerializer.cpp
+++ b/src/dawn/Serialization/IIRSerializer.cpp
@@ -660,7 +660,7 @@ void IIRSerializer::deserializeIIR(std::shared_ptr<iir::StencilInstantiation>& t
     int mssPos = 0;
     sir::Attr attributes;
     target->getIIR()->insertChild(
-        make_unique<iir::Stencil>(target->getMetaData(), attributes, protoStencils.stencilid()),
+        std::make_unique<iir::Stencil>(target->getMetaData(), attributes, protoStencils.stencilid()),
         target->getIIR());
     const auto& IIRStencil = target->getIIR()->getChild(stencilPos++);
 
@@ -699,7 +699,7 @@ void IIRSerializer::deserializeIIR(std::shared_ptr<iir::StencilInstantiation>& t
       if(protoMSS.looporder() == proto::iir::MultiStage_LoopOrder::MultiStage_LoopOrder_Parallel) {
         looporder = iir::LoopOrderKind::LK_Parallel;
       }
-      (IIRStencil)->insertChild(make_unique<iir::MultiStage>(target->getMetaData(), looporder));
+      (IIRStencil)->insertChild(std::make_unique<iir::MultiStage>(target->getMetaData(), looporder));
 
       const auto& IIRMSS = (IIRStencil)->getChild(mssPos++);
       IIRMSS->setID(protoMSS.multistageid());
@@ -712,11 +712,11 @@ void IIRSerializer::deserializeIIR(std::shared_ptr<iir::StencilInstantiation>& t
         int doMethodPos = 0;
         int stageID = protoStage.stageid();
 
-        IIRMSS->insertChild(make_unique<iir::Stage>(target->getMetaData(), stageID));
+        IIRMSS->insertChild(std::make_unique<iir::Stage>(target->getMetaData(), stageID));
         const auto& IIRStage = IIRMSS->getChild(stagePos++);
 
         for(const auto& protoDoMethod : protoStage.domethods()) {
-          (IIRStage)->insertChild(make_unique<iir::DoMethod>(
+          (IIRStage)->insertChild(std::make_unique<iir::DoMethod>(
               *makeInterval(protoDoMethod.interval()), target->getMetaData()));
 
           auto& IIRDoMethod = (IIRStage)->getChild(doMethodPos++);
@@ -733,7 +733,7 @@ void IIRSerializer::deserializeIIR(std::shared_ptr<iir::StencilInstantiation>& t
             for(auto readAccess : protoStmtAccessPair.accesses().readaccess()) {
               callerAccesses->addReadExtent(readAccess.first, makeExtents(&readAccess.second));
             }
-            auto insertee = make_unique<iir::StatementAccessesPair>(statement);
+            auto insertee = std::make_unique<iir::StatementAccessesPair>(statement);
             insertee->setCallerAccesses(callerAccesses);
             (IIRDoMethod)->insertChild(std::move(insertee));
           }

--- a/src/dawn/Support/DiagnosticsQueue.cpp
+++ b/src/dawn/Support/DiagnosticsQueue.cpp
@@ -22,13 +22,13 @@ DiagnosticsQueue::DiagnosticsQueue() : numErrors_(0), numWarnings_(0) {}
 void DiagnosticsQueue::push_back(const DiagnosticsMessage& msg) {
   numErrors_ += msg.getDiagKind() == DiagnosticsKind::Error;
   numWarnings_ += msg.getDiagKind() == DiagnosticsKind::Warning;
-  queue_.push_back(make_unique<DiagnosticsMessage>(msg));
+  queue_.push_back(std::make_unique<DiagnosticsMessage>(msg));
 }
 
 void DiagnosticsQueue::push_back(DiagnosticsMessage&& msg) {
   numErrors_ += msg.getDiagKind() == DiagnosticsKind::Error;
   numWarnings_ += msg.getDiagKind() == DiagnosticsKind::Warning;
-  queue_.push_back(make_unique<DiagnosticsMessage>(std::move(msg)));
+  queue_.push_back(std::make_unique<DiagnosticsMessage>(std::move(msg)));
 }
 
 void DiagnosticsQueue::clear() {

--- a/src/dawn/Support/STLExtras.h
+++ b/src/dawn/Support/STLExtras.h
@@ -28,47 +28,6 @@ namespace dawn {
 /// @{
 
 //===------------------------------------------------------------------------------------------===//
-//     Extra additions to <memory>
-//===------------------------------------------------------------------------------------------===//
-
-template< class T >
-using decay_t = typename std::decay<T>::type;
-
-/// @brief Constructs a `new T()` with the given args and returns a `unique_ptr<T>` which owns the
-/// object
-///
-/// @b Example:
-/// @code
-///   auto p = make_unique<int>();
-///   auto p = make_unique<std::tuple<int, int>>(0, 1);
-/// @endcode
-template <class T, class... Args>
-typename std::enable_if<!std::is_array<T>::value, std::unique_ptr<T>>::type
-make_unique(Args&&... args) {
-  return std::move(std::unique_ptr<T>(new T(std::forward<Args>(args)...)));
-}
-
-/// @brief Constructs a `new T[n]` with the given args and returns a `unique_ptr<T[]>` which owns
-/// the object
-///
-/// @param n size of the new array.
-///
-/// @b Example:
-/// @code
-///   auto p = make_unique<int[]>(2); // value-initializes the array with 0's.
-/// @endcode
-template <class T>
-typename std::enable_if<std::is_array<T>::value && std::extent<T>::value == 0,
-                        std::unique_ptr<T>>::type
-make_unique(std::size_t n) {
-  return std::unique_ptr<T>(new typename std::remove_extent<T>::type[n]());
-}
-
-/// @brief This function isn't used and is only here to provide better compile errors
-template <class T, class... Args>
-typename std::enable_if<std::extent<T>::value != 0>::type make_unique(Args&&...) = delete;
-
-//===------------------------------------------------------------------------------------------===//
 //     Extra additions to <functional>
 //===------------------------------------------------------------------------------------------===//
 

--- a/test/unit-test/dawn/IIR/TestIIRNode.cpp
+++ b/test/unit-test/dawn/IIR/TestIIRNode.cpp
@@ -58,7 +58,7 @@ class IIRNode : public ::testing::Test {
 public:
   std::unique_ptr<impl::Node1> root_;
 
-  IIRNode() : root_(make_unique<impl::Node1>()) {}
+  IIRNode() : root_(std::make_unique<impl::Node1>()) {}
 
   void SetUp() override {
 
@@ -77,48 +77,48 @@ public:
     // Node4:  2   3 5   6 8   9    12 13 15 16 18 19
     */
 
-    root_->insertChild(make_unique<impl::Node2>(), root_);
-    root_->insertChild(make_unique<impl::Node2>(), root_);
+    root_->insertChild(std::make_unique<impl::Node2>(), root_);
+    root_->insertChild(std::make_unique<impl::Node2>(), root_);
 
     auto node2_It = root_->childrenBegin();
 
-    (*node2_It)->insertChild(make_unique<impl::Node3>());
-    (*node2_It)->insertChild(make_unique<impl::Node3>());
-    (*node2_It)->insertChild(make_unique<impl::Node3>());
+    (*node2_It)->insertChild(std::make_unique<impl::Node3>());
+    (*node2_It)->insertChild(std::make_unique<impl::Node3>());
+    (*node2_It)->insertChild(std::make_unique<impl::Node3>());
 
     auto node3_It = (*node2_It)->childrenBegin();
-    (*node3_It)->insertChild(make_unique<impl::Node4>(2));
-    (*node3_It)->insertChild(make_unique<impl::Node4>(3));
+    (*node3_It)->insertChild(std::make_unique<impl::Node4>(2));
+    (*node3_It)->insertChild(std::make_unique<impl::Node4>(3));
 
     node3_It++;
 
-    (*node3_It)->insertChild(make_unique<impl::Node4>(5));
-    (*node3_It)->insertChild(make_unique<impl::Node4>(6));
+    (*node3_It)->insertChild(std::make_unique<impl::Node4>(5));
+    (*node3_It)->insertChild(std::make_unique<impl::Node4>(6));
 
     node3_It++;
 
-    (*node3_It)->insertChild(make_unique<impl::Node4>(8));
-    (*node3_It)->insertChild(make_unique<impl::Node4>(9));
+    (*node3_It)->insertChild(std::make_unique<impl::Node4>(8));
+    (*node3_It)->insertChild(std::make_unique<impl::Node4>(9));
 
     node2_It++;
 
-    (*node2_It)->insertChild(make_unique<impl::Node3>());
-    (*node2_It)->insertChild(make_unique<impl::Node3>());
-    (*node2_It)->insertChild(make_unique<impl::Node3>());
+    (*node2_It)->insertChild(std::make_unique<impl::Node3>());
+    (*node2_It)->insertChild(std::make_unique<impl::Node3>());
+    (*node2_It)->insertChild(std::make_unique<impl::Node3>());
 
     node3_It = (*node2_It)->childrenBegin();
-    (*node3_It)->insertChild(make_unique<impl::Node4>(12));
-    (*node3_It)->insertChild(make_unique<impl::Node4>(13));
+    (*node3_It)->insertChild(std::make_unique<impl::Node4>(12));
+    (*node3_It)->insertChild(std::make_unique<impl::Node4>(13));
 
     node3_It++;
 
-    (*node3_It)->insertChild(make_unique<impl::Node4>(15));
-    (*node3_It)->insertChild(make_unique<impl::Node4>(16));
+    (*node3_It)->insertChild(std::make_unique<impl::Node4>(15));
+    (*node3_It)->insertChild(std::make_unique<impl::Node4>(16));
 
     node3_It++;
 
-    (*node3_It)->insertChild(make_unique<impl::Node4>(18));
-    (*node3_It)->insertChild(make_unique<impl::Node4>(19));
+    (*node3_It)->insertChild(std::make_unique<impl::Node4>(18));
+    (*node3_It)->insertChild(std::make_unique<impl::Node4>(19));
   }
 
   void TearDown() override {}
@@ -133,7 +133,7 @@ TEST_F(IIRNode, replace) {
 
   EXPECT_EQ(n4_7->val_, 13);
 
-  std::unique_ptr<impl::Node4> repl = make_unique<impl::Node4>(-13);
+  std::unique_ptr<impl::Node4> repl = std::make_unique<impl::Node4>(-13);
   n3_3->replace(n4_7, repl);
 
   EXPECT_TRUE(root_->checkTreeConsistency());
@@ -156,7 +156,7 @@ TEST_F(IIRNode, insertChild) {
   // we insert multiple children since the consistency can be broken if the STL vector of children
   // gets reallocated because a resize operation
   for(int i = -1; i > -7; --i) {
-    n3_3->insertChild(make_unique<impl::Node4>(i));
+    n3_3->insertChild(std::make_unique<impl::Node4>(i));
   }
 
   EXPECT_EQ(n3_3->getChildren().size(), 8);
@@ -174,19 +174,19 @@ TEST_F(IIRNode, insertChild) {
 
 // test the insertChild API for the top node
 TEST_F(IIRNode, insertChildTopNode) {
-  auto newn2 = make_unique<impl::Node2>();
-  newn2->insertChild(make_unique<impl::Node3>());
-  newn2->insertChild(make_unique<impl::Node3>());
-  newn2->insertChild(make_unique<impl::Node3>());
+  auto newn2 = std::make_unique<impl::Node2>();
+  newn2->insertChild(std::make_unique<impl::Node3>());
+  newn2->insertChild(std::make_unique<impl::Node3>());
+  newn2->insertChild(std::make_unique<impl::Node3>());
   auto newn3It = (newn2)->childrenBegin();
-  (*newn3It)->insertChild(make_unique<impl::Node4>(-9));
+  (*newn3It)->insertChild(std::make_unique<impl::Node4>(-9));
   newn3It++;
-  (*newn3It)->insertChild(make_unique<impl::Node4>(-11));
-  (*newn3It)->insertChild(make_unique<impl::Node4>(-12));
+  (*newn3It)->insertChild(std::make_unique<impl::Node4>(-11));
+  (*newn3It)->insertChild(std::make_unique<impl::Node4>(-12));
   newn3It++;
-  (*newn3It)->insertChild(make_unique<impl::Node4>(-15));
-  (*newn3It)->insertChild(make_unique<impl::Node4>(-16));
-  (*newn3It)->insertChild(make_unique<impl::Node4>(-17));
+  (*newn3It)->insertChild(std::make_unique<impl::Node4>(-15));
+  (*newn3It)->insertChild(std::make_unique<impl::Node4>(-16));
+  (*newn3It)->insertChild(std::make_unique<impl::Node4>(-17));
 
   root_->insertChild(std::move(newn2), root_);
 
@@ -207,12 +207,12 @@ TEST_F(IIRNode, insertChildren) {
   const auto& n2_1 = root_->getChildren()[1];
   const auto& n3_3 = n2_1->getChildren()[0];
 
-  auto newn3 = make_unique<impl::Node3>();
+  auto newn3 = std::make_unique<impl::Node3>();
 
-  newn3->insertChild(make_unique<impl::Node4>(-3));
-  newn3->insertChild(make_unique<impl::Node4>(-4));
-  newn3->insertChild(make_unique<impl::Node4>(-5));
-  newn3->insertChild(make_unique<impl::Node4>(-6));
+  newn3->insertChild(std::make_unique<impl::Node4>(-3));
+  newn3->insertChild(std::make_unique<impl::Node4>(-4));
+  newn3->insertChild(std::make_unique<impl::Node4>(-5));
+  newn3->insertChild(std::make_unique<impl::Node4>(-6));
 
   n3_3->insertChildren(std::next(n3_3->childrenBegin()),
                        std::make_move_iterator(newn3->childrenBegin()),
@@ -232,22 +232,22 @@ TEST_F(IIRNode, insertChildren) {
 // test the insertChild API for top node
 TEST_F(IIRNode, insertChildrenTopNode) {
 
-  auto newn1 = make_unique<impl::Node1>();
+  auto newn1 = std::make_unique<impl::Node1>();
   {
-    auto newn2 = make_unique<impl::Node2>();
-    auto newn3 = make_unique<impl::Node3>();
+    auto newn2 = std::make_unique<impl::Node2>();
+    auto newn3 = std::make_unique<impl::Node3>();
 
-    newn3->insertChild(make_unique<impl::Node4>(-3));
-    newn3->insertChild(make_unique<impl::Node4>(-4));
+    newn3->insertChild(std::make_unique<impl::Node4>(-3));
+    newn3->insertChild(std::make_unique<impl::Node4>(-4));
     newn2->insertChild(std::move(newn3));
     newn1->insertChild(std::move(newn2), newn1);
   }
   {
-    auto newn2 = make_unique<impl::Node2>();
-    auto newn3 = make_unique<impl::Node3>();
+    auto newn2 = std::make_unique<impl::Node2>();
+    auto newn3 = std::make_unique<impl::Node3>();
 
-    newn3->insertChild(make_unique<impl::Node4>(-7));
-    newn3->insertChild(make_unique<impl::Node4>(-9));
+    newn3->insertChild(std::make_unique<impl::Node4>(-7));
+    newn3->insertChild(std::make_unique<impl::Node4>(-9));
     newn2->insertChild(std::move(newn3));
     newn1->insertChild(std::move(newn2), newn1);
   }

--- a/test/unit-test/dawn/IIR/TestIIRNodeIterator.cpp
+++ b/test/unit-test/dawn/IIR/TestIIRNodeIterator.cpp
@@ -57,7 +57,7 @@ class IIRNodeIterator : public ::testing::Test {
 public:
   std::unique_ptr<impl::Node1> root_;
 
-  IIRNodeIterator() : root_(make_unique<impl::Node1>()) {}
+  IIRNodeIterator() : root_(std::make_unique<impl::Node1>()) {}
 
   void SetUp() override {
 
@@ -76,48 +76,48 @@ public:
     // Node4:  2   3 5   6 8   9    12 13 15 16 18 19
     */
 
-    root_->insertChild(make_unique<impl::Node2>(), root_);
-    root_->insertChild(make_unique<impl::Node2>(), root_);
+    root_->insertChild(std::make_unique<impl::Node2>(), root_);
+    root_->insertChild(std::make_unique<impl::Node2>(), root_);
 
     auto node2_It = root_->childrenBegin();
 
-    (*node2_It)->insertChild(make_unique<impl::Node3>());
-    (*node2_It)->insertChild(make_unique<impl::Node3>());
-    (*node2_It)->insertChild(make_unique<impl::Node3>());
+    (*node2_It)->insertChild(std::make_unique<impl::Node3>());
+    (*node2_It)->insertChild(std::make_unique<impl::Node3>());
+    (*node2_It)->insertChild(std::make_unique<impl::Node3>());
 
     auto node3_It = (*node2_It)->childrenBegin();
-    (*node3_It)->insertChild(make_unique<impl::Node4>(2));
-    (*node3_It)->insertChild(make_unique<impl::Node4>(3));
+    (*node3_It)->insertChild(std::make_unique<impl::Node4>(2));
+    (*node3_It)->insertChild(std::make_unique<impl::Node4>(3));
 
     node3_It++;
 
-    (*node3_It)->insertChild(make_unique<impl::Node4>(5));
-    (*node3_It)->insertChild(make_unique<impl::Node4>(6));
+    (*node3_It)->insertChild(std::make_unique<impl::Node4>(5));
+    (*node3_It)->insertChild(std::make_unique<impl::Node4>(6));
 
     node3_It++;
 
-    (*node3_It)->insertChild(make_unique<impl::Node4>(8));
-    (*node3_It)->insertChild(make_unique<impl::Node4>(9));
+    (*node3_It)->insertChild(std::make_unique<impl::Node4>(8));
+    (*node3_It)->insertChild(std::make_unique<impl::Node4>(9));
 
     node2_It++;
 
-    (*node2_It)->insertChild(make_unique<impl::Node3>());
-    (*node2_It)->insertChild(make_unique<impl::Node3>());
-    (*node2_It)->insertChild(make_unique<impl::Node3>());
+    (*node2_It)->insertChild(std::make_unique<impl::Node3>());
+    (*node2_It)->insertChild(std::make_unique<impl::Node3>());
+    (*node2_It)->insertChild(std::make_unique<impl::Node3>());
 
     node3_It = (*node2_It)->childrenBegin();
-    (*node3_It)->insertChild(make_unique<impl::Node4>(12));
-    (*node3_It)->insertChild(make_unique<impl::Node4>(13));
+    (*node3_It)->insertChild(std::make_unique<impl::Node4>(12));
+    (*node3_It)->insertChild(std::make_unique<impl::Node4>(13));
 
     node3_It++;
 
-    (*node3_It)->insertChild(make_unique<impl::Node4>(15));
-    (*node3_It)->insertChild(make_unique<impl::Node4>(16));
+    (*node3_It)->insertChild(std::make_unique<impl::Node4>(15));
+    (*node3_It)->insertChild(std::make_unique<impl::Node4>(16));
 
     node3_It++;
 
-    (*node3_It)->insertChild(make_unique<impl::Node4>(18));
-    (*node3_It)->insertChild(make_unique<impl::Node4>(19));
+    (*node3_It)->insertChild(std::make_unique<impl::Node4>(18));
+    (*node3_It)->insertChild(std::make_unique<impl::Node4>(19));
   }
 
   void TearDown() override {}
@@ -161,31 +161,31 @@ TEST_F(IIRNodeIterator, LeafIterator) {
 }
 
 TEST_F(IIRNodeIterator, MissingLeaf) {
-  std::unique_ptr<impl::Node1> root = make_unique<impl::Node1>();
+  std::unique_ptr<impl::Node1> root = std::make_unique<impl::Node1>();
 
-  root->insertChild(make_unique<impl::Node2>(), root);
-  root->insertChild(make_unique<impl::Node2>(), root);
+  root->insertChild(std::make_unique<impl::Node2>(), root);
+  root->insertChild(std::make_unique<impl::Node2>(), root);
 
   auto node2_It = root->childrenBegin();
 
-  (*node2_It)->insertChild(make_unique<impl::Node3>());
-  (*node2_It)->insertChild(make_unique<impl::Node3>());
-  (*node2_It)->insertChild(make_unique<impl::Node3>());
+  (*node2_It)->insertChild(std::make_unique<impl::Node3>());
+  (*node2_It)->insertChild(std::make_unique<impl::Node3>());
+  (*node2_It)->insertChild(std::make_unique<impl::Node3>());
 
   auto node3_It = (*node2_It)->childrenBegin();
 
   node3_It++;
 
-  (*node3_It)->insertChild(make_unique<impl::Node4>(4));
+  (*node3_It)->insertChild(std::make_unique<impl::Node4>(4));
   node3_It++;
 
   //  here missing two leaf nodes
-  //  (*node3_It)->insertChild(make_unique<impl::Node4>(5));
+  //  (*node3_It)->insertChild(std::make_unique<impl::Node4>(5));
 
   node2_It++;
-  (*node2_It)->insertChild(make_unique<impl::Node3>());
+  (*node2_It)->insertChild(std::make_unique<impl::Node3>());
   node3_It = (*node2_It)->childrenBegin();
-  (*node3_It)->insertChild(make_unique<impl::Node4>(6));
+  (*node3_It)->insertChild(std::make_unique<impl::Node4>(6));
 
   // here missing to fill the final Node3 (since we inserted 3)
 

--- a/test/unit-test/dawn/IIR/TestIIRSerializer.cpp
+++ b/test/unit-test/dawn/IIR/TestIIRSerializer.cpp
@@ -291,7 +291,7 @@ TEST_F(IIRSerializerTest, IIRTests) {
   sir::Attr attributes;
   attributes.set(sir::Attr::AK_MergeStages);
   referenceInstantiaton->getIIR()->insertChild(
-      make_unique<iir::Stencil>(referenceInstantiaton->getMetaData(), attributes, 10),
+      std::make_unique<iir::Stencil>(referenceInstantiaton->getMetaData(), attributes, 10),
       referenceInstantiaton->getIIR());
   const auto& IIRStencil = referenceInstantiaton->getIIR()->getChild(0);
   auto deserialized = serializeAndDeserializeRef();
@@ -300,7 +300,7 @@ TEST_F(IIRSerializerTest, IIRTests) {
   IIR_EXPECT_NE(deserialized, referenceInstantiaton);
 
   (IIRStencil)
-      ->insertChild(make_unique<iir::MultiStage>(referenceInstantiaton->getMetaData(),
+      ->insertChild(std::make_unique<iir::MultiStage>(referenceInstantiaton->getMetaData(),
                                                  iir::LoopOrderKind::LK_Backward));
   const auto& IIRMSS = (IIRStencil)->getChild(0);
   IIRMSS->getCaches().emplace(
@@ -310,12 +310,12 @@ TEST_F(IIRSerializerTest, IIRTests) {
   IIRMSS->setLoopOrder(iir::LoopOrderKind::LK_Forward);
   IIR_EXPECT_NE(deserialized, referenceInstantiaton);
 
-  IIRMSS->insertChild(make_unique<iir::Stage>(referenceInstantiaton->getMetaData(), 12));
+  IIRMSS->insertChild(std::make_unique<iir::Stage>(referenceInstantiaton->getMetaData(), 12));
   const auto& IIRStage = IIRMSS->getChild(0);
   IIR_EXPECT_EQ(serializeAndDeserializeRef(), referenceInstantiaton);
 
   (IIRStage)->insertChild(
-      make_unique<iir::DoMethod>(iir::Interval(1, 5, 0, 1), referenceInstantiaton->getMetaData()));
+      std::make_unique<iir::DoMethod>(iir::Interval(1, 5, 0, 1), referenceInstantiaton->getMetaData()));
   IIR_EXPECT_EQ(serializeAndDeserializeRef(), referenceInstantiaton);
 
   auto& IIRDoMethod = (IIRStage)->getChild(0);
@@ -323,7 +323,7 @@ TEST_F(IIRSerializerTest, IIRTests) {
   auto stmt = std::make_shared<iir::ExprStmt>(expr);
   stmt->setID(22);
   auto statement = std::make_shared<Statement>(stmt, nullptr);
-  auto stmtAccessPair = make_unique<iir::StatementAccessesPair>(statement);
+  auto stmtAccessPair = std::make_unique<iir::StatementAccessesPair>(statement);
   std::shared_ptr<iir::Accesses> callerAccesses = std::make_shared<iir::Accesses>();
   stmtAccessPair->setCallerAccesses(callerAccesses);
 

--- a/test/unit-test/dawn/IIR/TestMain.cpp
+++ b/test/unit-test/dawn/IIR/TestMain.cpp
@@ -22,7 +22,7 @@ int main(int argc, char* argv[]) {
   testing::InitGoogleTest(&argc, argv);
 
   // Initialize Unittest-Logger
-  auto logger = dawn::make_unique<dawn::UnittestLogger>();
+  auto logger = std::make_unique<dawn::UnittestLogger>();
   dawn::Logger::getSingleton().registerLogger(logger.get());
 
   return RUN_ALL_TESTS();

--- a/test/unit-test/dawn/Optimizer/Passes/TestTemporaryToFunction.cpp
+++ b/test/unit-test/dawn/Optimizer/Passes/TestTemporaryToFunction.cpp
@@ -59,7 +59,7 @@ protected:
 
     // Generate code
     std::unique_ptr<codegen::CodeGen> CG;
-    CG = make_unique<codegen::gt::GTCodeGen>(
+    CG = std::make_unique<codegen::gt::GTCodeGen>(
         optimizer->getStencilInstantiationMap(), optimizer->getDiagnostics(),
         optimizer->getOptions().UseParallelEP, optimizer->getOptions().MaxHaloPoints);
     auto translationUnit = CG->generateCode();

--- a/test/unit-test/dawn/Optimizer/TestMain.cpp
+++ b/test/unit-test/dawn/Optimizer/TestMain.cpp
@@ -22,7 +22,7 @@ int main(int argc, char* argv[]) {
   testing::InitGoogleTest(&argc, argv);
 
   // Initialize Unittest-Logger
-  auto logger = dawn::make_unique<dawn::UnittestLogger>();
+  auto logger = std::make_unique<dawn::UnittestLogger>();
   dawn::Logger::getSingleton().registerLogger(logger.get());
 
   return RUN_ALL_TESTS();

--- a/test/unit-test/dawn/SIR/TestMain.cpp
+++ b/test/unit-test/dawn/SIR/TestMain.cpp
@@ -22,7 +22,7 @@ int main(int argc, char* argv[]) {
   testing::InitGoogleTest(&argc, argv);
 
   // Initialize Unittest-Logger
-  auto logger = dawn::make_unique<dawn::UnittestLogger>();
+  auto logger = std::make_unique<dawn::UnittestLogger>();
   dawn::Logger::getSingleton().registerLogger(logger.get());
 
   return RUN_ALL_TESTS();

--- a/test/unit-test/dawn/SIR/TestSIR.cpp
+++ b/test/unit-test/dawn/SIR/TestSIR.cpp
@@ -34,8 +34,8 @@ namespace {
 class SIRTest : public ::testing::Test {
 protected:
   virtual void SetUp() override {
-    sir1 = make_unique<SIR>();
-    sir2 = make_unique<SIR>();
+    sir1 = std::make_unique<SIR>();
+    sir2 = std::make_unique<SIR>();
   }
 
   virtual void TearDown() override {
@@ -43,8 +43,8 @@ protected:
     sir2.release();
   }
 
-  std::unique_ptr<SIR> sir1 = make_unique<SIR>();
-  std::unique_ptr<SIR> sir2 = make_unique<SIR>();
+  std::unique_ptr<SIR> sir1 = std::make_unique<SIR>();
+  std::unique_ptr<SIR> sir2 = std::make_unique<SIR>();
 };
 
 class SIRStencilTest : public SIRTest {


### PR DESCRIPTION
Setting CMake to compile with c++17 standard.
Substituting additions to <memory> in STLExtras.h with the actual c++ 17 std:: versions