### PR TITLE
Add python binding

### DIFF
--- a/dawn/CMakeLists.txt
+++ b/dawn/CMakeLists.txt
@@ -27,7 +27,7 @@ if(NOT CMAKE_INSTALL_PREFIX)
 endif()
 
 project(dawn C CXX)
-cmake_minimum_required(VERSION 3.3)
+cmake_minimum_required(VERSION 3.12.4)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
 set(YODA_ROOT CACHE PATH "path to yoda package")

--- a/dawn/src/CMakeLists.txt
+++ b/dawn/src/CMakeLists.txt
@@ -1,16 +1,17 @@
 ##===------------------------------------------------------------------------------*- CMake -*-===##
-##                          _                      
-##                         | |                     
-##                       __| | __ ___      ___ ___  
-##                      / _` |/ _` \ \ /\ / / '_  | 
+##                          _
+##                         | |
+##                       __| | __ ___      ___ ___
+##                      / _` |/ _` \ \ /\ / / '_  |
 ##                     | (_| | (_| |\ V  V /| | | |
 ##                      \__,_|\__,_| \_/\_/ |_| |_| - Compiler Toolchain
 ##
 ##
-##  This file is distributed under the MIT License (MIT). 
+##  This file is distributed under the MIT License (MIT).
 ##  See LICENSE.txt for details.
 ##
 ##===------------------------------------------------------------------------------------------===##
 
 add_subdirectory(dawn)
 add_subdirectory(dawn-c)
+add_subdirectory(dawn-python)

--- a/dawn/src/dawn-python/CMakeLists.txt
+++ b/dawn/src/dawn-python/CMakeLists.txt
@@ -26,16 +26,18 @@ if(NOT pybind11_fetch_POPULATED)
     add_subdirectory(${pybind11_fetch_SOURCE_DIR} ${pybind11_fetch_BINARY_DIR})
 endif()
 
