### PR TITLE
Use `make_grid` in the generated code

### DIFF
--- a/dawn/src/dawn/CodeGen/GridTools/GTCodeGen.cpp
+++ b/dawn/src/dawn/CodeGen/GridTools/GTCodeGen.cpp
@@ -526,7 +526,9 @@ void GTCodeGen::generateStencilClasses(
         .addType(c_gt() + "axis")
         .addTemplates(makeArrayRef({std::to_string(intervalDefinitions.Levels.size() - 1),
                                     "gridtools::axis_config::offset_limit<" +
-                                        std::to_string(intervalDefinitions.OffsetLimit) + ">"}));
+                                        std::to_string(intervalDefinitions.OffsetLimit) +
+                                        ">, gridtools::axis_config::extra_offsets<" +
+                                        std::to_string(intervalDefinitions.ExtraOffsets) + ">"}));
 
     // Generate typedef of the grid
     stencilClass.addTypeDef(getGridName(StencilName))

--- a/dawn/src/dawn/CodeGen/GridTools/GTCodeGen.cpp
+++ b/dawn/src/dawn/CodeGen/GridTools/GTCodeGen.cpp
@@ -136,7 +136,7 @@ void GTCodeGen::generateGridConstruction(MemberFunction& stencilConstructor,
   for(auto it = intervalDefinitions.Levels.begin(),
            end = std::prev(intervalDefinitions.Levels.end());
       it != end; ++it) {
-    gridLevelSizes.push_back(getLevel(*std::next(it)) + " - " + getLevel(*it) + " + 1");
+    gridLevelSizes.push_back(getLevel(*std::next(it)) + " - " + getLevel(*it));
   }
 
   std::string stencilName =

--- a/dawn/src/dawn/CodeGen/GridTools/GTCodeGen.h
+++ b/dawn/src/dawn/CodeGen/GridTools/GTCodeGen.h
@@ -61,6 +61,9 @@ public:
 
     // TODO we should compute the OffsetLimit, not use a hard-coded value!
     static constexpr int OffsetLimit = 3;
+
+    // TODO we should avoid the ExtraOffsets, not use a hard-coded value!
+    static constexpr int ExtraOffsets = 1;
   };
 
 private:


### PR DESCRIPTION
## Technical Description

The constructor of `gridtools::grid` is not part of the public API (indicated by the fact that it changed from v1.0 to v1.1). Thus, dawn should use `gridtools::make_grid` which is public API to create the grid.

### Resolves / Enhances

GT4Py uses Gridtools 1.1.

