### PR TITLE
SAP-refactoring: remove hard-coded ID for ast in DoMethod

### DIFF
--- a/dawn/examples/python/data/copy_stencil_ref.cpp
+++ b/dawn/examples/python/data/copy_stencil_ref.cpp
@@ -1,6 +1,6 @@
 namespace dawn_generated{
 namespace cuda{
-__global__ void __launch_bounds__(32)  copy_stencil_stencil11_ms22_kernel(const int isize, const int jsize, const int ksize, const int stride_111_1, const int stride_111_2, gridtools::clang::float_type * const in, gridtools::clang::float_type * const out) {
+__global__ void __launch_bounds__(32)  copy_stencil_stencil11_ms23_kernel(const int isize, const int jsize, const int ksize, const int stride_111_1, const int stride_111_2, gridtools::clang::float_type * const in, gridtools::clang::float_type * const out) {
 
   // Start kernel
   const unsigned int nx = isize;
@@ -101,7 +101,7 @@ public:
       const unsigned int nby = (ny + 1 - 1) / 1;
       const unsigned int nbz = (m_dom.ksize()+4-1) / 4;
       dim3 blocks(nbx, nby, nbz);
-      copy_stencil_stencil11_ms22_kernel<<<blocks, threads>>>(nx,ny,nz,in_ds.strides()[1],in_ds.strides()[2],(in.data()+in_ds.get_storage_info_ptr()->index(in.begin<0>(), in.begin<1>(),0 )),(out.data()+out_ds.get_storage_info_ptr()->index(out.begin<0>(), out.begin<1>(),0 )));
+      copy_stencil_stencil11_ms23_kernel<<<blocks, threads>>>(nx,ny,nz,in_ds.strides()[1],in_ds.strides()[2],(in.data()+in_ds.get_storage_info_ptr()->index(in.begin<0>(), in.begin<1>(),0 )),(out.data()+out_ds.get_storage_info_ptr()->index(out.begin<0>(), out.begin<1>(),0 )));
       };
 
       // stopping timers

--- a/dawn/examples/python/data/hori_diff_ref.cpp
+++ b/dawn/examples/python/data/hori_diff_ref.cpp
@@ -1,6 +1,6 @@
 namespace dawn_generated{
 namespace cuda{
-__global__ void __launch_bounds__(256)  hori_diff_stencil41_ms84_kernel(const int isize, const int jsize, const int ksize, const int stride_111_1, const int stride_111_2, gridtools::clang::float_type * const in, gridtools::clang::float_type * const out, gridtools::clang::float_type * const coeff) {
+__global__ void __launch_bounds__(256)  hori_diff_stencil41_ms87_kernel(const int isize, const int jsize, const int ksize, const int stride_111_1, const int stride_111_2, gridtools::clang::float_type * const in, gridtools::clang::float_type * const out, gridtools::clang::float_type * const coeff) {
 
   // Start kernel
   __shared__ gridtools::clang::float_type lap_ijcache[34*6];
@@ -118,7 +118,7 @@ public:
       const unsigned int nby = (ny + 4 - 1) / 4;
       const unsigned int nbz = (m_dom.ksize()+4-1) / 4;
       dim3 blocks(nbx, nby, nbz);
-      hori_diff_stencil41_ms84_kernel<<<blocks, threads>>>(nx,ny,nz,in_ds.strides()[1],in_ds.strides()[2],(in.data()+in_ds.get_storage_info_ptr()->index(in.begin<0>(), in.begin<1>(),0 )),(out.data()+out_ds.get_storage_info_ptr()->index(out.begin<0>(), out.begin<1>(),0 )),(coeff.data()+coeff_ds.get_storage_info_ptr()->index(coeff.begin<0>(), coeff.begin<1>(),0 )));
+      hori_diff_stencil41_ms87_kernel<<<blocks, threads>>>(nx,ny,nz,in_ds.strides()[1],in_ds.strides()[2],(in.data()+in_ds.get_storage_info_ptr()->index(in.begin<0>(), in.begin<1>(),0 )),(out.data()+out_ds.get_storage_info_ptr()->index(out.begin<0>(), out.begin<1>(),0 )),(coeff.data()+coeff_ds.get_storage_info_ptr()->index(coeff.begin<0>(), coeff.begin<1>(),0 )));
       };
 
       // stopping timers

--- a/dawn/examples/python/data/tridiagonal_solve_ref.cpp
+++ b/dawn/examples/python/data/tridiagonal_solve_ref.cpp
@@ -1,6 +1,6 @@
 namespace dawn_generated{
 namespace cuda{
-__global__ void __launch_bounds__(32)  tridiagonal_solve_stencil49_ms102_kernel(const int isize, const int jsize, const int ksize, const int stride_111_1, const int stride_111_2, gridtools::clang::float_type * const a, gridtools::clang::float_type * const b, gridtools::clang::float_type * const c, gridtools::clang::float_type * const d) {
+__global__ void __launch_bounds__(32)  tridiagonal_solve_stencil49_ms105_kernel(const int isize, const int jsize, const int ksize, const int stride_111_1, const int stride_111_2, gridtools::clang::float_type * const a, gridtools::clang::float_type * const b, gridtools::clang::float_type * const c, gridtools::clang::float_type * const d) {
 
   // Start kernel
   gridtools::clang::float_type c_kcache[2];
@@ -84,9 +84,9 @@ if(iblock >= 0 && iblock <= block_size_i -1 + 0 && jblock >= 0 && jblock <= bloc
       c_kcache[1] =c[idx111];
       d_kcache[1] =d[idx111];
   }  if(iblock >= 0 && iblock <= block_size_i -1 + 0 && jblock >= 0 && jblock <= block_size_j -1 + 0) {
-int __local_m_98 = ((gridtools::clang::float_type) 1.0 / (__ldg(&(b[idx111])) - (__ldg(&(a[idx111])) * c_kcache[0])));
-c_kcache[1] = (c_kcache[1] * __local_m_98);
-d_kcache[1] = ((d_kcache[1] - (__ldg(&(a[idx111])) * d_kcache[0])) * __local_m_98);
+int __local_m_100 = ((gridtools::clang::float_type) 1.0 / (__ldg(&(b[idx111])) - (__ldg(&(a[idx111])) * c_kcache[0])));
+c_kcache[1] = (c_kcache[1] * __local_m_100);
+d_kcache[1] = ((d_kcache[1] - (__ldg(&(a[idx111])) * d_kcache[0])) * __local_m_100);
   }
     // Flush of kcaches
 
@@ -113,7 +113,7 @@ if(iblock >= 0 && iblock <= block_size_i -1 + 0 && jblock >= 0 && jblock <= bloc
 
   // Final flush of kcaches
 }
-__global__ void __launch_bounds__(32)  tridiagonal_solve_stencil49_ms103_kernel(const int isize, const int jsize, const int ksize, const int stride_111_1, const int stride_111_2, gridtools::clang::float_type * const c, gridtools::clang::float_type * const d) {
+__global__ void __launch_bounds__(32)  tridiagonal_solve_stencil49_ms106_kernel(const int isize, const int jsize, const int ksize, const int stride_111_1, const int stride_111_2, gridtools::clang::float_type * const c, gridtools::clang::float_type * const d) {
 
   // Start kernel
   gridtools::clang::float_type d_kcache[2];
@@ -240,7 +240,7 @@ public:
       const unsigned int nby = (ny + 1 - 1) / 1;
       const unsigned int nbz = 1;
       dim3 blocks(nbx, nby, nbz);
-      tridiagonal_solve_stencil49_ms102_kernel<<<blocks, threads>>>(nx,ny,nz,a_ds.strides()[1],a_ds.strides()[2],(a.data()+a_ds.get_storage_info_ptr()->index(a.begin<0>(), a.begin<1>(),0 )),(b.data()+b_ds.get_storage_info_ptr()->index(b.begin<0>(), b.begin<1>(),0 )),(c.data()+c_ds.get_storage_info_ptr()->index(c.begin<0>(), c.begin<1>(),0 )),(d.data()+d_ds.get_storage_info_ptr()->index(d.begin<0>(), d.begin<1>(),0 )));
+      tridiagonal_solve_stencil49_ms105_kernel<<<blocks, threads>>>(nx,ny,nz,a_ds.strides()[1],a_ds.strides()[2],(a.data()+a_ds.get_storage_info_ptr()->index(a.begin<0>(), a.begin<1>(),0 )),(b.data()+b_ds.get_storage_info_ptr()->index(b.begin<0>(), b.begin<1>(),0 )),(c.data()+c_ds.get_storage_info_ptr()->index(c.begin<0>(), c.begin<1>(),0 )),(d.data()+d_ds.get_storage_info_ptr()->index(d.begin<0>(), d.begin<1>(),0 )));
       };
       {;
       gridtools::data_view<storage_ijk_t> c= gridtools::make_device_view(c_ds);
@@ -253,7 +253,7 @@ public:
       const unsigned int nby = (ny + 1 - 1) / 1;
       const unsigned int nbz = 1;
       dim3 blocks(nbx, nby, nbz);
-      tridiagonal_solve_stencil49_ms103_kernel<<<blocks, threads>>>(nx,ny,nz,c_ds.strides()[1],c_ds.strides()[2],(c.data()+c_ds.get_storage_info_ptr()->index(c.begin<0>(), c.begin<1>(),0 )),(d.data()+d_ds.get_storage_info_ptr()->index(d.begin<0>(), d.begin<1>(),0 )));
+      tridiagonal_solve_stencil49_ms106_kernel<<<blocks, threads>>>(nx,ny,nz,c_ds.strides()[1],c_ds.strides()[2],(c.data()+c_ds.get_storage_info_ptr()->index(c.begin<0>(), c.begin<1>(),0 )),(d.data()+d_ds.get_storage_info_ptr()->index(d.begin<0>(), d.begin<1>(),0 )));
       };
 
       // stopping timers

--- a/dawn/src/dawn/AST/ASTStmt.h
+++ b/dawn/src/dawn/AST/ASTStmt.h
@@ -67,9 +67,6 @@ public:
   Stmt(std::unique_ptr<StmtData> data, StmtKind kind, SourceLocation loc = SourceLocation())
       : kind_(kind), loc_(loc), statementID_(UIDGenerator::getInstance()->get()),
         data_(std::move(data)) {}
-  Stmt(int id, std::unique_ptr<StmtData> data, StmtKind kind, SourceLocation loc = SourceLocation())
-      : kind_(kind), loc_(loc), statementID_(id), data_(std::move(data)) {
-  } // TODO(SAP) remove after cleaning init of DoMethod::ast_
   Stmt(const Stmt& stmt)
       : std::enable_shared_from_this<Stmt>(stmt), kind_(stmt.getKind()),
         loc_(stmt.getSourceLocation()), statementID_(UIDGenerator::getInstance()->get()),
@@ -176,9 +173,6 @@ public:
   /// @name Constructor & Destructor
   /// @{
   BlockStmt(std::unique_ptr<StmtData> data, SourceLocation loc = SourceLocation());
-  BlockStmt(int id, std::unique_ptr<StmtData> data, SourceLocation loc = SourceLocation())
-      : Stmt(id, std::move(data), SK_BlockStmt, loc) {
-  } // TODO(SAP) remove after cleaning init of DoMethod::ast_
   BlockStmt(std::unique_ptr<StmtData> data, const std::vector<std::shared_ptr<Stmt>>& statements,
             SourceLocation loc = SourceLocation());
   BlockStmt(const BlockStmt& stmt);

--- a/dawn/src/dawn/IIR/ASTStmt.cpp
+++ b/dawn/src/dawn/IIR/ASTStmt.cpp
@@ -25,10 +25,6 @@ namespace iir {
 //     IIRStmtData
 //===------------------------------------------------------------------------------------------===//
 
-IIRStmtData::IIRStmtData(const IIRStmtData& other)
-    : StackTrace(other.StackTrace), CallerAccesses(other.CallerAccesses),
-      CalleeAccesses(other.CalleeAccesses) {}
-
 bool IIRStmtData::operator==(const IIRStmtData& rhs) const {
   return StackTrace == rhs.StackTrace && CallerAccesses == rhs.CallerAccesses &&
          CalleeAccesses == rhs.CalleeAccesses;

--- a/dawn/src/dawn/IIR/ASTStmt.h
+++ b/dawn/src/dawn/IIR/ASTStmt.h
@@ -32,9 +32,6 @@ struct Extents;
 struct IIRStmtData : public ast::StmtData {
   static const DataType ThisDataType = DataType::IIR_DATA_TYPE;
 
-  IIRStmtData() = default;
-  IIRStmtData(const IIRStmtData& other);
-
   bool operator==(const IIRStmtData&) const;
   bool operator!=(const IIRStmtData&) const;
 

--- a/dawn/src/dawn/IIR/DoMethod.cpp
+++ b/dawn/src/dawn/IIR/DoMethod.cpp
@@ -36,10 +36,8 @@ namespace dawn {
 namespace iir {
 
 DoMethod::DoMethod(Interval interval, const StencilMetaInformation& metaData)
-    : interval_(interval), id_(IndexGenerator::Instance().getIndex()), metaData_(metaData),
-      ast_{std::numeric_limits<int>::max(), // TODO(SAP) this number is here to keep IDs the same in
-                                            // tests. Will be removed in the next PR.
-           std::make_unique<iir::IIRStmtData>()} {}
+    : interval_(interval), id_(IndexGenerator::Instance().getIndex()),
+      metaData_(metaData), ast_{std::make_unique<iir::IIRStmtData>()} {}
 
 std::unique_ptr<DoMethod> DoMethod::clone() const {
   auto cloneMS = std::make_unique<DoMethod>(interval_, metaData_);

--- a/dawn/src/dawn/Optimizer/PassSetBoundaryCondition.cpp
+++ b/dawn/src/dawn/Optimizer/PassSetBoundaryCondition.cpp
@@ -276,10 +276,10 @@ bool PassSetBoundaryCondition::run(
         // condition. These calls are then replaced by {boundary_condition, stencil_call}
         AddBoundaryConditions visitor(stencilInstantiation, stencil.getStencilID());
 
-        for(std::shared_ptr<iir::Stmt>& stmt : controlFlow.getStatements()) {
+        for(std::shared_ptr<iir::Stmt>& controlFlowStmt : controlFlow.getStatements()) {
           visitor.reset();
 
-          stmt->accept(visitor);
+          controlFlowStmt->accept(visitor);
           std::vector<std::shared_ptr<iir::Stmt>> stencilCallWithBC_;
           stencilCallWithBC_.emplace_back(IDtoBCpair->second);
           for(auto& oldStencilCall : visitor.getStencilCallsToReplace()) {
@@ -287,13 +287,13 @@ bool PassSetBoundaryCondition::run(
             auto newBlockStmt = iir::makeBlockStmt();
             std::copy(stencilCallWithBC_.begin(), stencilCallWithBC_.end(),
                       std::back_inserter(newBlockStmt->getStatements()));
-            if(oldStencilCall == stmt) {
+            if(oldStencilCall == controlFlowStmt) {
               // Replace the the statement directly
               DAWN_ASSERT(visitor.getStencilCallsToReplace().size() == 1);
-              stmt = newBlockStmt;
+              controlFlowStmt = newBlockStmt;
             } else {
               // Recursively replace the statement
-              iir::replaceOldStmtWithNewStmtInStmt(stmt, oldStencilCall, newBlockStmt);
+              iir::replaceOldStmtWithNewStmtInStmt(controlFlowStmt, oldStencilCall, newBlockStmt);
             }
             stencilCallWithBC_.pop_back();
           }

--- a/dawn/src/dawn/Support/UIDGenerator.h
+++ b/dawn/src/dawn/Support/UIDGenerator.h
@@ -33,7 +33,7 @@ public:
   /// @brief Get a unique *strictly* positive identifer
   int get() { return (counter_++); }
 
-  void reset() { counter_ = 0; }
+  void reset() { counter_ = 1; }
 };
 
 } // namespace dawn

--- a/dawn/test/integration-test/RegenerateIIRMain.cpp
+++ b/dawn/test/integration-test/RegenerateIIRMain.cpp
@@ -27,11 +27,15 @@ int main(int argc, char* argv[]) {
   OptimizerContext optimizer(compiler.getDiagnostics(), optimizerOptions,
                              std::make_shared<dawn::SIR>());
 
-  auto copy_stencil = createCopyStencilIIRInMemory(optimizer);
-  UIDGenerator::getInstance()->reset();
-  IIRSerializer::serialize("reference_iir/copy_stencil.iir", copy_stencil, IIRSerializer::SK_Json);
-
-  auto lapl_stencil = createLapStencilIIRInMemory(optimizer);
-  UIDGenerator::getInstance()->reset();
-  IIRSerializer::serialize("reference_iir/lapl_stencil.iir", copy_stencil, IIRSerializer::SK_Json);
+  {
+    UIDGenerator::getInstance()->reset();
+    auto copy_stencil = createCopyStencilIIRInMemory(optimizer);
+    IIRSerializer::serialize("reference_iir/copy_stencil.iir", copy_stencil,
+                             IIRSerializer::SK_Json);
+  }
+  {
+    UIDGenerator::getInstance()->reset();
+    auto lap_stencil = createLapStencilIIRInMemory(optimizer);
+    IIRSerializer::serialize("reference_iir/lap_stencil.iir", lap_stencil, IIRSerializer::SK_Json);
+  }
 }

--- a/dawn/test/integration-test/TestIIRDeserializer.cpp
+++ b/dawn/test/integration-test/TestIIRDeserializer.cpp
@@ -211,7 +211,7 @@ void compareIIRs(std::shared_ptr<iir::StencilInstantiation> lhs,
   compareDerivedInformation(lhs->getIIR().get(), rhs->getIIR().get());
 }
 
-TEST(IIRDeserializerTestAgainst, CopyStencil) {
+TEST(IIRDeserializerTest, CopyStencil) {
   Options compileOptions;
   OptimizerContext::OptimizerContextOptions optimizerOptions;
   DawnCompiler compiler(&compileOptions);

--- a/dawn/test/integration-test/TestIIRDeserializer.cpp
+++ b/dawn/test/integration-test/TestIIRDeserializer.cpp
@@ -211,7 +211,7 @@ void compareIIRs(std::shared_ptr<iir::StencilInstantiation> lhs,
   compareDerivedInformation(lhs->getIIR().get(), rhs->getIIR().get());
 }
 
-TEST(IIRDeserializerTest, CopyStencil) {
+TEST(IIRDeserializerTestAgainst, CopyStencil) {
   Options compileOptions;
   OptimizerContext::OptimizerContextOptions optimizerOptions;
   DawnCompiler compiler(&compileOptions);
@@ -220,16 +220,15 @@ TEST(IIRDeserializerTest, CopyStencil) {
 
   // read IIR from file
   auto copy_stencil_from_file = readIIRFromFile(optimizer, "reference_iir/copy_stencil.iir");
-  UIDGenerator::getInstance()->reset();
 
   // generate IIR in memory
-  auto copy_stencil_memory = createCopyStencilIIRInMemory(optimizer);
   UIDGenerator::getInstance()->reset();
+  auto copy_stencil_memory = createCopyStencilIIRInMemory(optimizer);
 
   compareIIRs(copy_stencil_from_file, copy_stencil_memory);
 }
 
-TEST(IIRDeserializerTest, LaplStencil) {
+TEST(IIRDeserializerTest, LapStencil) {
   Options compileOptions;
   OptimizerContext::OptimizerContextOptions optimizerOptions;
   DawnCompiler compiler(&compileOptions);
@@ -238,11 +237,10 @@ TEST(IIRDeserializerTest, LaplStencil) {
 
   // read IIR from file
   auto lap_stencil_from_file = readIIRFromFile(optimizer, "reference_iir/lap_stencil.iir");
-  UIDGenerator::getInstance()->reset();
 
   // generate IIR in memory
-  auto lap_stencil_memory = createLapStencilIIRInMemory(optimizer);
   UIDGenerator::getInstance()->reset();
+  auto lap_stencil_memory = createLapStencilIIRInMemory(optimizer);
 
   compareIIRs(lap_stencil_from_file, lap_stencil_memory);
 }

--- a/dawn/test/integration-test/reference_iir/copy_stencil.iir
+++ b/dawn/test/integration-test/reference_iir/copy_stencil.iir
@@ -1,21 +1,21 @@
 {
  "metadata": {
   "accessIDToName": {
-   "9": "in_field",
-   "10": "out_field"
+   "11": "in_field",
+   "12": "out_field"
   },
   "accessIDToType": {
-   "9": 6,
-   "10": 6
+   "11": 6,
+   "12": 6
   },
   "literalIDToName": {},
   "fieldAccessIDs": [
-   9,
-   10
+   11,
+   12
   ],
   "APIFieldIDs": [
-   9,
-   10
+   11,
+   12
   ],
   "temporaryFieldIDs": [],
   "globalVariableIDs": [],
@@ -24,33 +24,33 @@
   },
   "fieldnameToBoundaryCondition": {},
   "fieldIDtoLegalDimensions": {
-   "9": {
+   "11": {
     "int1": 1,
     "int2": 1,
     "int3": 1
    },
-   "10": {
+   "12": {
     "int1": 1,
     "int2": 1,
     "int3": 1
    }
   },
   "idToStencilCall": {
-   "0": {
+   "1": {
     "stencil_call_decl_stmt": {
      "stencil_call": {
       "loc": {
        "Line": -1,
        "Column": -1
       },
-      "callee": "__code_gen_0",
+      "callee": "__code_gen_1",
       "arguments": []
      },
      "loc": {
       "Line": -1,
       "Column": -1
      },
-     "ID": 15
+     "ID": 17
     }
    }
   },
@@ -102,9 +102,9 @@
                    "Column": -1
                   },
                   "data": {
-                   "accessID": 10
+                   "accessID": 12
                   },
-                  "ID": 6
+                  "ID": 8
                  }
                 },
                 "op": "=",
@@ -132,28 +132,28 @@
                    "Column": -1
                   },
                   "data": {
-                   "accessID": 9
+                   "accessID": 11
                   },
-                  "ID": 8
+                  "ID": 10
                  }
                 },
                 "loc": {
                  "Line": -1,
                  "Column": -1
                 },
-                "ID": 12
+                "ID": 14
                }
               },
               "loc": {
                "Line": -1,
                "Column": -1
               },
-              "ID": 14
+              "ID": 16
              }
             },
             "accesses": {
              "writeAccess": {
-              "10": {
+              "12": {
                "extents": [
                 {
                  "minus": 0,
@@ -171,7 +171,7 @@
               }
              },
              "readAccess": {
-              "9": {
+              "11": {
                "extents": [
                 {
                  "minus": 0,
@@ -191,7 +191,7 @@
             }
            }
           ],
-          "doMethodID": 4,
+          "doMethodID": 6,
           "interval": {
            "lower_offset": 0,
            "upper_offset": 0,
@@ -200,15 +200,15 @@
           }
          }
         ],
-        "stageID": 3
+        "stageID": 4
        }
       ],
       "loopOrder": "Parallel",
-      "multiStageID": 2,
+      "multiStageID": 3,
       "Caches": {}
      }
     ],
-    "stencilID": 0,
+    "stencilID": 1,
     "attr": {
      "attributes": []
     }
@@ -222,14 +222,14 @@
        "Line": -1,
        "Column": -1
       },
-      "callee": "__code_gen_0",
+      "callee": "__code_gen_1",
       "arguments": []
      },
      "loc": {
       "Line": -1,
       "Column": -1
      },
-     "ID": 15
+     "ID": 17
     }
    }
   ],

--- a/dawn/test/integration-test/reference_iir/lap_stencil.iir
+++ b/dawn/test/integration-test/reference_iir/lap_stencil.iir
@@ -1,27 +1,27 @@
 {
  "metadata": {
   "accessIDToName": {
-   "27": "in",
-   "28": "tmp",
-   "29": "out"
+   "30": "in",
+   "31": "tmp",
+   "32": "out"
   },
   "accessIDToType": {
-   "27": 6,
-   "28": 3,
-   "29": 6
+   "30": 6,
+   "31": 3,
+   "32": 6
   },
   "literalIDToName": {},
   "fieldAccessIDs": [
-   27,
-   28,
-   29
+   30,
+   31,
+   32
   ],
   "APIFieldIDs": [
-   27,
-   29
+   30,
+   32
   ],
   "temporaryFieldIDs": [
-   28
+   31
   ],
   "globalVariableIDs": [],
   "versionedFields": {
@@ -29,38 +29,38 @@
   },
   "fieldnameToBoundaryCondition": {},
   "fieldIDtoLegalDimensions": {
-   "28": {
+   "32": {
+    "int1": 1,
+    "int2": 1,
+    "int3": 1
+   },
+   "30": {
+    "int1": 1,
+    "int2": 1,
+    "int3": 1
+   },
+   "31": {
     "int1": 0,
     "int2": 0,
     "int3": 0
-   },
-   "29": {
-    "int1": 1,
-    "int2": 1,
-    "int3": 1
-   },
-   "27": {
-    "int1": 1,
-    "int2": 1,
-    "int3": 1
    }
   },
   "idToStencilCall": {
-   "0": {
+   "1": {
     "stencil_call_decl_stmt": {
      "stencil_call": {
       "loc": {
        "Line": -1,
        "Column": -1
       },
-      "callee": "__code_gen_0",
+      "callee": "__code_gen_1",
       "arguments": []
      },
      "loc": {
       "Line": -1,
       "Column": -1
      },
-     "ID": 50
+     "ID": 53
     }
    }
   },
@@ -112,9 +112,9 @@
                    "Column": -1
                   },
                   "data": {
-                   "accessID": 28
+                   "accessID": 31
                   },
-                  "ID": 8
+                  "ID": 11
                  }
                 },
                 "op": "=",
@@ -146,9 +146,9 @@
                        "Column": -1
                       },
                       "data": {
-                       "accessID": 27
+                       "accessID": 30
                       },
-                      "ID": 13
+                      "ID": 16
                      }
                     },
                     "op": "+",
@@ -176,16 +176,16 @@
                        "Column": -1
                       },
                       "data": {
-                       "accessID": 27
+                       "accessID": 30
                       },
-                      "ID": 14
+                      "ID": 17
                      }
                     },
                     "loc": {
                      "Line": -1,
                      "Column": -1
                     },
-                    "ID": 33
+                    "ID": 36
                    }
                   },
                   "op": "+",
@@ -215,9 +215,9 @@
                        "Column": -1
                       },
                       "data": {
-                       "accessID": 27
+                       "accessID": 30
                       },
-                      "ID": 15
+                      "ID": 18
                      }
                     },
                     "op": "+",
@@ -245,42 +245,42 @@
                        "Column": -1
                       },
                       "data": {
-                       "accessID": 27
+                       "accessID": 30
                       },
-                      "ID": 16
+                      "ID": 19
                      }
                     },
                     "loc": {
                      "Line": -1,
                      "Column": -1
                     },
-                    "ID": 34
+                    "ID": 37
                    }
                   },
                   "loc": {
                    "Line": -1,
                    "Column": -1
                   },
