### PR TITLE
Add p_grad_c integration test

### DIFF
--- a/gtclang/.gitignore
+++ b/gtclang/.gitignore
@@ -12,6 +12,7 @@
 build*/
 install*/
 test/integration-test/CodeGen/generated*/
+test/integration-test/FV3/generated*/
 
 # Meta project information
 bundle/yoda/*
@@ -31,4 +32,3 @@ gh-pages*
 .vscode/
 **/compile_commands.json
 .clangd/
-

--- a/gtclang/test/integration-test/CMakeLists.txt
+++ b/gtclang/test/integration-test/CMakeLists.txt
@@ -32,18 +32,17 @@ macro(GET_COMPILER_FLAGS _KEY _RETVAL)
 endmacro(GET_COMPILER_FLAGS)
 
 function(code_generate_examples)
-  set(oneValueArgs BACKEND)
+  set(oneValueArgs BACKEND DIRECTORY)
   set(multiValueArgs EXAMPLES)
   cmake_parse_arguments(ARG "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN} )
 
-  set(codegen_examples_ ${ARG_EXAMPLES})
   set(backend ${ARG_BACKEND})
 
-  foreach(example ${codegen_examples_})
+  foreach(example ${ARG_EXAMPLES})
       # Add json inputfiles if they exist
       set(config_str "")
-      if(EXISTS "${cwd}/CodeGen/${example}.json")
-        set(config_str "--config=${cwd}/CodeGen/${example}.json")
+      if(EXISTS "${cwd}/${ARG_DIRECTORY}/${example}.json")
+        set(config_str "--config=${cwd}/${ARG_DIRECTORY}/${example}.json")
       endif()
 
       if(CMAKE_BUILD_TYPE MATCHES DEBUG)
@@ -55,34 +54,33 @@ function(code_generate_examples)
       GET_COMPILER_FLAGS(${example} flags)
       set(config_str "${config_str}" "${flags}")
 
-      file(MAKE_DIRECTORY "${cwd}/CodeGen/generated/")
+      file(MAKE_DIRECTORY "${cwd}/${ARG_DIRECTORY}/generated/")
 
       # Add make target
-      add_custom_command( OUTPUT ${cwd}/CodeGen/generated/${example}_${backend}.cpp
-        COMMAND $<TARGET_FILE:gtclang> "-backend=${backend}" ${config_str} "-o" "${cwd}/CodeGen/generated/${example}_${backend}.cpp"  "${cwd}/CodeGen/${example}.cpp"
-        DEPENDS ${cwd}/CodeGen/${example}.cpp gtclang
+      add_custom_command( OUTPUT ${cwd}/${ARG_DIRECTORY}/generated/${example}_${backend}.cpp
+        COMMAND $<TARGET_FILE:gtclang> "-backend=${backend}" ${config_str} "-o" "${cwd}/${ARG_DIRECTORY}/generated/${example}_${backend}.cpp"  "${cwd}/${ARG_DIRECTORY}/${example}.cpp"
+        DEPENDS ${cwd}/${ARG_DIRECTORY}/${example}.cpp gtclang
       )
 
-      add_custom_target(${example}_${backend}_codegen ALL DEPENDS ${cwd}/CodeGen/generated/${example}_${backend}.cpp)
-      set_source_files_properties(${cwd}/CodeGen/generated/${example}_${backend}.cpp PROPERTIES GENERATED TRUE)
+      add_custom_target(${example}_${backend}_codegen ALL DEPENDS ${cwd}/${ARG_DIRECTORY}/generated/${example}_${backend}.cpp)
+      set_source_files_properties(${cwd}/${ARG_DIRECTORY}/generated/${example}_${backend}.cpp PROPERTIES GENERATED TRUE)
 
-      add_custom_command(OUTPUT ${cwd}/CodeGen/generated/${example}_c++-naive.cpp
-        COMMAND $<TARGET_FILE:gtclang> "-backend=c++-naive" ${config_str} "-o" "${cwd}/CodeGen/generated/${example}_c++-naive.cpp"  "${cwd}/CodeGen/${example}.cpp"
-        DEPENDS ${cwd}/CodeGen/${example}.cpp gtclang
+      add_custom_command(OUTPUT ${cwd}/${ARG_DIRECTORY}/generated/${example}_c++-naive.cpp
+        COMMAND $<TARGET_FILE:gtclang> "-backend=c++-naive" ${config_str} "-o" "${cwd}/${ARG_DIRECTORY}/generated/${example}_c++-naive.cpp"  "${cwd}/${ARG_DIRECTORY}/${example}.cpp"
+        DEPENDS ${cwd}/${ARG_DIRECTORY}/${example}.cpp gtclang
       )
 
-      add_custom_target(${example}_c++-naive_codegen ALL DEPENDS ${cwd}/CodeGen/generated/${example}_c++-naive.cpp)
-      set_source_files_properties(${cwd}/CodeGen/generated/${example}_c++-naive.cpp PROPERTIES GENERATED TRUE)
+      add_custom_target(${example}_c++-naive_codegen ALL DEPENDS ${cwd}/${ARG_DIRECTORY}/generated/${example}_c++-naive.cpp)
+      set_source_files_properties(${cwd}/${ARG_DIRECTORY}/generated/${example}_c++-naive.cpp PROPERTIES GENERATED TRUE)
 
   endforeach()
 endfunction(code_generate_examples)
 
 function(compile_generated_examples)
-  set(oneValueArgs BACKEND)
+  set(oneValueArgs BACKEND DIRECTORY)
   set(multiValueArgs EXAMPLES DUMMY)
   cmake_parse_arguments(ARG "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN} )
 
-  set(codegen_examples_ ${ARG_EXAMPLES})
   set(backend ${ARG_BACKEND})
 
   if(NOT ${backend} STREQUAL "gt")
@@ -90,14 +88,14 @@ function(compile_generated_examples)
   endif()
 
   foreach(example ${ARG_DUMMY})
-      add_executable(${example}_benchmarks_${backend} ${cwd}/CodeGen/dummy.cpp)
-      set_property(SOURCE ${cwd}/CodeGen/dummy.cpp APPEND PROPERTY OBJECT_DEPENDS ${cwd}/CodeGen/generated/${example}_c++-naive.cpp)
+      add_executable(${example}_benchmarks_${backend} ${cwd}/${ARG_DIRECTORY}/dummy.cpp)
+      set_property(SOURCE ${cwd}/${ARG_DIRECTORY}/dummy.cpp APPEND PROPERTY OBJECT_DEPENDS ${cwd}/${ARG_DIRECTORY}/generated/${example}_c++-naive.cpp)
       if(GTCLANG_BUILD_CUDA_EXAMPLES)
-        set_property(SOURCE ${cwd}/CodeGen/dummy.cpp APPEND PROPERTY OBJECT_DEPENDS ${cwd}/CodeGen/generated/${example}_cuda.cpp)
+        set_property(SOURCE ${cwd}/${ARG_DIRECTORY}/dummy.cpp APPEND PROPERTY OBJECT_DEPENDS ${cwd}/${ARG_DIRECTORY}/generated/${example}_cuda.cpp)
       endif(GTCLANG_BUILD_CUDA_EXAMPLES)
   endforeach()
-  foreach(example ${codegen_examples_})
-      add_executable(${example}_benchmarks_${backend} "${cwd}/CodeGen/${example}_benchmark.cpp" "${cwd}/CodeGen/TestMain.cpp" "${cwd}/CodeGen/Options.cpp")
+  foreach(example ${ARG_EXAMPLES})
+      add_executable(${example}_benchmarks_${backend} "${cwd}/${ARG_DIRECTORY}/${example}_benchmark.cpp" "${cwd}/${ARG_DIRECTORY}/TestMain.cpp" "${cwd}/${ARG_DIRECTORY}/Options.cpp")
       target_include_directories(${example}_benchmarks_${backend} PUBLIC ${include_dirs})
       target_compile_definitions(${example}_benchmarks_${backend} PRIVATE -DOPTBACKEND=${backend})
       target_compile_features(${example}_benchmarks_${backend} PRIVATE cxx_std_11)
@@ -108,8 +106,8 @@ function(compile_generated_examples)
       add_dependencies(${example}_benchmarks_${backend} gtclang ${example}_c++-naive_codegen ${example}_${backend}_codegen)
       target_link_libraries(${example}_benchmarks_${backend} ${GTCLANG_UNITTEST_EXTERNAL_LIBRARIES} gtest)
 
-#      set_property(SOURCE ${cwd}/CodeGen/${example}_benchmark.cpp APPEND PROPERTY OBJECT_DEPENDS ${cwd}/CodeGen/generated/${example}_${backend}.cpp)
-#      set_property(SOURCE ${cwd}/CodeGen/${example}_benchmark.cpp APPEND PROPERTY OBJECT_DEPENDS ${cwd}/CodeGen/generated/${example}_c++-naive.cpp)
+#      set_property(SOURCE ${cwd}/${ARG_DIRECTORY}/${example}_benchmark.cpp APPEND PROPERTY OBJECT_DEPENDS ${cwd}/${ARG_DIRECTORY}/generated/${example}_${backend}.cpp)
+#      set_property(SOURCE ${cwd}/${ARG_DIRECTORY}/${example}_benchmark.cpp APPEND PROPERTY OBJECT_DEPENDS ${cwd}/${ARG_DIRECTORY}/generated/${example}_c++-naive.cpp)
 
       add_test(NAME CTest-${example}_benchmarks_${backend} COMMAND $<TARGET_FILE:${example}_benchmarks_${backend}> 12 12 10 --gtest_output=xml:${example}_unittest.xml)
 
@@ -117,19 +115,18 @@ function(compile_generated_examples)
 endfunction(compile_generated_examples)
 
 function(cuda_compile_generated_examples)
-  set(oneValueArgs BACKEND)
+  set(oneValueArgs BACKEND DIRECTORY)
   set(multiValueArgs EXAMPLES)
   cmake_parse_arguments(ARG "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN} )
 
-  set(codegen_examples_ ${ARG_EXAMPLES})
   set(backend ${ARG_BACKEND})
 
-  foreach(example ${codegen_examples_})
-      cuda_add_executable(${example}_benchmarks_${backend}_cuda "${cwd}/CodeGen/${example}_benchmark.cu" "${cwd}/CodeGen/TestMain.cpp" "${cwd}/CodeGen/Options.cpp")
+  foreach(example ${ARG_EXAMPLES})
+      cuda_add_executable(${example}_benchmarks_${backend}_cuda "${cwd}/${ARG_DIRECTORY}/${example}_benchmark.cu" "${cwd}/${ARG_DIRECTORY}/TestMain.cpp" "${cwd}/${ARG_DIRECTORY}/Options.cpp")
 
       target_include_directories(${example}_benchmarks_${backend}_cuda PUBLIC ${include_dirs})
       if(${backend} STREQUAL cuda)
-        add_dependencies(${example}_benchmarks_${backend}_cuda gtclang ${example}_c++-naive_codegen ${example}_${backend}_codegen)
+        add_dependencies(${example}_benchmarks_${backend}_cuda gtclang ${example}_c++-naive_${ARG_DIRECTORY} ${example}_${backend}_codegen)
       else()
         add_dependencies(${example}_benchmarks_${backend}_cuda gtclang ${example}_c++-naive_codegen ${example}_${backend}_codegen)
       endif()
@@ -144,7 +141,7 @@ function(cuda_compile_generated_examples)
 
       add_custom_target(
         dummy_${example}_${backend}
-        DEPENDS ${cwd}/CodeGen/generated/${example}_c++-naive.cpp
+        DEPENDS ${cwd}/${ARG_DIRECTORY}/generated/${example}_c++-naive.cpp
       )
 
       if(CTEST_CUDA_SUBMIT)
@@ -198,6 +195,8 @@ yoda_add_custom_dummy_target(NAME GTClangQtCreatorParseProjectIntegrationTest
 # Add a dummy target with all the source files so that they are included in a qt creator project
 yoda_add_custom_dummy_target(NAME GTClangQtCreatorParseProjectCodeGenTest
                          DIRECTORIES ${cwd}/CodeGen)
+yoda_add_custom_dummy_target(NAME GTClangQtCreatorParseProjectFV3Test
+                         DIRECTORIES ${cwd}/FV3)
 
 # Codegen tests require GridTools
 if(GTCLANG_HAS_GRIDTOOLS)
@@ -229,17 +228,37 @@ if(GTCLANG_HAS_GRIDTOOLS)
   if(GTCLANG_HAS_GRIDTOOLS)
     list(APPEND include_dirs "${GridTools_INCLUDE_PATH}")
     if(GTCLANG_BUILD_GT_CPU_EXAMPLES OR GTCLANG_BUILD_GT_GPU_EXAMPLES)
-      code_generate_examples(EXAMPLES ${codegen_examples} ${cuda_codegen_examples} BACKEND gt)
+      code_generate_examples(EXAMPLES ${codegen_examples} ${cuda_codegen_examples}
+        BACKEND gt
+        DIRECTORY CodeGen)
     endif()
     if(GTCLANG_BUILD_GT_CPU_EXAMPLES)
-      compile_generated_examples(EXAMPLES ${codegen_examples} DUMMY ${cuda_codegen_examples} BACKEND gt)
+      compile_generated_examples(EXAMPLES ${codegen_examples}
+        DUMMY ${cuda_codegen_examples}
+        BACKEND gt
+        DIRECTORY CodeGen)
     endif()
     if(GTCLANG_BUILD_GT_GPU_EXAMPLES)
-      cuda_compile_generated_examples(EXAMPLES ${codegen_examples} BACKEND gt)
+      cuda_compile_generated_examples(EXAMPLES ${codegen_examples}
+        BACKEND gt
+        DIRECTORY CodeGen)
     endif()
     if(GTCLANG_BUILD_CUDA_EXAMPLES)
-      code_generate_examples(EXAMPLES ${codegen_examples} ${cuda_codegen_examples} BACKEND cuda)
-      cuda_compile_generated_examples(EXAMPLES ${codegen_examples} ${cuda_codegen_examples} BACKEND cuda)
+      code_generate_examples(EXAMPLES ${codegen_examples} ${cuda_codegen_examples}
+        BACKEND cuda
+        DIRECTORY CodeGen)
+      cuda_compile_generated_examples(EXAMPLES ${codegen_examples} ${cuda_codegen_examples}
+        BACKEND cuda
+        DIRECTORY CodeGen)
     endif(GTCLANG_BUILD_CUDA_EXAMPLES)
   endif()
 endif()
+
+set(fv3_examples p_grad_c)
+
+code_generate_examples(EXAMPLES ${fv3_examples}
+  BACKEND gt
+  DIRECTORY FV3)
+compile_generated_examples(EXAMPLES ${fv3_examples}
+  BACKEND gt
+  DIRECTORY FV3)

--- a/gtclang/test/integration-test/CMakeLists.txt
+++ b/gtclang/test/integration-test/CMakeLists.txt
@@ -208,6 +208,9 @@ if(GTCLANG_HAS_GRIDTOOLS)
   set(cuda_codegen_examples intervals01 intervals02 intervals03 local_kcache kcache_fill kcache_fill_kparallel
       kcache_fill_backward kcache_flush kcache_epflush)
 
+  # examples from FV3
+  set(fv3_examples p_grad_c)
+
   set(codegen_example_benchmarks)
 
   ADD_COMPILER_FLAG_TO_EXAMPLE("boundary_condition_2" "-max-fields=2")
@@ -231,17 +234,26 @@ if(GTCLANG_HAS_GRIDTOOLS)
       code_generate_examples(EXAMPLES ${codegen_examples} ${cuda_codegen_examples}
         BACKEND gt
         DIRECTORY CodeGen)
+      code_generate_examples(EXAMPLES ${fv3_examples}
+        BACKEND gt
+        DIRECTORY FV3)
     endif()
     if(GTCLANG_BUILD_GT_CPU_EXAMPLES)
       compile_generated_examples(EXAMPLES ${codegen_examples}
         DUMMY ${cuda_codegen_examples}
         BACKEND gt
         DIRECTORY CodeGen)
+      compile_generated_examples(EXAMPLES ${fv3_examples}
+        BACKEND gt
+        DIRECTORY FV3)
     endif()
     if(GTCLANG_BUILD_GT_GPU_EXAMPLES)
       cuda_compile_generated_examples(EXAMPLES ${codegen_examples}
         BACKEND gt
         DIRECTORY CodeGen)
+      cuda_compile_generated_examples(EXAMPLES ${fv3_examples}
+        BACKEND gt
+        DIRECTORY FV3)
     endif()
     if(GTCLANG_BUILD_CUDA_EXAMPLES)
       code_generate_examples(EXAMPLES ${codegen_examples} ${cuda_codegen_examples}
@@ -253,12 +265,3 @@ if(GTCLANG_HAS_GRIDTOOLS)
     endif(GTCLANG_BUILD_CUDA_EXAMPLES)
   endif()
 endif()
-
-set(fv3_examples p_grad_c)
-
-code_generate_examples(EXAMPLES ${fv3_examples}
-  BACKEND gt
-  DIRECTORY FV3)
-compile_generated_examples(EXAMPLES ${fv3_examples}
-  BACKEND gt
-  DIRECTORY FV3)

--- a/gtclang/test/integration-test/CMakeLists.txt
+++ b/gtclang/test/integration-test/CMakeLists.txt
@@ -126,7 +126,7 @@ function(cuda_compile_generated_examples)
 
       target_include_directories(${example}_benchmarks_${backend}_cuda PUBLIC ${include_dirs})
       if(${backend} STREQUAL cuda)
-        add_dependencies(${example}_benchmarks_${backend}_cuda gtclang ${example}_c++-naive_${ARG_DIRECTORY} ${example}_${backend}_codegen)
+        add_dependencies(${example}_benchmarks_${backend}_cuda gtclang ${example}_c++-naive_codegen ${example}_${backend}_codegen)
       else()
         add_dependencies(${example}_benchmarks_${backend}_cuda gtclang ${example}_c++-naive_codegen ${example}_${backend}_codegen)
       endif()

--- a/gtclang/test/integration-test/FV3/Options.cpp
+++ b/gtclang/test/integration-test/FV3/Options.cpp
@@ -1,0 +1,23 @@
+//===--------------------------------------------------------------------------------*- C++ -*-===//
+//                         _       _
+//                        | |     | |
+//                    __ _| |_ ___| | __ _ _ __   __ _
+//                   / _` | __/ __| |/ _` | '_ \ / _` |
+//                  | (_| | || (__| | (_| | | | | (_| |
+//                   \__, |\__\___|_|\__,_|_| |_|\__, | - GridTools Clang DSL
+//                    __/ |                       __/ |
+//                   |___/                       |___/
+//
+//
+//  This file is distributed under the MIT License (MIT).
+//  See LICENSE.txt for details.
+//
+//===------------------------------------------------------------------------------------------===//
+#include "test/integration-test/CodeGen/Options.hpp"
+
+namespace dawn {
+Options& Options::getInstance() {
+  static Options instance;
+  return instance;
+}
+} // namespace dawn

--- a/gtclang/test/integration-test/FV3/Options.hpp
+++ b/gtclang/test/integration-test/FV3/Options.hpp
@@ -1,0 +1,46 @@
+//===--------------------------------------------------------------------------------*- C++ -*-===//
+//                         _       _
+//                        | |     | |
+//                    __ _| |_ ___| | __ _ _ __   __ _
+//                   / _` | __/ __| |/ _` | '_ \ / _` |
+//                  | (_| | || (__| | (_| | | | | (_| |
+//                   \__, |\__\___|_|\__,_|_| |_|\__, | - GridTools Clang DSL
+//                    __/ |                       __/ |
+//                   |___/                       |___/
+//
+//
+//  This file is distributed under the MIT License (MIT).
+//  See LICENSE.txt for details.
+//
+//===------------------------------------------------------------------------------------------===//
+#ifndef TEST_INTEGRATIONTEST_CODEGEN_OPTIONS_H
+#define TEST_INTEGRATIONTEST_CODEGEN_OPTIONS_H
+
+#include <string>
+
+namespace dawn {
+/**
+* @class Options
+* Singleton data container for program options
+*/
+class Options /* singleton */
+{
+private:
+  Options() {
+    for(int i = 0; i < 4; ++i) {
+      m_size[i] = 0;
+    }
+    m_verify = true;
+  }
+  Options(const Options&) {}
+  ~Options() {}
+
+public:
+  static Options& getInstance();
+
+  int m_size[4] = {12, 12, 12, 10};
+  bool m_verify;
+};
+} // namespace dawn
+
+#endif

--- a/gtclang/test/integration-test/FV3/TestMain.cpp
+++ b/gtclang/test/integration-test/FV3/TestMain.cpp
@@ -1,0 +1,34 @@
+//===--------------------------------------------------------------------------------*- C++ -*-===//
+//                         _       _
+//                        | |     | |
+//                    __ _| |_ ___| | __ _ _ __   __ _
+//                   / _` | __/ __| |/ _` | '_ \ / _` |
+//                  | (_| | || (__| | (_| | | | | (_| |
+//                   \__, |\__\___|_|\__,_|_| |_|\__, | - GridTools Clang DSL
+//                    __/ |                       __/ |
+//                   |___/                       |___/
+//
+//
+//  This file is distributed under the MIT License (MIT).
+//  See LICENSE.txt for details.
+//
+//===------------------------------------------------------------------------------------------===//
+#include <gtest/gtest.h>
+#include "test/integration-test/CodeGen/Options.hpp"
+
+using namespace dawn;
+
+int main(int argc, char** argv) {
+  // Pass command line arguments to googltest
+  ::testing::InitGoogleTest(&argc, argv);
+
+  if(argc < 4) {
+    printf("Usage: <pack>_stencil_<whatever> dimx dimy dimz\n where args are integer sizes of the data fields\n");
+    return 1;
+  }
+
+  for(int i = 0; i != 3; ++i) {
+    Options::getInstance().m_size[i] = atoi(argv[i + 1]);
+  }
+  return RUN_ALL_TESTS();
+}

--- a/gtclang/test/integration-test/FV3/p_grad_c.cpp
+++ b/gtclang/test/integration-test/FV3/p_grad_c.cpp
@@ -1,0 +1,41 @@
+#include "gridtools/clang_dsl.hpp"
+using namespace gridtools::clang;
+
+globals {
+  double dt2;
+  bool hydrostatic;
+};
+
+stencil p_grad_c {
+  storage_ij delpc;
+  storage pkc, gz, uc, vc, rdxc, rdyc;
+  var wk; // should be ij-only
+
+  Do {
+    vertical_region(k_start, k_end) {
+      if(hydrostatic) {
+        wk = pkc[k + 1] - pkc;
+      } else {
+        wk = delpc;
+      }
+
+      // //    do j=js,je
+      // //       do i=is,ie+1
+      // fills ghost in i-dir
+      uc += dt2 * rdxc / (wk[i - 1] + wk) *
+            ((gz[i - 1, k + 1] - gz) *
+                 (pkc[k + 1] - pkc[i - 1]) +
+             (gz[i - 1] - gz[k + 1]) *
+                 (pkc[i - 1, k + 1] - pkc));
+
+      // //    do j=js,je+1
+      // //       do i=is,ie
+      // fills ghost in j-dir
+      vc += dt2 * rdyc / (wk[j - 1] + wk) *
+            ((gz[j - 1, k + 1] - gz) *
+                 (pkc[k + 1] - pkc[j - 1]) +
+             (gz[j - 1] - gz[k + 1]) *
+                 (pkc[j - 1, k + 1] - pkc));
+    }
+  }
+};

--- a/gtclang/test/integration-test/FV3/p_grad_c.cpp
+++ b/gtclang/test/integration-test/FV3/p_grad_c.cpp
@@ -21,7 +21,6 @@ stencil p_grad_c {
 
       // //    do j=js,je
       // //       do i=is,ie+1
-      // fills ghost in i-dir
       uc += dt2 * rdxc / (wk[i - 1] + wk) *
             ((gz[i - 1, k + 1] - gz) *
                  (pkc[k + 1] - pkc[i - 1]) +
@@ -30,7 +29,6 @@ stencil p_grad_c {
 
       // //    do j=js,je+1
       // //       do i=is,ie
-      // fills ghost in j-dir
       vc += dt2 * rdyc / (wk[j - 1] + wk) *
             ((gz[j - 1, k + 1] - gz) *
                  (pkc[k + 1] - pkc[j - 1]) +

--- a/gtclang/test/integration-test/FV3/p_grad_c_benchmark.cpp
+++ b/gtclang/test/integration-test/FV3/p_grad_c_benchmark.cpp
@@ -1,0 +1,98 @@
+//===--------------------------------------------------------------------------------*- C++ -*-===//
+//                         _       _
+//                        | |     | |
+//                    __ _| |_ ___| | __ _ _ __   __ _
+//                   / _` | __/ __| |/ _` | '_ \ / _` |
+//                  | (_| | || (__| | (_| | | | | (_| |
+//                   \__, |\__\___|_|\__,_|_| |_|\__, | - GridTools Clang DSL
+//                    __/ |                       __/ |
+//                   |___/                       |___/
+//
+//
+//  This file is distributed under the MIT License (MIT).
+//  See LICENSE.txt for details.
+//
+//===------------------------------------------------------------------------------------------===//
+#define GRIDTOOLS_CLANG_GENERATED 1
+#define GRIDTOOLS_CLANG_HALO_EXTEND 3
+#define GT_VECTOR_LIMIT_SIZE 30
+
+#undef FUSION_MAX_VECTOR_SIZE
+#undef FUSION_MAX_MAP_SIZE
+#define FUSION_MAX_VECTOR_SIZE GT_VECTOR_LIMIT_SIZE
+#define FUSION_MAX_MAP_SIZE FUSION_MAX_VECTOR_SIZE
+#define BOOST_MPL_LIMIT_VECTOR_SIZE FUSION_MAX_VECTOR_SIZE
+#define BOOST_MPL_CFG_NO_PREPROCESSED_HEADERS
+
+#include <gtest/gtest.h>
+#include "gridtools/clang/verify.hpp"
+#include "test/integration-test/CodeGen/Macros.hpp"
+#include "test/integration-test/CodeGen/Options.hpp"
+#include "test/integration-test/FV3/generated/p_grad_c_c++-naive.cpp"
+
+#ifndef OPTBACKEND
+#define OPTBACKEND gt
+#endif
+
+// clang-format off
+#include INCLUDE_FILE(test/integration-test/FV3/generated/p_grad_c_,OPTBACKEND.cpp)
+// clang-format on
+
+using namespace dawn;
+TEST(p_grad_c, test) {
+  domain dom(Options::getInstance().m_size[0], Options::getInstance().m_size[1],
+             Options::getInstance().m_size[2]);
+  dom.set_halos(halo::value, halo::value, halo::value, halo::value, 0, 0);
+  verifier verif(dom);
+
+  meta_data_ij_t meta_data_ij(dom.isize(), dom.jsize(), 1);
+  storage_ij_t delpc(meta_data_ij, "delpc");
+
+  meta_data_t meta_data(dom.isize(), dom.jsize(), dom.ksize() + 1);
+  storage_t pkc(meta_data, "pkc");
+  storage_t gz(meta_data, "gz");
+  storage_t uc_gt(meta_data, "uc_gt"), uc_cxxnaive(meta_data, "uc_cxxnaive");
+  storage_t vc_gt(meta_data, "vc_gt"), vc_cxxnaive(meta_data, "vc_cxxnaive");
+  storage_t rdxc(meta_data, "rdxc");
+  storage_t rdyc(meta_data, "rdyc");
+
+  double dt2 = 0.001;
+
+  dawn_generated::OPTBACKEND::p_grad_c p_grad_c_gt(dom);
+  dawn_generated::cxxnaive::p_grad_c p_grad_c_cxxnaive(dom);
+
+  p_grad_c_gt.set_dt2(dt2);
+  p_grad_c_cxxnaive.set_dt2(dt2);
+
+  verif.fill(-1.0, delpc);
+  verif.fillMath(5.0, 1.2, 1.3, 1.7, 2.2, 3.5, pkc);
+  verif.fillMath(5.0, 1.2, 1.3, 1.7, 2.2, 3.5, gz, rdxc, rdyc);
+
+  // Test with hydrostatic = true
+  // {
+  verif.fillMath(8.0, 2.0, 1.5, 1.5, 2.0, 4.0, uc_gt, vc_gt, uc_cxxnaive, vc_cxxnaive);
+
+  p_grad_c_gt.set_hydrostatic(true);
+  p_grad_c_cxxnaive.set_hydrostatic(true);
+
+  p_grad_c_gt.run(delpc, pkc, gz, uc_gt, vc_gt, rdxc, rdyc);
+  p_grad_c_cxxnaive.run(delpc, pkc, gz, uc_cxxnaive, vc_cxxnaive, rdxc, rdyc);
+
+  ASSERT_TRUE(verif.verify(uc_gt, uc_cxxnaive));
+  ASSERT_TRUE(verif.verify(vc_gt, vc_cxxnaive));
+  // }
+
+  // Test with hydrostatic = false
+  // {
+  verif.fillMath(8.0, 2.0, 1.5, 1.5, 2.0, 4.0, uc_gt, vc_gt, uc_cxxnaive, vc_cxxnaive);
+
+  p_grad_c_gt.set_hydrostatic(false);
+  p_grad_c_cxxnaive.set_hydrostatic(false);
+
+  p_grad_c_gt.run(delpc, pkc, gz, uc_gt, vc_gt, rdxc, rdyc);
+  p_grad_c_cxxnaive.run(delpc, pkc, gz, uc_cxxnaive, vc_cxxnaive, rdxc, rdyc);
+
+  ASSERT_TRUE(verif.verify(uc_gt, uc_cxxnaive));
+  ASSERT_TRUE(verif.verify(vc_gt, vc_cxxnaive));
+  // }
+}

--- a/gtclang/test/integration-test/FV3/p_grad_c_benchmark.cpp
+++ b/gtclang/test/integration-test/FV3/p_grad_c_benchmark.cpp
@@ -56,17 +56,16 @@ TEST(p_grad_c, test) {
   storage_t rdxc(meta_data, "rdxc");
   storage_t rdyc(meta_data, "rdyc");
 
-  double dt2 = 0.001;
-
   dawn_generated::OPTBACKEND::p_grad_c p_grad_c_gt(dom);
   dawn_generated::cxxnaive::p_grad_c p_grad_c_cxxnaive(dom);
-
-  p_grad_c_gt.set_dt2(dt2);
-  p_grad_c_cxxnaive.set_dt2(dt2);
 
   verif.fill(-1.0, delpc);
   verif.fillMath(5.0, 1.2, 1.3, 1.7, 2.2, 3.5, pkc);
   verif.fillMath(5.0, 1.2, 1.3, 1.7, 2.2, 3.5, gz, rdxc, rdyc);
+
+  double dt2 = 0.001;
+  p_grad_c_gt.set_dt2(dt2);
+  p_grad_c_cxxnaive.set_dt2(dt2);
 
   // Test with hydrostatic = true
   // {

--- a/gtclang/test/integration-test/FV3/p_grad_c_benchmark.cu
+++ b/gtclang/test/integration-test/FV3/p_grad_c_benchmark.cu
@@ -1,0 +1,1 @@
+#include "p_grad_c_benchmark.cpp"


### PR DESCRIPTION
## Technical Description

Adds an FV3 stencil to the gtclang tests and sets up the integration test infrastructure for more to come later. To enable this, the cmake functions `code_generate_examples` and `code_compile_examples` were altered to add a `DIRECTORY` argument. The new test is automatically built when `GTCLANG_BUILD_GT_CPU_EXAMPLES` is enabled.

### Resolves / Enhances

Resolves #442.

### Testing

The test added so far is `p_grad_c` from `FV3/atmos_cubed_sphere/model/dyn_core.F90`.
