### PR TITLE
Refactor sir::Value using std::variant

### DIFF
--- a/dawn/src/dawn/SIR/SIR.cpp
+++ b/dawn/src/dawn/SIR/SIR.cpp
@@ -629,6 +629,22 @@ BuiltinTypeID sir::Value::typeToBuiltinTypeID(sir::Value::TypeKind type) {
   }
 }
 
+std::string sir::Value::toString() const {
+  DAWN_ASSERT(has_value());
+  switch(type_) {
+  case Boolean:
+    return std::get<bool>(*value_) ? "true" : "false";
+  case Integer:
+    return std::to_string(std::get<int>(*value_));
+  case Double:
+    return std::to_string(std::get<double>(*value_));
+  case String:
+    return std::get<std::string>(*value_);
+  default:
+    dawn_unreachable("invalid type");
+  }
+}
+
 std::shared_ptr<sir::VerticalRegion> sir::VerticalRegion::clone() const {
   return std::make_shared<sir::VerticalRegion>(Ast->clone(), VerticalInterval, LoopOrder, Loc);
 }

--- a/dawn/src/dawn/SIR/SIR.cpp
+++ b/dawn/src/dawn/SIR/SIR.cpp
@@ -616,23 +616,6 @@ const char* sir::Value::typeToString(sir::Value::TypeKind type) {
   dawn_unreachable("invalid type");
 }
 
