### PR TITLE
Optimizer gt104

### DIFF
--- a/dawn/src/dawn/Compiler/DawnCompiler.cpp
+++ b/dawn/src/dawn/Compiler/DawnCompiler.cpp
@@ -226,7 +226,17 @@ std::unique_ptr<OptimizerContext> DawnCompiler::runOptimizer(std::shared_ptr<SIR
 
       DAWN_LOG(INFO) << "Starting Optimization and Analysis passes for `"
                      << instantiation->getName() << "` ...";
-      if(!optimizer->getPassManager().runAllPassesOnStecilInstantiation(*optimizer, instantiation))
+
+      bool successfulCompilation = false;
+      if(getOptions().Debug) {
+        successfulCompilation = optimizer->getPassManager().runAllDebugPassesOnStecilInstantiation(
+            *optimizer, instantiation);
+      } else {
+        successfulCompilation = optimizer->getPassManager().runAllPassesOnStecilInstantiation(
+            *optimizer, instantiation);
+      }
+
+      if(!successfulCompilation)
         return nullptr;
 
       DAWN_LOG(INFO) << "Done with Optimization and Analysis passes for `"

--- a/dawn/src/dawn/Optimizer/OptimizerContext.h
+++ b/dawn/src/dawn/Optimizer/OptimizerContext.h
@@ -124,7 +124,7 @@ public:
   bool compareOptionsToPassFlags(const std::unique_ptr<T>& p) {
 
     bool retval;
-    if(options_.Debug)
+    if(true) // temporarily forced to true to see if other backends break
       retval = p->isDebug();
     else
       retval = true;

--- a/dawn/src/dawn/Optimizer/OptimizerOptions.inc
+++ b/dawn/src/dawn/Optimizer/OptimizerOptions.inc
@@ -37,7 +37,7 @@ OPT(int, MaxHaloPoints, 3, "max-halo", "",
 OPT(std::string, block_size, "", "block-size", "",
         "block size for tiled computations", "", true, false)
 OPT(bool, Debug, false, "debug", "",
-    "Compile to debug backend", "", false, true)
+    "Do not optimize, only run passes which are needed for correct parallel code", "", false, true)
 OPT(bool, SSA, false, "ssa", "",
     "Transform all statements into static single assigment (SSA) form", "", false, true)
 OPT(bool, MergeTemporaries, false, "merge-temporaries", "", 

--- a/dawn/src/dawn/Optimizer/PassManager.cpp
+++ b/dawn/src/dawn/Optimizer/PassManager.cpp
@@ -20,11 +20,16 @@
 
 namespace dawn {
 
-bool PassManager::runAllPassesOnStecilInstantiation(
-    OptimizerContext& context, const std::shared_ptr<iir::StencilInstantiation>& instantiation) {
+bool PassManager::runPassesOnStecilInstantiationImpl(
+    OptimizerContext& context, const std::shared_ptr<iir::StencilInstantiation>& instantiation,
+    bool debugBuild) {
   std::vector<std::string> passesRan;
 
   for(auto& pass : passes_) {
+    if(debugBuild && !pass->isDebug()) {
+      continue;
+    }
+
     for(const auto& dependency : pass->getDependencies())
       if(std::find(passesRan.begin(), passesRan.end(), dependency) == passesRan.end()) {
         DiagnosticsBuilder diag(DiagnosticsKind::Error);
@@ -40,6 +45,16 @@ bool PassManager::runAllPassesOnStecilInstantiation(
     passesRan.emplace_back(pass->getName());
   }
   return true;
+}
+
+bool PassManager::runAllPassesOnStecilInstantiation(
+    OptimizerContext& context, const std::shared_ptr<iir::StencilInstantiation>& instantiation) {
+  return runPassesOnStecilInstantiationImpl(context, instantiation, false);
+}
+
+bool PassManager::runAllDebugPassesOnStecilInstantiation(
+    OptimizerContext& context, const std::shared_ptr<iir::StencilInstantiation>& instantiation) {
+  return runPassesOnStecilInstantiationImpl(context, instantiation, true);
 }
 
 bool PassManager::runPassOnStecilInstantiation(

--- a/dawn/src/dawn/Optimizer/PassManager.h
+++ b/dawn/src/dawn/Optimizer/PassManager.h
@@ -33,6 +33,10 @@ class PassManager : public NonCopyable {
   std::list<std::unique_ptr<Pass>> passes_;
   std::unordered_map<std::string, int> passCounter_;
 
+  bool runPassesOnStecilInstantiationImpl(
+      OptimizerContext& context, const std::shared_ptr<iir::StencilInstantiation>& instantiation,
+      bool debugBuild);
+
 public:
   /// @brief Create a new pass at the end of the pass list
   template <class T, typename... Args>
@@ -49,6 +53,12 @@ public:
   /// @brief Run all passes on the `instantiation`
   /// @returns `true` on success, `false` otherwise
   bool runAllPassesOnStecilInstantiation(
+      OptimizerContext& context, const std::shared_ptr<iir::StencilInstantiation>& instantiation);
+
+  /// @brief Run all passes on the `instantiation` which are markes as debug, i.e. the passes
+  /// required to generate correct (parallel) code
+  /// @returns `true` on success, `false` otherwise
+  bool runAllDebugPassesOnStecilInstantiation(
       OptimizerContext& context, const std::shared_ptr<iir::StencilInstantiation>& instantiation);
 
   /// @brief Run the given pass on the `instantiation`

--- a/dawn/src/dawn/Optimizer/PassSetBoundaryCondition.cpp
+++ b/dawn/src/dawn/Optimizer/PassSetBoundaryCondition.cpp
@@ -116,7 +116,7 @@ public:
 };
 
 PassSetBoundaryCondition::PassSetBoundaryCondition(OptimizerContext& context)
-    : Pass(context, "PassSetBoundaryCondition") {}
+    : Pass(context, "PassSetBoundaryCondition", true) {}
 
 bool PassSetBoundaryCondition::run(
     const std::shared_ptr<iir::StencilInstantiation>& stencilInstantiation) {

--- a/dawn/src/dawn/Optimizer/PassSetStageGraph.cpp
+++ b/dawn/src/dawn/Optimizer/PassSetStageGraph.cpp
@@ -57,7 +57,7 @@ static bool depends(const iir::Stage& fromStage, const iir::Stage& toStage) {
 }
 
 PassSetStageGraph::PassSetStageGraph(OptimizerContext& context)
-    : Pass(context, "PassSetStageGraph") {
+    : Pass(context, "PassSetStageGraph", true) {
   dependencies_.push_back("PassSetStageName");
 }
 

--- a/dawn/src/dawn/Optimizer/PassSetSyncStage.cpp
+++ b/dawn/src/dawn/Optimizer/PassSetSyncStage.cpp
@@ -71,7 +71,8 @@ bool PassSetSyncStage::requiresSync(const iir::Stage& stage,
   return false;
 }
 
-PassSetSyncStage::PassSetSyncStage(OptimizerContext& context) : Pass(context, "PassSetSyncStage") {}
+PassSetSyncStage::PassSetSyncStage(OptimizerContext& context)
+    : Pass(context, "PassSetSyncStage", true) {}
 
 bool PassSetSyncStage::run(const std::shared_ptr<iir::StencilInstantiation>& instantiation) {
   for(const auto& doMethod : iterateIIROver<iir::DoMethod>(*(instantiation->getIIR()))) {

--- a/dawn/src/dawn/Optimizer/PassStencilSplitter.cpp
+++ b/dawn/src/dawn/Optimizer/PassStencilSplitter.cpp
@@ -43,7 +43,7 @@ static int mergePossible(const std::set<int>& fields, const iir::Stage* stage, i
 }
 
 PassStencilSplitter::PassStencilSplitter(OptimizerContext& context, int maxNumberOfFilelds)
-    : Pass(context, "PassStencilSplitter"), MaxFieldPerStencil(maxNumberOfFilelds) {
+    : Pass(context, "PassStencilSplitter", true), MaxFieldPerStencil(maxNumberOfFilelds) {
   dependencies_.push_back("PassSetStageGraph");
 }
 


### PR DESCRIPTION
## Technical Description

Turns out that the functionality to mark stencils as "required for correct functionality" is already there. Passes may register themselves as required for correctness in their constructors by setting debug = true. Unfortunate name but I guess this refers to a "Debug" build. However, the not all stencils required for correctness were setting the flag correctly. This is now corrected.

### Resolves / Enhances

GT-104


