### PR TITLE
Fix compilation for GTClang with LLVM 9

### DIFF
--- a/gtclang/src/gtclang/Support/ClangCompat/CompilerInvocation.h
+++ b/gtclang/src/gtclang/Support/ClangCompat/CompilerInvocation.h
@@ -22,7 +22,7 @@
 #include "llvm/Option/Option.h"
 
 namespace gtclang::clang_compat::CompilerInvocation {
-#if CLANG_VERSION_MAJOR < 9
+#if CLANG_VERSION_MAJOR <= 9
 inline bool CreateFromArgs(clang::CompilerInvocation& Res, llvm::opt::ArgStringList& ccArgs,
                            clang::DiagnosticsEngine& Diags) {
   return clang::CompilerInvocation::CreateFromArgs(

--- a/gtclang/src/gtclang/Support/ClangCompat/CompilerInvocation.h
+++ b/gtclang/src/gtclang/Support/ClangCompat/CompilerInvocation.h
@@ -22,7 +22,7 @@
 #include "llvm/Option/Option.h"
 
 namespace gtclang::clang_compat::CompilerInvocation {
-#if CLANG_VERSION_MAJOR <= 9
+#if CLANG_VERSION_MAJOR < 10
 inline bool CreateFromArgs(clang::CompilerInvocation& Res, llvm::opt::ArgStringList& ccArgs,
                            clang::DiagnosticsEngine& Diags) {
   return clang::CompilerInvocation::CreateFromArgs(

--- a/gtclang/src/gtclang/Support/ClangCompat/FileUtil.h
+++ b/gtclang/src/gtclang/Support/ClangCompat/FileUtil.h
@@ -21,7 +21,7 @@
 #include "clang/Basic/Version.h"
 
 namespace gtclang::clang_compat::FileUtil {
-#if CLANG_VERSION_MAJOR <= 9
+#if CLANG_VERSION_MAJOR < 10
 inline const clang::FileEntry* getFile(clang::FileManager& files, ::llvm::StringRef filename) {
   return files.getFile(filename);
 }

--- a/gtclang/src/gtclang/Support/ClangCompat/FileUtil.h
+++ b/gtclang/src/gtclang/Support/ClangCompat/FileUtil.h
@@ -21,7 +21,7 @@
 #include "clang/Basic/Version.h"
 
 namespace gtclang::clang_compat::FileUtil {
-#if CLANG_VERSION_MAJOR < 9
+#if CLANG_VERSION_MAJOR <= 9
 inline const clang::FileEntry* getFile(clang::FileManager& files, ::llvm::StringRef filename) {
   return files.getFile(filename);
 }


### PR DESCRIPTION
## Technical Description

Fix compilation with clang 9. I can still not use gtclang built with llvm 9, but at least it compiles.

### Resolves / Enhances

Regression from #344
