### PR TITLE
unstructured k offsets

### DIFF
--- a/dawn/prototype/README
+++ b/dawn/prototype/README
@@ -11,4 +11,4 @@ Compiling and running the prototype (until we have a proper setup)
 4. For atlas: cd prototype && g++ -o out atlas[TestCase]Driver.cpp -std=c++17 -I../../gtclang/src -I<path/to/atlas>/include -I<path/to/eckit>/include -L</path/to/atlas>/lib -latlas -L<path/to/eckit>/lib -leckit; ./out
    --> gmsh mymesh.msh
 
-NOTE: TestCase is curently one of [Copy|Diffusion]
+NOTE: TestCase is curently one of [Copy|Diffusion|VerticalSum]

--- a/dawn/prototype/atlasDiffusionDriver.cpp
+++ b/dawn/prototype/atlasDiffusionDriver.cpp
@@ -61,7 +61,8 @@ int main() {
     atlasInterface::Field<double> in_v = atlas::array::make_view<double, 2>(in);
     atlasInterface::Field<double> out_v = atlas::array::make_view<double, 2>(out);
 
-    dawn_generated::cxxnaiveico::generated<atlasInterface::atlasTag>(mesh, in_v, out_v).run();
+    dawn_generated::cxxnaiveico::generated<atlasInterface::atlasTag>(mesh, nb_levels, in_v, out_v)
+        .run();
 
     using std::swap;
     swap(in, out);

--- a/dawn/prototype/atlasVerticalSumDriver.cpp
+++ b/dawn/prototype/atlasVerticalSumDriver.cpp
@@ -11,7 +11,7 @@
 #include "atlas/output/Gmsh.h"
 #include "atlas_interface.hpp"
 
-#include "generated_copyEdgeToCell.hpp"
+#include "generated_verticalSum.hpp"
 
 int main() {
 
@@ -19,27 +19,26 @@ int main() {
   atlas::StructuredMeshGenerator generator;
   auto mesh = generator.generate(structuredGrid);
 
-  int nb_levels = 1;
-  atlas::functionspace::CellColumns fs(mesh, atlas::option::levels(nb_levels));
+  int nb_levels = 5;
+  atlas::functionspace::CellColumns fs(mesh, atlas::option::levels(nb_levels + 2));
   atlas::Field out{fs.createField<double>(atlas::option::name("out"))};
 
-  atlas::functionspace::EdgeColumns fs_edges(mesh, atlas::option::levels(nb_levels));
+  atlas::functionspace::CellColumns fs_edges(mesh, atlas::option::levels(nb_levels));
   atlas::Field in{fs_edges.createField<double>(atlas::option::name("in"))};
 
-  atlas::mesh::actions::build_edges(mesh);
-  atlas::mesh::actions::build_node_to_edge_connectivity(mesh);
-
   atlas::output::Gmsh gmesh("mymesh.msh");
-  gmesh.write(mesh);
 
-  for(int i = 0; i < 10; ++i) {
-    in.metadata().set("step", i);
-    gmesh.write(out);
+  atlasInterface::Field<double> in_v = atlas::array::make_view<double, 2>(in);
+  atlasInterface::Field<double> out_v = atlas::array::make_view<double, 2>(out);
 
-    atlasInterface::Field<double> in_v = atlas::array::make_view<double, 2>(in);
-    atlasInterface::Field<double> out_v = atlas::array::make_view<double, 2>(out);
-
-    dawn_generated::cxxnaiveico::generated<atlasInterface::atlasTag>(mesh, nb_levels, in_v, out_v)
-        .run();
+  for(int jLevel = 0; jLevel < nb_levels; ++jLevel) {
+    for(int jCell = 0; jCell < mesh.cells().size(); ++jCell) {
+      in_v(jCell, jLevel) = 10;
+    }
   }
+
+  dawn_generated::cxxnaiveico::generated<atlasInterface::atlasTag>(mesh, nb_levels, in_v, out_v)
+      .run();
+
+  gmesh.write(out);
 }

--- a/dawn/prototype/atlasVerticalSumDriver.cpp
+++ b/dawn/prototype/atlasVerticalSumDriver.cpp
@@ -31,9 +31,9 @@ int main() {
   atlasInterface::Field<double> in_v = atlas::array::make_view<double, 2>(in);
   atlasInterface::Field<double> out_v = atlas::array::make_view<double, 2>(out);
 
-  for(int jLevel = 0; jLevel < nb_levels; ++jLevel) {
-    for(int jCell = 0; jCell < mesh.cells().size(); ++jCell) {
-      in_v(jCell, jLevel) = 10;
+  for(int level = 0; level < nb_levels; ++level) {
+    for(int cell = 0; cell < mesh.cells().size(); ++cell) {
+      in_v(cell, level) = 10;
     }
   }
 

--- a/dawn/prototype/atlasVerticalSumDriver.cpp
+++ b/dawn/prototype/atlasVerticalSumDriver.cpp
@@ -20,7 +20,7 @@ int main() {
   auto mesh = generator.generate(structuredGrid);
 
   int nb_levels = 5;
-  atlas::functionspace::CellColumns fs(mesh, atlas::option::levels(nb_levels + 2));
+  atlas::functionspace::CellColumns fs(mesh, atlas::option::levels(nb_levels));
   atlas::Field out{fs.createField<double>(atlas::option::name("out"))};
 
   atlas::functionspace::CellColumns fs_edges(mesh, atlas::option::levels(nb_levels));

--- a/dawn/prototype/atlas_interface.hpp
+++ b/dawn/prototype/atlas_interface.hpp
@@ -51,8 +51,8 @@ struct atlasTag {};
 template <typename T>
 class Field {
 public:
-  T const& operator()(int f) const { return atlas_field_(f, 0); }
-  T& operator()(int f) { return atlas_field_(f, 0); }
+  T const& operator()(int f, int k) const { return atlas_field_(f, k); }
+  T& operator()(int f, int k) { return atlas_field_(f, k); }
 
   Field(atlas::array::ArrayView<T, 2> const& atlas_field) : atlas_field_(atlas_field) {}
 

--- a/dawn/prototype/mylib.cpp
+++ b/dawn/prototype/mylib.cpp
@@ -34,7 +34,7 @@ Face const& Edge::face(size_t i) const { return *faces_[i]; }
 
 int count_inner_faces(Grid const& grid) {
   int fcnt = 0;
-  for(auto& f : grid.faces()) {
+  for(const auto& f : grid.faces()) {
     if(inner_face(f)) {
       ++fcnt;
     }
@@ -81,14 +81,14 @@ std::ostream& toVtk(std::string const& name, FaceData<double> const& f_data, Gri
                     std::ostream& os) {
   os << "SCALARS " << name << "  float 1\nLOOKUP_TABLE default\n";
   for(int k_level = 0; k_level < f_data.k_size(); k_level++) {
-    for(auto& f : grid.faces())
+    for(const auto& f : grid.faces())
       if(inner_face(f))
         os << f_data(f, k_level) << '\n';
   }
 
   os << "SCALARS id int 1\nLOOKUP_TABLE default\n";
   for(int k_level = 0; k_level < f_data.k_size(); k_level++) {
-    for(auto& f : grid.faces()) {
+    for(const auto& f : grid.faces()) {
       if(inner_face(f)) {
         os << f.id() << '\n';
       }
@@ -101,7 +101,7 @@ std::ostream& toVtk(std::string const& name, EdgeData<double> const& e_data, Gri
   FaceData<double> f_data{grid, e_data.k_size()};
 
   for(int k_level = 0; k_level < f_data.k_size(); ++k_level) {
-    for(auto& cell : grid.faces()) {
+    for(const auto& cell : grid.faces()) {
       f_data(cell, k_level) = mylibInterface::reduceEdgeToCell(
           mylibInterface::mylibTag{}, grid, cell, 0,
           [&](auto& lhs, const auto& rhs) { lhs += f_data(cell, k_level); });

--- a/dawn/prototype/mylib.cpp
+++ b/dawn/prototype/mylib.cpp
@@ -86,8 +86,6 @@ std::ostream& toVtk(std::string const& name, FaceData<double> const& f_data, Gri
         os << f_data(f, k_level) << '\n';
   }
 
-  int fcnt = count_inner_faces(grid);
-
   os << "SCALARS id int 1\nLOOKUP_TABLE default\n";
   for(int k_level = 0; k_level < f_data.k_size(); k_level++) {
     for(auto& f : grid.faces()) {

--- a/dawn/prototype/mylib.hpp
+++ b/dawn/prototype/mylib.hpp
@@ -98,7 +98,7 @@ private:
 
 class Grid {
 public:
-  explicit Grid(int nx, int ny, bool periodic = false)
+  Grid(int nx, int ny, bool periodic = false)
       : faces_(2 * nx * ny), vertices_(periodic ? nx * ny : (nx + 1) * (ny + 1)),
         edges_(periodic ? 3 * nx * ny : 3 * (nx + 1) * (ny + 1)), nx_(nx), ny_(ny) {
     auto edge_at = [&](int i, int j, int c) -> Edge& {
@@ -280,7 +280,7 @@ public:
 
   std::vector<Face> const& faces() const { return faces_; }
   std::vector<Vertex> const& vertices() const { return vertices_; }
-  std::vector<Edge> edges() const { return edges_; }
+  std::vector<Edge> const& edges() const { return edges_; }
 
   auto nx() const { return nx_; }
   auto ny() const { return ny_; }

--- a/dawn/prototype/mylib.hpp
+++ b/dawn/prototype/mylib.hpp
@@ -298,12 +298,7 @@ template <typename O, typename T>
 class Data {
 public:
   explicit Data(size_t horizontal_size, size_t num_k_levels)
-  /*: data_(num_k_levels, std::vector<T>(horizontal_size))*/ {
-    data_ = std::vector<std::vector<T>>(num_k_levels);
-    for(int k = 0; k < num_k_levels; k++) {
-      data_[k] = std::vector<T>(horizontal_size);
-    }
-  }
+      : data_(num_k_levels, std::vector<T>(horizontal_size)) {}
   T& operator()(O const& f, size_t k_level) {
     if(f.id() != -1) {
       return data_[k_level][f.id()];

--- a/dawn/prototype/mylib.hpp
+++ b/dawn/prototype/mylib.hpp
@@ -297,7 +297,7 @@ private:
 template <typename O, typename T>
 class Data {
 public:
-  explicit Data(size_t horizontal_size, size_t num_k_levels)
+  Data(size_t horizontal_size, size_t num_k_levels)
       : data_(num_k_levels, std::vector<T>(horizontal_size)) {}
   T& operator()(O const& f, size_t k_level) {
     if(f.id() != -1) {
@@ -330,18 +330,17 @@ private:
 template <typename T>
 class FaceData : public Data<Face, T> {
 public:
-  explicit FaceData(Grid const& grid, int k_size) : Data<Face, T>(grid.faces().size(), k_size) {}
+  FaceData(Grid const& grid, int k_size) : Data<Face, T>(grid.faces().size(), k_size) {}
 };
 template <typename T>
 class VertexData : public Data<Vertex, T> {
 public:
-  explicit VertexData(Grid const& grid, int k_size)
-      : Data<Vertex, T>(grid.vertices().size(), k_size) {}
+  VertexData(Grid const& grid, int k_size) : Data<Vertex, T>(grid.vertices().size(), k_size) {}
 };
 template <typename T>
 class EdgeData : public Data<Edge, T> {
 public:
-  explicit EdgeData(Grid const& grid, int k_size) : Data<Edge, T>(grid.edges().size(), k_size) {}
+  EdgeData(Grid const& grid, int k_size) : Data<Edge, T>(grid.edges().size(), k_size) {}
 };
 
 std::ostream& toVtk(Grid const& grid, int k_size, std::ostream& os = std::cout);

--- a/dawn/prototype/mylibCopyDriver.cpp
+++ b/dawn/prototype/mylibCopyDriver.cpp
@@ -4,7 +4,10 @@
 
 #include "generated_copyEdgeToCell.hpp"
 
-int main() {
+using namespace mylibInterface
+
+    int
+    main() {
   int w = 20;
   Mesh m{w, w, true};
   mylib::FaceData<double> out(m);
@@ -15,6 +18,6 @@ int main() {
     toVtk(m, of);
     toVtk("temperature", out, m, of);
 
-    dawn_generated::cxxnaiveico::generated<mylibInterface::mylibTag>(m, in, out).run();
+    dawn_generated::cxxnaiveico::generated<mylibInterface::mylibTag>(m, 0, in, out).run();
   }
 }

--- a/dawn/prototype/mylibCopyDriver.cpp
+++ b/dawn/prototype/mylibCopyDriver.cpp
@@ -7,16 +7,17 @@
 using namespace mylibInterface;
 
 int main() {
-  int w = 20;
+  int w = 10;
+  int k_size = 10;
   Mesh m{w, w, true};
-  mylib::FaceData<double> out(m);
-  mylib::EdgeData<double> in(m);
+  mylib::FaceData<double> out(m, k_size);
+  mylib::EdgeData<double> in(m, k_size);
 
   for(int i = 0; i < 10; ++i) {
     std::ofstream of("of_" + std::to_string(i) + ".vtk");
-    toVtk(m, of);
+    toVtk(m, out.k_size(), of);
     toVtk("temperature", out, m, of);
 
-    dawn_generated::cxxnaiveico::generated<mylibInterface::mylibTag>(m, 0, in, out).run();
+    dawn_generated::cxxnaiveico::generated<mylibInterface::mylibTag>(m, k_size, in, out).run();
   }
 }

--- a/dawn/prototype/mylibCopyDriver.cpp
+++ b/dawn/prototype/mylibCopyDriver.cpp
@@ -4,10 +4,9 @@
 
 #include "generated_copyEdgeToCell.hpp"
 
-using namespace mylibInterface
+using namespace mylibInterface;
 
-    int
-    main() {
+int main() {
   int w = 20;
   Mesh m{w, w, true};
   mylib::FaceData<double> out(m);

--- a/dawn/prototype/mylibCopyDriver.cpp
+++ b/dawn/prototype/mylibCopyDriver.cpp
@@ -4,12 +4,10 @@
 
 #include "generated_copyEdgeToCell.hpp"
 
-using namespace mylibInterface;
-
 int main() {
   int w = 10;
   int k_size = 10;
-  Mesh m{w, w, true};
+  mylibInterface::Mesh m{w, w, true};
   mylib::FaceData<double> out(m, k_size);
   mylib::EdgeData<double> in(m, k_size);
 

--- a/dawn/prototype/mylibDiffusionDriver.cpp
+++ b/dawn/prototype/mylibDiffusionDriver.cpp
@@ -6,22 +6,23 @@
 
 int main() {
   int w = 32;
+  int k_size = 1;
   mylib::Grid m{w, w, true};
-  mylib::FaceData<double> in(m), out(m);
+  mylib::FaceData<double> in(m, k_size), out(m, k_size);
 
   for(auto& f : m.faces()) {
     auto center_x = w / 2.f - (1.f / 3) * (f.vertex(0).x() + f.vertex(1).x() + f.vertex(2).x());
     auto center_y = w / 2.f - (1.f / 3) * (f.vertex(0).y() + f.vertex(1).y() + f.vertex(2).y());
-    in(f) =
+    in(f, 0) =
         std::abs(center_x) < w / 5. && std::abs(center_y) < w / 5. && mylib::inner_face(f) ? 1 : 0;
   }
 
   for(int i = 0; i < 500; ++i) {
     std::ofstream of("of_" + std::to_string(i) + ".vtk");
-    toVtk(m, of);
+    toVtk(m, k_size, of);
     toVtk("temperature", in, m, of);
 
-    dawn_generated::cxxnaiveico::generated<mylibInterface::mylibTag>(m, in, out).run();
+    dawn_generated::cxxnaiveico::generated<mylibInterface::mylibTag>(m, k_size, in, out).run();
 
     using std::swap;
     swap(in, out);

--- a/dawn/prototype/mylibVerticalSumDriver.cpp
+++ b/dawn/prototype/mylibVerticalSumDriver.cpp
@@ -4,12 +4,10 @@
 
 #include "generated_verticalSum.hpp"
 
-using namespace mylibInterface;
-
 int main() {
   int w = 32;
   int k_size = 5;
-  Mesh m{w, w, true};
+  mylibInterface::Mesh m{w, w, true};
   mylib::FaceData<double> out(m, k_size);
   mylib::FaceData<double> in(m, k_size);
 

--- a/dawn/prototype/mylibVerticalSumDriver.cpp
+++ b/dawn/prototype/mylibVerticalSumDriver.cpp
@@ -1,0 +1,27 @@
+#include "mylib_interface.hpp"
+#include <fstream>
+#include <gridtools/clang_dsl.hpp>
+
+#include "generated_verticalSum.hpp"
+
+using namespace mylibInterface;
+
+int main() {
+  int w = 32;
+  int k_size = 5;
+  Mesh m{w, w, true};
+  mylib::FaceData<double> out(m, k_size);
+  mylib::FaceData<double> in(m, k_size);
+
+  for(int level = 0; level < k_size; ++level) {
+    for(const auto& face : m.faces()) {
+      in(face, level) = 10;
+    }
+  }
+
+  dawn_generated::cxxnaiveico::generated<mylibInterface::mylibTag>(m, k_size, in, out).run();
+
+  std::ofstream of("vertSum.vtk");
+  toVtk(m, out.k_size(), of);
+  toVtk("temperature", out, m, of);
+}

--- a/dawn/prototype/mylib_interface.hpp
+++ b/dawn/prototype/mylib_interface.hpp
@@ -17,9 +17,9 @@ mylib::VertexData<T> vertexFieldType(mylibTag);
 
 using Mesh = mylib::Grid;
 
-decltype(auto) getCells(mylibTag, mylib::Grid const& m) { return m.faces(); }
-decltype(auto) getEdges(mylibTag, mylib::Grid const& m) { return m.edges(); }
-decltype(auto) getVertices(mylibTag, mylib::Grid const& m) { return m.vertices(); }
+inline decltype(auto) getCells(mylibTag, mylib::Grid const& m) { return m.faces(); }
+inline decltype(auto) getEdges(mylibTag, mylib::Grid const& m) { return m.edges(); }
+inline decltype(auto) getVertices(mylibTag, mylib::Grid const& m) { return m.vertices(); }
 
 template <typename Objs, typename Init, typename Op>
 auto reduce(Objs&& objs, Init init, Op&& op) {

--- a/dawn/src/dawn/CodeGen/CXXNaive-ico/ASTStencilBody.cpp
+++ b/dawn/src/dawn/CodeGen/CXXNaive-ico/ASTStencilBody.cpp
@@ -210,7 +210,8 @@ void ASTStencilBody::visit(const std::shared_ptr<iir::FieldAccessExpr>& expr) {
       // accessName));
     }
   } else {
-    ss_ << "m_" << getName(expr) << "(" << argName_ << ")";
+    ss_ << "m_" << getName(expr) << "(" << argName_ << ","
+        << "k + " << expr->getOffset().verticalOffset() << ")";
   }
 }
 

--- a/dawn/src/dawn/CodeGen/CXXNaive-ico/ASTStencilBody.cpp
+++ b/dawn/src/dawn/CodeGen/CXXNaive-ico/ASTStencilBody.cpp
@@ -211,7 +211,7 @@ void ASTStencilBody::visit(const std::shared_ptr<iir::FieldAccessExpr>& expr) {
     }
   } else {
     ss_ << "m_" << getName(expr) << "(" << argName_ << ","
-        << "k + " << expr->getOffset().verticalOffset() << ")";
+        << "k+" << expr->getOffset().verticalOffset() << ")";
   }
 }
 

--- a/dawn/src/dawn/CodeGen/CXXNaive-ico/CXXNaiveCodeGen.cpp
+++ b/dawn/src/dawn/CodeGen/CXXNaive-ico/CXXNaiveCodeGen.cpp
@@ -53,6 +53,7 @@ namespace cxxnaiveico {
 //   where Op must be callable as
 //     Op(Init, ValueType);
 
+namespace {
 std::string makeLoopImpl(int iExtent, int jExtent, const std::string& dim, const std::string& lower,
                          const std::string& upper, const std::string& comparison,
                          const std::string& increment) {
@@ -74,6 +75,7 @@ std::string makeKLoop(bool isBackward, iir::Interval const& interval) {
   return isBackward ? makeLoopImpl(0, 0, "k", upper, lower, ">=", "--")
                     : makeLoopImpl(0, 0, "k", lower, upper, "<=", "++");
 }
+} // namespace
 
 CXXNaiveIcoCodeGen::CXXNaiveIcoCodeGen(stencilInstantiationContext& ctx, DiagnosticsEngine& engine,
                                        int maxHaloPoint)

--- a/dawn/src/dawn/Unittest/IIRBuilder.h
+++ b/dawn/src/dawn/Unittest/IIRBuilder.h
@@ -125,8 +125,20 @@ public:
     DAWN_ASSERT(si_);
     auto ret = std::make_unique<iir::DoMethod>(iir::Interval(s, e), si_->getMetaData());
     ret->setID(si_->nextUID());
-    [[maybe_unused]] int x[] = {
-        (DAWN_ASSERT(stmts), ret->getAST().push_back(std::move(stmts)), 0)...};
+    int x[] = {(DAWN_ASSERT(stmts), ret->getAST().push_back(std::move(stmts)), 0)...};
+    computeAccesses(si_.get(), ret->getAST().getStatements());
+    ret->updateLevel();
+    return ret;
+  }
+
+  template <typename... Stmts>
+  std::unique_ptr<iir::DoMethod> vregion(sir::Interval::LevelKind s, sir::Interval::LevelKind e,
+                                         int offsetLow, int offsetHigh, Stmts&&... stmts) {
+    DAWN_ASSERT(si_);
+    auto ret = std::make_unique<iir::DoMethod>(iir::Interval(s, e, offsetLow, offsetHigh),
+                                               si_->getMetaData());
+    ret->setID(si_->nextUID());
+    int x[] = {(DAWN_ASSERT(stmts), ret->getAST().push_back(std::move(stmts)), 0)...};
     computeAccesses(si_.get(), ret->getAST().getStatements());
     ret->updateLevel();
     return ret;

--- a/dawn/src/dawn/Unittest/IIRBuilder.h
+++ b/dawn/src/dawn/Unittest/IIRBuilder.h
@@ -125,7 +125,8 @@ public:
     DAWN_ASSERT(si_);
     auto ret = std::make_unique<iir::DoMethod>(iir::Interval(s, e), si_->getMetaData());
     ret->setID(si_->nextUID());
-    int x[] = {(DAWN_ASSERT(stmts), ret->getAST().push_back(std::move(stmts)), 0)...};
+    [[maybe_unused]] int x[] = {
+        (DAWN_ASSERT(stmts), ret->getAST().push_back(std::move(stmts)), 0)...};
     computeAccesses(si_.get(), ret->getAST().getStatements());
     ret->updateLevel();
     return ret;
@@ -138,7 +139,8 @@ public:
     auto ret = std::make_unique<iir::DoMethod>(iir::Interval(s, e, offsetLow, offsetHigh),
                                                si_->getMetaData());
     ret->setID(si_->nextUID());
-    int x[] = {(DAWN_ASSERT(stmts), ret->getAST().push_back(std::move(stmts)), 0)...};
+    [[maybe_unused]] int x[] = {
+        (DAWN_ASSERT(stmts), ret->getAST().push_back(std::move(stmts)), 0)...};
     computeAccesses(si_.get(), ret->getAST().getStatements());
     ret->updateLevel();
     return ret;

--- a/dawn/test/unit-test/dawn-c/TestCompiler.cpp
+++ b/dawn/test/unit-test/dawn-c/TestCompiler.cpp
@@ -105,6 +105,7 @@ TEST(CompilerTest, DISABLED_CodeGenSumEdgeToCells) {
                                                    b.lit(0.), LocType::Edges))))))));
 
   std::ofstream of("prototype/generated_copyEdgeToCell.hpp");
+  DAWN_ASSERT_MSG(of, "file could not be opened. Binary must be called from dawn/dawn");
   dump<dawn::codegen::cxxnaiveico::CXXNaiveIcoCodeGen>(of, stencil_instantiation);
   of.close();
 }
@@ -129,6 +130,7 @@ TEST(CompilerTest, DISABLED_SumVertical) {
                                                              Op::plus))))))));
 
   std::ofstream of("prototype/generated_verticalSum.hpp");
+  DAWN_ASSERT_MSG(of, "file could not be opened. Binary must be called from dawn/dawn");
   dump<dawn::codegen::cxxnaiveico::CXXNaiveIcoCodeGen>(of, stencil_instantiation);
   of.close();
 }
@@ -164,6 +166,7 @@ TEST(CompilerTest, DISABLED_CodeGenDiffusion) {
                                                Op::plus))))))));
 
   std::ofstream of("prototype/generated_Diffusion.hpp");
+  DAWN_ASSERT_MSG(of, "file could not be opened. Binary must be called from dawn/dawn");
   dump<dawn::codegen::cxxnaiveico::CXXNaiveIcoCodeGen>(of, stencil_instantiation);
   of.close();
 }

--- a/dawn/test/unit-test/dawn-c/TestCompiler.cpp
+++ b/dawn/test/unit-test/dawn-c/TestCompiler.cpp
@@ -123,11 +123,10 @@ TEST(CompilerTest, DISABLED_SumVertical) {
           LoopOrderKind::Parallel,
           b.stage(LocType::Cells,
                   b.vregion(dawn::sir::Interval::Start, dawn::sir::Interval::End, 1, -1,
-                            b.stmt(b.assignExpr(
-                                b.at(out_f),
-                                b.binaryExpr(b.at(in_f, dawn::iir::HOffsetType::noOffset, +1),
-                                             b.at(in_f, dawn::iir::HOffsetType::noOffset, -1),
-                                             Op::plus))))))));
+                            b.stmt(b.assignExpr(b.at(out_f),
+                                                b.binaryExpr(b.at(in_f, HOffsetType::noOffset, +1),
+                                                             b.at(in_f, HOffsetType::noOffset, -1),
+                                                             Op::plus))))))));
 
   std::ofstream of("prototype/generated_verticalSum.hpp");
   dump<dawn::codegen::cxxnaiveico::CXXNaiveIcoCodeGen>(of, stencil_instantiation);

--- a/dawn/test/unit-test/dawn-c/TestCompiler.cpp
+++ b/dawn/test/unit-test/dawn-c/TestCompiler.cpp
@@ -109,6 +109,31 @@ TEST(CompilerTest, DISABLED_CodeGenSumEdgeToCells) {
   of.close();
 }
 
+TEST(CompilerTest, DISABLED_SumVertical) {
+  using namespace dawn::iir;
+  using LocType = dawn::ast::Expr::LocationType;
+
+  UnstructuredIIRBuilder b;
+  auto in_f = b.field("in_field", LocType::Cells);
+  auto out_f = b.field("out_field", LocType::Cells);
+
+  auto stencil_instantiation = b.build(
+      "generated",
+      b.stencil(b.multistage(
+          LoopOrderKind::Parallel,
+          b.stage(LocType::Cells,
+                  b.vregion(dawn::sir::Interval::Start, dawn::sir::Interval::End, 1, -1,
+                            b.stmt(b.assignExpr(
+                                b.at(out_f),
+                                b.binaryExpr(b.at(in_f, dawn::iir::HOffsetType::noOffset, +1),
+                                             b.at(in_f, dawn::iir::HOffsetType::noOffset, -1),
+                                             Op::plus))))))));
+
+  std::ofstream of("prototype/generated_verticalSum.hpp");
+  dump<dawn::codegen::cxxnaiveico::CXXNaiveIcoCodeGen>(of, stencil_instantiation);
+  of.close();
+}
+
 TEST(CompilerTest, DISABLED_CodeGenDiffusion) {
   using namespace dawn::iir;
   using LocType = dawn::ast::Expr::LocationType;


### PR DESCRIPTION
## Technical Description

This PR now uses the k-offsets introduced previously. That is, vertical offsets are now used in the code generation of `CXXNaiveIco`. NOTE: This currently breaks `lukaslib` compatibility.

### Resolves / Enhances
Fixes #412 

### Testing

A test was introduced to the deactivated c-tests. Follow the `README` in dawn/prototype to generate and run stencil code that uses the k-offsets. (verticalSum / verticalSumDriver)



