### PR TITLE
Fix format all

### DIFF
--- a/dawn/prototype/mylibDriver.cpp
+++ b/dawn/prototype/mylibDriver.cpp
@@ -1,6 +1,6 @@
+#include "mylib_interface.hpp"
 #include <fstream>
 #include <gridtools/clang_dsl.hpp>
-#include "mylib_interface.hpp"
 using namespace mylibInterface;
 
 #include "generated.hpp"

--- a/dawn/src/dawn/IIR/AccessUtils.h
+++ b/dawn/src/dawn/IIR/AccessUtils.h
@@ -32,8 +32,7 @@ void recordWriteAccess(std::unordered_map<int, iir::Field>& inputOutputFields,
                        std::unordered_map<int, iir::Field>& outputFields, int AccessID,
                        const std::optional<iir::Extents>& extents,
                        iir::Interval const& doMethodInterval,
-                       ast::Expr::LocationType location = ast::Expr::LocationType::Cells
-                       );
+                       ast::Expr::LocationType location = ast::Expr::LocationType::Cells);
 
 /// @brief given a read access, with AccessID, it will recorded in the corresponding map of input,
 /// output or inputOutput

--- a/scripts/clang_format_all.sh
+++ b/scripts/clang_format_all.sh
@@ -17,6 +17,6 @@ if [[ "${CLANG_FORMAT_VERSION}" != "6.0" ]]; then
 fi
 
 file_list=$(find . -regextype posix-egrep -regex ".*\.(hpp|cpp|h|cu)$")
-for file in $(grep -v ${arg_list[@]} <<< $file_list); do
+for file in $(echo "$file_list" | grep -v ${arg_list[@]}); do
     $CLANG_FORMAT -style=file -i $file
 done

--- a/scripts/ignore_list.sh
+++ b/scripts/ignore_list.sh
@@ -4,5 +4,5 @@ ignore=(
     "^\./dawn/src/dawn/Support/External/"
     "^\./dawn/examples/python/data/"
     "^\./gtclang/test/utils/googletest/"
-    "^\./bundle/"
+    "/bundle/"
     )


### PR DESCRIPTION
## Technical Description

Fixes the format-all script

### Example

`./scripts/clang_format_all.sh`

### Dependencies

This PR is independent


