### PR TITLE
fix to reordering strategy

### DIFF
--- a/dawn/src/dawn/Optimizer/PassSetStageGraph.cpp
+++ b/dawn/src/dawn/Optimizer/PassSetStageGraph.cpp
@@ -43,8 +43,7 @@ static bool depends(const iir::Stage& fromStage, const iir::Stage& toStage) {
         // This used to check if IntendKind was Input or InputOutput, but this
         // reorders stages when there is a WAW dependency. Instead, we should
         // catch all output dependencies
-        if(!intervalsMatch)
-          return true;
+        return true;
         break;
       case iir::Field::IntendKind::InputOutput:
         return true;

--- a/dawn/src/dawn/Optimizer/PassSetStageGraph.cpp
+++ b/dawn/src/dawn/Optimizer/PassSetStageGraph.cpp
@@ -26,8 +26,6 @@ static bool depends(const iir::Stage& fromStage, const iir::Stage& toStage) {
   if(!fromStage.overlaps(toStage))
     return false;
 
-  bool intervalsMatch = fromStage.getEnclosingInterval() == toStage.getEnclosingInterval();
-
   for(const auto& fromFieldPair : fromStage.getFields()) {
     const iir::Field& fromField = fromFieldPair.second;
     for(const auto& toFieldPair : toStage.getFields()) {

--- a/gtclang/test/integration-test/PassStageMerger/Test07.cpp
+++ b/gtclang/test/integration-test/PassStageMerger/Test07.cpp
@@ -1,0 +1,32 @@
+//===--------------------------------------------------------------------------------*- C++ -*-===//
+//                         _       _
+//                        | |     | |
+//                    __ _| |_ ___| | __ _ _ __   __ _
+//                   / _` | __/ __| |/ _` | '_ \ / _` |
+//                  | (_| | || (__| | (_| | | | | (_| |
+//                   \__, |\__\___|_|\__,_|_| |_|\__, | - GridTools Clang DSL
+//                    __/ |                       __/ |
+//                   |___/                       |___/
+//
+//
+//  This file is distributed under the MIT License (MIT).
+//  See LICENSE.txt for details.
+//
+//===------------------------------------------------------------------------------------------===//
+// clang-format off
+// RUN: %gtclang% %file% -fno-codegen -fmerge-stages -fmerge-do-methods -freport-pass-stage-merger
+// EXPECTED_FILE: OUTPUT:%filename%_before.json,%filename%_after.json REFERENCE:%filename%_before_ref.json,%filename%_after_ref.json
+// clang-format on
+#include "gtclang_dsl_defs/gtclang_dsl.hpp"
+
+using namespace gridtools::clang;
+
+stencil Test {
+  storage in, out;
+
+  Do {
+
+    vertical_region(k_start, k_end) { out = in; }
+    vertical_region(k_start, k_end) { out = 0; }
+  }
+};

--- a/gtclang/test/integration-test/PassStageMerger/Test07_after_ref.json
+++ b/gtclang/test/integration-test/PassStageMerger/Test07_after_ref.json
@@ -1,0 +1,247 @@
+{
+  "IIR": {
+    "Fields": {
+      "in": {
+        "IsTemporary": false,
+        "dim": "[1,1,1]",
+        "field": {
+          "accessID": 15,
+          "extents": {
+            "read_access": "[<no_horizontal_extent>,(0,0)]",
+            "write_access": "null"
+          },
+          "intend": 2,
+          "interval": "{ Start : End }",
+          "redundant extents": {
+            "read_access": "[<no_horizontal_extent>,(0,0)]",
+            "write_access": "null"
+          }
+        }
+      },
+      "out": {
+        "IsTemporary": false,
+        "dim": "[1,1,1]",
+        "field": {
+          "accessID": 16,
+          "extents": {
+            "read_access": "null",
+            "write_access": "[<no_horizontal_extent>,(0,0)]"
+          },
+          "intend": 0,
+          "interval": "{ Start : End }",
+          "redundant extents": {
+            "read_access": "null",
+            "write_access": "[<no_horizontal_extent>,(0,0)]"
+          }
+        }
+      }
+    },
+    "Stencil0": {
+      "Fields": {
+        "in": {
+          "IsTemporary": false,
+          "dim": "[1,1,1]",
+          "field": {
+            "accessID": 15,
+            "extents": {
+              "read_access": "[<no_horizontal_extent>,(0,0)]",
+              "write_access": "null"
+            },
+            "intend": 2,
+            "interval": "{ Start : End }",
+            "redundant extents": {
+              "read_access": "[<no_horizontal_extent>,(0,0)]",
+              "write_access": "null"
+            }
+          }
+        },
+        "out": {
+          "IsTemporary": false,
+          "dim": "[1,1,1]",
+          "field": {
+            "accessID": 16,
+            "extents": {
+              "read_access": "null",
+              "write_access": "[<no_horizontal_extent>,(0,0)]"
+            },
+            "intend": 0,
+            "interval": "{ Start : End }",
+            "redundant extents": {
+              "read_access": "null",
+              "write_access": "[<no_horizontal_extent>,(0,0)]"
+            }
+          }
+        }
+      },
+      "ID": "17",
+      "MultiStages": [
+        {
+          "Caches": null,
+          "Fields": {
+            "in": {
+              "accessID": 15,
+              "extents": {
+                "read_access": "[<no_horizontal_extent>,(0,0)]",
+                "write_access": "null"
+              },
+              "intend": 2,
+              "interval": "{ Start : End }",
+              "redundant extents": {
+                "read_access": "[<no_horizontal_extent>,(0,0)]",
+                "write_access": "null"
+              }
+            },
+            "out": {
+              "accessID": 16,
+              "extents": {
+                "read_access": "null",
+                "write_access": "[<no_horizontal_extent>,(0,0)]"
+              },
+              "intend": 0,
+              "interval": "{ Start : End }",
+              "redundant extents": {
+                "read_access": "null",
+                "write_access": "[<no_horizontal_extent>,(0,0)]"
+              }
+            }
+          },
+          "ID": 39,
+          "Loop": "parallel",
+          "Stages": [
+            {
+              "DoMethods": [
+                {
+                  "Fields": {
+                    "in": {
+                      "accessID": 15,
+                      "extents": {
+                        "read_access": "[<no_horizontal_extent>,(0,0)]",
+                        "write_access": "null"
+                      },
+                      "intend": 2,
+                      "interval": "{ Start : End }",
+                      "redundant extents": {
+                        "read_access": "[<no_horizontal_extent>,(0,0)]",
+                        "write_access": "null"
+                      }
+                    },
+                    "out": {
+                      "accessID": 16,
+                      "extents": {
+                        "read_access": "null",
+                        "write_access": "[<no_horizontal_extent>,(0,0)]"
+                      },
+                      "intend": 0,
+                      "interval": "{ Start : End }",
+                      "redundant extents": {
+                        "read_access": "null",
+                        "write_access": "[<no_horizontal_extent>,(0,0)]"
+                      }
+                    }
+                  },
+                  "ID": 0,
+                  "Stmts": [
+                    {
+                      "read_accesses": [
+                        {
+                          "access_id": 15,
+                          "extents": "[<no_horizontal_extent>,(0,0)]",
+                          "name": "in"
+                        }
+                      ],
+                      "stmt": "out[<no_horizontal_offset>,0] = in[<no_horizontal_offset>,0];\n",
+                      "write_accesses": [
+                        {
+                          "access_id": 16,
+                          "extents": "[<no_horizontal_extent>,(0,0)]",
+                          "name": "out"
+                        }
+                      ]
+                    },
+                    {
+                      "read_accesses": null,
+                      "stmt": "out[<no_horizontal_offset>,0] = 0;\n",
+                      "write_accesses": [
+                        {
+                          "access_id": 16,
+                          "extents": "[<no_horizontal_extent>,(0,0)]",
+                          "name": "out"
+                        }
+                      ]
+                    }
+                  ],
+                  "interval": "{ Start : End }"
+                }
+              ],
+              "Extents": "[<no_horizontal_extent>,(0,0)]",
+              "Fields": {
+                "in": {
+                  "accessID": 15,
+                  "extents": {
+                    "read_access": "[<no_horizontal_extent>,(0,0)]",
+                    "write_access": "null"
+                  },
+                  "intend": 2,
+                  "interval": "{ Start : End }",
+                  "redundant extents": {
+                    "read_access": "[<no_horizontal_extent>,(0,0)]",
+                    "write_access": "null"
+                  }
+                },
+                "out": {
+                  "accessID": 16,
+                  "extents": {
+                    "read_access": "null",
+                    "write_access": "[<no_horizontal_extent>,(0,0)]"
+                  },
+                  "intend": 0,
+                  "interval": "{ Start : End }",
+                  "redundant extents": {
+                    "read_access": "null",
+                    "write_access": "[<no_horizontal_extent>,(0,0)]"
+                  }
+                }
+              },
+              "RequiresSync": false
+            }
+          ]
+        }
+      ]
+    },
+    "globals": null
+  },
+  "MetaInformation": {
+    "AccessIDToName": {
+      "15": "in",
+      "16": "out"
+    },
+    "FieldDims": {
+      "15": "[1,1,1]",
+      "16": "[1,1,1]"
+    },
+    "FieldToBC": null,
+    "GlobalAccessIDs": null,
+    "IDToStencilCall": {
+      "17": "stencil-call:__code_gen_17();\n"
+    },
+    "TemporaryAccessIDs": null,
+    "VariableVersions": {
+      "versionIDs": null,
+      "versions": null
+    },
+    "apiAccessIDs": [
+      15,
+      16
+    ],
+    "fieldAccessIDs": [
+      15,
+      16
+    ],
+    "filename": "Test07.cpp",
+    "literalAccessIDs": {
+      "-38": "0"
+    },
+    "stencilLocation": "24:8",
+    "stencilname": "Test"
+  }
+}

--- a/gtclang/test/integration-test/PassStageMerger/Test07_before_ref.json
+++ b/gtclang/test/integration-test/PassStageMerger/Test07_before_ref.json
@@ -1,0 +1,289 @@
+{
+  "IIR": {
+    "Fields": {
+      "in": {
+        "IsTemporary": false,
+        "dim": "[1,1,1]",
+        "field": {
+          "accessID": 15,
+          "extents": {
+            "read_access": "[<no_horizontal_extent>,(0,0)]",
+            "write_access": "null"
+          },
+          "intend": 2,
+          "interval": "{ Start : End }",
+          "redundant extents": {
+            "read_access": "[<no_horizontal_extent>,(0,0)]",
+            "write_access": "null"
+          }
+        }
+      },
+      "out": {
+        "IsTemporary": false,
+        "dim": "[1,1,1]",
+        "field": {
+          "accessID": 16,
+          "extents": {
+            "read_access": "null",
+            "write_access": "[<no_horizontal_extent>,(0,0)]"
+          },
+          "intend": 0,
+          "interval": "{ Start : End }",
+          "redundant extents": {
+            "read_access": "null",
+            "write_access": "[<no_horizontal_extent>,(0,0)]"
+          }
+        }
+      }
+    },
+    "Stencil0": {
+      "Fields": {
+        "in": {
+          "IsTemporary": false,
+          "dim": "[1,1,1]",
+          "field": {
+            "accessID": 15,
+            "extents": {
+              "read_access": "[<no_horizontal_extent>,(0,0)]",
+              "write_access": "null"
+            },
+            "intend": 2,
+            "interval": "{ Start : End }",
+            "redundant extents": {
+              "read_access": "[<no_horizontal_extent>,(0,0)]",
+              "write_access": "null"
+            }
+          }
+        },
+        "out": {
+          "IsTemporary": false,
+          "dim": "[1,1,1]",
+          "field": {
+            "accessID": 16,
+            "extents": {
+              "read_access": "null",
+              "write_access": "[<no_horizontal_extent>,(0,0)]"
+            },
+            "intend": 0,
+            "interval": "{ Start : End }",
+            "redundant extents": {
+              "read_access": "null",
+              "write_access": "[<no_horizontal_extent>,(0,0)]"
+            }
+          }
+        }
+      },
+      "ID": "17",
+      "MultiStages": [
+        {
+          "Caches": null,
+          "Fields": {
+            "in": {
+              "accessID": 15,
+              "extents": {
+                "read_access": "[<no_horizontal_extent>,(0,0)]",
+                "write_access": "null"
+              },
+              "intend": 2,
+              "interval": "{ Start : End }",
+              "redundant extents": {
+                "read_access": "[<no_horizontal_extent>,(0,0)]",
+                "write_access": "null"
+              }
+            },
+            "out": {
+              "accessID": 16,
+              "extents": {
+                "read_access": "null",
+                "write_access": "[<no_horizontal_extent>,(0,0)]"
+              },
+              "intend": 0,
+              "interval": "{ Start : End }",
+              "redundant extents": {
+                "read_access": "null",
+                "write_access": "[<no_horizontal_extent>,(0,0)]"
+              }
+            }
+          },
+          "ID": 39,
+          "Loop": "parallel",
+          "Stages": [
+            {
+              "DoMethods": [
+                {
+                  "Fields": {
+                    "in": {
+                      "accessID": 15,
+                      "extents": {
+                        "read_access": "[<no_horizontal_extent>,(0,0)]",
+                        "write_access": "null"
+                      },
+                      "intend": 2,
+                      "interval": "{ Start : End }",
+                      "redundant extents": {
+                        "read_access": "[<no_horizontal_extent>,(0,0)]",
+                        "write_access": "null"
+                      }
+                    },
+                    "out": {
+                      "accessID": 16,
+                      "extents": {
+                        "read_access": "null",
+                        "write_access": "[<no_horizontal_extent>,(0,0)]"
+                      },
+                      "intend": 0,
+                      "interval": "{ Start : End }",
+                      "redundant extents": {
+                        "read_access": "null",
+                        "write_access": "[<no_horizontal_extent>,(0,0)]"
+                      }
+                    }
+                  },
+                  "ID": 0,
+                  "Stmts": [
+                    {
+                      "read_accesses": [
+                        {
+                          "access_id": 15,
+                          "extents": "[<no_horizontal_extent>,(0,0)]",
+                          "name": "in"
+                        }
+                      ],
+                      "stmt": "out[<no_horizontal_offset>,0] = in[<no_horizontal_offset>,0];\n",
+                      "write_accesses": [
+                        {
+                          "access_id": 16,
+                          "extents": "[<no_horizontal_extent>,(0,0)]",
+                          "name": "out"
+                        }
+                      ]
+                    }
+                  ],
+                  "interval": "{ Start : End }"
+                }
+              ],
+              "Extents": "[<no_horizontal_extent>,(0,0)]",
+              "Fields": {
+                "in": {
+                  "accessID": 15,
+                  "extents": {
+                    "read_access": "[<no_horizontal_extent>,(0,0)]",
+                    "write_access": "null"
+                  },
+                  "intend": 2,
+                  "interval": "{ Start : End }",
+                  "redundant extents": {
+                    "read_access": "[<no_horizontal_extent>,(0,0)]",
+                    "write_access": "null"
+                  }
+                },
+                "out": {
+                  "accessID": 16,
+                  "extents": {
+                    "read_access": "null",
+                    "write_access": "[<no_horizontal_extent>,(0,0)]"
+                  },
+                  "intend": 0,
+                  "interval": "{ Start : End }",
+                  "redundant extents": {
+                    "read_access": "null",
+                    "write_access": "[<no_horizontal_extent>,(0,0)]"
+                  }
+                }
+              },
+              "RequiresSync": false
+            },
+            {
+              "DoMethods": [
+                {
+                  "Fields": {
+                    "out": {
+                      "accessID": 16,
+                      "extents": {
+                        "read_access": "null",
+                        "write_access": "[<no_horizontal_extent>,(0,0)]"
+                      },
+                      "intend": 0,
+                      "interval": "{ Start : End }",
+                      "redundant extents": {
+                        "read_access": "null",
+                        "write_access": "[<no_horizontal_extent>,(0,0)]"
+                      }
+                    }
+                  },
+                  "ID": 1,
+                  "Stmts": [
+                    {
+                      "read_accesses": null,
+                      "stmt": "out[<no_horizontal_offset>,0] = 0;\n",
+                      "write_accesses": [
+                        {
+                          "access_id": 16,
+                          "extents": "[<no_horizontal_extent>,(0,0)]",
+                          "name": "out"
+                        }
+                      ]
+                    }
+                  ],
+                  "interval": "{ Start : End }"
+                }
+              ],
+              "Extents": "[<no_horizontal_extent>,(0,0)]",
+              "Fields": {
+                "out": {
+                  "accessID": 16,
+                  "extents": {
+                    "read_access": "null",
+                    "write_access": "[<no_horizontal_extent>,(0,0)]"
+                  },
+                  "intend": 0,
+                  "interval": "{ Start : End }",
+                  "redundant extents": {
+                    "read_access": "null",
+                    "write_access": "[<no_horizontal_extent>,(0,0)]"
+                  }
+                }
+              },
+              "RequiresSync": false
+            }
+          ]
+        }
+      ]
+    },
+    "globals": null
+  },
+  "MetaInformation": {
+    "AccessIDToName": {
+      "15": "in",
+      "16": "out"
+    },
+    "FieldDims": {
+      "15": "[1,1,1]",
+      "16": "[1,1,1]"
+    },
+    "FieldToBC": null,
+    "GlobalAccessIDs": null,
+    "IDToStencilCall": {
+      "17": "stencil-call:__code_gen_17();\n"
+    },
+    "TemporaryAccessIDs": null,
+    "VariableVersions": {
+      "versionIDs": null,
+      "versions": null
+    },
+    "apiAccessIDs": [
+      15,
+      16
+    ],
+    "fieldAccessIDs": [
+      15,
+      16
+    ],
+    "filename": "Test07.cpp",
+    "literalAccessIDs": {
+      "-38": "0"
+    },
+    "stencilLocation": "24:8",
+    "stencilname": "Test"
+  }
+}


### PR DESCRIPTION
## Technical Description

This fixes the greedy reorder strategy to do what we expect in the write after write case

###  Enhances

Fixes illegal execution order


### Example

```
stencil Test {
  storage in, out;
  Do {
    vertical_region(k_start, k_end) {
      out = in;
    }
    vertical_region(k_start, k_end) {
      out = 0;
    }
  }
};
```

