### PR TITLE
Default constructible Offsets and Extents

### DIFF
--- a/dawn/src/dawn/AST/Offsets.h
+++ b/dawn/src/dawn/AST/Offsets.h
@@ -117,7 +117,11 @@ private:
 
 template <typename T>
 T offset_cast(HorizontalOffset const& offset) {
-  static std::remove_reference_t<T> nullOffset{};
+  using PlainT = std::remove_reference_t<T>;
+  static_assert(std::is_base_of_v<HorizontalOffsetImpl, PlainT>,
+                "Can only be casted to a valid horizontal offset implementation");
+  static_assert(std::is_const_v<PlainT>, "Can only be casted to const");
+  static PlainT nullOffset{};
   return offset.impl_ ? dynamic_cast<T>(*offset.impl_) : nullOffset;
 }
 

--- a/dawn/src/dawn/AST/Offsets.h
+++ b/dawn/src/dawn/AST/Offsets.h
@@ -71,25 +71,42 @@ private:
 
 class HorizontalOffset {
 public:
+  HorizontalOffset() = default;
+
   explicit HorizontalOffset(cartesian_) : impl_(std::make_unique<CartesianOffset>()) {}
   HorizontalOffset(cartesian_, int iOffset, int jOffset)
       : impl_(std::make_unique<CartesianOffset>(iOffset, jOffset)) {}
   HorizontalOffset(HorizontalOffset const& other) { *this = other; }
   HorizontalOffset& operator=(HorizontalOffset const& other) {
-    impl_ = other.impl_->clone();
+    if(other.impl_)
+      impl_ = other.impl_->clone();
+    else
+      impl_ = nullptr;
     return *this;
   }
   HorizontalOffset(HorizontalOffset&& other) = default;
   HorizontalOffset& operator=(HorizontalOffset&& other) = default;
 
-  bool operator==(HorizontalOffset const& other) const { return *impl_ == *other.impl_; }
+  bool operator==(HorizontalOffset const& other) const {
+    if(impl_ && other.impl_)
+      return *impl_ == *other.impl_;
+    else if(impl_)
+      return isZero();
+    else if(other.impl_)
+      return other.isZero();
+    else
+      return true;
+  }
   bool operator!=(HorizontalOffset const& other) const { return !(*this == other); }
 
   HorizontalOffset& operator+=(HorizontalOffset const& other) {
-    *impl_ += *other.impl_;
+    if(impl_ && other.impl_)
+      *impl_ += *other.impl_;
+    else if(other.impl_)
+      *this = other;
     return *this;
   }
-  bool isZero() const { return impl_->isZero(); }
+  bool isZero() const { return !impl_ || impl_->isZero(); }
 
   template <typename T>
   friend T offset_cast(HorizontalOffset const& offset);
@@ -100,11 +117,14 @@ private:
 
 template <typename T>
 T offset_cast(HorizontalOffset const& offset) {
-  return dynamic_cast<T>(*offset.impl_);
+  static std::remove_reference_t<T> nullOffset{};
+  return offset.impl_ ? dynamic_cast<T>(*offset.impl_) : nullOffset;
 }
 
 class Offsets {
 public:
+  Offsets() = default;
+
   Offsets(cartesian_, int i, int j, int k)
       : horizontalOffset_(cartesian, i, j), verticalOffset_(k) {}
   Offsets(cartesian_, std::array<int, 3> const& structuredOffsets)
@@ -125,6 +145,7 @@ public:
     return *this;
   }
 
+  // corresponds to the default initialized offset
   bool isZero() const { return verticalOffset_ == 0 && horizontalOffset_.isZero(); }
 
 private:

--- a/dawn/src/dawn/CodeGen/Cuda/CacheProperties.cpp
+++ b/dawn/src/dawn/CodeGen/Cuda/CacheProperties.cpp
@@ -34,9 +34,10 @@ makeCacheProperties(const std::unique_ptr<iir::MultiStage>& ms,
   for(const auto& cacheP : ms->getCaches()) {
     const int accessID = cacheP.first;
     auto originalExtent = ms->getField(accessID).getExtentsRB();
-    iir::Extents limitedExtent = originalExtent.limit(
-        {ast::cartesian, -maxRedundantLines, maxRedundantLines, -maxRedundantLines,
-         maxRedundantLines, -maxRedundantLines, maxRedundantLines});
+    iir::Extents limitedExtent = iir::limit(
+        originalExtent,
+        iir::Extents{ast::cartesian, -maxRedundantLines, maxRedundantLines, -maxRedundantLines,
+                     maxRedundantLines, -maxRedundantLines, maxRedundantLines});
     maxExtents.merge(limitedExtent);
 
     if(limitedExtent == originalExtent) {

--- a/dawn/src/dawn/CodeGen/Cuda/CacheProperties.cpp
+++ b/dawn/src/dawn/CodeGen/Cuda/CacheProperties.cpp
@@ -34,7 +34,9 @@ makeCacheProperties(const std::unique_ptr<iir::MultiStage>& ms,
   for(const auto& cacheP : ms->getCaches()) {
     const int accessID = cacheP.first;
     auto originalExtent = ms->getField(accessID).getExtentsRB();
-    iir::Extents limitedExtent = originalExtent.limit(-maxRedundantLines, maxRedundantLines);
+    iir::Extents limitedExtent = originalExtent.limit(
+        {ast::cartesian, -maxRedundantLines, maxRedundantLines, -maxRedundantLines,
+         maxRedundantLines, -maxRedundantLines, maxRedundantLines});
     maxExtents.merge(limitedExtent);
 
     if(limitedExtent == originalExtent) {

--- a/dawn/src/dawn/IIR/Extents.cpp
+++ b/dawn/src/dawn/IIR/Extents.cpp
@@ -67,9 +67,9 @@ bool Extents::isVerticalPointwise() const { return verticalExtent_.isPointwise()
 bool Extents::hasVerticalCenter() const {
   return verticalExtent_.minus() <= 0 && verticalExtent_.plus() >= 0;
 }
-Extents Extents::limit(int minus, int plus) const {
-  DAWN_ASSERT(minus <= 0 && plus >= 0);
-  return Extents{horizontalExtent_.limit(minus, plus), verticalExtent_.limit(minus, plus)};
+Extents Extents::limit(Extents const& other) const {
+  return Extents{horizontalExtent_.limit(other.horizontalExtent()),
+                 verticalExtent_.limit(other.verticalExtent())};
 }
 
 bool Extents::isPointwise() const {

--- a/dawn/src/dawn/IIR/Extents.cpp
+++ b/dawn/src/dawn/IIR/Extents.cpp
@@ -24,17 +24,13 @@ namespace iir {
 
 Extent operator+(Extent lhs, Extent const& rhs) { return lhs += rhs; }
 
+Extents::Extents() : Extents(HorizontalExtent{}, Extent{}) {}
 Extents::Extents(HorizontalExtent const& hExtent, Extent const& vExtent)
     : verticalExtent_(vExtent), horizontalExtent_(hExtent) {}
 
 Extents::Extents(const ast::Offsets& offset)
     : verticalExtent_(offset.verticalOffset(), offset.verticalOffset()),
-      horizontalExtent_(ast::cartesian) {
-  auto const& hOffset = ast::offset_cast<ast::CartesianOffset const&>(offset.horizontalOffset());
-
-  horizontalExtent_ = HorizontalExtent(ast::cartesian, hOffset.offsetI(), hOffset.offsetI(),
-                                       hOffset.offsetJ(), hOffset.offsetJ());
-}
+      horizontalExtent_(offset.horizontalOffset()) {}
 
 Extents::Extents(ast::cartesian_, int extent1minus, int extent1plus, int extent2minus,
                  int extent2plus, int extent3minus, int extent3plus)
@@ -72,6 +68,7 @@ bool Extents::hasVerticalCenter() const {
   return verticalExtent_.minus() <= 0 && verticalExtent_.plus() >= 0;
 }
 Extents Extents::limit(int minus, int plus) const {
+  DAWN_ASSERT(minus <= 0 && plus >= 0);
   return Extents{horizontalExtent_.limit(minus, plus), verticalExtent_.limit(minus, plus)};
 }
 

--- a/dawn/src/dawn/IIR/Extents.cpp
+++ b/dawn/src/dawn/IIR/Extents.cpp
@@ -23,6 +23,14 @@ namespace dawn {
 namespace iir {
 
 Extent operator+(Extent lhs, Extent const& rhs) { return lhs += rhs; }
+Extent merge(Extent lhs, Extent const& rhs) {
+  lhs.merge(rhs);
+  return lhs;
+}
+Extent limit(Extent lhs, Extent const& rhs) {
+  lhs.limit(rhs);
+  return rhs;
+}
 
 Extents::Extents() : Extents(HorizontalExtent{}, Extent{}) {}
 Extents::Extents(HorizontalExtent const& hExtent, Extent const& vExtent)
@@ -56,6 +64,14 @@ Extents& Extents::operator+=(const Extents& other) {
   return *this;
 }
 Extents operator+(Extents lhs, const Extents& rhs) { return lhs += rhs; }
+Extents merge(Extents lhs, Extents const& rhs) {
+  lhs.merge(rhs);
+  return lhs;
+}
+Extents limit(Extents lhs, Extents const& rhs) {
+  lhs.limit(rhs);
+  return lhs;
+}
 
 void Extents::addVerticalCenter() { verticalExtent_.merge(0); }
 
@@ -66,9 +82,9 @@ bool Extents::isVerticalPointwise() const { return verticalExtent_.isPointwise()
 bool Extents::hasVerticalCenter() const {
   return verticalExtent_.minus() <= 0 && verticalExtent_.plus() >= 0;
 }
-Extents Extents::limit(Extents const& other) const {
-  return Extents{horizontalExtent_.limit(other.horizontalExtent()),
-                 verticalExtent_.limit(other.verticalExtent())};
+void Extents::limit(Extents const& other) {
+  horizontalExtent_.limit(other.horizontalExtent());
+  verticalExtent_.limit(other.verticalExtent());
 }
 
 bool Extents::isPointwise() const {

--- a/dawn/src/dawn/IIR/Extents.cpp
+++ b/dawn/src/dawn/IIR/Extents.cpp
@@ -29,8 +29,7 @@ Extents::Extents(HorizontalExtent const& hExtent, Extent const& vExtent)
     : verticalExtent_(vExtent), horizontalExtent_(hExtent) {}
 
 Extents::Extents(const ast::Offsets& offset)
-    : verticalExtent_(offset.verticalOffset(), offset.verticalOffset()),
-      horizontalExtent_(offset.horizontalOffset()) {}
+    : verticalExtent_(offset.verticalOffset()), horizontalExtent_(offset.horizontalOffset()) {}
 
 Extents::Extents(ast::cartesian_, int extent1minus, int extent1plus, int extent2minus,
                  int extent2plus, int extent3minus, int extent3plus)

--- a/dawn/src/dawn/IIR/Extents.h
+++ b/dawn/src/dawn/IIR/Extents.h
@@ -92,6 +92,7 @@ public:
 
   void merge(HorizontalExtentImpl const& other) { mergeImpl(other); }
   void merge(ast::HorizontalOffset const& other) { mergeImpl(other); }
+  void addCenter() { addCenterImpl(); }
   bool operator==(HorizontalExtentImpl const& other) const { return equalsImpl(other); }
   bool isPointwise() const { return isPointwiseImpl(); }
   std::unique_ptr<HorizontalExtentImpl> limit(int minus, int plus) const {
@@ -102,6 +103,7 @@ protected:
   virtual void addImpl(HorizontalExtentImpl const& other) = 0;
   virtual void mergeImpl(HorizontalExtentImpl const& other) = 0;
   virtual void mergeImpl(ast::HorizontalOffset const& other) = 0;
+  virtual void addCenterImpl() = 0;
   virtual bool equalsImpl(HorizontalExtentImpl const& other) const = 0;
   virtual std::unique_ptr<HorizontalExtentImpl> cloneImpl() const = 0;
   virtual bool isPointwiseImpl() const = 0;
@@ -133,6 +135,8 @@ public:
     extents_[0].merge(Extent(offsetCartesian.offsetI(), offsetCartesian.offsetI()));
     extents_[1].merge(Extent(offsetCartesian.offsetJ(), offsetCartesian.offsetJ()));
   }
+
+  void addCenterImpl() override { mergeImpl(CartesianExtent()); }
 
   bool equalsImpl(HorizontalExtentImpl const& other) const override {
     auto const& otherCartesian = dynamic_cast<CartesianExtent const&>(other);
@@ -215,8 +219,12 @@ public:
   void merge(const HorizontalExtent& other) {
     if(impl_ && other.impl_)
       impl_->merge(*other.impl_);
-    else if(other.impl_)
+    else if(impl_)
+      impl_->addCenter();
+    else if(other.impl_) {
       *this = other;
+      impl_->addCenter();
+    }
   }
   void merge(const ast::HorizontalOffset& other) {
     if(impl_)

--- a/dawn/src/dawn/IIR/Extents.h
+++ b/dawn/src/dawn/IIR/Extents.h
@@ -57,7 +57,7 @@ public:
 
   void limit(Extent const& other) {
     minus_ = std::max(minus_, other.minus_);
-    plus_ = std::max(plus_, other.plus_);
+    plus_ = std::min(plus_, other.plus_);
   }
 
   Extent& operator+=(const Extent& other) {

--- a/dawn/src/dawn/IIR/Extents.h
+++ b/dawn/src/dawn/IIR/Extents.h
@@ -91,7 +91,6 @@ public:
   std::unique_ptr<HorizontalExtentImpl> clone() const { return cloneImpl(); }
 
   void merge(HorizontalExtentImpl const& other) { mergeImpl(other); }
-  void merge(ast::HorizontalOffset const& other) { mergeImpl(other); }
   void addCenter() { addCenterImpl(); }
   bool operator==(HorizontalExtentImpl const& other) const { return equalsImpl(other); }
   bool isPointwise() const { return isPointwiseImpl(); }
@@ -102,7 +101,6 @@ public:
 protected:
   virtual void addImpl(HorizontalExtentImpl const& other) = 0;
   virtual void mergeImpl(HorizontalExtentImpl const& other) = 0;
-  virtual void mergeImpl(ast::HorizontalOffset const& other) = 0;
   virtual void addCenterImpl() = 0;
   virtual bool equalsImpl(HorizontalExtentImpl const& other) const = 0;
   virtual std::unique_ptr<HorizontalExtentImpl> cloneImpl() const = 0;
@@ -128,12 +126,6 @@ public:
     auto const& otherCartesian = dynamic_cast<CartesianExtent const&>(other);
     extents_[0].merge(otherCartesian.extents_[0]);
     extents_[1].merge(otherCartesian.extents_[1]);
-  }
-
-  void mergeImpl(ast::HorizontalOffset const& offset) override {
-    auto const& offsetCartesian = ast::offset_cast<ast::CartesianOffset const&>(offset);
-    extents_[0].merge(Extent(offsetCartesian.offsetI(), offsetCartesian.offsetI()));
-    extents_[1].merge(Extent(offsetCartesian.offsetJ(), offsetCartesian.offsetJ()));
   }
 
   void addCenterImpl() override { mergeImpl(CartesianExtent()); }
@@ -226,12 +218,7 @@ public:
       impl_->addCenter();
     }
   }
-  void merge(const ast::HorizontalOffset& other) {
-    if(impl_)
-      impl_->merge(other);
-    else
-      *this = other;
-  }
+  void merge(const ast::HorizontalOffset& other) { merge(HorizontalExtent{other}); }
   bool isPointwise() const { return !impl_ || impl_->isPointwise(); }
   HorizontalExtent limit(int minus, int plus) const {
     DAWN_ASSERT(minus <= 0 && plus >= 0);

--- a/dawn/src/dawn/IIR/Extents.h
+++ b/dawn/src/dawn/IIR/Extents.h
@@ -225,6 +225,8 @@ public:
   void limit(HorizontalExtent const& other) {
     if(impl_ && other.impl_)
       impl_->limit(*other.impl_);
+    else if(!other.impl_)
+      *this = other;
   }
 
 private:

--- a/dawn/src/dawn/IIR/Extents.h
+++ b/dawn/src/dawn/IIR/Extents.h
@@ -40,7 +40,7 @@ public:
   /// @name Constructors and Assignment
   /// @{
   Extent(int minus, int plus) : minus_(minus), plus_(plus) {}
-  explicit Extent(int extent) : Extent(extent, extent) {}
+  explicit Extent(int offset) : Extent(offset, offset) {}
   Extent() : Extent(0, 0) {}
   /// @}
 

--- a/dawn/src/dawn/IIR/Extents.h
+++ b/dawn/src/dawn/IIR/Extents.h
@@ -224,7 +224,7 @@ public:
   bool isPointwise() const { return !impl_ || impl_->isPointwise(); }
   void limit(HorizontalExtent const& other) {
     if(impl_ && other.impl_)
-      impl_->merge(*other.impl_);
+      impl_->limit(*other.impl_);
     else if(other.impl_)
       *this = other;
   }
@@ -252,7 +252,7 @@ public:
   /// @name Constructors and Assignment
   /// @{
   Extents();
-  Extents(const ast::Offsets& offset);
+  explicit Extents(const ast::Offsets& offset);
   Extents(ast::cartesian_, int extent1minus, int extent1plus, int extent2minus, int extent2plus,
           int extent3minus, int extent3plus);
   Extents(HorizontalExtent const& hExtent, Extent const& vExtent);

--- a/dawn/src/dawn/IIR/Extents.h
+++ b/dawn/src/dawn/IIR/Extents.h
@@ -40,7 +40,7 @@ public:
   /// @name Constructors and Assignment
   /// @{
   Extent(int minus, int plus) : minus_(minus), plus_(plus) {}
-  Extent(int extent) : Extent(extent, extent) {}
+  explicit Extent(int extent) : Extent(extent, extent) {}
   Extent() : Extent(0, 0) {}
   /// @}
 
@@ -49,12 +49,11 @@ public:
 
   /// @name Operators
   /// @{
-  Extent& merge(const Extent& other) {
+  void merge(const Extent& other) {
     minus_ = std::min(minus_, other.minus_);
     plus_ = std::max(plus_, other.plus_);
-    return *this;
   }
-  Extent& merge(int other) { return merge(Extent{other, other}); }
+  void merge(int other) { merge(Extent{other, other}); }
 
   Extent limit(Extent const& other) const {
     return {std::max(minus_, other.minus()), std::min(plus_, other.plus())};

--- a/dawn/src/dawn/IIR/Extents.h
+++ b/dawn/src/dawn/IIR/Extents.h
@@ -236,7 +236,7 @@ private:
 
 template <typename T>
 T extent_cast(HorizontalExtent const& extent) {
-  static CartesianExtent nullExtent{};
+  static std::remove_reference_t<T> nullExtent{};
   return extent.impl_ ? dynamic_cast<T>(*extent.impl_) : nullExtent;
 }
 

--- a/dawn/src/dawn/IIR/Extents.h
+++ b/dawn/src/dawn/IIR/Extents.h
@@ -85,27 +85,27 @@ public:
   virtual ~HorizontalExtentImpl() = default;
 
   HorizontalExtentImpl& operator+=(HorizontalExtentImpl const& other) {
-    add_impl(other);
+    addImpl(other);
     return *this;
   }
-  std::unique_ptr<HorizontalExtentImpl> clone() const { return clone_impl(); }
+  std::unique_ptr<HorizontalExtentImpl> clone() const { return cloneImpl(); }
 
-  void merge(HorizontalExtentImpl const& other) { merge_impl(other); }
-  void merge(ast::HorizontalOffset const& other) { merge_impl(other); }
-  bool equals(HorizontalExtentImpl const& other) const { return equals_impl(other); }
-  bool isPointwise() const { return isPointwise_impl(); }
+  void merge(HorizontalExtentImpl const& other) { mergeImpl(other); }
+  void merge(ast::HorizontalOffset const& other) { mergeImpl(other); }
+  bool operator==(HorizontalExtentImpl const& other) const { return equalsImpl(other); }
+  bool isPointwise() const { return isPointwiseImpl(); }
   std::unique_ptr<HorizontalExtentImpl> limit(int minus, int plus) const {
-    return limit_impl(minus, plus);
+    return limitImpl(minus, plus);
   }
 
 protected:
-  virtual void add_impl(HorizontalExtentImpl const& other) = 0;
-  virtual void merge_impl(HorizontalExtentImpl const& other) = 0;
-  virtual void merge_impl(ast::HorizontalOffset const& other) = 0;
-  virtual bool equals_impl(HorizontalExtentImpl const& other) const = 0;
-  virtual std::unique_ptr<HorizontalExtentImpl> clone_impl() const = 0;
-  virtual bool isPointwise_impl() const = 0;
-  virtual std::unique_ptr<HorizontalExtentImpl> limit_impl(int minus, int plus) const = 0;
+  virtual void addImpl(HorizontalExtentImpl const& other) = 0;
+  virtual void mergeImpl(HorizontalExtentImpl const& other) = 0;
+  virtual void mergeImpl(ast::HorizontalOffset const& other) = 0;
+  virtual bool equalsImpl(HorizontalExtentImpl const& other) const = 0;
+  virtual std::unique_ptr<HorizontalExtentImpl> cloneImpl() const = 0;
+  virtual bool isPointwiseImpl() const = 0;
+  virtual std::unique_ptr<HorizontalExtentImpl> limitImpl(int minus, int plus) const = 0;
 };
 
 class CartesianExtent : public HorizontalExtentImpl {
@@ -116,39 +116,39 @@ public:
 
   CartesianExtent() : CartesianExtent(0, 0, 0, 0) {}
 
-  void add_impl(HorizontalExtentImpl const& other) override {
+  void addImpl(HorizontalExtentImpl const& other) override {
     auto const& otherCartesian = dynamic_cast<CartesianExtent const&>(other);
     extents_[0] += otherCartesian.extents_[0];
     extents_[1] += otherCartesian.extents_[1];
   }
 
-  void merge_impl(HorizontalExtentImpl const& other) override {
+  void mergeImpl(HorizontalExtentImpl const& other) override {
     auto const& otherCartesian = dynamic_cast<CartesianExtent const&>(other);
     extents_[0].merge(otherCartesian.extents_[0]);
     extents_[1].merge(otherCartesian.extents_[1]);
   }
 
-  void merge_impl(ast::HorizontalOffset const& offset) override {
+  void mergeImpl(ast::HorizontalOffset const& offset) override {
     auto const& offsetCartesian = ast::offset_cast<ast::CartesianOffset const&>(offset);
     extents_[0].merge(Extent(offsetCartesian.offsetI(), offsetCartesian.offsetI()));
     extents_[1].merge(Extent(offsetCartesian.offsetJ(), offsetCartesian.offsetJ()));
   }
 
-  bool equals_impl(HorizontalExtentImpl const& other) const override {
+  bool equalsImpl(HorizontalExtentImpl const& other) const override {
     auto const& otherCartesian = dynamic_cast<CartesianExtent const&>(other);
     return extents_[0] == otherCartesian.extents_[0] && extents_[1] == otherCartesian.extents_[1];
   }
 
-  std::unique_ptr<HorizontalExtentImpl> clone_impl() const override {
+  std::unique_ptr<HorizontalExtentImpl> cloneImpl() const override {
     return std::make_unique<CartesianExtent>(extents_[0].minus(), extents_[0].plus(),
                                              extents_[1].minus(), extents_[1].plus());
   }
 
-  bool isPointwise_impl() const override {
+  bool isPointwiseImpl() const override {
     return extents_[0].isPointwise() && extents_[1].isPointwise();
   }
 
-  std::unique_ptr<HorizontalExtentImpl> limit_impl(int minus, int plus) const override {
+  std::unique_ptr<HorizontalExtentImpl> limitImpl(int minus, int plus) const override {
     return std::make_unique<CartesianExtent>(extents_[0].limit(minus, plus),
                                              extents_[1].limit(minus, plus));
   }
@@ -177,12 +177,13 @@ public:
   HorizontalExtent(ast::cartesian_, int iMinus, int iPlus, int jMinus, int jPlus)
       : impl_(std::make_unique<CartesianExtent>(iMinus, iPlus, jMinus, jPlus)) {}
 
-  HorizontalExtent(HorizontalExtent const& other)
-      : impl_(other.impl_ ? other.impl_->clone() : nullptr) {}
+  HorizontalExtent(HorizontalExtent const& other) { *this = other; }
   HorizontalExtent(HorizontalExtent&& other) = default;
   HorizontalExtent& operator=(HorizontalExtent const& other) {
     if(other.impl_)
       impl_ = other.impl_->clone();
+    else
+      impl_ = nullptr;
     return *this;
   }
   HorizontalExtent& operator=(HorizontalExtent&& other) = default;
@@ -194,7 +195,7 @@ public:
 
   bool operator==(HorizontalExtent const& other) const {
     if(impl_ && other.impl_)
-      return impl_->equals(*other.impl_);
+      return *impl_ == *other.impl_;
     else if(impl_)
       return isPointwise();
     else if(other.impl_)
@@ -223,7 +224,7 @@ public:
     else
       *this = other;
   }
-  bool isPointwise() const { return impl_ ? impl_->isPointwise() : true; }
+  bool isPointwise() const { return !impl_ || impl_->isPointwise(); }
   HorizontalExtent limit(int minus, int plus) const {
     DAWN_ASSERT(minus <= 0 && plus >= 0);
     return impl_ ? impl_->limit(minus, plus) : *this;

--- a/dawn/src/dawn/IIR/Extents.h
+++ b/dawn/src/dawn/IIR/Extents.h
@@ -225,8 +225,6 @@ public:
   void limit(HorizontalExtent const& other) {
     if(impl_ && other.impl_)
       impl_->limit(*other.impl_);
-    else if(other.impl_)
-      *this = other;
   }
 
 private:

--- a/dawn/src/dawn/IIR/Extents.h
+++ b/dawn/src/dawn/IIR/Extents.h
@@ -40,6 +40,7 @@ public:
   /// @name Constructors and Assignment
   /// @{
   Extent(int minus, int plus) : minus_(minus), plus_(plus) {}
+  Extent(int extent) : Extent(extent, extent) {}
   Extent() : Extent(0, 0) {}
   /// @}
 

--- a/dawn/src/dawn/IIR/MultiStage.cpp
+++ b/dawn/src/dawn/IIR/MultiStage.cpp
@@ -159,10 +159,9 @@ Extent MultiStage::getKCacheVertExtent(const int accessID) const {
   if(cache.getCacheIOPolicy() == iir::Cache::CacheIOPolicy::epflush) {
     DAWN_ASSERT(cache.getWindow());
     auto window = *(cache.getWindow());
-    return vertExtent.merge(iir::Extent{window.m_m, window.m_p});
-  } else {
-    return vertExtent;
+    vertExtent.merge(iir::Extent{window.m_m, window.m_p});
   }
+  return vertExtent;
 }
 
 std::optional<Extents> MultiStage::computeExtents(const int accessID,

--- a/dawn/test/unit-test/dawn/AST/CMakeLists.txt
+++ b/dawn/test/unit-test/dawn/AST/CMakeLists.txt
@@ -12,8 +12,11 @@
 ##
 ##===------------------------------------------------------------------------------------------===##
 
-add_subdirectory(AST)
-add_subdirectory(Optimizer)
-add_subdirectory(IIR)
-add_subdirectory(SIR)
-add_subdirectory(Support)
+dawn_add_unittest_impl(
+  NAME DawnUnittestAST
+  SOURCES
+          TestOffset.cpp
+          TestMain.cpp
+)
+target_include_directories(DawnUnittestAST PUBLIC $<TARGET_PROPERTY:DawnASTObjects,INCLUDE_DIRECTORIES>)
+

--- a/dawn/test/unit-test/dawn/AST/TestMain.cpp
+++ b/dawn/test/unit-test/dawn/AST/TestMain.cpp
@@ -1,0 +1,20 @@
+//===--------------------------------------------------------------------------------*- C++ -*-===//
+//                          _
+//                         | |
+//                       __| | __ ___      ___ ___
+//                      / _` |/ _` \ \ /\ / / '_  |
+//                     | (_| | (_| |\ V  V /| | | |
+//                      \__,_|\__,_| \_/\_/ |_| |_| - Compiler Toolchain
+//
+//
+//  This file is distributed under the MIT License (MIT).
+//  See LICENSE.txt for details.
+//
+//===------------------------------------------------------------------------------------------===//
+
+#include <gtest/gtest.h>
+
+int main(int argc, char* argv[]) {
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/dawn/test/unit-test/dawn/AST/TestOffset.cpp
+++ b/dawn/test/unit-test/dawn/AST/TestOffset.cpp
@@ -1,0 +1,120 @@
+//===--------------------------------------------------------------------------------*- C++ -*-===//
+//                          _
+//                         | |
+//                       __| | __ ___      ___ ___
+//                      / _` |/ _` \ \ /\ / / '_  |
+//                     | (_| | (_| |\ V  V /| | | |
+//                      \__,_|\__,_| \_/\_/ |_| |_| - Compiler Toolchain
+//
+//
+//  This file is distributed under the MIT License (MIT).
+//  See LICENSE.txt for details.
+//
+//===------------------------------------------------------------------------------------------===//
+
+#include "dawn/IIR/Extents.h"
+#include <gtest/gtest.h>
+
+using namespace dawn;
+using namespace ast;
+
+namespace {
+TEST(OffsetsTest, Construction) {
+  EXPECT_EQ(Offsets(cartesian, 1, 2, 3), Offsets(cartesian, std::array<int, 3>{1, 2, 3}));
+  EXPECT_EQ(Offsets(cartesian, 0, 0, 0), Offsets(cartesian));
+  EXPECT_EQ(Offsets(cartesian, 0, 0, 0), Offsets());
+
+  Offsets offset1{cartesian, 1, 2, 3};
+  Offsets offset2{cartesian, 3, 2, 1};
+
+  // copy assignment
+  offset2 = offset1;
+  EXPECT_EQ(offset1, offset2);
+
+  // move assignment
+  Offsets offset3;
+  offset3 = std::move(offset2);
+  EXPECT_EQ(offset1, offset3);
+
+  // move constructor
+  Offsets offset4{std::move(offset3)};
+  EXPECT_EQ(offset1, offset4);
+
+  // copy constructor
+  Offsets offset5{offset1};
+  EXPECT_EQ(offset1, offset5);
+}
+
+TEST(OffsetsTest, NullConstruction) {
+  Offsets offset1{cartesian, 1, 2, 3};
+  Offsets offset2{cartesian, 3, 2, 1};
+
+  Offsets nullOffset1;
+  Offsets nullOffset2;
+
+  // copy assignment
+  nullOffset1 = offset1;
+  EXPECT_EQ(nullOffset1, offset1);
+  nullOffset1 = nullOffset2;
+  EXPECT_EQ(nullOffset1, nullOffset2);
+
+  // move assignment
+  Offsets offset3{offset1};
+  offset3 = std::move(nullOffset2);
+  EXPECT_EQ(nullOffset1, offset3);
+  nullOffset2 = Offsets{};
+
+  // move constructor
+  Offsets offset4{std::move(nullOffset2)};
+  EXPECT_EQ(nullOffset1, offset4);
+  nullOffset2 = Offsets{};
+
+  // copy constructor
+  Offsets offset5{nullOffset2};
+  EXPECT_EQ(nullOffset1, nullOffset2);
+  EXPECT_EQ(nullOffset1, offset5);
+}
+
+TEST(OffsetsTest, OffsetCast) {
+  Offsets offset{cartesian, 1, 2, 3};
+  auto const& hOffset = offset_cast<CartesianOffset const&>(offset.horizontalOffset());
+  EXPECT_EQ(hOffset.offsetI(), 1);
+  EXPECT_EQ(hOffset.offsetJ(), 2);
+
+  Offsets offset2{};
+  auto const& hOffset2 = offset_cast<CartesianOffset const&>(offset2.horizontalOffset());
+  EXPECT_EQ(hOffset2.offsetI(), 0);
+  EXPECT_EQ(hOffset2.offsetJ(), 0);
+}
+
+TEST(OffsetsTest, Add) {
+  Offsets offset{cartesian, 1, 2, 3};
+  offset += offset;
+  EXPECT_EQ(offset, Offsets(cartesian, 2, 4, 6));
+
+  offset += Offsets();
+  EXPECT_EQ(offset, Offsets(cartesian, 2, 4, 6));
+
+  Offsets offset2{};
+  offset2 += offset2;
+  EXPECT_EQ(offset2, Offsets(cartesian));
+  offset2 += offset;
+  EXPECT_EQ(offset2, Offsets(cartesian, 2, 4, 6));
+}
+
+TEST(OffsetsTest, isZero) {
+  EXPECT_TRUE(Offsets().isZero());
+  EXPECT_TRUE(Offsets(cartesian).isZero());
+  EXPECT_TRUE(Offsets(cartesian, 0, 0, 0).isZero());
+
+  EXPECT_FALSE(Offsets(cartesian, 1, 0, 0).isZero());
+  EXPECT_FALSE(Offsets(cartesian, 0, 1, 0).isZero());
+  EXPECT_FALSE(Offsets(cartesian, 0, 0, 1).isZero());
+}
+
+TEST(OffsetsTest, verticalOffset) {
+  EXPECT_EQ(Offsets().verticalOffset(), 0);
+  EXPECT_EQ(Offsets(cartesian, 1, 2, 3).verticalOffset(), 3);
+}
+
+} // namespace

--- a/dawn/test/unit-test/dawn/IIR/TestExtent.cpp
+++ b/dawn/test/unit-test/dawn/IIR/TestExtent.cpp
@@ -38,6 +38,12 @@ TEST(ExtentsTest, Construction) {
   Extents extents5{std::move(extents4)};
   EXPECT_EQ(extents5, expected);
 }
+TEST(ExtentsTest, EmptyConstruction) {
+  EXPECT_EQ(Extents(ast::cartesian), Extents());
+  EXPECT_NE(Extents(ast::cartesian, -1, 1, -1, 1, -1, 1), Extents());
+
+  EXPECT_EQ(Extents(), Extents());
+}
 
 TEST(ExtentsTest, PointWise) {
   Extents extents1(ast::Offsets{ast::cartesian, 0, 1, 0});
@@ -51,29 +57,36 @@ TEST(ExtentsTest, PointWise) {
   Extents extents3(ast::Offsets{ast::cartesian, 0, 0, 1});
   EXPECT_TRUE(extents3.isHorizontalPointwise());
   EXPECT_FALSE(extents3.isVerticalPointwise());
+
+  EXPECT_TRUE(Extents().isPointwise());
 }
 
-TEST(ExtentsTest, Merge1) {
+TEST(ExtentsTest, MergeWithExtent) {
   Extents extents(ast::Offsets{ast::cartesian, -1, 1, 0});
   Extents extentsToMerge(ast::Offsets{ast::cartesian, 3, 2, 1});
   extents.merge(extentsToMerge);
 
   EXPECT_EQ(extents, Extents(ast::cartesian, -1, 3, 1, 2, 0, 1));
+
+  Extents emptyExtent;
+  emptyExtent.merge(Extents());
+  EXPECT_EQ(emptyExtent, Extents());
+  emptyExtent.merge(Extents(ast::cartesian, -1, -1, 1, 1, 0, 0));
+  EXPECT_EQ(emptyExtent, Extents(ast::cartesian, -1, -1, 1, 1, 0, 0));
+  emptyExtent.merge(Extents());
+  EXPECT_EQ(emptyExtent, Extents(ast::cartesian, -1, -1, 1, 1, 0, 0));
 }
 
-TEST(ExtentsTest, Merge2) {
+TEST(ExtentsTest, MergeWithOffset) {
   Extents extents(ast::Offsets{ast::cartesian, -1, 1, 0});
-  Extents extentsToMerge(ast::Offsets{ast::cartesian, -2, 2, 0});
-  extents.merge(extentsToMerge);
-
+  extents.merge(ast::Offsets{ast::cartesian, -2, 2, 0});
   EXPECT_EQ(extents, Extents(ast::cartesian, -2, -1, 1, 2, 0, 0));
-}
 
-TEST(ExtentsTest, Merge3) {
-  Extents extents(ast::Offsets{ast::cartesian, -1, 1, 0});
-  extents.merge(ast::Offsets{ast::cartesian, -2, 0, 0});
-
-  EXPECT_EQ(extents, Extents(ast::cartesian, -2, -1, 0, 1, 0, 0));
+  Extents emptyExtent;
+  emptyExtent.merge(ast::Offsets{ast::cartesian, 0, 0, 0});
+  EXPECT_EQ(emptyExtent, Extents());
+  emptyExtent.merge(ast::Offsets{ast::cartesian, 1, 2, 3});
+  EXPECT_EQ(emptyExtent, Extents(ast::cartesian, 0, 1, 0, 2, 0, 3));
 }
 
 TEST(ExtentsTest, Add) {
@@ -81,6 +94,11 @@ TEST(ExtentsTest, Add) {
   EXPECT_EQ(extents + extents, Extents(ast::cartesian, -4, 4, 0, 0, 0, 0));
   extents += extents;
   EXPECT_EQ(extents, Extents(ast::cartesian, -4, 4, 0, 0, 0, 0));
+
+  Extents emptyExtent;
+  EXPECT_EQ(emptyExtent + extents, extents);
+  EXPECT_EQ(extents + emptyExtent, extents);
+  EXPECT_EQ(emptyExtent + emptyExtent, emptyExtent);
 }
 
 TEST(ExtentsTest, addCenter) {

--- a/dawn/test/unit-test/dawn/IIR/TestExtent.cpp
+++ b/dawn/test/unit-test/dawn/IIR/TestExtent.cpp
@@ -73,17 +73,14 @@ TEST(ExtentsTest, PointWise) {
 TEST(ExtentsTest, MergeWithExtent) {
   Extents extents(ast::Offsets{ast::cartesian, -1, 1, 0});
   Extents extentsToMerge(ast::Offsets{ast::cartesian, 3, 2, 1});
-  extents.merge(extentsToMerge);
+  EXPECT_EQ(merge(extents, extentsToMerge), Extents(ast::cartesian, -1, 3, 1, 2, 0, 1));
 
-  EXPECT_EQ(extents, Extents(ast::cartesian, -1, 3, 1, 2, 0, 1));
-
-  Extents emptyExtent;
-  emptyExtent.merge(Extents());
-  EXPECT_EQ(emptyExtent, Extents());
-  emptyExtent.merge(Extents(ast::cartesian, -1, -1, 1, 1, 0, 0));
-  EXPECT_EQ(emptyExtent, Extents(ast::cartesian, -1, 0, 0, 1, 0, 0));
-  emptyExtent.merge(Extents());
-  EXPECT_EQ(emptyExtent, Extents(ast::cartesian, -1, 0, 0, 1, 0, 0));
+  EXPECT_EQ(merge(Extents(), Extents()), Extents());
+  EXPECT_EQ(merge(Extents(ast::cartesian, -1, -1, 1, 1, 0, 0), Extents()),
+            Extents(ast::cartesian, -1, 0, 0, 1, 0, 0));
+  EXPECT_EQ(merge(Extents(ast::cartesian, -1, 2, -2, 1, 0, 0),
+                  Extents(ast::cartesian, -2, 1, -1, 2, 0, 0)),
+            Extents(ast::cartesian, -2, 2, -2, 2, 0, 0));
 }
 
 TEST(ExtentsTest, MergeWithOffset) {
@@ -96,6 +93,15 @@ TEST(ExtentsTest, MergeWithOffset) {
   EXPECT_EQ(emptyExtent, Extents());
   emptyExtent.merge(ast::Offsets{ast::cartesian, 1, 2, 3});
   EXPECT_EQ(emptyExtent, Extents(ast::cartesian, 0, 1, 0, 2, 0, 3));
+}
+TEST(ExtentsTest, Limit) {
+  EXPECT_EQ(limit(Extents{ast::cartesian, -2, 2, -2, 2, 0, 0},
+                  Extents{ast::cartesian, -1, 1, -1, 1, 0, 0}),
+            Extents(ast::cartesian, -1, 1, -1, 1, 0, 0));
+
+  EXPECT_EQ(limit(Extents{ast::cartesian, -2, 1, -1, 2, 0, 0},
+                  Extents{ast::cartesian, -1, 2, -2, 1, 0, 0}),
+            Extents(ast::cartesian, -1, 1, -1, 1, 0, 0));
 }
 
 TEST(ExtentsTest, Add) {

--- a/dawn/test/unit-test/dawn/IIR/TestExtent.cpp
+++ b/dawn/test/unit-test/dawn/IIR/TestExtent.cpp
@@ -51,7 +51,7 @@ TEST(ExtentsTest, EmptyConstruction) {
 
   Extents extents2{ast::cartesian, -1, 1, -1, 1, -1, 1};
   extents2 = std::move(nullExtent);
-  EXPECT_EQ(extents2, nullExtent);
+  EXPECT_EQ(extents2, Extents());
 }
 
 TEST(ExtentsTest, PointWise) {

--- a/dawn/test/unit-test/dawn/IIR/TestExtent.cpp
+++ b/dawn/test/unit-test/dawn/IIR/TestExtent.cpp
@@ -81,9 +81,9 @@ TEST(ExtentsTest, MergeWithExtent) {
   emptyExtent.merge(Extents());
   EXPECT_EQ(emptyExtent, Extents());
   emptyExtent.merge(Extents(ast::cartesian, -1, -1, 1, 1, 0, 0));
-  EXPECT_EQ(emptyExtent, Extents(ast::cartesian, -1, -1, 1, 1, 0, 0));
+  EXPECT_EQ(emptyExtent, Extents(ast::cartesian, -1, 0, 0, 1, 0, 0));
   emptyExtent.merge(Extents());
-  EXPECT_EQ(emptyExtent, Extents(ast::cartesian, -1, -1, 1, 1, 0, 0));
+  EXPECT_EQ(emptyExtent, Extents(ast::cartesian, -1, 0, 0, 1, 0, 0));
 }
 
 TEST(ExtentsTest, MergeWithOffset) {

--- a/dawn/test/unit-test/dawn/IIR/TestExtent.cpp
+++ b/dawn/test/unit-test/dawn/IIR/TestExtent.cpp
@@ -43,6 +43,15 @@ TEST(ExtentsTest, EmptyConstruction) {
   EXPECT_NE(Extents(ast::cartesian, -1, 1, -1, 1, -1, 1), Extents());
 
   EXPECT_EQ(Extents(), Extents());
+
+  Extents nullExtent;
+  Extents extents1{ast::cartesian, -1, 1, -1, 1, -1, 1};
+  extents1 = nullExtent;
+  EXPECT_EQ(extents1, nullExtent);
+
+  Extents extents2{ast::cartesian, -1, 1, -1, 1, -1, 1};
+  extents2 = std::move(nullExtent);
+  EXPECT_EQ(extents2, nullExtent);
 }
 
 TEST(ExtentsTest, PointWise) {


### PR DESCRIPTION
## Technical Description

Extents and offsets are now default constructible. The default constructor creates a null offset/extent that can be used with and transformed into an unstructured and/or cartesian offset/extent. This is very helpful for generic passes that need to be able to create offsets/extents, but are not aware of the grid type.

- Adds default constructor for offset
- Adds default constructor for extent
- Adds tests for Offset class
- Improve tests for Extent class

resolves #369

### Examples

```
Extents my_extent{};
Extents cartesian_extent{ast::cartesian};
auto added_extent = my_extent + cartesian_extent;
auto const& hExtent = extent_cast<CartesianExtent const&>(added_extent.horizontalExtent());
// throws bad_cast when unstructured extents are implemented:
// auto const& hExtent = extent_cast<UnstructuredExtent const&>(added_extent.horizontalExtent());
```

Zero extents can be converted to any extent kind:
```
Extents my_extent{};
auto const& hExtent = extent_cast<CartesianExtent const&>(my_extent.horizontalExtent());
```

### Dependencies

No dependencies