-                  "ID": 35
+                  "ID": 38
                  }
                 },
                 "loc": {
                  "Line": -1,
                  "Column": -1
                 },
-                "ID": 37
+                "ID": 40
                }
               },
               "loc": {
                "Line": -1,
                "Column": -1
               },
-              "ID": 39
+              "ID": 42
              }
             },
             "accesses": {
              "writeAccess": {
-              "28": {
+              "31": {
                "extents": [
                 {
                  "minus": 0,
@@ -298,7 +298,7 @@
               }
              },
              "readAccess": {
-              "27": {
+              "30": {
                "extents": [
                 {
                  "minus": -2,
@@ -318,7 +318,7 @@
             }
            }
           ],
-          "doMethodID": 5,
+          "doMethodID": 7,
           "interval": {
            "lower_offset": 0,
            "upper_offset": 0,
@@ -327,7 +327,7 @@
           }
          }
         ],
-        "stageID": 3
+        "stageID": 4
        },
        {
         "doMethods": [
@@ -362,9 +362,9 @@
                    "Column": -1
                   },
                   "data": {
-                   "accessID": 29
+                   "accessID": 32
                   },
-                  "ID": 18
+                  "ID": 21
                  }
                 },
                 "op": "=",
@@ -396,9 +396,9 @@
                        "Column": -1
                       },
                       "data": {
-                       "accessID": 28
+                       "accessID": 31
                       },
-                      "ID": 23
+                      "ID": 26
                      }
                     },
                     "op": "+",
