### PR TITLE
Add check_modularization script

### DIFF
--- a/dawn/scripts/check_modularization/check_modularization.sh
+++ b/dawn/scripts/check_modularization/check_modularization.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+# no_dependency "<of_module>" "<on_module>"
+# checks that <of_module> does not depend on <on_module>
+# i.e. <of_module> does not include any file from <on_module>
+function no_dependency() {
+    last_result=`grep -rE "#include .*$2/.*(hpp|h)" src/dawn/$1 | wc -l`
+    if [ "$last_result" -gt 0 ]; then
+        echo "ERROR Modularization violated: found dependency of $1 on $2"
+        echo "`grep -rE "#include .*$2/.*(hpp|h)" src/dawn/$1`"
+    fi
+    modularization_result=$(( modularization_result || last_result ))
+}
+
+function are_independent() {
+    no_dependency "$1" "$2"
+    no_dependency "$2" "$1"
+}
+modularization_result=0
+
+# # list of non-dependencies
+no_dependency "Support" "SIR"
+no_dependency "Support" "IIR"
+no_dependency "Support" "CodeGen"
+no_dependency "Support" "Serialization"
+no_dependency "Support" "Optimizer"
+no_dependency "Support" "Compiler"
+
+no_dependency "SIR" "IIR"
+no_dependency "SIR" "Optimizer"
+no_dependency "SIR" "Compiler"
+no_dependency "SIR" "Serialization"
+no_dependency "SIR" "CodeGen"
+
+no_dependency "IIR" "Optimizer"
+no_dependency "IIR" "Compiler"
+no_dependency "IIR" "Serialization"
+no_dependency "IIR" "CodeGen"
+
+no_dependency "Serialization" "Compiler"
+no_dependency "Optimizer" "Compiler"
+no_dependency "CodeGen" "Compiler"
+
+are_independent "Serialization" "Optimizer"
+are_independent "Optimizer" "CodeGen"
+are_independent "Optimizer" "CodeGen"
+
+exit $modularization_result

--- a/scripts/git_hooks/check_modularization
+++ b/scripts/git_hooks/check_modularization
@@ -4,10 +4,10 @@
 # checks that <of_module> does not depend on <on_module>
 # i.e. <of_module> does not include any file from <on_module>
 function no_dependency() {
-    last_result=`grep -rE "#include .*$2/.*(hpp|h)" src/dawn/$1 | wc -l`
+    last_result=`grep -rE "#include .*$2/.*(hpp|h)" dawn/src/dawn/$1 | wc -l`
     if [ "$last_result" -gt 0 ]; then
         echo "ERROR Modularization violated: found dependency of $1 on $2"
-        echo "`grep -rE "#include .*$2/.*(hpp|h)" src/dawn/$1`"
+        echo "`grep -rE "#include .*$2/.*(hpp|h)" dawn/src/dawn/$1`"
     fi
     modularization_result=$(( modularization_result || last_result ))
 }
@@ -20,13 +20,20 @@ modularization_result=0
 
 # # list of non-dependencies
 no_dependency "Support" "SIR"
+no_dependency "Support" "AST"
 no_dependency "Support" "IIR"
 no_dependency "Support" "CodeGen"
 no_dependency "Support" "Serialization"
 no_dependency "Support" "Optimizer"
 no_dependency "Support" "Compiler"
 
-no_dependency "SIR" "IIR"
+no_dependency "AST" "IIR"
+#no_dependency "AST" "SIR"
+no_dependency "AST" "Optimizer"
+no_dependency "AST" "Compiler"
+no_dependency "AST" "Serialization"
+no_dependency "AST" "CodeGen"
+
 no_dependency "SIR" "Optimizer"
 no_dependency "SIR" "Compiler"
 no_dependency "SIR" "Serialization"
@@ -43,6 +50,7 @@ no_dependency "CodeGen" "Compiler"
 
 are_independent "Serialization" "Optimizer"
 are_independent "Optimizer" "CodeGen"
-are_independent "Optimizer" "CodeGen"
+#are_independent "SIR" "IIR"
+#are_independent "SIR" "CodeGen"
 
 exit $modularization_result

--- a/scripts/git_hooks/pre-commit
+++ b/scripts/git_hooks/pre-commit
@@ -19,7 +19,7 @@ SCRIPTPATH=`dirname $SCRIPT`
 ##################################################################
 # SETTINGS
 # set path to clang-format binary
-CLANG_FORMAT=`which clang-format`
+CLANG_FORMAT=`which clang-format-6`
 
 ## parsing the clang format version from an output like
 ## Ubuntu clang-format version 3.7.1-2ubuntu2
@@ -161,6 +161,9 @@ else
 
     error_code=$((error_code || 1 ))
 fi
+
+${SCRIPTPATH}/check_modularization
+modularization_result=$?
 
 # exit if errors
 error_code=$((error_code || modularization_result ))

--- a/scripts/git_hooks/pre-commit
+++ b/scripts/git_hooks/pre-commit
@@ -19,7 +19,7 @@ SCRIPTPATH=`dirname $SCRIPT`
 ##################################################################
 # SETTINGS
 # set path to clang-format binary
-CLANG_FORMAT=`which clang-format-6`
+CLANG_FORMAT=`which clang-format`
 
 ## parsing the clang format version from an output like
 ## Ubuntu clang-format version 3.7.1-2ubuntu2


### PR DESCRIPTION
## Technical Description

Adds the `check_modularization.sh`-script from GridTools. Complains if we have unexpected dependencies between the modules defined in #238



