### PR TITLE
Coding Conventions

### DIFF
--- a/_sources/coding.txt
+++ b/_sources/coding.txt
@@ -21,6 +21,8 @@ Naming of Types, Functions, Variables, and Enumerators
 
   * **Members** should start with a lower-case letter and contain an `_` suffix (e.g ``myMember_``) 
 
+  * **Namespaces** are all lower case and are in snake_case (e.g. `dawn_generated`)
+
 For types, functions and enumerators you should follow the LLVM style.
 
 Source Code Formatting
@@ -82,25 +84,53 @@ while the following is considered bad
 
   const char **ptr = ...
 
-Includes
-^^^^^^^^^^^^^^^^^^^^^^^^
+Include Order
+^^^^^^^^^^^^^
+
+Includes should be placed in the following order
+
+# Headers in the same folder
+# Headers in the same library
+# Other libraries
+# `std` headers
+
+For headers in the same folder, do not put the absolute path
 
 Miscellaneous Guidelines
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
-** Do not use `inline` on class member functions
-** Do not use `extern` in free header functions
-** Prefer `#pragma once` over include guards
-** Always use braces for `if-else` and loop bodies (also if they are one line)
+** Do not define member functions which are longer than one line in header files (except for templated functions). E.g.
 
-    Naming of struct vs. class members
+.. code-block:: cpp
+
+  class Foo {
+    int i;
+    int getI() { return i; }
+  };
+
+is ok. The following is not:
+
+.. code-block:: cpp
+
+  class Bar {
+    int computeI() { 
+      bool converged = false;
+      while (!converged) {
+        //some complicated algorithm
+      }
+    }
+  };
+
+** Do not use `extern` in free header functions since its redundant. 
+
+** Prefer `#pragma once` over include guards, since include guards need to be maintaned if the header file is renamed and code or includes could accidentally be placed outside of the guards.
+
+** Always use braces for `if-else` and loop bodies (also if they are one line). This helps to avoid bugs, for example if additional statements are appended to a loop or if-else clause at a later stage.
+
     virtual in derived functions (no)
-    include order and absolute vs. relative path (same folder -> same library -> other -> std; no absolute path if in same folder)
     east const / west const (east const)
-    naming of namespaces?
-
 
 Clang Format
 ============ 
 
-To enforce most of these coding standards, there is a `clang-format <https://clang.llvm.org/docs/ClangFormat.html>`_ file located in the root directory at ``<dawn-dir>/.clangformat``. There is also a git pre-commit hook to enforce that all code commited is formatted according to the `.clang-format` file. 
+To enforce most of these coding standards, there is a `clang-format <https://clang.llvm.org/docs/ClangFormat.html>`_ file located in the root directory at ``<dawn-dir>/.clangformat``. There is also a git pre-commit hook to ensure that all code commited is formatted according to the `.clang-format` file. 

--- a/_sources/coding.txt
+++ b/_sources/coding.txt
@@ -6,10 +6,10 @@ Introduction
 
 This document attempts to describe a few coding standards that are being used in the Dawn source tree. Although no coding standards should be regarded as absolute requirements to be followed in all instances, you should try to follow the `LLVM <https://llvm.org/docs/CodingStandards.html>`_ coding standard. We deviate from the LLVM standard in certain areas as listed in the following.
 
-Supported C++11 Language and Library Features
+Supported C++17 Language and Library Features
 =============================================
 
-While LLVM restricts the usage of C++11, we do not impose any constraints on the allowed features. While we generally allow the usage of C++ exceptions, you should avoid them at the interface boundary to make exposing the API more convenient - `RTII <https://en.wikipedia.org/wiki/Run-time_type_information>`_ should be avoided.
+We do not impose any restrictions on C++17 features. The generated code however needs to be compliant to C++11. While we generally allow the usage of C++ exceptions, you should avoid them at the interface boundary to make exposing the API more convenient.
 
 Style Issues
 ============
@@ -25,6 +25,8 @@ For types, functions and enumerators you should follow the LLVM style.
 
 Source Code Formatting
 ======================