@@ -426,16 +426,16 @@
                        "Column": -1
                       },
                       "data": {
-                       "accessID": 28
+                       "accessID": 31
                       },
-                      "ID": 24
+                      "ID": 27
                      }
                     },
                     "loc": {
                      "Line": -1,
                      "Column": -1
                     },
-                    "ID": 43
+                    "ID": 46
                    }
                   },
                   "op": "+",
@@ -465,9 +465,9 @@
                        "Column": -1
                       },
                       "data": {
-                       "accessID": 28
+                       "accessID": 31
                       },
-                      "ID": 25
+                      "ID": 28
                      }
                     },
                     "op": "+",
@@ -495,42 +495,42 @@
                        "Column": -1
                       },
                       "data": {
-                       "accessID": 28
+                       "accessID": 31
                       },
-                      "ID": 26
+                      "ID": 29
                      }
                     },
                     "loc": {
                      "Line": -1,
                      "Column": -1
                     },
-                    "ID": 44
+                    "ID": 47
                    }
                   },
                   "loc": {
                    "Line": -1,
                    "Column": -1
                   },
-                  "ID": 45
+                  "ID": 48
                  }
                 },
                 "loc": {
                  "Line": -1,
                  "Column": -1
                 },
-                "ID": 47
+                "ID": 50
                }
               },
               "loc": {
                "Line": -1,
                "Column": -1
               },
-              "ID": 49
+              "ID": 52
              }
             },
             "accesses": {
              "writeAccess": {
-              "29": {
+              "32": {
                "extents": [
                 {
                  "minus": 0,
@@ -548,7 +548,7 @@
               }
              },
              "readAccess": {
-              "28": {
+              "31": {
                "extents": [
                 {
                  "minus": -1,
@@ -568,7 +568,7 @@
             }
            }
           ],
-          "doMethodID": 6,
+          "doMethodID": 9,
           "interval": {
            "lower_offset": 0,
            "upper_offset": 0,
@@ -577,15 +577,15 @@
           }
          }
         ],
-        "stageID": 4
+        "stageID": 5
        }
       ],
       "loopOrder": "Parallel",
-      "multiStageID": 2,
+      "multiStageID": 3,
       "Caches": {}
      }
     ],
-    "stencilID": 0,
+    "stencilID": 1,
     "attr": {
      "attributes": []
     }
@@ -599,14 +599,14 @@
        "Line": -1,
        "Column": -1
       },
-      "callee": "__code_gen_0",
+      "callee": "__code_gen_1",
       "arguments": []
      },
      "loc": {
       "Line": -1,
       "Column": -1
      },
-     "ID": 50
+     "ID": 53
     }
    }
   ],

