### PR TITLE
add reference update scripts

### DIFF
--- a/dawn/test/integration-test/reference_iir/update_references.sh
+++ b/dawn/test/integration-test/reference_iir/update_references.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+usage()
+{
+    echo "usage: update_references.sh [-d path_to_dawn_build] [-h]"
+}
+
+while [ "$1" != "" ]; do
+    case $1 in
+        -d | --dawn )        shift
+                                dawn_path=$1
+                                ;;
+        -h | --help )           usage
+                                exit
+                                ;;
+        * )                     usage
+                                exit 1
+    esac
+    shift
+done
+
+script=$(readlink -f $0)
+script_path=$(dirname $script)
+repo_path=$(git rev-parse --show-toplevel)
+
+# find DawnUpdateIIRReferences
+if [[ "$dawn_path" == "" ]]; then
+    if [[ -f "$repo_path/dawn/build/bin/integrationtest/DawnUpdateIIRReferences" ]]; then
+        update_path="$repo_path/dawn/build/bin/integrationtest/DawnUpdateIIRReferences"
+    elif [[ -f "$repo_path/dawn/bundle/build/dawn-prefix/src/dawn-build/bin/integrationtest/" ]]; then
+        update_path="$repo_path/dawn/bundle/build/dawn-prefix/src/dawn-build/bin/integrationtest/DawnUpdateIIRReferences"
+    else
+        echo "Cannot find DawnUpdateIIRReferences."
+        exit 1
+    fi
+else
+    if [[ -f "dawn_path/bin/integrationtest/DawnUpdateIIRReferences" ]]; then
+        update_path="dawn_path/bin/integrationtest/DawnUpdateIIRReferences"
+    else
+        echo "Cannot find DawnUpdateIIRReferences."
+        exit 1
+    fi
+fi
+
+# run the script
+pushd $(dirname $update_path) > /dev/null
+  $update_path
+popd > /dev/null

--- a/dawn/test/integration-test/reference_iir/update_references.sh
+++ b/dawn/test/integration-test/reference_iir/update_references.sh
@@ -35,7 +35,7 @@ if [[ "$dawn_path" == "" ]]; then
     fi
 else
     if [[ -f "$dawn_path/bin/integrationtest/DawnUpdateIIRReferences" ]]; then
-        update_path="$dawn_path/bin/integrationtest/DawnUpdateIIRReferences"
+        update_path=$(readlink -f "$dawn_path/bin/integrationtest/DawnUpdateIIRReferences")
     else
         echo "Cannot find DawnUpdateIIRReferences."
         exit 1

--- a/dawn/test/integration-test/reference_iir/update_references.sh
+++ b/dawn/test/integration-test/reference_iir/update_references.sh
@@ -34,8 +34,8 @@ if [[ "$dawn_path" == "" ]]; then
         exit 1
     fi
 else
-    if [[ -f "dawn_path/bin/integrationtest/DawnUpdateIIRReferences" ]]; then
-        update_path="dawn_path/bin/integrationtest/DawnUpdateIIRReferences"
+    if [[ -f "$dawn_path/bin/integrationtest/DawnUpdateIIRReferences" ]]; then
+        update_path="$dawn_path/bin/integrationtest/DawnUpdateIIRReferences"
     else
         echo "Cannot find DawnUpdateIIRReferences."
         exit 1

