### PR TITLE
Temporarily disable IIR Optimizer no-dependency check

### DIFF
--- a/dawn/src/dawn/IIR/IIRBuilder.cpp
+++ b/dawn/src/dawn/IIR/IIRBuilder.cpp
@@ -75,7 +75,7 @@ std::string toStr(Op operation, std::vector<Op> const& valid_ops) {
 }
 } // namespace
 
-dawn::codegen::stencilInstantiationContext
+std::map<std::string, std::shared_ptr<iir::StencilInstantiation>>
 IIRBuilder::build(std::string const& name, std::unique_ptr<iir::Stencil> stencil) {
   DAWN_ASSERT(si_);
   // setup the whole stencil instantiation
@@ -114,7 +114,7 @@ IIRBuilder::build(std::string const& name, std::unique_ptr<iir::Stencil> stencil
   optimizer->restoreIIR("<restored>", std::move(si_));
   auto new_si = optimizer->getStencilInstantiationMap()["<restored>"];
 
-  dawn::codegen::stencilInstantiationContext map;
+  std::map<std::string, std::shared_ptr<iir::StencilInstantiation>> map;
   map[new_si->getName()] = std::move(new_si);
 
   return map;

--- a/dawn/src/dawn/IIR/IIRBuilder.h
+++ b/dawn/src/dawn/IIR/IIRBuilder.h
@@ -15,7 +15,6 @@
 #ifndef DAWN_IIR_IIRBUILDER_H
 #define DAWN_IIR_IIRBUILDER_H
 
-#include "dawn/CodeGen/CodeGen.h"
 #include "dawn/IIR/ASTExpr.h"
 #include "dawn/IIR/ASTStmt.h"
 #include "dawn/IIR/AccessComputation.h"
@@ -187,8 +186,8 @@ public:
   }
 
   // generates the final instantiation context
-  dawn::codegen::stencilInstantiationContext build(std::string const& name,
-                                                   std::unique_ptr<iir::Stencil> stencil);
+  std::map<std::string, std::shared_ptr<iir::StencilInstantiation>>
+  build(std::string const& name, std::unique_ptr<iir::Stencil> stencil);
 
 protected:
   std::shared_ptr<iir::StencilInstantiation> si_;

--- a/scripts/git_hooks/check_modularization
+++ b/scripts/git_hooks/check_modularization
@@ -39,7 +39,8 @@ no_dependency "SIR" "Compiler"
 no_dependency "SIR" "Serialization"
 no_dependency "SIR" "CodeGen"
 
-no_dependency "IIR" "Optimizer"
+#TODO re-enable this no-dependency check once IIRBuilder is moved back to unit tests
+#no_dependency "IIR" "Optimizer"
 no_dependency "IIR" "Compiler"
 no_dependency "IIR" "Serialization"
 no_dependency "IIR" "CodeGen"


### PR DESCRIPTION
## Technical Description

Since `IIRBuilder` has been moved to IIR, the `check_modularization` pre-commit hook blocks us from committing as `IIRBuilder` depends on Optimizer (it uses `restoreIIR()`) and on CodeGen.
This is a temporary fix to allow `IIRBuilder` to stay in IIR until it's moved back to tests (or another decision is taken). It removes the dependency on CodeGen (not needed in any case) and it disables the no-dependency check IIR->Optimizer.

### Dependencies

None