--- a/gtclang/test/integration-test/IIRSerializer/AccessTest_ref.iir
+++ b/gtclang/test/integration-test/IIRSerializer/AccessTest_ref.iir
@@ -24,12 +24,12 @@
   },
   "fieldnameToBoundaryCondition": {},
   "fieldIDtoLegalDimensions": {
-   "19": {
+   "20": {
     "int1": 1,
     "int2": 1,
     "int3": 1
    },
-   "20": {
+   "19": {
     "int1": 1,
     "int2": 1,
     "int3": 1
@@ -399,7 +399,7 @@
        }
       ],
       "loopOrder": "Parallel",
-      "multiStageID": 42,
+      "multiStageID": 43,
       "Caches": {}
      }
     ],
@@ -430,5 +430,5 @@
   ],
   "boundaryConditions": []
  },
- "filename": "/code/gtclang/test/integration-test/IIRSerializer/AccessTest.cpp"
+ "filename": "/home/vogtha/projects/toolchain/dawn/gtclang/test/integration-test/IIRSerializer/AccessTest.cpp"
 }

--- a/gtclang/test/integration-test/IIRSerializer/CopyTest_ref.iir
+++ b/gtclang/test/integration-test/IIRSerializer/CopyTest_ref.iir
@@ -1,8 +1,8 @@
 {
  "metadata": {
   "accessIDToName": {
-   "10": "field_b",
-   "9": "field_a"
+   "9": "field_a",
+   "10": "field_b"
   },
   "accessIDToType": {
    "9": 6,
@@ -204,7 +204,7 @@
        }
       ],
       "loopOrder": "Parallel",
-      "multiStageID": 22,
+      "multiStageID": 23,
       "Caches": {}
      }
     ],
