### PR TITLE
Fix pre-commit ignore list

### DIFF
--- a/dawn/src/dawn/CodeGen/GridTools/GTCodeGen.cpp
+++ b/dawn/src/dawn/CodeGen/GridTools/GTCodeGen.cpp
@@ -360,7 +360,6 @@ void GTCodeGen::generateStencilWrapperCtr(
 
   StencilWrapperConstructor.addArg("const " + c_gtc() + "domain& dom");
 
-
   // Initialize allocated fields
   if(metadata.hasAccessesOfType<iir::FieldAccessType::InterStencilTemporary>()) {
     std::vector<std::string> tempFields;

--- a/dawn/src/dawn/IIR/StencilFunctionInstantiation.cpp
+++ b/dawn/src/dawn/IIR/StencilFunctionInstantiation.cpp
@@ -414,9 +414,8 @@ void StencilFunctionInstantiation::update() {
     int AccessID = argIdxCallerAccessIDPair.second;
     if(!inputFields.count(AccessID) && !outputFields.count(AccessID) &&
        !inputOutputFields.count(AccessID)) {
-      inputFields.emplace(AccessID,
-                          Field(AccessID, Field::IntendKind::Input, Extents{},
-                                Extents{}, interval_));
+      inputFields.emplace(
+          AccessID, Field(AccessID, Field::IntendKind::Input, Extents{}, Extents{}, interval_));
       unusedFields_.insert(AccessID);
     }
   }

--- a/scripts/clang_format_all.sh
+++ b/scripts/clang_format_all.sh
@@ -3,11 +3,6 @@ SCRIPT=$(readlink -f $0)
 SCRIPTPATH=`dirname $SCRIPT`
 
 source ${SCRIPTPATH}/ignore_list.sh
-arg_list=("")
-for i in "${ignore_regex_list[@]}"; do
-    arg_list+=("-e")
-    arg_list+=("$i")
-done
 
 CLANG_FORMAT=`which clang-format`
 CLANG_FORMAT_VERSION=`${CLANG_FORMAT} --version | sed 's/.*clang-format version \([[:digit:]]\.[[:digit:]]\).*/\1/g'`
@@ -16,7 +11,19 @@ if [[ "${CLANG_FORMAT_VERSION}" != "6.0" ]]; then
     exit 1
 fi
 
+in_ignore_regex_list() {
+	local file=$1
+	shift
+    local ignore_regex_list=$@
+    
+	for regex in $ignore_regex_list; do 
+        [[ "$file" =~ $regex ]] && return 0;
+    done
+    return 1;
+}
+
 file_list=$(find . -regextype posix-egrep -regex ".*\.(hpp|cpp|h|cu)$")
-for file in $(echo "$file_list" | grep -v ${arg_list[@]}); do
+for file in $(echo "$file_list"); do
+    if in_ignore_regex_list "$file" "${ignore_regex_list[@]}"; then continue; fi
     $CLANG_FORMAT -style=file -i $file
 done

--- a/scripts/clang_format_all.sh
+++ b/scripts/clang_format_all.sh
@@ -4,7 +4,7 @@ SCRIPTPATH=`dirname $SCRIPT`
 
 source ${SCRIPTPATH}/ignore_list.sh
 arg_list=("")
-for i in "${ignore[@]}"; do
+for i in "${ignore_regex_list[@]}"; do
     arg_list+=("-e")
     arg_list+=("$i")
 done

--- a/scripts/git_hooks/pre-commit
+++ b/scripts/git_hooks/pre-commit
@@ -130,7 +130,7 @@ git diff-index --cached --diff-filter=ACMR --name-only $against -- | while read 
 do
     # ignore file if we do check for file extensions and the file
     # does not match any of the extensions specified in $FILE_EXTS
-    if $PARSE_EXTS && ! matches_extension "$file" "${list_files_to_skip[@]}"; then
+    if $PARSE_EXTS && ! matches_extension "$file" "${ignore_regex_list[@]}"; then
         continue;
     fi
 

--- a/scripts/ignore_list.sh
+++ b/scripts/ignore_list.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
-ignore=(
-    "^\./dawn/test/utils/googletest/"
-    "^\./dawn/src/dawn/Support/External/"
-    "^\./dawn/examples/python/data/"
-    "^\./gtclang/test/utils/googletest/"
+ignore_regex_list=(
+    "^(\./)?dawn/test/utils/googletest/"
+    "^(\./)?dawn/src/dawn/Support/External/"
+    "^(\./)?dawn/examples/python/data/"
+    "^(\./)?gtclang/test/utils/googletest/"
     "/bundle/"
     )


### PR DESCRIPTION
## Technical Description

Fix `pre-commit` which was not using the ignore list (regular expressions) defined by `ignore_list.sh`. Also fixes such list which was incorrect as it assumed that the file paths outputted by `git diff-index` were of the form `./dawn/something`, while they actually are like `dawn/something`.