-sir::Value::Value(TypeKind type) : isConstexpr_(false) {
-  switch(type) {
-  case Boolean:
-    valueImpl_ = std::make_unique<ValueImpl<std::decay_t<bool>>>(false);
-    break;
-  case Integer:
-    valueImpl_ = std::make_unique<ValueImpl<std::decay_t<int>>>(0);
-    break;
-  case Double:
-    valueImpl_ = std::make_unique<ValueImpl<std::decay_t<double>>>(0.0);
-    break;
-  case String:
-    valueImpl_ = std::make_unique<ValueImpl<std::decay_t<std::string>>>("");
-    break;
-  }
-}
-
 BuiltinTypeID sir::Value::typeToBuiltinTypeID(sir::Value::TypeKind type) {
   switch(type) {
   case Boolean:
@@ -644,27 +627,6 @@ BuiltinTypeID sir::Value::typeToBuiltinTypeID(sir::Value::TypeKind type) {
   default:
     dawn_unreachable("invalid type");
   }
-}
-
-std::string sir::Value::toString() const {
-  std::stringstream ss;
-  switch(valueImpl_->getType()) {
-  case Boolean:
-    ss << (getValue<bool>() ? "true" : "false");
-    break;
-  case Integer:
-    ss << getValue<int>();
-    break;
-  case Double:
-    ss << getValue<double>();
-    break;
-  case String:
-    ss << "\"" << getValue<std::string>() << "\"";
-    break;
-  default:
-    dawn_unreachable("invalid type");
-  }
-  return ss.str();
 }
 
 std::shared_ptr<sir::VerticalRegion> sir::VerticalRegion::clone() const {

--- a/dawn/src/dawn/SIR/SIR.h
+++ b/dawn/src/dawn/SIR/SIR.h
@@ -279,16 +279,26 @@ struct Stencil : public dawn::NonCopyable {
 ///
 /// @ingroup sir
 
-struct Value : NonCopyable {
+class Value : NonCopyable {
+public:
   enum TypeKind { Boolean = 0, Integer, Double, String };
 
+private:
+  template <typename T>
+  struct TypeInfo {};
+
+  std::optional<std::variant<bool, int, double, std::string>> value_;
+  bool is_constexpr_;
+  TypeKind type_;
+
+public:
   template <class T>
   explicit Value(T&& value)
       : value_{std::forward<T>(value)}, is_constexpr_{false}, type_{TypeInfo<T>::Type} {}
 
   template <class T>
   explicit Value(T value, bool is_constexpr)
-      : value_{value}, is_constexpr_{is_constexpr}, type_{TypeInfo<T>::Type} {}
+      : value_{std::forward<T>(value)}, is_constexpr_{is_constexpr}, type_{TypeInfo<T>::Type} {}
 
   explicit Value(TypeKind type) : value_{}, is_constexpr_{false}, type_{type} {}
 
@@ -329,14 +339,6 @@ struct Value : NonCopyable {
     valueJson["value"] = toString();
     return valueJson;
   }
-
-  template <typename T>
-  struct TypeInfo {};
-
-private:
-  std::optional<std::variant<bool, int, double, std::string>> value_;
-  bool is_constexpr_;
-  TypeKind type_;
 };
 
 template <>

--- a/dawn/src/dawn/SIR/SIR.h
+++ b/dawn/src/dawn/SIR/SIR.h
@@ -25,11 +25,11 @@
 #include "dawn/Support/Type.h"
 #include <iosfwd>
 #include <memory>
+#include <optional>
 #include <string>
 #include <unordered_map>
-#include <vector>
 #include <variant>
-#include <optional>
+#include <vector>
 
 namespace dawn {
 
@@ -284,11 +284,11 @@ struct Value : NonCopyable {
 
   template <class T>
   explicit Value(T&& value)
-    : value_{value}, is_constexpr_{false}, type_{TypeInfo<T>::Type} {}
+      : value_{std::forward<T>(value)}, is_constexpr_{false}, type_{TypeInfo<T>::Type} {}
 
   template <class T>
   explicit Value(T value, bool is_constexpr)
-    : value_{value}, is_constexpr_{is_constexpr}, type_{TypeInfo<T>::Type} {}
+      : value_{value}, is_constexpr_{is_constexpr}, type_{TypeInfo<T>::Type} {}
 
   explicit Value(TypeKind type) : value_{}, is_constexpr_{false}, type_{type} {}
 
@@ -302,7 +302,7 @@ struct Value : NonCopyable {
   static BuiltinTypeID typeToBuiltinTypeID(TypeKind type);
 
   /// Convert the value to string
-  std::string toString() const { return std::string{typeToString(type_)}; }
+  std::string toString() const { return typeToString(type_); }
 
   /// @brief Check if value is set
   bool has_value() const { return value_.has_value(); }
@@ -330,7 +330,8 @@ struct Value : NonCopyable {
     return valueJson;
   }
 
-  template <typename T> struct TypeInfo {};
+  template <typename T>
+  struct TypeInfo {};
 
 private:
   std::optional<std::variant<bool, int, double, std::string>> value_;
@@ -338,20 +339,24 @@ private:
   TypeKind type_;
 };
 
-template <> struct Value::TypeInfo<bool> {
- static const TypeKind Type = Boolean;
+template <>
+struct Value::TypeInfo<bool> {
+  static constexpr TypeKind Type = Boolean;
 };
 
-template <> struct Value::TypeInfo<int> {
-  static const TypeKind Type = Integer;
+template <>
+struct Value::TypeInfo<int> {
+  static constexpr TypeKind Type = Integer;
 };
 
-template <> struct Value::TypeInfo<double> {
-  static const TypeKind Type = Double;
+template <>
+struct Value::TypeInfo<double> {
+  static constexpr TypeKind Type = Double;
 };
 
-template <> struct Value::TypeInfo<std::string> {
-  static const TypeKind Type = String;
+template <>
+struct Value::TypeInfo<std::string> {
+  static constexpr TypeKind Type = String;
 };
 
 using GlobalVariableMap = std::unordered_map<std::string, std::shared_ptr<Value>>;

--- a/dawn/src/dawn/SIR/SIR.h
+++ b/dawn/src/dawn/SIR/SIR.h
@@ -28,6 +28,8 @@
 #include <string>
 #include <unordered_map>
 #include <vector>
+#include <variant>
+#include <optional>
 
 namespace dawn {
 
@@ -272,8 +274,8 @@ struct Stencil : public dawn::NonCopyable {
 
 /// @brief Representation of a value of a global variable
 ///
-/// This is a very primitive (i.e non-copyable) version of boost::any. Further, the possible
-/// values are restricted to `bool`, `int`, `double` or `std::string`.
+/// This is a very primitive (i.e non-copyable, immutable) version of boost::any.
+/// Further, the possible values are restricted to `bool`, `int`, `double` or `std::string`.
 ///
 /// @ingroup sir
 
@@ -281,19 +283,17 @@ struct Value : NonCopyable {
   enum TypeKind { Boolean = 0, Integer, Double, String };
 
   template <class T>
-  explicit Value(T&& value) : isConstexpr_(false) {
-    valueImpl_ = std::make_unique<ValueImpl<std::decay_t<T>>>(std::forward<T>(value));
-  }
+  explicit Value(T&& value)
+    : value_{value}, is_constexpr_{false}, type_{TypeInfo<T>::Type} {}
 
   template <class T>
-  explicit Value(T value, bool isConstexpr) : isConstexpr_(isConstexpr) {
-    valueImpl_ = std::make_unique<ValueImpl<std::decay_t<T>>>(std::forward<T>(value));
-  }
+  explicit Value(T value, bool is_constexpr)
+    : value_{value}, is_constexpr_{is_constexpr}, type_{TypeInfo<T>::Type} {}
 
-  explicit Value(TypeKind type);
+  explicit Value(TypeKind type) : value_{}, is_constexpr_{false}, type_{type} {}
 
   /// @brief Get/Set if the variable is `constexpr`
-  bool isConstexpr() const { return isConstexpr_; }
+  bool isConstexpr() const { return is_constexpr_; }
 
   /// @brief `TypeKind` to string
   static const char* typeToString(TypeKind type);
@@ -302,89 +302,59 @@ struct Value : NonCopyable {
   static BuiltinTypeID typeToBuiltinTypeID(TypeKind type);
 
   /// Convert the value to string
-  std::string toString() const;
+  std::string toString() const { return std::string{typeToString(type_)}; }
 
   /// @brief Check if value is set
-  bool has_value() const { return valueImpl_->has_value(); }
+  bool has_value() const { return value_.has_value(); }
 
   /// @brief Get/Set the underlying type
-  TypeKind getType() const { return valueImpl_->getType(); }
+  TypeKind getType() const { return type_; }
 
   /// @brief Get the value as type `T`
   /// @returns Copy of the value
   template <class T>
   T getValue() const {
     DAWN_ASSERT(has_value());
-    DAWN_ASSERT_MSG(TypeInfo<T>::Type == valueImpl_->getType(), "type mismatch");
-    return *(T*)valueImpl_->get();
+    DAWN_ASSERT_MSG(getType() == TypeInfo<T>::Type, "type mismatch");
+    return std::get<T>(*value_);
   }
-
-  template <class T>
-  struct TypeInfo {
-    static const TypeKind Type;
-  };
 
   bool operator==(const Value& rhs) const;
   CompareResult comparison(const sir::Value& rhs) const;
 
   json::json jsonDump() const {
     json::json valueJson;
-    valueJson["type"] = Value::typeToString(valueImpl_->getType());
+    valueJson["type"] = Value::typeToString(getType());
     valueJson["isConstexpr"] = isConstexpr();
     valueJson["value"] = toString();
     return valueJson;
   }
 
+  template <typename T> struct TypeInfo {};
+
 private:
-  struct ValueImplBase {
-    virtual ~ValueImplBase() {}
-    virtual void* get() = 0;
-    virtual TypeKind getType() const = 0;
-    virtual bool has_value() const = 0;
-  };
-
-  template <class T>
-  struct ValueImpl : public ValueImplBase {
-    T* ValuePtr;
-
-    ValueImpl() : ValuePtr(nullptr) {}
-    ValueImpl(const T& value) : ValuePtr(new T) { *ValuePtr = value; }
-    ~ValueImpl() {
-      if(ValuePtr)
-        delete ValuePtr;
-    }
-    void* get() override { return (void*)ValuePtr; }
-    TypeKind getType() const override { return TypeInfo<T>::Type; }
-    bool has_value() const override { return ValuePtr != nullptr; }
-  };
-
-  bool isConstexpr_;
-  std::unique_ptr<ValueImplBase> valueImpl_;
+  std::optional<std::variant<bool, int, double, std::string>> value_;
+  bool is_constexpr_;
+  TypeKind type_;
 };
 
-template <>
-struct Value::TypeInfo<bool> {
-  static const Value::TypeKind Type = Value::Boolean;
+template <> struct Value::TypeInfo<bool> {
+ static const TypeKind Type = Boolean;
 };
 
-template <>
-struct Value::TypeInfo<int> {
-  static const Value::TypeKind Type = Value::Integer;
+template <> struct Value::TypeInfo<int> {
+  static const TypeKind Type = Integer;
 };
 
-template <>
-struct Value::TypeInfo<double> {
-  static const Value::TypeKind Type = Value::Double;
+template <> struct Value::TypeInfo<double> {
+  static const TypeKind Type = Double;
 };
 
-template <>
-struct Value::TypeInfo<std::string> {
-  static const Value::TypeKind Type = Value::String;
+template <> struct Value::TypeInfo<std::string> {
+  static const TypeKind Type = String;
 };
 
-/// @brief Representation of the global variable map (key/value pair)
-/// @ingroup sir
-using GlobalVariableMap = std::unordered_map<std::string, std::shared_ptr<sir::Value>>;
+using GlobalVariableMap = std::unordered_map<std::string, std::shared_ptr<Value>>;
 
 } // namespace sir
 

--- a/dawn/src/dawn/SIR/SIR.h
+++ b/dawn/src/dawn/SIR/SIR.h
@@ -282,23 +282,18 @@ struct Stencil : public dawn::NonCopyable {
 class Value : NonCopyable {
 public:
   enum TypeKind { Boolean = 0, Integer, Double, String };
-
-private:
   template <typename T>
-  struct TypeInfo {};
+  struct TypeInfo;
 
-  std::optional<std::variant<bool, int, double, std::string>> value_;
-  bool is_constexpr_;
-  TypeKind type_;
-
-public:
   template <class T>
   explicit Value(T&& value)
-      : value_{std::forward<T>(value)}, is_constexpr_{false}, type_{TypeInfo<T>::Type} {}
+      : value_{std::forward<T>(value)},
+        is_constexpr_{false}, type_{TypeInfo<std::decay_t<T>>::Type} {}
 
   template <class T>
   explicit Value(T value, bool is_constexpr)
-      : value_{std::forward<T>(value)}, is_constexpr_{is_constexpr}, type_{TypeInfo<T>::Type} {}
+      : value_{std::forward<T>(value)},
+        is_constexpr_{is_constexpr}, type_{TypeInfo<std::decay_t<T>>::Type} {}
 
   explicit Value(TypeKind type) : value_{}, is_constexpr_{false}, type_{type} {}
 
@@ -312,7 +307,7 @@ public:
   static BuiltinTypeID typeToBuiltinTypeID(TypeKind type);
 
   /// Convert the value to string
-  std::string toString() const { return typeToString(type_); }
+  std::string toString() const;
 
   /// @brief Check if value is set
   bool has_value() const { return value_.has_value(); }
@@ -339,6 +334,11 @@ public:
     valueJson["value"] = toString();
     return valueJson;
   }
+
+private:
+  std::optional<std::variant<bool, int, double, std::string>> value_;
+  bool is_constexpr_;
+  TypeKind type_;
 };
 
 template <>


### PR DESCRIPTION
This removes the custom sir::Value in favor of using the std::variant container. Fixes #293.