### PR TITLE
Replace dawn bundle by a simple CMake script

### DIFF
--- a/dawn/bundle/CMakeLists.txt
+++ b/dawn/bundle/CMakeLists.txt
@@ -1,12 +1,10 @@
-##===------------------------------------------------------------------------------*- CMake -*-===##
-##                         _       _
-##                        | |     | |
-##                    __ _| |_ ___| | __ _ _ __   __ _
-##                   / _` | __/ __| |/ _` | '_ \ / _` |
-##                  | (_| | || (__| | (_| | | | | (_| |
-##                   \__, |\__\___|_|\__,_|_| |_|\__, | - GridTools Clang DSL
-##                    __/ |                       __/ |
-##                   |___/                       |___/
+##===--------------------------------------------------------------------------------*- C++ -*-===##
+##                          _
+##                         | |
+##                       __| | __ ___      ___ ___
+##                      / _` |/ _` \ \ /\ / / '_  |
+##                     | (_| | (_| |\ V  V /| | | |
+##                      \__,_|\__,_| \_/\_/ |_| |_| - Compiler Toolchain
 ##
 ##
 ##  This file is distributed under the MIT License (MIT).
@@ -14,102 +12,60 @@
 ##
 ##===------------------------------------------------------------------------------------------===##
 
+# This file builds dependencies for dawn. It is optionally used in place of
+# manually installing these packages.
+
+# NOTE: These options affect the _dependencies_, not dawn itself.
+
 if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE "RelWithDebInfo" CACHE STRING
       "Choose the type of build, options are: Debug Release RelWithDebInfo." FORCE)
 endif()
 
-if(NOT BUILD_SHARED_LIBS)
-  set(BUILD_SHARED_LIBS ON CACHE BOOL "Build shared libraries." FORCE)
-endif()
-
-if(NOT CMAKE_INSTALL_PREFIX)
-  set(CMAKE_INSTALL_PREFIX "${CMAKE_SOURCE_DIR}/install" CACHE STRING
-      "Install path prefix, prepended onto install directories." FORCE)
-endif()
-
-project(dawn C CXX)
-enable_testing()
 cmake_minimum_required(VERSION 3.8.1)
+project(dawn-bundle
+  LANGUAGES C CXX)
 
-list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
-list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/../cmake")
+option(DAWN_PYTHON "Installs protobuf python bindings for use in dawn." ON)
 
-include(DawnCloneRepository)
-
-set(DAWN_YODA_GIT_URL "https:///github.com/MeteoSwiss-APN/yoda.git"
-    CACHE PATH "URL of the dawn git repository to clone")
-set(DAWN_YODA_GIT_BRANCH "1.0.9" CACHE STRING "Branch of the dawn git repository to clone")
-dawn_clone_repository(NAME yoda URL ${DAWN_YODA_GIT_URL} BRANCH ${DAWN_YODA_GIT_BRANCH} SOURCE_DIR DAWN_YODA_SOURCE_DIR )
-#
-list(APPEND CMAKE_MODULE_PATH "${DAWN_YODA_SOURCE_DIR}/cmake")
-include(yodaInit)
-
-yoda_init()
-
-include(yodaAddTargetCleanAll)
-
-# Add custom targets
-yoda_add_target_clean_all(
-  "${CMAKE_BINARY_DIR}/prefix"
-  "${CMAKE_BINARY_DIR}/thirdparty"
-  "${CMAKE_BINARY_DIR}/dawn-cmake"
-  "${CMAKE_BINARY_DIR}/dawn"
-  "${CMAKE_BINARY_DIR}/dawn-prefix"
-  "${CMAKE_BINARY_DIR}/gtclang"
-  "${CMAKE_BINARY_DIR}/gtclang-prefix"
-  "${CMAKE_BINARY_DIR}/Makefile"
-  "${CMAKE_BINARY_DIR}/yoda-cmake"
-  "${CMAKE_BINARY_DIR}/protobuf"
-  "${CMAKE_BINARY_DIR}/protobuf-prefix"
-)
-
-option(DAWN_BUNDLE_PYTHON "Build and install the Python module interface to HIR" OFF)
-option(DAWN_BUNDLE_JAVA "Build and install the java interface to HIR" OFF)
-option(DAWN_PYTHON_EXAMPLES "Build the python examples of generating HIR" OFF)
-
-if( DAWN_BUNDLE_PYTHON )
-  if(NOT DEFINED PYTHON_EXECUTABLE)
-    find_package(PythonInterp 3 REQUIRED)
-  endif()
+# Require Python for protobuf bindings
+if(DAWN_PYTHON)
+  find_package(Python3 COMPONENTS Interpreter)
+  set(protobuf_step_targets python-build python-install)
 endif()
 
-include("thirdparty/DawnAddProtobuf")
+include(ExternalProject)
 
-set(dawn_cmake_args -DProtobuf_DIR=${Protobuf_DIR} -DDAWN_PYTHON=${DAWN_BUNDLE_PYTHON} -DDAWN_EXAMPLES=${DAWN_PYTHON_EXAMPLES} -DDAWN_JAVA=${DAWN_BUNDLE_JAVA})
+# Dependency: Protobuf
+# C++ protobuf
+set(protobuf_version "3.4.0")
+set(protobuf_version_short "3.4")
 
-yoda_find_package(
-  PACKAGE dawn
-  FORWARD_VARS
-    BINARY_DIR dawn_binary_dir
-  DEPENDS "protobuf"
-  ADDITIONAL
-    SOURCE_DIR "${CMAKE_SOURCE_DIR}/../"
-    YODA_ROOT "${DAWN_YODA_SOURCE_DIR}"
-    CMAKE_ARGS
-        ${dawn_cmake_args}
+ExternalProject_Add(protobuf
+  URL https://github.com/google/protobuf/archive/v${protobuf_version}.tar.gz
+  URL_HASH MD5=1d077a7d4db3d75681f5c333f2de9b1a
+  DOWNLOAD_DIR "${CMAKE_SOURCE_DIR}/downloads/"
+  PREFIX "${CMAKE_BINARY_DIR}/protobuf-prefix"
+  SOURCE_SUBDIR cmake
+  CMAKE_ARGS
+    "-DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>"
+    "-Dprotobuf_BUILD_EXAMPLES=OFF"
+    "-Dprotobuf_BUILD_SHARED_LIBS=OFF"
+    "-Dprotobuf_BUILD_TESTS=OFF"
+    "-Dprotobuf_INSTALL_EXAMPLES=OFF"
+  STEP_TARGETS "${protobuf_step_targets}"
 )
 
-if(NOT(dawn_binary_dir))
-  message(FATAL_ERROR "dawn binary dir was not defined by External_dawn")
-endif()
 
-add_test(NAME dawn-tests
-  COMMAND  ${CMAKE_COMMAND} --build ${dawn_binary_dir} --target test
+ExternalProject_Add_Step(
+  protobuf python-build
+  COMMAND PROTOC=<INSTALL_DIR>/bin/protoc ${Python3_EXECUTABLE} setup.py build
+  WORKING_DIRECTORY "<SOURCE_DIR>/python"
+  DEPENDEES build install
 )
 
-set(conf_bundle_filename ${CMAKE_BINARY_DIR}/dawn-conf.bundle)
-file(WRITE ${conf_bundle_filename} "conf")
-
-install(
-  FILES ${conf_bundle_filename}
-  DESTINATION bundle_conf
+ExternalProject_Add_Step(
+  protobuf python-install
+  COMMAND ${CMAKE_COMMAND} -E copy_directory "<SOURCE_DIR>/python" "<INSTALL_DIR>/python"
+  DEPENDEES build install python-build
 )
-
-if(DAWN_BUNDLE_PYTHON)
-  if(NOT DEFINED PROTOBUF_PYTHON_INSTALL)
-    message(FATAL_ERROR "protobuf python not set")
-  endif()
-  install(DIRECTORY ${PROTOBUF_PYTHON_INSTALL}/google DESTINATION ${CMAKE_INSTALL_PREFIX}/python)
-  install (SCRIPT "${CMAKE_SOURCE_DIR}/PostInstall.cmake")
-endif(DAWN_BUNDLE_PYTHON)

--- a/dawn/bundle/CMakeLists.txt
+++ b/dawn/bundle/CMakeLists.txt
@@ -37,7 +37,7 @@ endif()
 include(ExternalProject)
 
 # Dependency: Protobuf
-# C++ protobuf
+# C++ Protobuf
 set(protobuf_version "3.4.0")
 set(protobuf_version_short "3.4")
 
@@ -56,7 +56,7 @@ ExternalProject_Add(protobuf
   STEP_TARGETS "${protobuf_step_targets}"
 )
 
-
+# Python Protobuf
 ExternalProject_Add_Step(
   protobuf python-build
   COMMAND PROTOC=<INSTALL_DIR>/bin/protoc ${Python3_EXECUTABLE} setup.py build


### PR DESCRIPTION
## Technical Description

Replaces dawn bundle by a CMake script that downloads Protobuf.

### Resolves / Enhances

Part of #409.