### PR TITLE
Fix Names of local variables

### DIFF
--- a/dawn/src/dawn/Optimizer/Renaming.cpp
+++ b/dawn/src/dawn/Optimizer/Renaming.cpp
@@ -44,6 +44,7 @@ public:
     if(varAccessID == oldAccessID_)
       varAccessID = newAccessID_;
     iir::ASTVisitorForwarding::visit(stmt);
+    stmt->getName() = instantiation_->getNameFromAccessID(varAccessID);
   }
 
   virtual void visit(const std::shared_ptr<iir::StencilFunCallExpr>& expr) override {
@@ -57,6 +58,7 @@ public:
     int& varAccessID = *expr->getData<iir::IIRAccessExprData>().AccessID;
     if(varAccessID == oldAccessID_)
       varAccessID = newAccessID_;
+    expr->setName(instantiation_->getNameFromAccessID(varAccessID));
   }
 
   void visit(const std::shared_ptr<iir::FieldAccessExpr>& expr) override {

--- a/gtclang/test/integration-test/PassPreprocessor/BracketAccessTest.cpp
+++ b/gtclang/test/integration-test/PassPreprocessor/BracketAccessTest.cpp
@@ -33,10 +33,10 @@ stencil Test01 {
 
   void Do() {
     vertical_region(k_start, k_start) {
-      foo[i, j + 1, k] = 5;      // EXPECTED: %line%: foo(i, j + 1, k) = 5;
-      foo = bar[i];              // EXPECTED: %line%: foo = bar(i);
-      foo[i] = bar[i, j];        // EXPECTED: %line%: foo(i) = bar(i, j);
-      foo = TestFun(bar[i + 1]); // EXPECTED: %line%: foo = TestFun(bar(i + 1));
+      foo[i, j + 1, k] = 5;      // EXPECTED: %line%: foo\(i, j \+ 1, k\) = 5;
+      foo = bar[i];              // EXPECTED: %line%: foo = bar\(i\);
+      foo[i] = bar[i, j];        // EXPECTED: %line%: foo\(i\) = bar\(i, j\);
+      foo = TestFun(bar[i + 1]); // EXPECTED: %line%: foo = TestFun\(bar\(i \+ 1\)\);
     }
   }
 };
@@ -46,7 +46,7 @@ stencil Test02 {
 
   void Do() {
     vertical_region(k_start, k_start) 
-      foo[i, j + 1, k] = bar; // EXPECTED: %line%: foo(i, j + 1, k) = bar;
+      foo[i, j + 1, k] = bar; // EXPECTED: %line%: foo\(i, j \+ 1, k\) = bar;
   }
 };
 
@@ -55,7 +55,7 @@ stencil Test03 {
 
   void Do() {
     vertical_region(k_start, k_start) 
-      foo[i, j + 1, k] = bar; // EXPECTED: %line%: foo(i, j + 1, k) = bar;
+      foo[i, j + 1, k] = bar; // EXPECTED: %line%: foo\(i, j \+ 1, k\) = bar;
   }
 };
 

--- a/gtclang/test/integration-test/PassPreprocessor/DoMethodTest.cpp
+++ b/gtclang/test/integration-test/PassPreprocessor/DoMethodTest.cpp
@@ -23,7 +23,7 @@ using namespace gridtools::clang;
 stencil Test01 {
   storage foo;
 
-  Do { // EXPECTED: %line%: void Do () {
+  Do { // EXPECTED: %line%: void Do \(\) \{
     for(auto k : {k_end, k_start})
       foo = foo;
   }
@@ -32,7 +32,7 @@ stencil Test01 {
 stencil Test02 {
   storage foo;
 
-  Do() { // EXPECTED: %line%: void Do() {
+  Do() { // EXPECTED: %line%: void Do\(\) \{
     for(auto k : {k_end, k_start})
       foo = foo;
   }
@@ -41,7 +41,7 @@ stencil Test02 {
 stencil_function TestFun01 {
   storage foo;
 
-  Do { // EXPECTED: %line%: void Do () {
+  Do { // EXPECTED: %line%: void Do \(\) \{
     foo = foo;
   }
 };
@@ -49,7 +49,7 @@ stencil_function TestFun01 {
 stencil_function TestFun02 {
   storage foo;
 
-  Do { // EXPECTED: %line%: double Do () {
+  Do { // EXPECTED: %line%: double Do \(\) \{
     return foo;
   }
 };
@@ -57,7 +57,7 @@ stencil_function TestFun02 {
 stencil_function TestFun03 {
   storage foo;
 
-  Do() { // EXPECTED: %line%: void Do() {
+  Do() { // EXPECTED: %line%: void Do\(\) \{
     foo = foo;
   }
 };
@@ -65,7 +65,7 @@ stencil_function TestFun03 {
 stencil_function TestFun04 {
   storage foo;
 
-  Do() { // EXPECTED: %line%: double Do() {
+  Do() { // EXPECTED: %line%: double Do\(\) \{
     return foo;
   }
 };
@@ -73,7 +73,7 @@ stencil_function TestFun04 {
 stencil_function TestFun05 {
   storage foo;
 
-  void Do(k_from = k_start, k_to = k_end) { // EXPECTED: %line%: void Do(interval0 k_from = k_start, interval0 k_to = k_end) {
+  void Do(k_from = k_start, k_to = k_end) { // EXPECTED: %line%: void Do\(interval0 k_from = k_start, interval0 k_to = k_end\) \{
     foo = foo;
   }
 };
@@ -81,7 +81,7 @@ stencil_function TestFun05 {
 stencil_function TestFun06 {
   storage foo;
 
-  Do(k_from = k_start, k_to = k_end) { // EXPECTED: %line%: void Do(interval0 k_from = k_start, interval0 k_to = k_end) {
+  Do(k_from = k_start, k_to = k_end) { // EXPECTED: %line%: void Do\(interval0 k_from = k_start, interval0 k_to = k_end\) \{
     foo = foo;
   }
 };
@@ -89,7 +89,7 @@ stencil_function TestFun06 {
 stencil_function TestFun07 {
   storage foo;
 
-  Do(k_from = k_start, k_to = k_end) { // EXPECTED: %line%: double Do(interval0 k_from = k_start, interval0 k_to = k_end) {
+  Do(k_from = k_start, k_to = k_end) { // EXPECTED: %line%: double Do\(interval0 k_from = k_start, interval0 k_to = k_end\) \{
     return foo;
   }
 };
@@ -97,13 +97,13 @@ stencil_function TestFun07 {
 stencil_function TestFun08 {
   storage foo;
 
-  Do() {} // EXPECTED: %line%: void Do() {}
+  Do() {} // EXPECTED: %line%: void Do\(\) {}
 };
 
 stencil_function TestFun09 {
   storage foo;
 
-  Do {} // EXPECTED: %line%: void Do () {}
+  Do {} // EXPECTED: %line%: void Do \(\) {}
 };
 
 int main() {}

--- a/gtclang/test/integration-test/PassPreprocessor/VerticalRegionTest.cpp
+++ b/gtclang/test/integration-test/PassPreprocessor/VerticalRegionTest.cpp
@@ -24,16 +24,16 @@ stencil Test01 {
   storage foo;
 
   void Do() {
-    vertical_region(k_start, k_start) // EXPECTED: %line%: for(auto __k_loopvar__ : {k_start, k_start})
+    vertical_region(k_start, k_start) // EXPECTED: %line%: for\(auto __k_loopvar__ : \{k_start, k_start\}\)
         foo = 1;
 
-    vertical_region(k_start, k_end - 1) // EXPECTED: %line%: for(auto __k_loopvar__ : {k_start, k_end-1})
+    vertical_region(k_start, k_end - 1) // EXPECTED: %line%: for\(auto __k_loopvar__ : \{k_start, k_end-1\}\)
         foo = 1;
 
-    vertical_region(k_start + 1, k_end - 1) // EXPECTED: %line%: for(auto __k_loopvar__ : {k_start+1, k_end-1})
+    vertical_region(k_start + 1, k_end - 1) // EXPECTED: %line%: for\(auto __k_loopvar__ : \{k_start\+1, k_end-1\}\)
         foo = 1;
 
-    vertical_region(k_end, k_end) { // EXPECTED: %line%: for(auto __k_loopvar__ : {k_end, k_end}) {
+    vertical_region(k_end, k_end) { // EXPECTED: %line%: for\(auto __k_loopvar__ : \{k_end, k_end\}\) \{
       foo = 1;
     }
   }

--- a/gtclang/test/integration-test/PassSetCaches/KCacheTest02b.cpp
+++ b/gtclang/test/integration-test/PassSetCaches/KCacheTest02b.cpp
@@ -17,7 +17,7 @@
 // RUN: %gtclang% %file% -fno-codegen -freport-pass-set-caches
 // EXPECTED: PASS: PassSetCaches: Test: MS0: tmp:cache_type::k:fill_and_flush
 // EXPECTED: PASS: PassSetCaches: Test: MS1: b:cache_type::k:fill
-// EXPECTED: PASS: PassSetCaches: Test: MS1: tmp:cache_type::k:bpfill:[0,0]
+// EXPECTED: PASS: PassSetCaches: Test: MS1: tmp:cache_type::k:bpfill:\[0,0\]
 
 #include "gtclang_dsl_defs/gtclang_dsl.hpp"
 

--- a/gtclang/test/integration-test/PassSetCaches/KCacheTest03.cpp
+++ b/gtclang/test/integration-test/PassSetCaches/KCacheTest03.cpp
@@ -15,7 +15,7 @@
 //===------------------------------------------------------------------------------------------===//
 
 // RUN: %gtclang% %file% -fno-codegen -freport-pass-set-caches
-// EXPECTED: PASS: PassSetCaches: Test: MS0: tmp:cache_type::k:flush:[0,0]
+// EXPECTED: PASS: PassSetCaches: Test: MS0: tmp:cache_type::k:flush:\[0,0\]
 // EXPECTED: PASS: PassSetCaches: Test: MS1: tmp:cache_type::k:fill
 
 #include "gtclang_dsl_defs/gtclang_dsl.hpp"

--- a/gtclang/test/integration-test/PassSetCaches/KCacheTest04.cpp
+++ b/gtclang/test/integration-test/PassSetCaches/KCacheTest04.cpp
@@ -15,7 +15,7 @@
 //===------------------------------------------------------------------------------------------===//
 
 // RUN: %gtclang% %file% -fno-codegen -freport-pass-set-caches
-// EXPECTED: PASS: PassSetCaches: Test: MS0: tmp:cache_type::k:flush:[0,0]
+// EXPECTED: PASS: PassSetCaches: Test: MS0: tmp:cache_type::k:flush:\[0,0\]
 // EXPECTED: PASS: PassSetCaches: Test: MS1: tmp:cache_type::k:fill_and_flush
 // EXPECTED: PASS: PassSetCaches: Test: MS1: b1:cache_type::k:fill
 // EXPECTED: PASS: PassSetCaches: Test: MS2: b2:cache_type::k:fill

--- a/gtclang/test/integration-test/PassSetCaches/KCacheTest06.cpp
+++ b/gtclang/test/integration-test/PassSetCaches/KCacheTest06.cpp
@@ -15,8 +15,8 @@
 //===------------------------------------------------------------------------------------------===//
 
 // RUN: %gtclang% %file% -fno-codegen -freport-pass-set-caches
-// EXPECTED: PASS: PassSetCaches: Test: MS0: tmp:cache_type::k:epflush:[-3,0]
-// EXPECTED: PASS: PassSetCaches: Test: MS1: tmp:cache_type::k:bpfill:[0,3]
+// EXPECTED: PASS: PassSetCaches: Test: MS0: tmp:cache_type::k:epflush:\[-3,0\]
+// EXPECTED: PASS: PassSetCaches: Test: MS1: tmp:cache_type::k:bpfill:\[0,3\]
 
 #include "gtclang_dsl_defs/gtclang_dsl.hpp"
 

--- a/gtclang/test/integration-test/PassTemporaryType/PromoteTest01.cpp
+++ b/gtclang/test/integration-test/PassTemporaryType/PromoteTest01.cpp
@@ -15,7 +15,7 @@
 //===------------------------------------------------------------------------------------------===//
 
 // RUN: %gtclang% %file% -fno-codegen -freport-pass-temporary-type
-// EXPECTED: PASS: PassTemporaryType: Test: promote:local_variable
+// EXPECTED: PASS: PassTemporaryType: Test: promote:.*local_variable.*
 
 #include "gtclang_dsl_defs/gtclang_dsl.hpp"
 

--- a/gtclang/test/integration-test/PassTemporaryType/PromoteTest02.cpp
+++ b/gtclang/test/integration-test/PassTemporaryType/PromoteTest02.cpp
@@ -15,7 +15,7 @@
 //===------------------------------------------------------------------------------------------===//
 
 // RUN: %gtclang% %file% -fno-codegen -freport-pass-temporary-type
-// EXPECTED: PASS: PassTemporaryType: Test: promote:local_variable
+// EXPECTED: PASS: PassTemporaryType: Test: promote:.*local_variable.*
 
 #include "gtclang_dsl_defs/gtclang_dsl.hpp"
 

--- a/gtclang/test/integration-test/PassTemporaryType/PromoteTest03.cpp
+++ b/gtclang/test/integration-test/PassTemporaryType/PromoteTest03.cpp
@@ -15,7 +15,7 @@
 //===------------------------------------------------------------------------------------------===//
 
 // RUN: %gtclang% %file% -fno-codegen -freport-pass-temporary-type
-// EXPECTED: PASS: PassTemporaryType: Test: promote:local_variable
+// EXPECTED: PASS: PassTemporaryType: Test: promote:.*local_variable.*
 
 #include "gtclang_dsl_defs/gtclang_dsl.hpp"
 

--- a/gtclang/test/integration-test/PassTemporaryType/PromoteTest04.cpp
+++ b/gtclang/test/integration-test/PassTemporaryType/PromoteTest04.cpp
@@ -15,7 +15,7 @@
 //===------------------------------------------------------------------------------------------===//
 
 // RUN: %gtclang% %file% -fno-codegen -freport-pass-temporary-type
-// EXPECTED: PASS: PassTemporaryType: Test: promote:local_variable
+// EXPECTED: PASS: PassTemporaryType: Test: promote:.*local_variable.*
 
 #include "gtclang_dsl_defs/gtclang_dsl.hpp"
 

--- a/gtclang/test/integration-test/PassTemporaryType/PromoteTest05.cpp
+++ b/gtclang/test/integration-test/PassTemporaryType/PromoteTest05.cpp
@@ -15,7 +15,7 @@
 //===------------------------------------------------------------------------------------------===//
 
 // RUN: %gtclang% %file% -fno-codegen -freport-pass-temporary-type
-// EXPECTED: PASS: PassTemporaryType: Test: promote:local_variable
+// EXPECTED: PASS: PassTemporaryType: Test: promote:.*local_variable.*
 
 #include "gtclang_dsl_defs/gtclang_dsl.hpp"
 


### PR DESCRIPTION
## Technical Description

The names stored in the expressions are now the used ones instead of the user provided ones

### Resolves / Enhances

See example output

### Example

```
#include "gtclang_dsl_defs/gtclang_dsl.hpp"

using namespace gridtools::clang;
stencil A {

  storage in_field, out_field;
  Do {
    vertical_region(k_start, k_end) {
      double ee = in_field + 5;
      out_field = ee;
    }
  }
};
```
now prints:
```
StencilInstantiation : A
  Stencil_0
  {
    MultiStage_0 [parallel]
    {
      Stage_0
      {
        Do_0 { Start : End }
        {
          float_type __local_ee_31 = (in_field[<no_horizontal_offset>,0] + 5);
            Write Accesses:
              __local_ee_31 : [<no_horizontal_extent>,(0,0)]
            Read Accesses:
              5 : [<no_horizontal_extent>,(0,0)]
              in_field : [<no_horizontal_extent>,(0,0)]

          out_field[<no_horizontal_offset>,0] = __local_ee_31;
            Write Accesses:
              out_field : [<no_horizontal_extent>,(0,0)]
            Read Accesses:
              __local_ee_31 : [<no_horizontal_extent>,(0,0)]

        }
        Extents: [<no_horizontal_extent>,(0,0)]
      }
    }
  }
```

instead of 
```
StencilInstantiation : A
  Stencil_0
  {
    MultiStage_0 [parallel]
    {
      Stage_0
      {
        Do_0 { Start : End }
        {
          float_type ee = (in_field[<no_horizontal_offset>,0] + 5);
            Write Accesses:
              __local_ee_31 : [<no_horizontal_extent>,(0,0)]
            Read Accesses:
              5 : [<no_horizontal_extent>,(0,0)]
              in_field : [<no_horizontal_extent>,(0,0)]

          out_field[<no_horizontal_offset>,0] = ee;
            Write Accesses:
              out_field : [<no_horizontal_extent>,(0,0)]
            Read Accesses:
              __local_ee_31 : [<no_horizontal_extent>,(0,0)]

        }
        Extents: [<no_horizontal_extent>,(0,0)]
      }
    }
  }
```



