### PR TITLE
Make atlas optional unless flag to force running tests is set

### DIFF
--- a/gtclang/cmake/GTClangOptions.cmake
+++ b/gtclang/cmake/GTClangOptions.cmake
@@ -28,7 +28,7 @@ option(GTCLANG_USE_CCACHE "Use compile cache (ccache)" ON)
 option(GTCLANG_BUILD_GT_CPU_EXAMPLES "Build cpu GT examples" ON)
 option(GTCLANG_BUILD_GT_GPU_EXAMPLES "Build gpu GT examples" OFF)
 option(GTCLANG_BUILD_CUDA_EXAMPLES "Build cuda native examples" OFF)
-option(GTCLANG_ATLAS_INTEGRATION_TESTS "Run atlas integration tests (need atlas and eckit)" ON)
+option(GTCLANG_FORCE_ATLAS_INTEGRATION_TESTS "Force running atlas integration tests (need atlas and eckit)" OFF)
 
 set(GTCLANG_HAS_CUDA 0)
 if(GTCLANG_BUILD_GT_GPU_EXAMPLES OR GTCLANG_BUILD_CUDA_EXAMPLES)

--- a/gtclang/scripts/jenkins/build.sh
+++ b/gtclang/scripts/jenkins/build.sh
@@ -86,7 +86,7 @@ cd $build_dir
 CMAKE_ARGS="-DCMAKE_BUILD_TYPE=${build_type} -DBOOST_ROOT=${BOOST_DIR} -DGTCLANG_ENABLE_GRIDTOOLS=ON \
         -DProtobuf_DIR=${PROTOBUFDIR}  -DLLVM_ROOT=${LLVM_DIR}" 
 
-CMAKE_ARGS="${CMAKE_ARGS} -DGTCLANG_ATLAS_INTEGRATION_TESTS=ON -Datlas_DIR=${ATLAS_DIR}/release/cpu/lib/cmake/atlas -Deckit_DIR=${ECKIT_DIR}/lib/cmake/eckit"
+CMAKE_ARGS="${CMAKE_ARGS} -DGTCLANG_FORCE_ATLAS_INTEGRATION_TESTS=ON -Datlas_DIR=${ATLAS_DIR}/release/cpu/lib/cmake/atlas -Deckit_DIR=${ECKIT_DIR}/lib/cmake/eckit"
 
 if [ -n ${INSTALL_DIR} ]; then
   CMAKE_ARGS="${CMAKE_ARGS} -DCMAKE_INSTALL_PREFIX=${INSTALL_DIR}"

--- a/gtclang/test/atlas-integration-test/CMakeLists.txt
+++ b/gtclang/test/atlas-integration-test/CMakeLists.txt
@@ -12,17 +12,21 @@
 ##
 ##===------------------------------------------------------------------------------------------===##
 
-if(GTCLANG_ATLAS_INTEGRATION_TESTS)
-
+if(GTCLANG_FORCE_ATLAS_INTEGRATION_TESTS)
+    find_package(eckit REQUIRED)
+    find_package(atlas REQUIRED)
+else()
     find_package(eckit)
     if(NOT eckit_FOUND)
-            message(FATAL_ERROR "Couldn't find eckit. If you don't need atlas set GTCLANG_ATLAS_INTEGRATION_TESTS to OFF.")
+            message(WARNING "Couldn't find eckit. Atlas integration tests are disabled.")
     endif()
-
     find_package(atlas)
     if(NOT atlas_FOUND)
-            message(FATAL_ERROR "Couldn't find atlas. If you don't need atlas set GTCLANG_ATLAS_INTEGRATION_TESTS to OFF.")
+            message(WARNING "Couldn't find atlas. Atlas integration tests are disabled.")
     endif()
+endif()
+
+if(eckit_FOUND AND atlas_FOUND)
 
     # Need to specify here the names of the stencil codes that are going to be generated.
     set(generated_stencil_codes generated_copyCell.hpp
@@ -76,7 +80,4 @@ if(GTCLANG_ATLAS_INTEGRATION_TESTS)
     target_include_directories(AtlasIntegrationTestCompareOutput PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/reference)
     target_include_directories(AtlasIntegrationTestCompareOutput PRIVATE ${CMAKE_SOURCE_DIR}/src)
 
-
-else()
-    message(STATUS "Atlas integration tests are disabled.")
 endif()


### PR DESCRIPTION
## Technical Description

If atlas is not found, tests are not run (but a cmake warning will pop up), unless the `GTCLANG_FORCE_ATLAS_INTEGRATION_TESTS` flag is set to ON, which will trigger an error.
Default for this flag is OFF.
