### PR TITLE
Fix dangling reference

### DIFF
--- a/dawn/src/dawn/IIR/StencilMetaInformation.h
+++ b/dawn/src/dawn/IIR/StencilMetaInformation.h
@@ -199,7 +199,7 @@ public:
 
   int getStencilIDFromStencilCallStmt(const std::shared_ptr<iir::StencilCallDeclStmt>& stmt) const;
 
-  Extents getBoundaryConditionExtentsFromBCStmt(
+  Extents const& getBoundaryConditionExtentsFromBCStmt(
       const std::shared_ptr<iir::BoundaryConditionDeclStmt>& stmt) const {
     DAWN_ASSERT_MSG(boundaryConditionToExtentsMap_.count(stmt),
                     "Boundary Condition does not have a matching Extent");


### PR DESCRIPTION
## Technical Description

In [StencilFunctionAsBCGenerator](https://github.com/MeteoSwiss-APN/dawn/blob/462107cf58910e1734e20a671214452c6ad5c13a/dawn/src/dawn/CodeGen/StencilFunctionAsBCGenerator.cpp#L51) we took a reference from the member of a temporary. For some compilers this resulted in garbage values in the generated code.

Now we return a reference instead of a value.