@@ -235,5 +235,5 @@
   ],
   "boundaryConditions": []
  },
- "filename": "/code/gtclang/test/integration-test/IIRSerializer/CopyTest.cpp"
+ "filename": "/home/vogtha/projects/toolchain/dawn/gtclang/test/integration-test/IIRSerializer/CopyTest.cpp"
 }

--- a/gtclang/test/integration-test/IIRSerializer/NestedStencils_ref.iir
+++ b/gtclang/test/integration-test/IIRSerializer/NestedStencils_ref.iir
@@ -204,7 +204,7 @@
        }
       ],
       "loopOrder": "Parallel",
-      "multiStageID": 89,
+      "multiStageID": 93,
       "Caches": {}
      }
     ],
@@ -235,5 +235,5 @@
   ],
   "boundaryConditions": []
  },
- "filename": "/code/gtclang/test/integration-test/IIRSerializer/NestedStencils.cpp"
+ "filename": "/home/vogtha/projects/toolchain/dawn/gtclang/test/integration-test/IIRSerializer/NestedStencils.cpp"
 }

--- a/gtclang/test/integration-test/IIRSerializer/StencilFnCallTest_ref.iir
+++ b/gtclang/test/integration-test/IIRSerializer/StencilFnCallTest_ref.iir
@@ -1,9 +1,9 @@
 {
  "metadata": {
   "accessIDToName": {
+   "36": "__local_fn_36",
    "16": "a",
-   "17": "b",
-   "34": "__local_fn_34"
+   "17": "b"
   },
   "accessIDToType": {
    "16": 6,
@@ -84,7 +84,7 @@
                "is_const": true,
                "is_volatile": false
               },
-              "name": "__local_fn_34",
+              "name": "__local_fn_36",
               "dimension": 0,
               "op": "=",
               "init_list": [
@@ -114,7 +114,7 @@
                  "data": {
                   "accessID": 16
                  },
-                 "ID": 32
+                 "ID": 33
                 }
                }
               ],