--- a/dawn/test/unit-test/dawn/Optimizer/Passes/update_references.sh
+++ b/dawn/test/unit-test/dawn/Optimizer/Passes/update_references.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+usage()
+{
+    echo "usage: update_references.sh [-g path_to_gtclang] [-h]"
+}
+
+while [ "$1" != "" ]; do
+    case $1 in
+        -g | --gtclang )        shift
+                                gtclang_path=$1
+                                ;;
+        -h | --help )           usage
+                                exit
+                                ;;
+        * )                     usage
+                                exit 1
+    esac
+    shift
+done
+
+script=$(readlink -f $0)
+script_path=$(dirname $script)
+repo_path=$(git rev-parse --show-toplevel)
+
+# find gtclang
+if [[ "$gtclang_path" == "" ]]; then
+    if [[ -f "$repo_path/gtclang/build/bin/gtclang" ]]; then
+        gtclang_path="$repo_path/gtclang/build/bin/gtclang"
+    elif [[ -f "$repo_path/gtclang/bundle/install/bin/gtclang" ]]; then
+        gtclang_path="$repo_path/gtclang/bundle/install/bin/gtclang"
+    else
+        echo "Cannot find gtclang."
+        exit 1
+    fi
+fi
+
+# update references
+for file_path in $(ls $script_path/samples/*.cpp); do
+    echo "Generate reference for $file_path"
+    $gtclang_path $file_path -fwrite-sir -fno-codegen
+
+    filename=$(basename -- "$file_path")
+    file_we="${filename%.cpp}"
+    mv $script_path/samples/${file_we}_gen.sir $script_path/${file_we}.sir
+done

--- a/dawn/test/unit-test/dawn/Optimizer/Passes/update_references.sh
+++ b/dawn/test/unit-test/dawn/Optimizer/Passes/update_references.sh
@@ -36,6 +36,7 @@ if [[ "$gtclang_path" == "" ]]; then
 else
     if [[ ! -f "$gtclang_path" ]]; then
         echo "Cannot find gtclang"
+        exit 1
     fi
 fi
 

--- a/dawn/test/unit-test/dawn/Optimizer/Passes/update_references.sh
+++ b/dawn/test/unit-test/dawn/Optimizer/Passes/update_references.sh
@@ -33,6 +33,10 @@ if [[ "$gtclang_path" == "" ]]; then
         echo "Cannot find gtclang."
         exit 1
     fi
+else
+    if [[ ! -f "$gtclang_path" ]]; then
+        echo "Cannot find gtclang"
+    fi
 fi
 
 # update references

--- a/gtclang/test/integration-test/update_references.sh
+++ b/gtclang/test/integration-test/update_references.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+usage()
+{
+    echo "usage: update_references.sh [-g path_to_gtclang-tester-node-code-gen] [-h]"
+}
+
+while [ "$1" != "" ]; do
+    case $1 in
+        -g | --gtclang )        shift
+                                script_path=$1
+                                ;;
+        -h | --help )           usage
+                                exit
+                                ;;
+        * )                     usage
+                                exit 1
+    esac
+    shift
+done
+
+script=$(readlink -f $0)
+repo_path=$(git rev-parse --show-toplevel)
+
+# find gtclang script
+if [[ "$script_path" == "" ]]; then
+    if [[ -f "$repo_path/gtclang/build/gtclang-tester-no-codegen.sh" ]]; then
+        script_path="$repo_path/gtclang/build/gtclang-tester-no-codegen.sh"
+    elif [[ -f ="$repo_path/gtclang/bundle/build/gtclang-prefix/src/gtclang-build/gtclang-tester-no-codegen.sh" ]]; then
+        script_path="$repo_path/gtclang/bundle/build/gtclang-prefix/src/gtclang-build/gtclang-tester-no-codegen.sh"
+    else
+        echo "WARN: Cannot find gtclang-tester-no-codegen.sh - skip generation."
+    fi
+fi
+
+# update references
+bash $script_path -g

--- a/gtclang/test/integration-test/update_references.sh
+++ b/gtclang/test/integration-test/update_references.sh
@@ -2,13 +2,13 @@
 
 usage()
 {
-    echo "usage: update_references.sh [-g path_to_gtclang-tester-node-code-gen] [-h]"
+    echo "usage: update_references.sh [-g path_to_gtclang_build] [-h]"
 }
 
 while [ "$1" != "" ]; do
     case $1 in
         -g | --gtclang )        shift
-                                script_path=$1
+                                gtclang_build=$1
                                 ;;
         -h | --help )           usage
                                 exit
@@ -23,13 +23,21 @@ script=$(readlink -f $0)
 repo_path=$(git rev-parse --show-toplevel)
 
 # find gtclang script
-if [[ "$script_path" == "" ]]; then
+if [[ "$gtclang_build" == "" ]]; then
     if [[ -f "$repo_path/gtclang/build/gtclang-tester-no-codegen.sh" ]]; then
         script_path="$repo_path/gtclang/build/gtclang-tester-no-codegen.sh"
     elif [[ -f ="$repo_path/gtclang/bundle/build/gtclang-prefix/src/gtclang-build/gtclang-tester-no-codegen.sh" ]]; then
         script_path="$repo_path/gtclang/bundle/build/gtclang-prefix/src/gtclang-build/gtclang-tester-no-codegen.sh"
+    else 
+        echo "Cannot find gtclang-tester-no-codegen.sh."
+        exit 1
+    fi
+else
+    if [[ -f "$gtclang_build/gtclang-tester-no-codegen.sh" ]]; then
+        update_path="$gtclang_build/gtclang-tester-no-codegen.sh"
     else
-        echo "WARN: Cannot find gtclang-tester-no-codegen.sh - skip generation."
+        echo "Cannot find gtclang-tester-no-codegen.sh"
+        exit 1
     fi
 fi
 

--- a/gtclang/test/integration-test/update_references.sh
+++ b/gtclang/test/integration-test/update_references.sh
@@ -34,7 +34,7 @@ if [[ "$gtclang_build" == "" ]]; then
     fi
 else
     if [[ -f "$gtclang_build/gtclang-tester-no-codegen.sh" ]]; then
-        update_path="$gtclang_build/gtclang-tester-no-codegen.sh"
+        script_path="$gtclang_build/gtclang-tester-no-codegen.sh"
     else
         echo "Cannot find gtclang-tester-no-codegen.sh"
         exit 1


### PR DESCRIPTION
## Technical Description

Adds update scripts for all generated references in dawn and gtclang. 

All scripts try to guess the proper paths from yoda and normal build, otherwise, the options can be provided.

### Testing

Try to change some references and then run the update scripts.

### Dependencies