-pybind11_add_module(dawn_python MODULE DawnPython.cpp)
-target_link_libraries(dawn_python
-  pybind11::pybind11
-  DawnASTObjects
-  DawnSIRObjects
-  DawnSupportObjects
-  DawnCompilerObjects
-  DawnSerializerObjects
-  DawnIIRObjects
-  DawnOptimizerObjects
-  DawnCodeGenObjects
-  ${DAWN_EXTERNAL_LIBRARIES}
+yoda_combine_libraries(
+  NAME dawn_python
+  OBJECTS DawnSupportObjects
+          DawnCompilerObjects
+          DawnIIRObjects
+          DawnOptimizerObjects
+          DawnCodeGenObjects
+  INSTALL_DESTINATION ${DAWN_INSTALL_LIB_DIR}
+  VERSION ${DAWN_VERSION}
+  DEPENDS ${DAWN_EXTERNAL_LIBRARIES} DawnSIRStatic DawnSerializerStatic pybind11::pybind11
+  EXPORT_GROUP DawnTargets
 )
+set_target_properties(dawn_pythonStatic PROPERTIES PREFIX "")
+set_target_properties(dawn_pythonShared PROPERTIES PREFIX "")
+install(TARGETS pybind11 DESTINATION ${DAWN_INSTALL_LIB_DIR} EXPORT DawnTargets)

--- a/dawn/src/dawn-python/CMakeLists.txt
+++ b/dawn/src/dawn-python/CMakeLists.txt
@@ -1,0 +1,57 @@
+##===------------------------------------------------------------------------------*- CMake -*-===##
+##                          _
+##                         | |
+##                       __| | __ ___      ___ ___
+##                      / _` |/ _` \ \ /\ / / '_  |
+##                     | (_| | (_| |\ V  V /| | | |
+##                      \__,_|\__,_| \_/\_/ |_| |_| - Compiler Toolchain
+##
+##
+##  This file is distributed under the MIT License (MIT).
+##  See LICENSE.txt for details.
+##
+##===------------------------------------------------------------------------------------------===##
+
+include(FetchContent)
+
+
+FetchContent_Declare(
+    pybind11_fetch
+    GIT_REPOSITORY https://github.com/pybind/pybind11
+    GIT_TAG v2.4
+)
+FetchContent_GetProperties(pybind11_fetch)
+if(NOT pybind11_fetch_POPULATED)
+    message(STATUS "Fetch pybind11 for python-binding")
+    FetchContent_Populate(pybind11_fetch)
+    add_subdirectory(${pybind11_fetch_SOURCE_DIR} ${pybind11_fetch_BINARY_DIR})
+endif()
+
+add_library(dawn_python SHARED DawnPython.cpp)
+yoda_combine_libraries(
+  NAME dawn_python
+  OBJECTS DawnCObjects
+          DawnSupportObjects
+          DawnCompilerObjects
+          DawnIIRObjects
+          DawnOptimizerObjects
+          DawnCodeGenObjects
+  INSTALL_DESTINATION ${DAWN_INSTALL_LIB_DIR}
+  VERSION ${DAWN_VERSION}
+  DEPENDS ${DAWN_EXTERNAL_LIBRARIES} DawnSIRStatic DawnSerializerStatic
+  EXPORT_GROUP DawnTargets
+)
+
+target_link_libraries(dawn_python
+    pybind11::pybind11
+  # DawnCObjects
+  DawnASTObjects
+  DawnSIRObjects
+  DawnSupportObjects
+  DawnCompilerObjects
+  DawnIIRObjects
+  DawnOptimizerObjects
+  DawnCodeGenObjects
+
+  protobuf
+)

--- a/dawn/src/dawn-python/CMakeLists.txt
+++ b/dawn/src/dawn-python/CMakeLists.txt
@@ -28,30 +28,17 @@ if(NOT pybind11_fetch_POPULATED)
 endif()
 
 add_library(dawn_python SHARED DawnPython.cpp)
-yoda_combine_libraries(
-  NAME dawn_python
-  OBJECTS DawnCObjects
-          DawnSupportObjects
-          DawnCompilerObjects
-          DawnIIRObjects
-          DawnOptimizerObjects
-          DawnCodeGenObjects
-  INSTALL_DESTINATION ${DAWN_INSTALL_LIB_DIR}
-  VERSION ${DAWN_VERSION}
-  DEPENDS ${DAWN_EXTERNAL_LIBRARIES} DawnSIRStatic DawnSerializerStatic
-  EXPORT_GROUP DawnTargets
-)
 
 target_link_libraries(dawn_python
-    pybind11::pybind11
-  # DawnCObjects
+  pybind11::pybind11
   DawnASTObjects
   DawnSIRObjects
   DawnSupportObjects
   DawnCompilerObjects
+  DawnSerializerObjects
   DawnIIRObjects
   DawnOptimizerObjects
   DawnCodeGenObjects
-
-  protobuf
+  ${DAWN_EXTERNAL_LIBRARIES}
 )
+set_target_properties(dawn_python PROPERTIES PREFIX "")

--- a/dawn/src/dawn-python/CMakeLists.txt
+++ b/dawn/src/dawn-python/CMakeLists.txt
@@ -26,8 +26,7 @@ if(NOT pybind11_fetch_POPULATED)
     add_subdirectory(${pybind11_fetch_SOURCE_DIR} ${pybind11_fetch_BINARY_DIR})
 endif()
 
-add_library(dawn_python SHARED DawnPython.cpp)
-
+pybind11_add_module(dawn_python MODULE DawnPython.cpp)
 target_link_libraries(dawn_python
   pybind11::pybind11
   DawnASTObjects
@@ -40,4 +39,3 @@ target_link_libraries(dawn_python
   DawnCodeGenObjects
   ${DAWN_EXTERNAL_LIBRARIES}
 )
-set_target_properties(dawn_python PROPERTIES PREFIX "")

--- a/dawn/src/dawn-python/CMakeLists.txt
+++ b/dawn/src/dawn-python/CMakeLists.txt
@@ -14,7 +14,6 @@
 
 include(FetchContent)
 
-
 FetchContent_Declare(
     pybind11_fetch
     GIT_REPOSITORY https://github.com/pybind/pybind11

--- a/dawn/src/dawn-python/CMakeLists.txt
+++ b/dawn/src/dawn-python/CMakeLists.txt
@@ -27,7 +27,7 @@ if(NOT pybind11_fetch_POPULATED)
 endif()
 
 yoda_combine_libraries(
-  NAME dawn_python
+  NAME pydawn
   OBJECTS DawnSupportObjects
           DawnCompilerObjects
           DawnIIRObjects
@@ -38,6 +38,6 @@ yoda_combine_libraries(
   DEPENDS ${DAWN_EXTERNAL_LIBRARIES} DawnSIRStatic DawnSerializerStatic pybind11::pybind11
   EXPORT_GROUP DawnTargets
 )
-set_target_properties(dawn_pythonStatic PROPERTIES PREFIX "")
-set_target_properties(dawn_pythonShared PROPERTIES PREFIX "")
+set_target_properties(pydawnStatic PROPERTIES PREFIX "")
+set_target_properties(pydawnShared PROPERTIES PREFIX "")
 install(TARGETS pybind11 DESTINATION ${DAWN_INSTALL_LIB_DIR} EXPORT DawnTargets)

--- a/dawn/src/dawn-python/DawnPython.cpp
+++ b/dawn/src/dawn-python/DawnPython.cpp
@@ -16,7 +16,7 @@ enum class Backend { gridtools, cuda, naive };
 std::string dawnCompile(std::string const& sir, Backend backend) {
 
   auto inMemorySIR =
-      dawn::SIRSerializer::deserializeFromString(sir, dawn::SIRSerializer::Format::Byte);
+      dawn::SIRSerializer::deserializeFromString(sir, dawn::SIRSerializer::Format::Json);
   auto translationUnit = DawnCompiler{}.compile(inMemorySIR);
   std::ostringstream ss;
   for(auto const& macroDefine : translationUnit->getPPDefines())

--- a/dawn/src/dawn-python/DawnPython.cpp
+++ b/dawn/src/dawn-python/DawnPython.cpp
@@ -1,0 +1,42 @@
+#include "dawn/Compiler/DawnCompiler.h"
+#include "dawn/Serialization/SIRSerializer.h"
+
+// #include <pybind11/pybind11.h>
+// #include <pybind11/stl.h>
+
+#include <sstream>
+#include <string>
+
+// namespace py = ::pybind11;
+
+namespace dawn {
+namespace {
+
+enum class Backend { gridtools, cuda, naive };
+std::string dawnCompile(std::string const& sir, Backend backend) {
+
+  auto inMemorySIR =
+      dawn::SIRSerializer::deserializeFromString(sir, dawn::SIRSerializer::Format::Byte);
+  auto translationUnit = DawnCompiler{}.compile(inMemorySIR);
+  std::ostringstream ss;
+  for(auto const& macroDefine : translationUnit->getPPDefines())
+    ss << macroDefine << "\n";
+
+  ss << translationUnit->getGlobals();
+  for(auto const& s : translationUnit->getStencils())
+    ss << s.second;
+
+  return ss.str();
+}
+} // namespace
+} // namespace dawn
+
+// PYBIND11_MODULE(libdawn_python, m) {
+// py::enum_<dawn::Backend>(m, "Backend")
+// .value("GridTools", dawn::Backend::gridtools)
+// .value("Cuda", dawn::Backend::cuda)
+// .value("Naive", dawn::Backend::naive)
+// .export_values();
+// m.def("compile", &dawn::dawnCompile, "Compiles", py::arg("SIR"), py::arg("backend"));
+// }
+

--- a/dawn/src/dawn-python/DawnPython.cpp
+++ b/dawn/src/dawn-python/DawnPython.cpp
@@ -1,13 +1,13 @@
 #include "dawn/Compiler/DawnCompiler.h"
 #include "dawn/Serialization/SIRSerializer.h"
 
-// #include <pybind11/pybind11.h>
-// #include <pybind11/stl.h>
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
 
 #include <sstream>
 #include <string>
 
-// namespace py = ::pybind11;
+namespace py = ::pybind11;
 
 namespace dawn {
 namespace {
@@ -31,12 +31,12 @@ std::string dawnCompile(std::string const& sir, Backend backend) {
 } // namespace
 } // namespace dawn
 
-// PYBIND11_MODULE(libdawn_python, m) {
-// py::enum_<dawn::Backend>(m, "Backend")
-// .value("GridTools", dawn::Backend::gridtools)
-// .value("Cuda", dawn::Backend::cuda)
-// .value("Naive", dawn::Backend::naive)
-// .export_values();
-// m.def("compile", &dawn::dawnCompile, "Compiles", py::arg("SIR"), py::arg("backend"));
-// }
+PYBIND11_MODULE(dawn_python, m) {
+  py::enum_<dawn::Backend>(m, "Backend")
+      .value("GridTools", dawn::Backend::gridtools)
+      .value("Cuda", dawn::Backend::cuda)
+      .value("Naive", dawn::Backend::naive)
+      .export_values();
+  m.def("compile", &dawn::dawnCompile, "Compiles", py::arg("SIR"), py::arg("backend"));
+}
 


### PR DESCRIPTION
## Technical Description

Adds preliminary python bindings to GridTools (to be used in GT4Py). 

### Example

Current usage:
```
import dawn_python

with open("sir.json", 'r') as f:
    content = f.read()

with open("out.cpp", 'w') as f:
    f.write(dawn_python.compile(content, dawn_python.Cuda))
```
where `sir.json` is the serialized protobuf representation of the SIR: