### PR TITLE
Enable address sanitizer in Debug mode

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,9 +66,7 @@ include(DawnMacros)
 yoda_set_cxx_standard(c++11)
 
 # Set C++ flags
-if(CMAKE_BUILD_TYPE STREQUAL "Debug")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=address")
-endif()
+dawn_set_cxx_flags()
 
 # Add custom targets
 yoda_add_target_clean_all(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,10 +67,7 @@ yoda_set_cxx_standard(c++11)
 
 # Set C++ flags
 if(CMAKE_BUILD_TYPE STREQUAL "Debug")
-  message(STATUS "address")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=address")
-else()
-  message(STATUS "no address")
 endif()
 
 # Add custom targets

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,7 +66,12 @@ include(DawnMacros)
 yoda_set_cxx_standard(c++11)
 
 # Set C++ flags
-dawn_set_cxx_flags()
+if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+  message(STATUS "address")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=address")
+else()
+  message(STATUS "no address")
+endif()
 
 # Add custom targets
 yoda_add_target_clean_all(

--- a/cmake/DawnMacros.cmake
+++ b/cmake/DawnMacros.cmake
@@ -55,6 +55,10 @@ macro(dawn_set_cxx_flags)
   yoda_check_and_set_cxx_flag("-Wno-sign-compare" HAVE_GCC_WNO_SIGN_COMPARE)
   yoda_check_and_set_cxx_flag("-Wno-unused-parameter" HAVE_GCC_WNO_UNUSDED_PARAMETER)
 
+  if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+    yoda_check_and_set_cxx_flag("-fsanitize=address" HAVE_GCC_SANITIZE_ADDRESS)
+  endif()
+
   if(BUILD_SHARED_LIBS)
     yoda_check_and_set_cxx_flag("-fPIC" HAVE_GCC_PIC)
   endif()

--- a/src/dawn/Support/DoubleSidedMap.h
+++ b/src/dawn/Support/DoubleSidedMap.h
@@ -26,7 +26,6 @@ class DoubleSidedMap {
   std::unordered_map<Key2, Key1> reverseMap_;
 
 public:
-
   /// Add a new element to the map. This function asserts that neither key1 nor key2 is already
   /// present. That is, one to one relation (bijective mapping) is maintained
   void add(const Key1& key1, const Key2& key2) {
@@ -39,12 +38,14 @@ public:
 
   void directEraseKey(const Key1& key1) {
     const auto& key2 = directAt(key1);
-    erase(key1, key2);
+    reverseMap_.erase(key2); // order matters as key2 references elem of directMap_
+    directMap_.erase(key1);
   }
 
   void reverseEraseKey(const Key2& key2) {
-    const auto& key1 = reverseAt(key2);
-    erase(key1, key2);
+    const auto& key1 = reverseAt(key2); // order matters as key1 references elem of reverseMap_
+    directMap_.erase(key1);
+    reverseMap_.erase(key2);
   }
 
   const Key2& directAt(const Key1& key1) const { return directMap_.at(key1); }
@@ -55,12 +56,6 @@ public:
 
   const std::unordered_map<Key1, Key2>& getDirectMap() const { return directMap_; }
   const std::unordered_map<Key2, Key1>& getReverseMap() const { return reverseMap_; }
-
-private:
-  void erase(const Key1& key1, const Key2& key2) {
-    directMap_.erase(key1);
-    reverseMap_.erase(key2);
-  }
 };
 } // namespace dawn
 #endif

--- a/test/unit-test/dawn/IIR/TestIIRSerializer.cpp
+++ b/test/unit-test/dawn/IIR/TestIIRSerializer.cpp
@@ -19,6 +19,7 @@
 #include "dawn/Optimizer/OptimizerContext.h"
 #include "dawn/Serialization/IIRSerializer.h"
 #include "dawn/Support/DiagnosticsEngine.h"
+#include "dawn/Support/STLExtras.h"
 #include <gtest/gtest.h>
 
 using namespace dawn;
@@ -175,10 +176,10 @@ protected:
     dawn::DiagnosticsEngine diag;
     std::shared_ptr<SIR> sir = std::make_shared<SIR>();
     dawn::OptimizerContext::OptimizerContextOptions options;
-    context_ = new OptimizerContext(diag, options, sir);
+    context_ = make_unique<OptimizerContext>(diag, options, sir);
   }
   virtual void TearDown() override {}
-  OptimizerContext* context_;
+  std::unique_ptr<OptimizerContext> context_;
 };
 
 class IIRSerializerTest : public createEmptyOptimizerContext {
@@ -192,7 +193,7 @@ protected:
 
   std::shared_ptr<iir::StencilInstantiation> serializeAndDeserializeRef() {
     return IIRSerializer::deserializeFromString(
-        IIRSerializer::serializeToString(referenceInstantiaton), context_);
+        IIRSerializer::serializeToString(referenceInstantiaton), context_.get());
   }
 
   std::shared_ptr<iir::StencilInstantiation> referenceInstantiaton;
@@ -246,7 +247,8 @@ TEST_F(IIRSerializerTest, SimpleDataStructures) {
   IIR_EXPECT_NE(deserializedStencilInstantiaion, referenceInstantiaton);
 
   referenceInstantiaton->getMetaData().insertAccessOfType(
-      iir::FieldAccessType::FAT_StencilTemporary, 713, "field3"); //access ids should be globally unique, not only per type
+      iir::FieldAccessType::FAT_StencilTemporary, 713,
+      "field3"); // access ids should be globally unique, not only per type
   IIR_EXPECT_EQ(serializeAndDeserializeRef(), referenceInstantiaton);
 
   // This would fail, since 712 is already present


### PR DESCRIPTION
and fix
- use-after-free in DoubleSidedMap
- memory leak in unittest