### PR TITLE
Fix clang-tidy warnings

### DIFF
--- a/dawn/.clang-tidy
+++ b/dawn/.clang-tidy
@@ -4,8 +4,8 @@ WarningsAsErrors: ''
 HeaderFilterRegex: ''
 AnalyzeTemporaryDtors: false
 FormatStyle:     none
-User:            vogtha
-CheckOptions:    
+User:
+CheckOptions:
   - key:             cert-dcl16-c.NewSuffixes
     value:           'L;LL;LU;LLU'
   - key:             cppcoreguidelines-non-private-member-variables-in-classes.IgnoreClassesWithAllMemberVariablesBeingPublic
@@ -31,4 +31,3 @@ CheckOptions:
   - key:             modernize-use-nullptr.NullMacros
     value:           'NULL'
 ...
-

--- a/dawn/.clang-tidy
+++ b/dawn/.clang-tidy
@@ -1,0 +1,34 @@
+---
+Checks:          'clang-diagnostic-*,clang-analyzer-*'
+WarningsAsErrors: ''
+HeaderFilterRegex: ''
+AnalyzeTemporaryDtors: false
+FormatStyle:     none
+User:            vogtha
+CheckOptions:    
+  - key:             cert-dcl16-c.NewSuffixes
+    value:           'L;LL;LU;LLU'
+  - key:             cppcoreguidelines-non-private-member-variables-in-classes.IgnoreClassesWithAllMemberVariablesBeingPublic
+    value:           '1'
+  - key:             google-readability-braces-around-statements.ShortStatementLines
+    value:           '1'
+  - key:             google-readability-function-size.StatementThreshold
+    value:           '800'
+  - key:             google-readability-namespace-comments.ShortNamespaceLines
+    value:           '10'
+  - key:             google-readability-namespace-comments.SpacesBeforeComments
+    value:           '2'
+  - key:             modernize-loop-convert.MaxCopySize
+    value:           '16'
+  - key:             modernize-loop-convert.MinConfidence
+    value:           reasonable
+  - key:             modernize-loop-convert.NamingStyle
+    value:           CamelCase
+  - key:             modernize-pass-by-value.IncludeStyle
+    value:           llvm
+  - key:             modernize-replace-auto-ptr.IncludeStyle
+    value:           llvm
+  - key:             modernize-use-nullptr.NullMacros
+    value:           'NULL'
+...
+

--- a/dawn/cmake/DawnMacros.cmake
+++ b/dawn/cmake/DawnMacros.cmake
@@ -56,7 +56,7 @@ macro(dawn_set_cxx_flags)
   yoda_check_and_set_cxx_flag("-Wno-unused-parameter" HAVE_GCC_WNO_UNUSDED_PARAMETER)
 
   if(CMAKE_BUILD_TYPE STREQUAL "Debug")
-    yoda_check_and_set_cxx_flag("-fsanitize=address" HAVE_GCC_SANITIZE_ADDRESS)
+    yoda_check_and_set_cxx_flag("-fsanitize=address,undefined" HAVE_GCC_SANITIZE_ADDRESS)
   endif()
 
   if(BUILD_SHARED_LIBS)

