### PR TITLE
Point to new protobuf install location

### DIFF
--- a/dawn/scripts/jenkins/env_daint.sh
+++ b/dawn/scripts/jenkins/env_daint.sh
@@ -7,6 +7,6 @@ module load cray-python/3.6.5.7
 module swap PrgEnv-cray PrgEnv-gnu
 
 export BOOST_DIR=/project/c14/install/daint/boost/boost_1_67_0/
-export PROTOBUFDIR="/scratch/snx3000/jenkins/workspace/protobuf/slave/daint/install/lib64/cmake/protobuf/"
+export PROTOBUFDIR="/project/c14/install/daint/protobuf/lib64/cmake/protobuf/"
 export CXX=`which g++`
 export CC=`which gcc`

--- a/dawn/scripts/jenkins/env_kesch.sh
+++ b/dawn/scripts/jenkins/env_kesch.sh
@@ -9,5 +9,5 @@ module load python/3.6.2-gmvolf-17.02
 export CXX=`which g++`
 export CC=`which gcc`
 export BOOST_DIR=/project/c14/install/kesch/boost/boost_1_67_0/
-export PROTOBUFDIR="/scratch/jenkins/workspace/protobuf/slave/kesch/install/lib64/cmake/protobuf/"
+export PROTOBUFDIR="/project/c14/install/kesch/protobuf/lib64/cmake/protobuf/"
 

--- a/gtclang/scripts/jenkins/env_daint.sh
+++ b/gtclang/scripts/jenkins/env_daint.sh
@@ -6,7 +6,7 @@ module load /users/jenkins/easybuild/daint/haswell/modules/all/CMake/3.12.4
 module swap PrgEnv-cray PrgEnv-gnu
 module load cudatoolkit/10.1.105_3.27-7.0.1.1_4.1__ga311ce7
 
-export PROTOBUFDIR="/scratch/snx3000/jenkins/workspace/protobuf/slave/daint/install/lib64/cmake/protobuf/"
+export PROTOBUFDIR="/project/c14/install/daint/protobuf/lib64/cmake/protobuf/"
 export BOOST_DIR=/project/c14/install/daint/boost/boost_1_67_0/
 export ATLAS_DIR=/project/c14/install/daint/atlas_install
 export ECKIT_DIR=/project/c14/install/daint/eckit_install

--- a/gtclang/scripts/jenkins/env_kesch.sh
+++ b/gtclang/scripts/jenkins/env_kesch.sh
@@ -6,7 +6,7 @@ module load /users/jenkins/easybuild/kesch/modules/all/cmake/3.12.4
 module load python/3.6.2-gmvolf-17.02
 module load cudatoolkit/8.0.61
 
-export PROTOBUFDIR="/scratch/jenkins/workspace/protobuf/slave/kesch/install/lib64/cmake/protobuf/"
+export PROTOBUFDIR="/project/c14/install/kesch/protobuf/lib64/cmake/protobuf/"
 export CXX=`which g++`
 export CC=`which gcc`
 export BOOST_DIR=/project/c14/install/kesch/boost/boost_1_67_0/


### PR DESCRIPTION
## Technical Description

Protobuf gets now installed in `/project/c14/install/daint/protobuf/`. Previously it was installed in `/scratch/snx3000`, which gets wiped once in a while.