+
+These rules have been updated as of December 2019. All new code should conform to these rules. Old code can be adapted continousely if it is affected by a new task. 
 
 Source Code Width
 ^^^^^^^^^^^^^^^^^
@@ -80,13 +82,25 @@ while the following is considered bad
 
   const char **ptr = ...
 
+Includes
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+Miscellaneous Guidelines
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+** Do not use `inline` on class member functions
+** Do not use `extern` in free header functions
+** Prefer `#pragma once` over include guards
+** Always use braces for `if-else` and loop bodies (also if they are one line)
+
+    Naming of struct vs. class members
+    virtual in derived functions (no)
+    include order and absolute vs. relative path (same folder -> same library -> other -> std; no absolute path if in same folder)
+    east const / west const (east const)
+    naming of namespaces?
+
+
 Clang Format
 ============ 
 
-To enforce most of these coding standards, CMake can be configured to run `clang-format <https://clang.llvm.org/docs/ClangFormat.html>`_ on each file with
-
-.. code-block:: bash
-
-  make format
-
-The clang-format file is located in the root directory at ``<dawn-dir>/.clangformat``.
+To enforce most of these coding standards, there is a `clang-format <https://clang.llvm.org/docs/ClangFormat.html>`_ file located in the root directory at ``<dawn-dir>/.clangformat``. There is also a git pre-commit hook to enforce that all code commited is formatted according to the `.clang-format` file. 

--- a/_sources/coding.txt
+++ b/_sources/coding.txt
@@ -84,6 +84,19 @@ while the following is considered bad
 
   const char **ptr = ...
 
+Minimal Code
+^^^^^^^^^^^^
+
+Always favor minimal code. Do not introduce convenience functions without a good reason, e.g.
+
+.. code-block:: cpp
+  class Foo {
+    Foo(int, int, int);
+    Foo(std::array<int, 3>);
+  };
+
+is bad. Delete one of the constructors.
+
 Include Order
 ^^^^^^^^^^^^^
 
@@ -94,7 +107,7 @@ Includes should be placed in the following order
 # Other libraries
 # `std` headers
 
-For headers in the same folder, do not put the absolute path
+For headers in the same folder, do not put the absolute path.
 
 Miscellaneous Guidelines
 ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -127,8 +140,7 @@ is ok. The following is not:
 
 ** Always use braces for `if-else` and loop bodies (also if they are one line). This helps to avoid bugs, for example if additional statements are appended to a loop or if-else clause at a later stage.
 
-    virtual in derived functions (no)
-    east const / west const (east const)
+** `virtual` functions should specify exactly on of `virtual`, `override` and `final`, see also `C++ Core Guidelines C.128 <https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Rh-override>`_
 
 Clang Format
 ============ 

--- a/_sources/coding.txt
+++ b/_sources/coding.txt
@@ -21,7 +21,9 @@ Naming of Types, Functions, Variables, and Enumerators
 
   * **Members** should start with a lower-case letter and contain an `_` suffix (e.g ``myMember_``) 
 
-  * **Namespaces** are all lower case and are in snake_case (e.g. `dawn_generated`)
+  * **Namespaces** are all lower case and are in snake_case (e.g. ``dawn_generated``)
+
+  * **Template Typenames** all start with an uppercase T, followed by an uppercase name (e.g. ``TValue``, ``TWeight``)
 
 For types, functions and enumerators you should follow the LLVM style.
 


### PR DESCRIPTION
## Technical Description

This is the PR to update our coding conventions. Some points left open before are now further clarified. 

* east vs. west const was left open for now, since there seems to be a `clang-format` rule for this [in the near future](https://reviews.llvm.org/D69764), making the point obsolete.
* I agree that a naming convention for template parameters would be nice to improve legibility. Currently most of the template parameters we use (which aren't simply `T`) start with an uppercase letter, clashing with the convention for class names. Maybe it would be reasonable to have all template parameters start with `T`? This is already respected in parts of the code, e.g. in `dawn/IIR/IIRNode.h` which uses  `template <typename TNodeType>`, `template <typename TParent, typename TChild>` etc. 