--- a/dawn/src/dawn-c/Options.cpp
+++ b/dawn/src/dawn-c/Options.cpp
@@ -86,8 +86,10 @@ int dawnOptionsHas(const dawnOptions_t* options, const char* name) {
 dawnOptionsEntry_t* dawnOptionsGet(const dawnOptions_t* options, const char* name) {
   const OptionsWrapper* optionsWrapper = toConstOptionsWrapper(options);
   const dawnOptionsEntry_t* entry = optionsWrapper->getOption(name);
-  if(!entry)
+  if(!entry) {
     dawnFatalError(dawn::format("option '%s' does not exist", name).c_str());
+    return nullptr; // silence a clang-tidy warning
+  }
   return OptionsEntryWrapper::copy(entry);
 }
 

--- a/dawn/src/dawn-c/util/Allocate.h
+++ b/dawn/src/dawn-c/util/Allocate.h
@@ -30,7 +30,7 @@ T* allocate() noexcept {
   T* data = (T*)std::malloc(sizeof(T));
   if(!data)
     dawnFatalError("out of memory");
-  std::memset(data, 0, sizeof(T));
+  std::memset(data, 0, sizeof(T)); // NOLINT(clang-analyzer-core.NonNullParamChecker)
   return data;
 }
 
@@ -41,7 +41,7 @@ T* allocate(std::size_t n) noexcept {
   T* data = (T*)std::malloc(n * sizeof(T));
   if(!data)
     dawnFatalError("out of memory");
-  std::memset(data, 0, sizeof(T) * n);
+  std::memset(data, 0, sizeof(T) * n); // NOLINT(clang-analyzer-core.NonNullParamChecker)
   return data;
 }
 
@@ -53,6 +53,7 @@ inline char* allocateAndCopyString(StringType&& str) {
   buffer = (char*)std::malloc((str.size() + 1) * sizeof(char));
   if(!buffer)
     dawnFatalError("out of memory");
+  // NOLINTNEXTLINE(clang-analyzer-core.NonNullParamChecker)
   std::memcpy(buffer, str.c_str(), str.size() + 1);
   return buffer;
 }

--- a/dawn/src/dawn/IIR/MultiStage.cpp
+++ b/dawn/src/dawn/IIR/MultiStage.cpp
@@ -127,7 +127,7 @@ iir::Cache& MultiStage::setCache(iir::Cache::CacheType type, iir::Cache::IOPolic
 }
 
 Interval::IntervalLevel MultiStage::lastLevelComputed(const int accessID) const {
-  Interval::IntervalLevel level;
+  Interval::IntervalLevel level{};
   bool init = false;
   for(const auto& doMethod : iterateIIROver<DoMethod>(*this)) {
     if(!doMethod->getFields().count(accessID)) {

--- a/dawn/src/dawn/IIR/StencilInstantiation.cpp
+++ b/dawn/src/dawn/IIR/StencilInstantiation.cpp
@@ -132,7 +132,6 @@ namespace {
 /// @brief Get the orignal name of the field (or variable) given by AccessID and a list of
 /// SourceLocations where this field (or variable) was accessed.
 class OriginalNameGetter : public iir::ASTVisitorForwarding {
-  const StencilMetaInformation& metadata_;
   const int AccessID_;
   const bool captureLocation_;
 
@@ -140,8 +139,8 @@ class OriginalNameGetter : public iir::ASTVisitorForwarding {
   std::vector<SourceLocation> locations_;
 
 public:
-  OriginalNameGetter(const StencilMetaInformation& metadata, int AccessID, bool captureLocation)
-      : metadata_(metadata), AccessID_(AccessID), captureLocation_(captureLocation) {}
+  OriginalNameGetter(int AccessID, bool captureLocation)
+      : AccessID_(AccessID), captureLocation_(captureLocation) {}
 
   virtual void visit(const std::shared_ptr<iir::VarDeclStmt>& stmt) override {
     if(iir::getAccessID(stmt) == AccessID_) {
@@ -191,13 +190,13 @@ public:
 std::pair<std::string, std::vector<SourceLocation>>
 StencilInstantiation::getOriginalNameAndLocationsFromAccessID(
     int AccessID, const std::shared_ptr<iir::Stmt>& stmt) const {
-  OriginalNameGetter orignalNameGetter(metadata_, AccessID, true);
+  OriginalNameGetter orignalNameGetter(AccessID, true);
   stmt->accept(orignalNameGetter);
   return orignalNameGetter.getNameLocationPair();
 }
 
 std::string StencilInstantiation::getOriginalNameFromAccessID(int AccessID) const {
-  OriginalNameGetter orignalNameGetter(metadata_, AccessID, true);
+  OriginalNameGetter orignalNameGetter(AccessID, true);
 
   for(const auto& stmt : iterateIIROverStmt(*getIIR())) {
     stmt->accept(orignalNameGetter);

--- a/dawn/src/dawn/Optimizer/PassDataLocalityMetric.cpp
+++ b/dawn/src/dawn/Optimizer/PassDataLocalityMetric.cpp
@@ -31,7 +31,6 @@ namespace dawn {
 namespace {
 
 class ReadWriteCounter : public iir::ASTVisitorForwarding {
-  const std::shared_ptr<iir::StencilInstantiation>& instantiation_;
   const iir::StencilMetaInformation& metadata_;
   OptimizerContext& context_;
 
@@ -64,8 +63,8 @@ class ReadWriteCounter : public iir::ASTVisitorForwarding {
 public:
   ReadWriteCounter(const std::shared_ptr<iir::StencilInstantiation>& instantiation,
                    OptimizerContext& context, const iir::MultiStage& multiStage)
-      : instantiation_(instantiation), metadata_(instantiation->getMetaData()), context_(context),
-        numReads_(0), numWrites_(0), multiStage_(multiStage), fields_(multiStage_.getFields()) {}
+      : metadata_(instantiation->getMetaData()), context_(context), numReads_(0), numWrites_(0),
+        multiStage_(multiStage), fields_(multiStage_.getFields()) {}
 
   std::size_t getNumReads() const { return numReads_; }
   std::size_t getNumWrites() const { return numWrites_; }

--- a/dawn/src/dawn/Optimizer/PassSSA.cpp
+++ b/dawn/src/dawn/Optimizer/PassSSA.cpp
@@ -49,35 +49,37 @@ bool PassSSA::run(const std::shared_ptr<iir::StencilInstantiation>& stencilInsta
         iir::AssignmentExpr* assignment = nullptr;
         if(iir::ExprStmt* exprStmt = dyn_cast<iir::ExprStmt>(stmt.get()))
           assignment = dyn_cast<iir::AssignmentExpr>(exprStmt->getExpr().get());
+        if(assignment) {
+          std::vector<int> AccessIDsToRename;
+          const auto& callerAccesses = stmt->getData<iir::IIRStmtData>().CallerAccesses;
 
-        std::vector<int> AccessIDsToRename;
-        const auto& callerAccesses = stmt->getData<iir::IIRStmtData>().CallerAccesses;
+          for(const std::pair<int, iir::Extents>& readAccess : callerAccesses->getReadAccesses()) {
+            int AccessID = readAccess.first;
+            if(!tochedAccessIDs.count(AccessID))
+              tochedAccessIDs.insert(AccessID);
+          }
 
-        for(const std::pair<int, iir::Extents>& readAccess : callerAccesses->getReadAccesses()) {
-          int AccessID = readAccess.first;
-          if(!tochedAccessIDs.count(AccessID))
+          // Every write to a field which was has been touched (read/written) will get a new version
+          for(const std::pair<int, iir::Extents>& writeAccess :
+              callerAccesses->getWriteAccesses()) {
+
+            int AccessID = writeAccess.first;
+
+            if(tochedAccessIDs.count(AccessID))
+              // Field was already written to, rename it in all remaining occurences
+              AccessIDsToRename.push_back(AccessID);
+
             tochedAccessIDs.insert(AccessID);
+          }
+
+          for(int AccessID : AccessIDsToRename) {
+            tochedAccessIDs.insert(
+                createVersionAndRename(stencilInstantiation.get(), AccessID, &stencil, stageIdx,
+                                       stmtIdx, assignment->getLeft(), RenameDirection::Below));
+          }
+
+          DAG->insertStatement(stmt);
         }
-
-        // Every write to a field which was has been touched (read/written) will get a new version
-        for(const std::pair<int, iir::Extents>& writeAccess : callerAccesses->getWriteAccesses()) {
-
-          int AccessID = writeAccess.first;
-
-          if(tochedAccessIDs.count(AccessID))
-            // Field was already written to, rename it in all remaining occurences
-            AccessIDsToRename.push_back(AccessID);
-
-          tochedAccessIDs.insert(AccessID);
-        }
-
-        for(int AccessID : AccessIDsToRename) {
-          tochedAccessIDs.insert(createVersionAndRename(
-              stencilInstantiation.get(), AccessID, &stencil, stageIdx, stmtIdx,
-              assignment->getLeft(), RenameDirection::Below)); // TODO assignment might be nullptr
-        }
-
-        DAG->insertStatement(stmt);
       }
     }
   }

--- a/dawn/src/dawn/Optimizer/PassSSA.cpp
+++ b/dawn/src/dawn/Optimizer/PassSSA.cpp
@@ -72,9 +72,9 @@ bool PassSSA::run(const std::shared_ptr<iir::StencilInstantiation>& stencilInsta
         }
 
         for(int AccessID : AccessIDsToRename) {
-          tochedAccessIDs.insert(
-              createVersionAndRename(stencilInstantiation.get(), AccessID, &stencil, stageIdx,
-                                     stmtIdx, assignment->getLeft(), RenameDirection::Below));
+          tochedAccessIDs.insert(createVersionAndRename(
+              stencilInstantiation.get(), AccessID, &stencil, stageIdx, stmtIdx,
+              assignment->getLeft(), RenameDirection::Below)); // TODO assignment might be nullptr
         }
 
         DAG->insertStatement(stmt);

--- a/dawn/src/dawn/Optimizer/PassTemporaryType.cpp
+++ b/dawn/src/dawn/Optimizer/PassTemporaryType.cpp
@@ -32,15 +32,14 @@ namespace dawn {
 namespace {
 
 class StencilFunArgumentDetector : public iir::ASTVisitorForwarding {
-  const iir::StencilMetaInformation& metadata_;
   int AccessID_;
 
   int argListNesting_;
   bool usedInStencilFun_;
 
 public:
-  StencilFunArgumentDetector(const iir::StencilMetaInformation& metadata, int AccessID)
-      : metadata_(metadata), AccessID_(AccessID), argListNesting_(0), usedInStencilFun_(false) {}
+  StencilFunArgumentDetector(int AccessID)
+      : AccessID_(AccessID), argListNesting_(0), usedInStencilFun_(false) {}
 
   virtual void visit(const std::shared_ptr<iir::StencilFunCallExpr>& expr) override {
     argListNesting_++;
@@ -60,7 +59,7 @@ public:
 /// any statement of the `stencil`
 /// @returns `true` if field is used as an argument
 bool usedAsArgumentInStencilFun(const std::unique_ptr<iir::Stencil>& stencil, int AccessID) {
-  StencilFunArgumentDetector visitor(stencil->getMetadata(), AccessID);
+  StencilFunArgumentDetector visitor(AccessID);
   stencil->accept(visitor);
   return visitor.usedInStencilFun();
 }

--- a/dawn/src/dawn/Optimizer/Replacing.cpp
+++ b/dawn/src/dawn/Optimizer/Replacing.cpp
@@ -27,15 +27,13 @@ namespace {
 
 /// @brief Get all field and variable accesses identifier by `AccessID`
 class GetFieldAndVarAccesses : public iir::ASTVisitorForwarding {
-  const iir::StencilMetaInformation& metadata_;
   int AccessID_;
 
   std::vector<std::shared_ptr<iir::FieldAccessExpr>> fieldAccessExprToReplace_;
   std::vector<std::shared_ptr<iir::VarAccessExpr>> varAccessesToReplace_;
 
 public:
-  GetFieldAndVarAccesses(iir::StencilMetaInformation& metadata, int AccessID)
-      : metadata_(metadata), AccessID_(AccessID) {}
+  GetFieldAndVarAccesses(int AccessID) : AccessID_(AccessID) {}
 
   void visit(const std::shared_ptr<iir::VarAccessExpr>& expr) override {
     if(iir::getAccessID(expr) == AccessID_)
@@ -63,11 +61,10 @@ public:
 
 } // anonymous namespace
 
-void replaceFieldWithVarAccessInStmts(iir::StencilMetaInformation& metadata, iir::Stencil* stencil,
-                                      int AccessID, const std::string& varname,
+void replaceFieldWithVarAccessInStmts(iir::Stencil* stencil, int AccessID,
+                                      const std::string& varname,
                                       ArrayRef<std::shared_ptr<iir::Stmt>> stmts) {
-
-  GetFieldAndVarAccesses visitor(metadata, AccessID);
+  GetFieldAndVarAccesses visitor(AccessID);
   for(const auto& stmt : stmts) {
     visitor.reset();
 
@@ -83,11 +80,12 @@ void replaceFieldWithVarAccessInStmts(iir::StencilMetaInformation& metadata, iir
   }
 }
 
-void replaceVarWithFieldAccessInStmts(iir::StencilMetaInformation& metadata, iir::Stencil* stencil,
-                                      int AccessID, const std::string& fieldname,
+void replaceVarWithFieldAccessInStmts(iir::StencilMetaInformation& /*unused*/,
+                                      iir::Stencil* stencil, int AccessID,
+                                      const std::string& fieldname,
                                       ArrayRef<std::shared_ptr<iir::Stmt>> stmts) {
 
-  GetFieldAndVarAccesses visitor(metadata, AccessID);
+  GetFieldAndVarAccesses visitor(AccessID);
   for(const auto& stmt : stmts) {
     visitor.reset();
 

--- a/dawn/src/dawn/Optimizer/Replacing.cpp
+++ b/dawn/src/dawn/Optimizer/Replacing.cpp
@@ -80,8 +80,7 @@ void replaceFieldWithVarAccessInStmts(iir::Stencil* stencil, int AccessID,
   }
 }
 
-void replaceVarWithFieldAccessInStmts(iir::StencilMetaInformation& /*unused*/,
-                                      iir::Stencil* stencil, int AccessID,
+void replaceVarWithFieldAccessInStmts(iir::Stencil* stencil, int AccessID,
                                       const std::string& fieldname,
                                       ArrayRef<std::shared_ptr<iir::Stmt>> stmts) {
 

--- a/dawn/src/dawn/Optimizer/Replacing.h
+++ b/dawn/src/dawn/Optimizer/Replacing.h
@@ -44,8 +44,8 @@ void replaceFieldWithVarAccessInStmts(iir::Stencil* stencil, int AccessID,
 /// @brief Replace all variable accesses with field accesses in the given `stmts`
 ///
 /// This will also modify the underlying AccessID maps of the StencilInstantiation.
-void replaceVarWithFieldAccessInStmts(iir::StencilMetaInformation& metadata, iir::Stencil* stencil,
-                                      int AccessID, const std::string& fieldname,
+void replaceVarWithFieldAccessInStmts(iir::Stencil* stencil, int AccessID,
+                                      const std::string& fieldname,
                                       ArrayRef<std::shared_ptr<iir::Stmt>> stmts);
 
 /// @brief Replace all stencil calls to `oldStencilID` with a series of stencil calls to

--- a/dawn/src/dawn/Optimizer/Replacing.h
+++ b/dawn/src/dawn/Optimizer/Replacing.h
@@ -37,8 +37,8 @@ class StencilMetaInformation;
 /// @brief Replace all field accesses with variable accesses in the given `stmts`
 ///
 /// This will also modify the underlying AccessID maps of the StencilInstantiation.
-void replaceFieldWithVarAccessInStmts(iir::StencilMetaInformation& metadata, iir::Stencil* stencil,
-                                      int AccessID, const std::string& varname,
+void replaceFieldWithVarAccessInStmts(iir::Stencil* stencil, int AccessID,
+                                      const std::string& varname,
                                       ArrayRef<std::shared_ptr<iir::Stmt>> stmts);
 
 /// @brief Replace all variable accesses with field accesses in the given `stmts`

--- a/dawn/src/dawn/Optimizer/StatementMapper.cpp
+++ b/dawn/src/dawn/Optimizer/StatementMapper.cpp
@@ -93,13 +93,10 @@ void StatementMapper::visit(const std::shared_ptr<iir::IfStmt>& stmt) {
 void StatementMapper::visit(const std::shared_ptr<iir::VarDeclStmt>& stmt) {
   DAWN_ASSERT(initializedWithBlockStmt_);
 
-  int accessID = -1;
-  if(stmt->getData<iir::VarDeclStmtData>().AccessID) {
-    accessID = iir::getAccessID(stmt);
-  } else {
+  if(!stmt->getData<iir::VarDeclStmtData>().AccessID) {
     // This is the first time we encounter this variable. We have to make sure the name is not
     // already used in another scope!
-    accessID = instantiation_->nextUID();
+    int accessID = instantiation_->nextUID();
 
     std::string globalName;
     if(context_.getOptions().KeepVarnames)

--- a/dawn/src/dawn/Optimizer/TemporaryHandling.cpp
+++ b/dawn/src/dawn/Optimizer/TemporaryHandling.cpp
@@ -107,8 +107,7 @@ void demoteTemporaryFieldToLocalVariable(iir::StencilInstantiation* instantiatio
   // Replace all field accesses with variable accesses
   stencil->forEachStatement(
       [&](ArrayRef<std::shared_ptr<iir::Stmt>> stmts) -> void {
-        replaceFieldWithVarAccessInStmts(instantiation->getMetaData(), stencil, AccessID, varname,
-                                         stmts);
+        replaceFieldWithVarAccessInStmts(stencil, AccessID, varname, stmts);
       },
       lifetime);
 

--- a/dawn/src/dawn/Optimizer/TemporaryHandling.cpp
+++ b/dawn/src/dawn/Optimizer/TemporaryHandling.cpp
@@ -33,8 +33,7 @@ void promoteLocalVariableToTemporaryField(iir::StencilInstantiation* instantiati
   // Replace all variable accesses with field accesses
   stencil->forEachStatement(
       [&](ArrayRef<std::shared_ptr<iir::Stmt>> stmt) -> void {
-        replaceVarWithFieldAccessInStmts(instantiation->getMetaData(), stencil, accessID, fieldname,
-                                         stmt);
+        replaceVarWithFieldAccessInStmts(stencil, accessID, fieldname, stmt);
       },
       lifetime);
 

--- a/dawn/src/dawn/Support/ArrayRef.h
+++ b/dawn/src/dawn/Support/ArrayRef.h
@@ -78,6 +78,8 @@ public:
 
 /// @brief Construct an ArrayRef from a std::initializer_list
 #pragma GCC diagnostic push
+// Probably not an issue, see discussion
+// http://lists.llvm.org/pipermail/llvm-dev/2018-September/126078.html
 #pragma GCC diagnostic ignored "-Winit-list-lifetime"
   ArrayRef(const std::initializer_list<T>& Vec)
       : data_(Vec.begin() == Vec.end() ? nullptr : Vec.begin()), length_(Vec.size()) {}

--- a/dawn/src/dawn/Support/ArrayRef.h
+++ b/dawn/src/dawn/Support/ArrayRef.h
@@ -76,9 +76,12 @@ public:
   template <size_t N>
   constexpr ArrayRef(const T (&Arr)[N]) : data_(Arr), length_(N) {}
 
-  /// @brief Construct an ArrayRef from a std::initializer_list
+/// @brief Construct an ArrayRef from a std::initializer_list
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Winit-list-lifetime"
   ArrayRef(const std::initializer_list<T>& Vec)
       : data_(Vec.begin() == Vec.end() ? nullptr : Vec.begin()), length_(Vec.size()) {}
+#pragma GCC diagnostic pop
 
   /// @brief Construct an ArrayRef from a SmallVector.
   ///

--- a/dawn/src/dawn/Support/EditDistance.h
+++ b/dawn/src/dawn/Support/EditDistance.h
@@ -56,6 +56,9 @@ unsigned computeEditDistance(ArrayRef<T> fromArray, ArrayRef<T> toArray,
   typename ArrayRef<T>::size_type m = fromArray.size();
   typename ArrayRef<T>::size_type n = toArray.size();
 
+  if(n == 0)
+    return m;
+
   const unsigned SmallBufferSize = 64;
   unsigned SmallBuffer[SmallBufferSize];
   std::unique_ptr<unsigned[]> Allocated;

--- a/dawn/test/unit-test/dawn/Support/TestSmallVector.cpp
+++ b/dawn/test/unit-test/dawn/Support/TestSmallVector.cpp
@@ -705,7 +705,7 @@ TEST(SmallVectorCustomTest, NoAssignTest) {
   int x = 0;
   SmallVector<notassignable, 2> vec;
   vec.push_back(notassignable(x));
-  x = 42;
+  x = 42; // NOLINT(clang-analyzer-deadcode.DeadStores)
   EXPECT_EQ(42, vec.pop_back_val().x_);
 }
 

--- a/gtclang/cmake/GTClangMacros.cmake
+++ b/gtclang/cmake/GTClangMacros.cmake
@@ -1,7 +1,7 @@
 ##===------------------------------------------------------------------------------*- CMake -*-===##
-##                         _       _       
+##                         _       _
 ##                        | |     | |
-##                    __ _| |_ ___| | __ _ _ __   __ _ 
+##                    __ _| |_ ___| | __ _ _ __   __ _
 ##                   / _` | __/ __| |/ _` | '_ \ / _` |
 ##                  | (_| | || (__| | (_| | | | | (_| |
 ##                   \__, |\__\___|_|\__,_|_| |_|\__, | - GridTools Clang DSL
@@ -9,7 +9,7 @@
 ##                   |___/                       |___/
 ##
 ##
-##  This file is distributed under the MIT License (MIT). 
+##  This file is distributed under the MIT License (MIT).
 ##  See LICENSE.txt for details.
 ##
 ##===------------------------------------------------------------------------------------------===##
@@ -32,7 +32,7 @@ macro(gtclang_set_cxx_flags)
 
   # Architecture
   yoda_check_and_set_cxx_flag("-march=native" HAVE_GCC_MARCH_NATIVE)
-  
+
   # Pthread
   yoda_check_and_set_cxx_flag("-pthread" HAVE_GCC_PTHREAD)
 
@@ -56,7 +56,11 @@ macro(gtclang_set_cxx_flags)
   yoda_check_and_set_cxx_flag("-Wno-sign-compare" HAVE_GCC_WNO_SIGN_COMPARE)
   yoda_check_and_set_cxx_flag("-Wno-unused-parameter" HAVE_GCC_WNO_UNUSDED_PARAMETER)
   yoda_check_and_set_cxx_flag("-Wno-shadow" HAVE_GCC_WNO_SHADOW)
-  
+
+  if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+    yoda_check_and_set_cxx_flag("-fsanitize=address,undefined" HAVE_GCC_SANITIZE_ADDRESS)
+  endif()
+
   if(BUILD_SHARED_LIBS)
     yoda_check_and_set_cxx_flag("-fPIC" HAVE_GCC_PIC)
   endif()
@@ -65,7 +69,7 @@ macro(gtclang_set_cxx_flags)
     if(YODA_COMPILER_CLANG)
       yoda_check_and_set_cxx_flag("-Qunused-arguments" HAVE_CLANG_UNUSED_ARGUMENTS)
       yoda_check_and_set_cxx_flag("-fcolor-diagnostics" HAVE_CLANG_COLOR_DIAGNOSTICS)
-      yoda_check_and_set_cxx_flag("-Wno-undefined-var-template" 
+      yoda_check_and_set_cxx_flag("-Wno-undefined-var-template"
                                      HAVE_CLANG_WNO_UNDEFINED_VAR_TEMPLATE)
     endif()
 
@@ -91,10 +95,10 @@ macro(gtclang_gen_install_config)
   set(GTCLANG_INSTALL_ROOT "")
 
   configure_package_config_file(
-    ${CMAKE_SOURCE_DIR}/cmake/templates/gtclangConfig.cmake.in 
+    ${CMAKE_SOURCE_DIR}/cmake/templates/gtclangConfig.cmake.in
     ${CMAKE_CURRENT_BINARY_DIR}/cmake/gtclangConfig.cmake
     INSTALL_DESTINATION ${GTCLANG_INSTALL_CMAKE_DIR}
-    PATH_VARS 
+    PATH_VARS
       GTCLANG_INSTALL_ROOT
       GTCLANG_INSTALL_INCLUDE_DIR
       GTCLANG_INSTALL_LIB_DIR
@@ -108,5 +112,3 @@ macro(gtclang_gen_install_config)
     DESTINATION ${GTCLANG_INSTALL_CMAKE_DIR}
   )
 endmacro()
-
-


### PR DESCRIPTION
## Technical Description

Adds a minimal `.clang-tidy` config file (created with `clang-tidy -dump-config`) to dawn. Fix several warnings and disable some.
Adds `-fsanitize=address,undefined` to dawn and gtclang in debug mode.