@@ -123,14 +123,14 @@
                "Column": -1
               },
               "data": {
-               "accessID": 34
+               "accessID": 36
               },
-              "ID": 36
+              "ID": 38
              }
             },
             "accesses": {
              "writeAccess": {
-              "34": {
+              "36": {
                "extents": [
                 {
                  "minus": 0,
@@ -204,16 +204,16 @@
                 "op": "=",
                 "right": {
                  "var_access_expr": {
-                  "name": "__local_fn_34",
+                  "name": "__local_fn_36",
                   "is_external": false,
                   "loc": {
                    "Line": -1,
                    "Column": -1
                   },
                   "data": {
-                   "accessID": 34
+                   "accessID": 36
                   },
-                  "ID": 35
+                  "ID": 37
                  }
                 },
                 "loc": {
@@ -250,7 +250,7 @@
               }
              },
              "readAccess": {
-              "34": {
+              "36": {
                "extents": [
                 {
                  "minus": 0,
@@ -283,7 +283,7 @@
        }
       ],
       "loopOrder": "Parallel",
-      "multiStageID": 33,
+      "multiStageID": 35,
       "Caches": {}
      }
     ],
@@ -314,5 +314,5 @@
   ],
   "boundaryConditions": []
  },
- "filename": "/code/gtclang/test/integration-test/IIRSerializer/StencilFnCallTest.cpp"
+ "filename": "/home/vogtha/projects/toolchain/dawn/gtclang/test/integration-test/IIRSerializer/StencilFnCallTest.cpp"
 }

--- a/gtclang/test/integration-test/PassStageMerger/Test01_after_ref.json
+++ b/gtclang/test/integration-test/PassStageMerger/Test01_after_ref.json
@@ -199,7 +199,7 @@
               }
             }
           },
-          "ID": 38,
+          "ID": 40,
           "Loop": "parallel",
           "Stages": [
             {

--- a/gtclang/test/integration-test/PassStageMerger/Test01_before_ref.json
+++ b/gtclang/test/integration-test/PassStageMerger/Test01_before_ref.json
@@ -199,7 +199,7 @@
               }
             }
           },
-          "ID": 38,
+          "ID": 40,
           "Loop": "parallel",
           "Stages": [
             {

--- a/gtclang/test/integration-test/PassStageMerger/Test02_after_ref.json
+++ b/gtclang/test/integration-test/PassStageMerger/Test02_after_ref.json
@@ -199,7 +199,7 @@
               }
             }
           },
-          "ID": 38,
+          "ID": 40,
           "Loop": "parallel",
           "Stages": [
             {

--- a/gtclang/test/integration-test/PassStageMerger/Test02_before_ref.json
+++ b/gtclang/test/integration-test/PassStageMerger/Test02_before_ref.json
@@ -199,7 +199,7 @@
               }
             }
           },
-          "ID": 38,
+          "ID": 40,
           "Loop": "parallel",
           "Stages": [
             {

--- a/gtclang/test/integration-test/PassStageMerger/Test03_after_ref.json
+++ b/gtclang/test/integration-test/PassStageMerger/Test03_after_ref.json
@@ -199,7 +199,7 @@
               }
             }
           },
-          "ID": 38,
+          "ID": 40,
           "Loop": "parallel",
           "Stages": [
             {

--- a/gtclang/test/integration-test/PassStageMerger/Test03_before_ref.json
+++ b/gtclang/test/integration-test/PassStageMerger/Test03_before_ref.json
@@ -199,7 +199,7 @@
               }
             }
           },
-          "ID": 38,
+          "ID": 40,
           "Loop": "parallel",
           "Stages": [
             {

--- a/gtclang/test/integration-test/PassStageMerger/Test04_after_ref.json
+++ b/gtclang/test/integration-test/PassStageMerger/Test04_after_ref.json
@@ -105,7 +105,7 @@
               }
             }
           },
-          "ID": 50,
+          "ID": 53,
           "Loop": "parallel",
           "Stages": [
             {

--- a/gtclang/test/integration-test/PassStageMerger/Test04_before_ref.json
+++ b/gtclang/test/integration-test/PassStageMerger/Test04_before_ref.json
@@ -105,7 +105,7 @@
               }
             }
           },
-          "ID": 50,
+          "ID": 53,
           "Loop": "parallel",
           "Stages": [
             {

--- a/gtclang/test/integration-test/PassStageMerger/Test05_after_ref.json
+++ b/gtclang/test/integration-test/PassStageMerger/Test05_after_ref.json
@@ -152,7 +152,7 @@
               }
             }
           },
-          "ID": 37,
+          "ID": 39,
           "Loop": "parallel",
           "Stages": [
             {

--- a/gtclang/test/integration-test/PassStageMerger/Test05_before_ref.json
+++ b/gtclang/test/integration-test/PassStageMerger/Test05_before_ref.json
@@ -152,7 +152,7 @@
               }
             }
           },
-          "ID": 37,
+          "ID": 39,
           "Loop": "parallel",
           "Stages": [
             {

--- a/gtclang/test/integration-test/PassStageMerger/Test06_after_ref.json
+++ b/gtclang/test/integration-test/PassStageMerger/Test06_after_ref.json
@@ -152,7 +152,7 @@
               }
             }
           },
-          "ID": 37,
+          "ID": 39,
           "Loop": "parallel",
           "Stages": [
             {

--- a/gtclang/test/integration-test/PassStageMerger/Test06_before_ref.json
+++ b/gtclang/test/integration-test/PassStageMerger/Test06_before_ref.json
@@ -152,7 +152,7 @@
               }
             }
           },
-          "ID": 37,
+          "ID": 39,
           "Loop": "parallel",
           "Stages": [
             {

--- a/gtclang/test/integration-test/PassStageReordering/Test01_after_ref.json
+++ b/gtclang/test/integration-test/PassStageReordering/Test01_after_ref.json
@@ -105,7 +105,7 @@
               }
             }
           },
