### PR TITLE
Support for clang 9

### DIFF
--- a/gtclang/src/gtclang/Support/ASTUtils.h
+++ b/gtclang/src/gtclang/Support/ASTUtils.h
@@ -17,6 +17,7 @@
 #include <string>
 #include <type_traits>
 
+#include "gtclang/Support/ClangCompat/ImplicitNodes.h"
 #include "clang/AST/ASTFwd.h"
 
 namespace gtclang {
@@ -34,11 +35,8 @@ extern std::string getClassNameFromConstructExpr(clang::CXXConstructExpr* expr);
 /// @param expr               clang stmt
 ///
 /// @ingroup support
-template <typename T>
-typename std::enable_if<std::is_base_of<clang::Stmt, typename std::decay<T>::type>::value, T*>::type
-skipAllImplicitNodes(T* e) {
-  while(e != e->IgnoreImplicit())
-    e = e->IgnoreImplicit();
-  return e;
+template <typename StmtT>
+StmtT* skipAllImplicitNodes(StmtT* s) {
+  return clang_compat::skipAllImplicitNodes(s);
 }
 } // namespace gtclang

--- a/gtclang/src/gtclang/Support/ClangCompat/ImplicitNodes.h
+++ b/gtclang/src/gtclang/Support/ClangCompat/ImplicitNodes.h
@@ -1,0 +1,54 @@
+//===--------------------------------------------------------------------------------*- C++ -*-===//
+//                         _       _
+//                        | |     | |
+//                    __ _| |_ ___| | __ _ _ __   __ _
+//                   / _` | __/ __| |/ _` | '_ \ / _` |
+//                  | (_| | || (__| | (_| | | | | (_| |
+//                   \__, |\__\___|_|\__,_|_| |_|\__, | - GridTools Clang DSL
+//                    __/ |                       __/ |
+//                   |___/                       |___/
+//
+//
+//  This file is distributed under the MIT License (MIT).
+//  See LICENSE.txt for details.
+//
+//===------------------------------------------------------------------------------------------===//
+
+#ifndef GTCLANG_SUPPORT_CLANGCOMPAT_IMPLICIT_NODES_H
+#define GTCLANG_SUPPORT_CLANGCOMPAT_IMPLICIT_NODES_H
+
+#include "clang/AST/Expr.h"
+#include "clang/Basic/Version.h"
+
+// TODO skipAllImplicitNodes should be refactored to be only called for Exprs (not Stmts)
+// to reflect the change in clang 9
+
+namespace gtclang {
+namespace clang_compat {
+
+#if CLANG_VERSION_MAJOR < 9
+template <typename StmtT>
+typename std::enable_if<std::is_base_of<clang::Stmt, typename std::decay<StmtT>::type>::value,
+                        StmtT*>::type
+skipAllImplicitNodes(StmtT* e) {
+  while(e != e->IgnoreImplicit())
+    e = e->IgnoreImplicit();
+  return e;
+}
+#else
+template <typename StmtT>
+typename std::enable_if<std::is_base_of<clang::Stmt, typename std::decay<StmtT>::type>::value,
+                        StmtT*>::type
+skipAllImplicitNodes(StmtT* s) {
+  if(auto* e = llvm::dyn_cast_or_null<clang::Expr>(s)) {
+    while(e != e->IgnoreImplicit())
+      e = e->IgnoreImplicit();
+    return e;
+  }
+  return s;
+}
+#endif
+} // namespace clang_compat
+} // namespace gtclang
+
+#endif // GTCLANG_SUPPORT_CLANGCOMPAT_IMPLICIT_NODES_H


### PR DESCRIPTION
## Technical Description

Support for clang 9.
`skipImplicitNodes()` is moved from Stmt down to Expr.