### PR TITLE
add timers to GT-codegen

### DIFF
--- a/dawn/src/dawn/CodeGen/Cuda/CudaCodeGen.cpp
+++ b/dawn/src/dawn/CodeGen/Cuda/CudaCodeGen.cpp
@@ -671,7 +671,7 @@ std::unique_ptr<TranslationUnit> CudaCodeGen::generateCode() {
   std::string filename = generateFileName(context_);
   // TODO missing the BC
   return std::make_unique<TranslationUnit>(filename, std::move(ppDefines), std::move(stencils),
-                                      std::move(globals));
+                                           std::move(globals));
 }
 
 } // namespace cuda

--- a/dawn/src/dawn/CodeGen/GridTools/GTCodeGen.cpp
+++ b/dawn/src/dawn/CodeGen/GridTools/GTCodeGen.cpp
@@ -26,8 +26,8 @@
 #include "dawn/Support/DiagnosticsEngine.h"
 #include "dawn/Support/Logging.h"
 #include "dawn/Support/StringUtil.h"
-#include <optional>
 #include <map>
+#include <optional>
 #include <string>
 #include <unordered_map>
 
@@ -74,14 +74,14 @@ GTCodeGen::IntervalDefinitions::IntervalDefinitions(const iir::Stencil& stencil)
       } else {
         interval = cache.getInterval();
       }
-     if(interval)
+      if(interval)
         intervalProperties_.insert(*interval);
 
       // for the kcaches with fill, the interval could span beyond the axis of the do methods.
       // We need to extent the axis, to make sure that at least on interval will trigger the begin
       // of the kcache interval
       if(cache.getCacheIOPolicy() == iir::Cache::CacheIOPolicy::fill) {
-       DAWN_ASSERT(interval);
+        DAWN_ASSERT(interval);
         Levels.insert(interval->lowerLevel());
         Levels.insert(interval->upperLevel());
         Axis.merge(*interval);
@@ -332,6 +332,8 @@ void GTCodeGen::generateStencilWrapperRun(
 
   RangeToString apiFieldArgs(",", "", "");
   RunMethod.addStatement("sync_storages(" + apiFieldArgs(apiFieldNames) + ")");
+  RunMethod.addComment("starting timers");
+  RunMethod.addStatement("start()");
 
   ASTStencilDesc stencilDescCGVisitor(stencilInstantiation, codeGenProperties,
                                       stencilIDToRunArguments);
@@ -341,7 +343,8 @@ void GTCodeGen::generateStencilWrapperRun(
     statement->accept(stencilDescCGVisitor);
     RunMethod << stencilDescCGVisitor.getCodeAndResetStream();
   }
-
+  RunMethod.addComment("stopping timers");
+  RunMethod.addStatement("pause()");
   RunMethod.addStatement("sync_storages(" + apiFieldArgs(apiFieldNames) + ")");
   RunMethod.commit();
 }
@@ -683,10 +686,10 @@ void GTCodeGen::generateStencilClasses(
           } else {
             cInterval = cache.getInterval();
           }
-         DAWN_ASSERT(cInterval || cache.getCacheIOPolicy() == iir::Cache::local);
+          DAWN_ASSERT(cInterval || cache.getCacheIOPolicy() == iir::Cache::local);
 
           std::string intervalName;
-         if(cInterval) {
+          if(cInterval) {
             DAWN_ASSERT(intervalDefinitions.intervalProperties_.count(*(cInterval)));
             intervalName = intervalDefinitions.intervalProperties_.find(*cInterval)->name_;
           }
@@ -971,7 +974,7 @@ std::unique_ptr<TranslationUnit> GTCodeGen::generateCode() {
 
   std::string filename = generateFileName(context_);
   return std::make_unique<TranslationUnit>(filename, std::move(ppDefines), std::move(stencils),
-                                      std::move(globals));
+                                           std::move(globals));
 }
 
 std::vector<std::string> GTCodeGen::buildFieldTemplateNames(


### PR DESCRIPTION
## Technical Description

This PR adds start and pause instructions to the GT-Backend

### Resolves / Enhances

Resolves the fact that we currently do not  have daily profiling of the GT-Backend

### Dependencies

This PR is independent