-          "ID": 22,
+          "ID": 23,
           "Loop": "parallel",
           "Stages": [
             {

--- a/gtclang/test/integration-test/PassStageReordering/Test02_after_ref.json
+++ b/gtclang/test/integration-test/PassStageReordering/Test02_after_ref.json
@@ -293,7 +293,7 @@
               }
             }
           },
-          "ID": 68,
+          "ID": 72,
           "Loop": "parallel",
           "Stages": [
             {

--- a/gtclang/test/integration-test/PassStageReordering/Test02_before_ref.json
+++ b/gtclang/test/integration-test/PassStageReordering/Test02_before_ref.json
@@ -361,7 +361,7 @@
               }
             }
           },
-          "ID": 62,
+          "ID": 63,
           "Loop": "parallel",
           "Stages": [
             {
@@ -481,7 +481,7 @@
               }
             }
           },
-          "ID": 64,
+          "ID": 66,
           "Loop": "parallel",
           "Stages": [
             {
@@ -601,7 +601,7 @@
               }
             }
           },
-          "ID": 66,
+          "ID": 69,
           "Loop": "parallel",
           "Stages": [
             {

--- a/gtclang/test/integration-test/PassStageReordering/Test03_after_ref.json
+++ b/gtclang/test/integration-test/PassStageReordering/Test03_after_ref.json
@@ -152,7 +152,7 @@
               }
             }
           },
-          "ID": 35,
+          "ID": 38,
           "Loop": "forward",
           "Stages": [
             {

--- a/gtclang/test/integration-test/PassStageReordering/Test03_before_ref.json
+++ b/gtclang/test/integration-test/PassStageReordering/Test03_before_ref.json
@@ -139,7 +139,7 @@
               }
             }
           },
-          "ID": 31,
+          "ID": 32,
           "Loop": "parallel",
           "Stages": [
             {
@@ -259,7 +259,7 @@
               }
             }
           },
-          "ID": 32,
+          "ID": 33,
           "Loop": "parallel",
           "Stages": [
             {

--- a/gtclang/test/integration-test/PassStageReordering/Test04_after_ref.json
+++ b/gtclang/test/integration-test/PassStageReordering/Test04_after_ref.json
@@ -280,7 +280,7 @@
               }
             }
           },
-          "ID": 64,
+          "ID": 70,
           "Loop": "forward",
           "Stages": [
             {
@@ -570,7 +570,7 @@
               }
             }
           },
-          "ID": 65,
+          "ID": 71,
           "Loop": "parallel",
           "Stages": [
             {

--- a/gtclang/test/integration-test/PassStageReordering/Test04_before_ref.json
+++ b/gtclang/test/integration-test/PassStageReordering/Test04_before_ref.json
@@ -241,7 +241,7 @@
               }
             }
           },
-          "ID": 56,
+          "ID": 58,
           "Loop": "parallel",
           "Stages": [
             {
@@ -361,7 +361,7 @@
               }
             }
           },
-          "ID": 57,
+          "ID": 59,
           "Loop": "parallel",
           "Stages": [
             {
@@ -481,7 +481,7 @@
               }
             }
           },
-          "ID": 60,
+          "ID": 64,
           "Loop": "parallel",
           "Stages": [
             {
@@ -601,7 +601,7 @@
               }
             }
           },
-          "ID": 61,
+          "ID": 65,
           "Loop": "parallel",
           "Stages": [
             {

--- a/gtclang/test/integration-test/PassStageReordering/Test05_after_ref.json
+++ b/gtclang/test/integration-test/PassStageReordering/Test05_after_ref.json
@@ -152,7 +152,7 @@
               }
             }
           },
-          "ID": 40,
+          "ID": 42,
           "Loop": "parallel",
           "Stages": [
             {

--- a/gtclang/test/integration-test/PassStageReordering/Test05_before_ref.json
+++ b/gtclang/test/integration-test/PassStageReordering/Test05_before_ref.json
@@ -259,7 +259,7 @@
               }
             }
           },
-          "ID": 38,
+          "ID": 39,
           "Loop": "parallel",
           "Stages": [
             {

--- a/gtclang/test/integration-test/PassStageReordering/Test06_after_ref.json
+++ b/gtclang/test/integration-test/PassStageReordering/Test06_after_ref.json
@@ -220,7 +220,7 @@
               }
             }
           },
-          "ID": 56,
+          "ID": 58,
           "Loop": "parallel",
           "Stages": [
             {
@@ -409,7 +409,7 @@
               }
             }
           },
-          "ID": 57,
+          "ID": 59,
           "Loop": "parallel",
           "Stages": [
             {

--- a/gtclang/test/integration-test/PassStageReordering/Test06_before_ref.json
+++ b/gtclang/test/integration-test/PassStageReordering/Test06_before_ref.json
@@ -409,7 +409,7 @@
               }
             }
           },
-          "ID": 54,
+          "ID": 55,
           "Loop": "parallel",
           "Stages": [
             {

--- a/gtclang/test/integration-test/PassStageReordering/Test07_after_ref.json
+++ b/gtclang/test/integration-test/PassStageReordering/Test07_after_ref.json
@@ -335,7 +335,7 @@
               }
             }
           },
-          "ID": 83,
+          "ID": 91,
           "Loop": "parallel",
           "Stages": [
             {
@@ -651,7 +651,7 @@
               }
             }
           },
-          "ID": 84,
+          "ID": 92,
           "Loop": "parallel",
           "Stages": [
             {
@@ -941,7 +941,7 @@
               }
             }
           },
-          "ID": 85,
+          "ID": 93,
           "Loop": "parallel",
           "Stages": [
             {


### PR DESCRIPTION
## Technical Description

Removes the temporary hard-coded ID which required an update of the reference, because of changes in later IDs.

Also fixes the broken reference generator of the deserialize test.

Remaining TODOs to complete the refactoring:
1) Cleanup Protobuf still contains StatementAccessesPair messages
2) Replace the IIRNode-like API in DoMethod.