### PR TITLE
Fix replace names

### DIFF
--- a/dawn/prototype/atlas_interface.hpp
+++ b/dawn/prototype/atlas_interface.hpp
@@ -1,6 +1,24 @@
-#pragma once
+//===--------------------------------------------------------------------------------*- C++ -*-===//
+//                          _
+//                         | |
+//                       __| | __ ___      ___ ___
+//                      / _` |/ _` \ \ /\ / / '_  |
+//                     | (_| | (_| |\ V  V /| | | |
+//                      \__,_|\__,_| \_/\_/ |_| |_| - Compiler Toolchain
+//
+//
+//  This file is distributed under the MIT License (MIT).
+//  See LICENSE.txt for details.
+//
+//===------------------------------------------------------------------------------------------===//
+
+#ifndef DAWN_INTERFACE_ATLAS_INTERFACE_H_
+#define DAWN_INTERFACE_ATLAS_INTERFACE_H_
+
 #include "atlas/mesh.h"
+#include <algorithm>
 #include <cassert>
+#include <iterator>
 
 namespace utility {
 namespace impl_ {
@@ -99,6 +117,7 @@ std::vector<int> const& cellNeighboursOfCell(atlas::Mesh const& m, int const& id
       }
     }
   }
+  // assert(neighs[idx].size() >= 1 && neighs[idx].size() <= 3);
   return neighs[idx];
 }
 
@@ -108,6 +127,7 @@ std::vector<int> const& edgeNeighboursOfCell(atlas::Mesh const& m, int const& id
   if(neighs.count(idx) == 0) {
     neighs[idx] = getNeighs(m.cells().edge_connectivity(), idx);
   }
+  // assert(neighs[idx].size() == 3);
   return neighs[idx];
 }
 
@@ -117,6 +137,7 @@ std::vector<int> const& nodeNeighboursOfCell(atlas::Mesh const& m, int const& id
   if(neighs.count(idx) == 0) {
     neighs[idx] = getNeighs(m.cells().node_connectivity(), idx);
   }
+  // assert(neighs[idx].size() == 3);
   return neighs[idx];
 }
 
@@ -124,8 +145,9 @@ std::vector<int> cellNeighboursOfEdge(atlas::Mesh const& m, int const& idx) {
   // note this is only a workaround and does only work as long as we have only one mesh
   static std::map<int, std::vector<int>> neighs;
   if(neighs.count(idx) == 0) {
-    neighs[idx] = getNeighs(m.cells().cell_connectivity(), idx);
+    neighs[idx] = getNeighs(m.edges().cell_connectivity(), idx);
   }
+  assert(neighs[idx].size() == 1 || neighs[idx].size() == 2); // boundary edges may have 1 cell
   return neighs[idx];
 }
 
@@ -133,8 +155,9 @@ std::vector<int> nodeNeighboursOfEdge(atlas::Mesh const& m, int const& idx) {
   // note this is only a workaround and does only work as long as we have only one mesh
   static std::map<int, std::vector<int>> neighs;
   if(neighs.count(idx) == 0) {
-    neighs[idx] = getNeighs(m.cells().node_connectivity(), idx);
+    neighs[idx] = getNeighs(m.edges().node_connectivity(), idx);
   }
+  assert(neighs[idx].size() == 2);
   return neighs[idx];
 }
 
@@ -142,8 +165,9 @@ std::vector<int> cellNeighboursOfNode(atlas::Mesh const& m, int const& idx) {
   // note this is only a workaround and does only work as long as we have only one mesh
   static std::map<int, std::vector<int>> neighs;
   if(neighs.count(idx) == 0) {
-    neighs[idx] = getNeighs(m.cells().cell_connectivity(), idx);
+    neighs[idx] = getNeighs(m.edges().cell_connectivity(), idx);
   }
+  // assert(neighs[idx].size() == 5 || neighs[idx].size() == 6);
   return neighs[idx];
 }
 
@@ -153,6 +177,7 @@ std::vector<int> edgeNeighboursOfNode(atlas::Mesh const& m, int const& idx) {
   if(neighs.count(idx) == 0) {
     neighs[idx] = getNeighs(m.cells().edge_connectivity(), idx);
   }
+  // assert(neighs[idx].size() == 5 || neighs[idx].size() == 6);
   return neighs[idx];
 }
 
@@ -173,58 +198,139 @@ std::vector<int> nodeNeighboursOfNode(atlas::Mesh const& m, int const& idx) {
       }
     }
   }
+  // assert(neighs[idx].size() == 5 || neighs[idx].size() == 6);
   return neighs[idx];
 }
 
+// weighted versions
+
+template <typename Init, typename Op, typename Weight>
+auto reduceCellToCell(atlasTag, atlas::Mesh const& m, int idx, Init init, Op&& op,
+                      const std::vector<Weight>&& weights) {
+  static_assert(std::is_arithmetic<Weight>::value, "weights need to be of arithmetic type!\n");
+  int i = 0;
+  for(auto&& objIdx : cellNeighboursOfCell(m, idx))
+    op(init, objIdx, weights[i++]);
+  return init;
+}
+template <typename Init, typename Op, typename Weight>
+auto reduceEdgeToCell(atlasTag, atlas::Mesh const& m, int idx, Init init, Op&& op,
+                      const std::vector<Weight>&& weights) {
+  static_assert(std::is_arithmetic<Weight>::value, "weights need to be of arithmetic type!\n");
+  int i = 0;
+  for(auto&& objIdx : edgeNeighboursOfCell(m, idx))
+    op(init, objIdx, weights[i++]);
+  return init;
+}
+template <typename Init, typename Op, typename Weight>
+auto reduceVertexToCell(atlasTag, atlas::Mesh const& m, int idx, Init init, Op&& op,
+                        const std::vector<Weight>&& weights) {
+  static_assert(std::is_arithmetic<Weight>::value, "weights need to be of arithmetic type!\n");
+  int i = 0;
+  for(auto&& objIdx : nodeNeighboursOfCell(m, idx))
+    op(init, objIdx, weights[i++]);
+  return init;
+}
+
+template <typename Init, typename Op, typename Weight>
+auto reduceCellToEdge(atlasTag, atlas::Mesh const& m, int idx, Init init, Op&& op,
+                      const std::vector<Weight>&& weights) {
+  static_assert(std::is_arithmetic<Weight>::value, "weights need to be of arithmetic type!\n");
+  int i = 0;
+  for(auto&& objIdx : cellNeighboursOfEdge(m, idx))
+    op(init, objIdx, weights[i++]);
+  return init;
+}
+template <typename Init, typename Op, typename Weight>
+auto reduceVertexToEdge(atlasTag, atlas::Mesh const& m, int idx, Init init, Op&& op,
+                        const std::vector<Weight>&& weights) {
+  static_assert(std::is_arithmetic<Weight>::value, "weights need to be of arithmetic type!\n");
+  int i = 0;
+  for(auto&& objIdx : nodeNeighboursOfEdge(m, idx))
+    op(init, objIdx, weights[i++]);
+  return init;
+}
+
+template <typename Init, typename Op, typename Weight>
+auto reduceCellToVertex(atlasTag, atlas::Mesh const& m, int idx, Init init, Op&& op,
+                        const std::vector<Weight>&& weights) {
+  static_assert(std::is_arithmetic<Weight>::value, "weights need to be of arithmetic type!\n");
+  int i = 0;
+  for(auto&& objIdx : cellNeighboursOfNode(m, idx))
+    op(init, objIdx, weights[i++]);
+  return init;
+}
+template <typename Init, typename Op, typename Weight>
+auto reduceEdgeToVertex(atlasTag, atlas::Mesh const& m, int idx, Init init, Op&& op,
+                        const std::vector<Weight>&& weights) {
+  static_assert(std::is_arithmetic<Weight>::value, "weights need to be of arithmetic type!\n");
+  int i = 0;
+  for(auto&& objIdx : edgeNeighboursOfNode(m, idx))
+    op(init, objIdx, weights[i++]);
+  return init;
+}
+template <typename Init, typename Op, typename Weight>
+auto reduceVertexToVertex(atlasTag, atlas::Mesh const& m, int idx, Init init, Op&& op,
+                          const std::vector<Weight>&& weights) {
+  static_assert(std::is_arithmetic<Weight>::value, "weights need to be of arithmetic type!\n");
+  int i = 0;
+  for(auto&& objIdx : nodeNeighboursOfNode(m, idx))
+    op(init, objIdx, weights[i++]);
+  return init;
+}
+
+// unweighted versions
+
 template <typename Init, typename Op>
 auto reduceCellToCell(atlasTag, atlas::Mesh const& m, int idx, Init init, Op&& op) {
-  for(auto&& obj : cellNeighboursOfCell(m, idx))
-    op(init, obj);
+  for(auto&& objIdx : cellNeighboursOfCell(m, idx))
+    op(init, objIdx);
   return init;
 }
 template <typename Init, typename Op>
 auto reduceEdgeToCell(atlasTag, atlas::Mesh const& m, int idx, Init init, Op&& op) {
-  for(auto&& obj : edgeNeighboursOfCell(m, idx))
-    op(init, obj);
+  for(auto&& objIdx : edgeNeighboursOfCell(m, idx))
+    op(init, objIdx);
   return init;
 }
 template <typename Init, typename Op>
 auto reduceVertexToCell(atlasTag, atlas::Mesh const& m, int idx, Init init, Op&& op) {
-  for(auto&& obj : nodeNeighboursOfCell(m, idx))
-    op(init, obj);
+  for(auto&& objIdx : nodeNeighboursOfCell(m, idx))
+    op(init, objIdx);
   return init;
 }
 
 template <typename Init, typename Op>
 auto reduceCellToEdge(atlasTag, atlas::Mesh const& m, int idx, Init init, Op&& op) {
-  for(auto&& obj : cellNeighboursOfEdge(m, idx))
-    op(init, obj);
+  for(auto&& objIdx : cellNeighboursOfEdge(m, idx))
+    op(init, objIdx);
   return init;
 }
 template <typename Init, typename Op>
 auto reduceVertexToEdge(atlasTag, atlas::Mesh const& m, int idx, Init init, Op&& op) {
-  for(auto&& obj : nodeNeighboursOfEdge(m, idx))
-    op(init, obj);
+  for(auto&& objIdx : nodeNeighboursOfEdge(m, idx))
+    op(init, objIdx);
   return init;
 }
 
 template <typename Init, typename Op>
 auto reduceCellToVertex(atlasTag, atlas::Mesh const& m, int idx, Init init, Op&& op) {
-  for(auto&& obj : cellNeighboursOfNode(m, idx))
-    op(init, obj);
+  for(auto&& objIdx : cellNeighboursOfNode(m, idx))
+    op(init, objIdx);
   return init;
 }
 template <typename Init, typename Op>
 auto reduceEdgeToVertex(atlasTag, atlas::Mesh const& m, int idx, Init init, Op&& op) {
-  for(auto&& obj : edgeNeighboursOfNode(m, idx))
-    op(init, obj);
+  for(auto&& objIdx : edgeNeighboursOfNode(m, idx))
+    op(init, objIdx);
   return init;
 }
 template <typename Init, typename Op>
 auto reduceVertexToVertex(atlasTag, atlas::Mesh const& m, int idx, Init init, Op&& op) {
-  for(auto&& obj : nodeNeighboursOfNode(m, idx))
-    op(init, obj);
+  for(auto&& objIdx : nodeNeighboursOfNode(m, idx))
+    op(init, objIdx);
   return init;
 }
 
 } // namespace atlasInterface
+#endif

--- a/dawn/src/dawn/AST/ASTExpr.cpp
+++ b/dawn/src/dawn/AST/ASTExpr.cpp
@@ -15,6 +15,7 @@
 #include "dawn/AST/ASTExpr.h"
 #include "dawn/AST/ASTUtil.h"
 #include "dawn/AST/ASTVisitor.h"
+#include "dawn/SIR/SIR.h"
 #include "dawn/Support/Assert.h"
 #include "dawn/Support/Casting.h"
 #include "dawn/Support/StringRef.h"
@@ -445,16 +446,26 @@ bool LiteralAccessExpr::equals(const Expr* other) const {
          (data_ ? data_->equals(otherPtr->data_.get()) : !otherPtr->data_);
 }
 
-ReductionOverNeighborExpr::ReductionOverNeighborExpr(std::string const& op,
-                                                     std::shared_ptr<Expr> const& rhs,
-                                                     std::shared_ptr<Expr> const& init,
-                                                     ast::Expr::LocationType rhs_location,
-                                                     SourceLocation loc)
-    : Expr(Kind::ReductionOverNeighborExpr, loc), op_(op),
+//===------------------------------------------------------------------------------------------===//
+//     ReductionOverNeighborExpr
+//===------------------------------------------------------------------------------------------===//
+
+ReductionOverNeighborExpr::ReductionOverNeighborExpr(
+    std::string const& op, std::shared_ptr<Expr> const& rhs, std::shared_ptr<Expr> const& init,
+    ast::Expr::LocationType lhs_location, ast::Expr::LocationType rhs_location, SourceLocation loc)
+    : Expr(Kind::ReductionOverNeighborExpr, loc), op_(op), lhs_location_(lhs_location),
       rhs_location_(rhs_location), operands_{rhs, init} {}
+
+ReductionOverNeighborExpr::ReductionOverNeighborExpr(
+    std::string const& op, std::shared_ptr<Expr> const& rhs, std::shared_ptr<Expr> const& init,
+    std::vector<std::shared_ptr<sir::Value>> weights, ast::Expr::LocationType lhs_location,
+    ast::Expr::LocationType rhs_location, SourceLocation loc)
+    : Expr(Kind::ReductionOverNeighborExpr, loc), op_(op), weights_(weights),
+      lhs_location_(lhs_location), rhs_location_(rhs_location), operands_{rhs, init} {}
 
 ReductionOverNeighborExpr::ReductionOverNeighborExpr(ReductionOverNeighborExpr const& expr)
     : Expr(Kind::ReductionOverNeighborExpr, expr.getSourceLocation()), op_(expr.getOp()),
+      weights_(expr.getWeights()), lhs_location_(expr.getRhsLocation()),
       rhs_location_(expr.getRhsLocation()), operands_{expr.getRhs()->clone(),
                                                       expr.getInit()->clone()} {}
 
@@ -464,10 +475,11 @@ operator=(ReductionOverNeighborExpr const& expr) {
   op_ = expr.op_;
   operands_[Rhs] = expr.getRhs();
   operands_[Init] = expr.getInit();
+  rhs_location_ = expr.getRhsLocation();
+  lhs_location_ = expr.getLhsLocation();
+  weights_ = expr.getWeights();
   return *this;
 }
-
-ast::Expr::LocationType ReductionOverNeighborExpr::getRhsLocation() const { return rhs_location_; }
 
 std::shared_ptr<Expr> ReductionOverNeighborExpr::clone() const {
   return std::make_shared<ReductionOverNeighborExpr>(*this);
@@ -475,8 +487,24 @@ std::shared_ptr<Expr> ReductionOverNeighborExpr::clone() const {
 
 bool ReductionOverNeighborExpr::equals(const Expr* other) const {
   const ReductionOverNeighborExpr* otherPtr = dyn_cast<ReductionOverNeighborExpr>(other);
-  return otherPtr && otherPtr->getInit() == getInit() && otherPtr->getOp() == getOp() &&
-         otherPtr->getRhs() == getRhs();
+
+  if(weights_.has_value()) {
+    if(!otherPtr->getWeights().has_value()) {
+      return false;
+    }
+    if(otherPtr->getWeights()->size() != weights_->size()) {
+      return false;
+    }
+    for(int i = 0; i < weights_->size(); i++) {
+      if(!weights_->at(i)->comparison(*otherPtr->getWeights()->at(i))) {
+        return false;
+      }
+    }
+  }
+
+  return otherPtr && *otherPtr->getInit() == *getInit() && otherPtr->getOp() == getOp() &&
+         *otherPtr->getRhs() == *getRhs();
 }
+
 } // namespace ast
 } // namespace dawn

--- a/dawn/src/dawn/AST/ASTExpr.h
+++ b/dawn/src/dawn/AST/ASTExpr.h
@@ -29,6 +29,11 @@
 #include <vector>
 
 namespace dawn {
+
+namespace sir {
+class Value;
+} // namespace sir
+
 namespace ast {
 class ASTVisitor;
 
@@ -618,6 +623,8 @@ private:
   enum OperandKind { Rhs = 0, Init };
 
   std::string op_ = "+";
+  std::optional<std::vector<std::shared_ptr<sir::Value>>> weights_;
+  ast::Expr::LocationType lhs_location_;
   ast::Expr::LocationType rhs_location_;
   std::array<std::shared_ptr<Expr>, 2> operands_;
 
@@ -626,6 +633,13 @@ public:
   /// @{
   ReductionOverNeighborExpr(std::string const& op, std::shared_ptr<Expr> const& rhs,
                             std::shared_ptr<Expr> const& init,
+                            ast::Expr::LocationType lhs_location = ast::Expr::LocationType::Cells,
+                            ast::Expr::LocationType rhs_location = ast::Expr::LocationType::Cells,
+                            SourceLocation loc = SourceLocation());
+  ReductionOverNeighborExpr(std::string const& op, std::shared_ptr<Expr> const& rhs,
+                            std::shared_ptr<Expr> const& init,
+                            std::vector<std::shared_ptr<sir::Value>> weights,
+                            ast::Expr::LocationType lhs_location = ast::Expr::LocationType::Cells,
                             ast::Expr::LocationType rhs_location = ast::Expr::LocationType::Cells,
                             SourceLocation loc = SourceLocation());
   ReductionOverNeighborExpr(ReductionOverNeighborExpr const& stmt);
@@ -637,14 +651,21 @@ public:
   std::string const& getOp() const { return op_; }
   std::shared_ptr<Expr> const& getRhs() const { return operands_[Rhs]; }
   void setRhs(std::shared_ptr<Expr> rhs) { operands_[Rhs] = std::move(rhs); }
-  ast::Expr::LocationType getRhsLocation() const;
+  ast::Expr::LocationType getRhsLocation() const { return rhs_location_; };
+  ast::Expr::LocationType getLhsLocation() const { return lhs_location_; };
+  const std::optional<std::vector<std::shared_ptr<sir::Value>>>& getWeights() const {
+    return weights_;
+  };
 
   ExprRangeType getChildren() override { return ExprRangeType(operands_); }
-  std::shared_ptr<Expr> clone() const override;
-  bool equals(const Expr* other) const override;
+
   static bool classof(const Expr* expr) {
     return expr->getKind() == Kind::ReductionOverNeighborExpr;
   }
+
+  std::shared_ptr<Expr> clone() const override;
+  bool equals(const Expr* other) const override;
+
   ACCEPTVISITOR(Expr, ReductionOverNeighborExpr)
 };
 

--- a/dawn/src/dawn/AST/ASTStringifier.cpp
+++ b/dawn/src/dawn/AST/ASTStringifier.cpp
@@ -257,7 +257,9 @@ public:
     }
   }
 
-  void visit(const std::shared_ptr<LiteralAccessExpr>& expr) override { ss_ << expr->getValue(); }
+  void visit(const std::shared_ptr<LiteralAccessExpr>& expr) override {
+    ss_ << expr->getBuiltinType() << " " << expr->getValue();
+  }
 
   std::string toString() const { return ss_.str(); }
 };

--- a/dawn/src/dawn/CodeGen/ASTCodeGenCXX.cpp
+++ b/dawn/src/dawn/CodeGen/ASTCodeGenCXX.cpp
@@ -172,6 +172,8 @@ const char* ASTCodeGenCXX::builtinTypeIDToCXXType(const BuiltinTypeID& builtinTy
     return "bool";
   case BuiltinTypeID::Float:
     return "::dawn::float_type";
+  case BuiltinTypeID::Double:
+    return "::dawn::float_type";
   case BuiltinTypeID::Integer:
     return "int";
   default:

--- a/dawn/src/dawn/CodeGen/CXXNaive-ico/ASTStencilBody.cpp
+++ b/dawn/src/dawn/CodeGen/CXXNaive-ico/ASTStencilBody.cpp
@@ -18,6 +18,7 @@
 #include "dawn/IIR/AST.h"
 #include "dawn/IIR/ASTExpr.h"
 #include "dawn/IIR/StencilFunctionInstantiation.h"
+#include "dawn/SIR/SIR.h"
 #include "dawn/Support/Unreachable.h"
 
 namespace dawn {
@@ -72,15 +73,44 @@ void ASTStencilBody::visit(const std::shared_ptr<iir::ReductionOverNeighborExpr>
       return "";
     }
   };
-  std::string typeString = getLocationTypeString(expr->getRhsLocation());
-  ss_ << std::string(indent_, ' ') << "reduce" + typeString + "ToCell(LibTag{}, m_mesh, loc, ";
+  std::string typeStringRHS = getLocationTypeString(expr->getRhsLocation());
+  std::string typeStringLHS = getLocationTypeString(expr->getLhsLocation());
+
+  bool hasWeights = expr->getWeights().has_value();
+
+  ss_ << std::string(indent_, ' ')
+      << "reduce" + typeStringRHS + "To" + typeStringLHS + "(LibTag{}, m_mesh, loc, ";
   expr->getInit()->accept(*this);
-  ss_ << ", [&](auto& lhs, auto const& red_loc) { return lhs " << expr->getOp() << "= ";
+  if(hasWeights) {
+    ss_ << ", [&](auto& lhs, auto const& red_loc, auto const& weight) { return lhs "
+        << expr->getOp() << "= ";
+    ss_ << "weight * ";
+  } else {
+    ss_ << ", [&](auto& lhs, auto const& red_loc) { return lhs " << expr->getOp() << "= ";
+  }
+
   auto argName = argName_;
   argName_ = "red_loc";
   expr->getRhs()->accept(*this);
   argName_ = argName;
-  ss_ << ";})";
+  ss_ << ";}";
+  if(hasWeights) {
+    auto weights = expr->getWeights().value();
+    bool first = true;
+    auto typeStr = sir::Value::typeToString(weights[0]->getType());
+    ss_ << ", std::vector<" << typeStr << ">({";
+    for(auto const& weight : weights) {
+      if(!first) {
+        ss_ << ", ";
+      }
+      assert(weight->has_value());
+      ss_ << weight->toString();
+      first = false;
+    }
+
+    ss_ << "})";
+  }
+  ss_ << ")";
 }
 
 void ASTStencilBody::visit(const std::shared_ptr<iir::VerticalRegionDeclStmt>& stmt) {

--- a/dawn/src/dawn/IIR/DoMethod.cpp
+++ b/dawn/src/dawn/IIR/DoMethod.cpp
@@ -51,6 +51,8 @@ public:
     DAWN_ASSERT_MSG(accessmap.size() == 1, "can only be one write access");
     std::string realName = metadata_.getNameFromAccessID(accessmap.begin()->first);
     stmt->getName() = realName;
+    for(const auto& expr : stmt->getInitList())
+      expr->accept(*this);
   }
   void visit(const std::shared_ptr<VarAccessExpr>& expr) override {
     auto data = expr->getData<iir::IIRAccessExprData>();

--- a/dawn/src/dawn/SIR/SIR.cpp
+++ b/dawn/src/dawn/SIR/SIR.cpp
@@ -611,6 +611,8 @@ const char* sir::Value::typeToString(sir::Value::Kind type) {
     return "int";
   case Kind::Double:
     return "double";
+  case Kind::Float:
+    return "float";
   case Kind::String:
     return "std::string";
   }
@@ -624,6 +626,8 @@ BuiltinTypeID sir::Value::typeToBuiltinTypeID(sir::Value::Kind type) {
   case Kind::Integer:
     return BuiltinTypeID::Integer;
   case Kind::Double:
+    return BuiltinTypeID::Double;
+  case Kind::Float:
     return BuiltinTypeID::Float;
   default:
     dawn_unreachable("invalid type");
@@ -639,6 +643,8 @@ std::string sir::Value::toString() const {
     return std::to_string(std::get<int>(*value_));
   case Kind::Double:
     return std::to_string(std::get<double>(*value_));
+  case Kind::Float:
+    return std::to_string(std::get<float>(*value_));
   case Kind::String:
     return std::get<std::string>(*value_);
   default:

--- a/dawn/src/dawn/SIR/SIR.h
+++ b/dawn/src/dawn/SIR/SIR.h
@@ -348,7 +348,7 @@ struct Stencil : public dawn::NonCopyable {
 
 class Value : NonCopyable {
 public:
-  enum class Kind { Boolean = 0, Integer, Double, String };
+  enum class Kind { Boolean = 0, Integer, Float, Double, String };
   template <typename T>
   struct TypeInfo;
 
@@ -403,7 +403,7 @@ public:
   }
 
 private:
-  std::optional<std::variant<bool, int, double, std::string>> value_;
+  std::optional<std::variant<bool, int, float, double, std::string>> value_;
   bool is_constexpr_;
   Kind type_;
 };
@@ -416,6 +416,11 @@ struct Value::TypeInfo<bool> {
 template <>
 struct Value::TypeInfo<int> {
   static constexpr Kind Type = Kind::Integer;
+};
+
+template <>
+struct Value::TypeInfo<float> {
+  static constexpr Kind Type = Kind::Float;
 };
 
 template <>

--- a/dawn/src/dawn/SIR/proto/SIR/SIR.proto
+++ b/dawn/src/dawn/SIR/proto/SIR/SIR.proto
@@ -91,10 +91,11 @@ message GlobalVariableValue {
     int32 integer_value = 2;
     double double_value = 3;
     string string_value = 4;
+    float float_value = 5;
   }
 
   // Is the value a a compile time constant?
-  bool is_constexpr = 5;
+  bool is_constexpr = 6;
 }
 
 // @brief Map of global variables

--- a/dawn/src/dawn/SIR/proto/SIR/statements.proto
+++ b/dawn/src/dawn/SIR/proto/SIR/statements.proto
@@ -123,6 +123,7 @@ message BuiltinType {
     Boolean = 2;
     Integer = 3;
     Float = 4;
+    Double = 5;
   }
 
   TypeID type_id = 1; // Type identifier
@@ -622,6 +623,16 @@ message LiteralAccessExpr {
   int32 ID = 5;            // ID of the Expr
 }
 
+message Weight {
+  oneof Value {
+    bool boolean_value = 1;
+    int32 integer_value = 2;
+    double double_value = 3;
+    string string_value = 4;
+    float float_value = 5;
+  }
+}
+
 // @brief Reduction operation over neighbors
 //
 // @ingroup sir_proto
@@ -629,6 +640,7 @@ message ReductionOverNeighborExpr {
   string op = 1; // Reduction operation
   Expr rhs = 2;  // Operation to be applied for each neighbor
   Expr init = 3; // Initial value of reduction
+  repeated Weight weights = 4; // weights
 }
 
 // @brief Abstract syntax tree of the SIR

--- a/dawn/src/dawn/Support/Type.cpp
+++ b/dawn/src/dawn/Support/Type.cpp
@@ -38,6 +38,9 @@ std::ostream& operator<<(std::ostream& os, Type type) {
     case BuiltinTypeID::Float:
       os << "float_type";
       break;
+    case BuiltinTypeID::Double:
+      os << "double_type";
+      break;
     default:
       dawn_unreachable("invalid BuiltinTypeID");
     }

--- a/dawn/src/dawn/Support/Type.h
+++ b/dawn/src/dawn/Support/Type.h
@@ -22,7 +22,7 @@ namespace dawn {
 
 /// @brief Builtin types recognized by the SIR
 /// @ingroup support
-enum class BuiltinTypeID : int { Invalid = 0, Auto, Boolean, Integer, Float };
+enum class BuiltinTypeID : int { Invalid = 0, Auto, Boolean, Integer, Float, Double };
 
 /// @brief Const-volatile qualifiers
 /// @ingroup support

--- a/dawn/src/dawn/Unittest/IIRBuilder.cpp
+++ b/dawn/src/dawn/Unittest/IIRBuilder.cpp
@@ -39,40 +39,6 @@ Array3i asArray(FieldType ft) {
   }
   dawn_unreachable("Unreachable");
 }
-std::string toStr(Op operation, std::vector<Op> const& valid_ops) {
-  DAWN_ASSERT(std::find(valid_ops.begin(), valid_ops.end(), operation) != valid_ops.end());
-  switch(operation) {
-  case Op::plus:
-    return "+";
-  case Op::minus:
-    return "-";
-  case Op::multiply:
-    return "*";
-  case Op::assign:
-    return "";
-  case Op::divide:
-    return "/";
-  case Op::equal:
-    return "==";
-  case Op::notEqual:
-    return "!=";
-  case Op::greater:
-    return ">";
-  case Op::less:
-    return "<";
-  case Op::greaterEqual:
-    return ">=";
-  case Op::lessEqual:
-    return "<=";
-  case Op::logicalAnd:
-    return "&&";
-  case Op::locigalOr:
-    return "||";
-  case Op::logicalNot:
-    return "!";
-  }
-  dawn_unreachable("Unreachable");
-}
 } // namespace
 
 dawn::codegen::stencilInstantiationContext
@@ -119,16 +85,17 @@ IIRBuilder::build(std::string const& name, std::unique_ptr<iir::Stencil> stencil
 
   return map;
 }
-std::shared_ptr<iir::Expr>
-IIRBuilder::reduceOverNeighborExpr(Op operation, std::shared_ptr<iir::Expr>&& rhs,
-                                   std::shared_ptr<iir::Expr>&& init,
-                                   ast::Expr::LocationType rhs_location) {
+
+std::shared_ptr<iir::Expr> IIRBuilder::reduceOverNeighborExpr(
+    Op operation, std::shared_ptr<iir::Expr>&& rhs, std::shared_ptr<iir::Expr>&& init,
+    ast::Expr::LocationType lhs_location, ast::Expr::LocationType rhs_location) {
   auto expr = std::make_shared<iir::ReductionOverNeighborExpr>(
       toStr(operation, {Op::multiply, Op::plus, Op::minus, Op::assign, Op::divide}), std::move(rhs),
-      std::move(init), rhs_location);
+      std::move(init), lhs_location, rhs_location);
   expr->setID(si_->nextUID());
   return expr;
 }
+
 std::shared_ptr<iir::Expr> IIRBuilder::binaryExpr(std::shared_ptr<iir::Expr>&& lhs,
                                                   std::shared_ptr<iir::Expr>&& rhs, Op operation) {
   DAWN_ASSERT(si_);

--- a/dawn/src/interface/atlas_interface.hpp
+++ b/dawn/src/interface/atlas_interface.hpp
@@ -16,7 +16,9 @@
 #define DAWN_INTERFACE_ATLAS_INTERFACE_H_
 
 #include "atlas/mesh.h"
+#include <algorithm>
 #include <cassert>
+#include <iterator>
 
 namespace utility {
 namespace impl_ {
@@ -115,6 +117,7 @@ std::vector<int> const& cellNeighboursOfCell(atlas::Mesh const& m, int const& id
       }
     }
   }
+  // assert(neighs[idx].size() >= 1 && neighs[idx].size() <= 3);
   return neighs[idx];
 }
 
@@ -124,6 +127,7 @@ std::vector<int> const& edgeNeighboursOfCell(atlas::Mesh const& m, int const& id
   if(neighs.count(idx) == 0) {
     neighs[idx] = getNeighs(m.cells().edge_connectivity(), idx);
   }
+  // assert(neighs[idx].size() == 3);
   return neighs[idx];
 }
 
@@ -133,6 +137,7 @@ std::vector<int> const& nodeNeighboursOfCell(atlas::Mesh const& m, int const& id
   if(neighs.count(idx) == 0) {
     neighs[idx] = getNeighs(m.cells().node_connectivity(), idx);
   }
+  // assert(neighs[idx].size() == 3);
   return neighs[idx];
 }
 
@@ -140,8 +145,9 @@ std::vector<int> cellNeighboursOfEdge(atlas::Mesh const& m, int const& idx) {
   // note this is only a workaround and does only work as long as we have only one mesh
   static std::map<int, std::vector<int>> neighs;
   if(neighs.count(idx) == 0) {
-    neighs[idx] = getNeighs(m.cells().cell_connectivity(), idx);
+    neighs[idx] = getNeighs(m.edges().cell_connectivity(), idx);
   }
+  assert(neighs[idx].size() == 1 || neighs[idx].size() == 2); // boundary edges may have 1 cell
   return neighs[idx];
 }
 
@@ -149,8 +155,9 @@ std::vector<int> nodeNeighboursOfEdge(atlas::Mesh const& m, int const& idx) {
   // note this is only a workaround and does only work as long as we have only one mesh
   static std::map<int, std::vector<int>> neighs;
   if(neighs.count(idx) == 0) {
-    neighs[idx] = getNeighs(m.cells().node_connectivity(), idx);
+    neighs[idx] = getNeighs(m.edges().node_connectivity(), idx);
   }
+  assert(neighs[idx].size() == 2);
   return neighs[idx];
 }
 
@@ -158,8 +165,9 @@ std::vector<int> cellNeighboursOfNode(atlas::Mesh const& m, int const& idx) {
   // note this is only a workaround and does only work as long as we have only one mesh
   static std::map<int, std::vector<int>> neighs;
   if(neighs.count(idx) == 0) {
-    neighs[idx] = getNeighs(m.cells().cell_connectivity(), idx);
+    neighs[idx] = getNeighs(m.edges().cell_connectivity(), idx);
   }
+  // assert(neighs[idx].size() == 5 || neighs[idx].size() == 6);
   return neighs[idx];
 }
 
@@ -169,6 +177,7 @@ std::vector<int> edgeNeighboursOfNode(atlas::Mesh const& m, int const& idx) {
   if(neighs.count(idx) == 0) {
     neighs[idx] = getNeighs(m.cells().edge_connectivity(), idx);
   }
+  // assert(neighs[idx].size() == 5 || neighs[idx].size() == 6);
   return neighs[idx];
 }
 
@@ -189,57 +198,137 @@ std::vector<int> nodeNeighboursOfNode(atlas::Mesh const& m, int const& idx) {
       }
     }
   }
+  // assert(neighs[idx].size() == 5 || neighs[idx].size() == 6);
   return neighs[idx];
 }
 
+// weighted versions
+
+template <typename Init, typename Op, typename Weight>
+auto reduceCellToCell(atlasTag, atlas::Mesh const& m, int idx, Init init, Op&& op,
+                      const std::vector<Weight>&& weights) {
+  static_assert(std::is_arithmetic<Weight>::value, "weights need to be of arithmetic type!\n");
+  int i = 0;
+  for(auto&& objIdx : cellNeighboursOfCell(m, idx))
+    op(init, objIdx, weights[i++]);
+  return init;
+}
+template <typename Init, typename Op, typename Weight>
+auto reduceEdgeToCell(atlasTag, atlas::Mesh const& m, int idx, Init init, Op&& op,
+                      const std::vector<Weight>&& weights) {
+  static_assert(std::is_arithmetic<Weight>::value, "weights need to be of arithmetic type!\n");
+  int i = 0;
+  for(auto&& objIdx : edgeNeighboursOfCell(m, idx))
+    op(init, objIdx, weights[i++]);
+  return init;
+}
+template <typename Init, typename Op, typename Weight>
+auto reduceVertexToCell(atlasTag, atlas::Mesh const& m, int idx, Init init, Op&& op,
+                        const std::vector<Weight>&& weights) {
+  static_assert(std::is_arithmetic<Weight>::value, "weights need to be of arithmetic type!\n");
+  int i = 0;
+  for(auto&& objIdx : nodeNeighboursOfCell(m, idx))
+    op(init, objIdx, weights[i++]);
+  return init;
+}
+
+template <typename Init, typename Op, typename Weight>
+auto reduceCellToEdge(atlasTag, atlas::Mesh const& m, int idx, Init init, Op&& op,
+                      const std::vector<Weight>&& weights) {
+  static_assert(std::is_arithmetic<Weight>::value, "weights need to be of arithmetic type!\n");
+  int i = 0;
+  for(auto&& objIdx : cellNeighboursOfEdge(m, idx))
+    op(init, objIdx, weights[i++]);
+  return init;
+}
+template <typename Init, typename Op, typename Weight>
+auto reduceVertexToEdge(atlasTag, atlas::Mesh const& m, int idx, Init init, Op&& op,
+                        const std::vector<Weight>&& weights) {
+  static_assert(std::is_arithmetic<Weight>::value, "weights need to be of arithmetic type!\n");
+  int i = 0;
+  for(auto&& objIdx : nodeNeighboursOfEdge(m, idx))
+    op(init, objIdx, weights[i++]);
+  return init;
+}
+
+template <typename Init, typename Op, typename Weight>
+auto reduceCellToVertex(atlasTag, atlas::Mesh const& m, int idx, Init init, Op&& op,
+                        const std::vector<Weight>&& weights) {
+  static_assert(std::is_arithmetic<Weight>::value, "weights need to be of arithmetic type!\n");
+  int i = 0;
+  for(auto&& objIdx : cellNeighboursOfNode(m, idx))
+    op(init, objIdx, weights[i++]);
+  return init;
+}
+template <typename Init, typename Op, typename Weight>
+auto reduceEdgeToVertex(atlasTag, atlas::Mesh const& m, int idx, Init init, Op&& op,
+                        const std::vector<Weight>&& weights) {
+  static_assert(std::is_arithmetic<Weight>::value, "weights need to be of arithmetic type!\n");
+  int i = 0;
+  for(auto&& objIdx : edgeNeighboursOfNode(m, idx))
+    op(init, objIdx, weights[i++]);
+  return init;
+}
+template <typename Init, typename Op, typename Weight>
+auto reduceVertexToVertex(atlasTag, atlas::Mesh const& m, int idx, Init init, Op&& op,
+                          const std::vector<Weight>&& weights) {
+  static_assert(std::is_arithmetic<Weight>::value, "weights need to be of arithmetic type!\n");
+  int i = 0;
+  for(auto&& objIdx : nodeNeighboursOfNode(m, idx))
+    op(init, objIdx, weights[i++]);
+  return init;
+}
+
+// unweighted versions
+
 template <typename Init, typename Op>
 auto reduceCellToCell(atlasTag, atlas::Mesh const& m, int idx, Init init, Op&& op) {
-  for(auto&& obj : cellNeighboursOfCell(m, idx))
-    op(init, obj);
+  for(auto&& objIdx : cellNeighboursOfCell(m, idx))
+    op(init, objIdx);
   return init;
 }
 template <typename Init, typename Op>
 auto reduceEdgeToCell(atlasTag, atlas::Mesh const& m, int idx, Init init, Op&& op) {
-  for(auto&& obj : edgeNeighboursOfCell(m, idx))
-    op(init, obj);
+  for(auto&& objIdx : edgeNeighboursOfCell(m, idx))
+    op(init, objIdx);
   return init;
 }
 template <typename Init, typename Op>
 auto reduceVertexToCell(atlasTag, atlas::Mesh const& m, int idx, Init init, Op&& op) {
-  for(auto&& obj : nodeNeighboursOfCell(m, idx))
-    op(init, obj);
+  for(auto&& objIdx : nodeNeighboursOfCell(m, idx))
+    op(init, objIdx);
   return init;
 }
 
 template <typename Init, typename Op>
 auto reduceCellToEdge(atlasTag, atlas::Mesh const& m, int idx, Init init, Op&& op) {
-  for(auto&& obj : cellNeighboursOfEdge(m, idx))
-    op(init, obj);
+  for(auto&& objIdx : cellNeighboursOfEdge(m, idx))
+    op(init, objIdx);
   return init;
 }
 template <typename Init, typename Op>
 auto reduceVertexToEdge(atlasTag, atlas::Mesh const& m, int idx, Init init, Op&& op) {
-  for(auto&& obj : nodeNeighboursOfEdge(m, idx))
-    op(init, obj);
+  for(auto&& objIdx : nodeNeighboursOfEdge(m, idx))
+    op(init, objIdx);
   return init;
 }
 
 template <typename Init, typename Op>
 auto reduceCellToVertex(atlasTag, atlas::Mesh const& m, int idx, Init init, Op&& op) {
-  for(auto&& obj : cellNeighboursOfNode(m, idx))
-    op(init, obj);
+  for(auto&& objIdx : cellNeighboursOfNode(m, idx))
+    op(init, objIdx);
   return init;
 }
 template <typename Init, typename Op>
 auto reduceEdgeToVertex(atlasTag, atlas::Mesh const& m, int idx, Init init, Op&& op) {
-  for(auto&& obj : edgeNeighboursOfNode(m, idx))
-    op(init, obj);
+  for(auto&& objIdx : edgeNeighboursOfNode(m, idx))
+    op(init, objIdx);
   return init;
 }
 template <typename Init, typename Op>
 auto reduceVertexToVertex(atlasTag, atlas::Mesh const& m, int idx, Init init, Op&& op) {
-  for(auto&& obj : nodeNeighboursOfNode(m, idx))
-    op(init, obj);
+  for(auto&& objIdx : nodeNeighboursOfNode(m, idx))
+    op(init, objIdx);
   return init;
 }
 

--- a/dawn/test/unit-test/dawn-c/TestCompiler.cpp
+++ b/dawn/test/unit-test/dawn-c/TestCompiler.cpp
@@ -98,11 +98,11 @@ TEST(CompilerTest, DISABLED_CodeGenSumEdgeToCells) {
           LoopOrderKind::Parallel,
           b.stage(LocType::Edges, b.vregion(dawn::sir::Interval::Start, dawn::sir::Interval::End,
                                             b.stmt(b.assignExpr(b.at(in_f), b.lit(10))))),
-          b.stage(b.vregion(
-              dawn::sir::Interval::Start, dawn::sir::Interval::End,
-              b.stmt(b.assignExpr(b.at(out_f), b.reduceOverNeighborExpr(
-                                                   Op::plus, b.at(in_f, HOffsetType::withOffset, 0),
-                                                   b.lit(0.), LocType::Edges))))))));
+          b.stage(b.vregion(dawn::sir::Interval::Start, dawn::sir::Interval::End,
+                            b.stmt(b.assignExpr(
+                                b.at(out_f), b.reduceOverNeighborExpr(
+                                                 Op::plus, b.at(in_f, HOffsetType::withOffset, 0),
+                                                 b.lit(0.), LocType::Cells, LocType::Edges))))))));
 
   std::ofstream of("prototype/generated_copyEdgeToCell.hpp");
   DAWN_ASSERT_MSG(of, "file could not be opened. Binary must be called from dawn/dawn");
@@ -152,14 +152,15 @@ TEST(CompilerTest, DISABLED_CodeGenDiffusion) {
               dawn::sir::Interval::Start, dawn::sir::Interval::End, b.declareVar(cnt),
               b.stmt(b.assignExpr(b.at(cnt),
                                   b.reduceOverNeighborExpr(Op::plus, b.lit(1), b.lit(0),
+                                                           dawn::ast::Expr::LocationType::Cells,
                                                            dawn::ast::Expr::LocationType::Cells))),
               b.stmt(b.assignExpr(
                   b.at(out_f),
-                  b.reduceOverNeighborExpr(Op::plus, b.at(in_f, HOffsetType::withOffset, 0),
-                                           b.binaryExpr(b.unaryExpr(b.at(cnt), Op::minus),
-                                                        b.at(in_f, HOffsetType::withOffset, 0),
-                                                        Op::multiply),
-                                           dawn::ast::Expr::LocationType::Cells))),
+                  b.reduceOverNeighborExpr(
+                      Op::plus, b.at(in_f, HOffsetType::withOffset, 0),
+                      b.binaryExpr(b.unaryExpr(b.at(cnt), Op::minus),
+                                   b.at(in_f, HOffsetType::withOffset, 0), Op::multiply),
+                      dawn::ast::Expr::LocationType::Cells, dawn::ast::Expr::LocationType::Cells))),
               b.stmt(b.assignExpr(b.at(out_f),
                                   b.binaryExpr(b.at(in_f),
                                                b.binaryExpr(b.lit(0.1), b.at(out_f), Op::multiply),

--- a/gtclang/test/atlas-integration-test/GenerateUnstructuredStencils.cpp
+++ b/gtclang/test/atlas-integration-test/GenerateUnstructuredStencils.cpp
@@ -17,6 +17,7 @@
 #include "dawn/CodeGen/CXXNaive-ico/CXXNaiveCodeGen.h"
 #include "dawn/Unittest/IIRBuilder.h"
 
+#include <c++/7/optional>
 #include <cstring>
 #include <fstream>
 
@@ -85,15 +86,16 @@ int main() {
     auto in_f = b.field("in_field", LocType::Edges);
     auto out_f = b.field("out_field", LocType::Cells);
 
-    auto stencil_instantiation = b.build(
-        "accumulateEdgeToCell",
-        b.stencil(b.multistage(
-            LoopOrderKind::Parallel,
-            b.stage(b.vregion(dawn::sir::Interval::Start, dawn::sir::Interval::End,
-                              b.stmt(b.assignExpr(
-                                  b.at(out_f), b.reduceOverNeighborExpr(
-                                                   Op::plus, b.at(in_f, HOffsetType::withOffset, 0),
-                                                   b.lit(0.), LocType::Edges))))))));
+    auto stencil_instantiation =
+        b.build("accumulateEdgeToCell",
+                b.stencil(b.multistage(
+                    LoopOrderKind::Parallel,
+                    b.stage(b.vregion(
+                        dawn::sir::Interval::Start, dawn::sir::Interval::End,
+                        b.stmt(b.assignExpr(b.at(out_f),
+                                            b.reduceOverNeighborExpr(
+                                                Op::plus, b.at(in_f, HOffsetType::withOffset, 0),
+                                                b.lit(0.), LocType::Cells, LocType::Edges))))))));
 
     std::ofstream of("generated/generated_accumulateEdgeToCell.hpp");
     dump<dawn::codegen::cxxnaiveico::CXXNaiveIcoCodeGen>(of, stencil_instantiation);
@@ -141,6 +143,7 @@ int main() {
                 dawn::sir::Interval::Start, dawn::sir::Interval::End, b.declareVar(cnt),
                 b.stmt(b.assignExpr(
                     b.at(cnt), b.reduceOverNeighborExpr(Op::plus, b.lit(1), b.lit(0),
+                                                        dawn::ast::Expr::LocationType::Cells,
                                                         dawn::ast::Expr::LocationType::Cells))),
                 b.stmt(b.assignExpr(
                     b.at(out_f),
@@ -148,6 +151,7 @@ int main() {
                                              b.binaryExpr(b.unaryExpr(b.at(cnt), Op::minus),
                                                           b.at(in_f, HOffsetType::withOffset, 0),
                                                           Op::multiply),
+                                             dawn::ast::Expr::LocationType::Cells,
                                              dawn::ast::Expr::LocationType::Cells))),
                 b.stmt(b.assignExpr(
                     b.at(out_f),
@@ -155,6 +159,42 @@ int main() {
                                  Op::plus))))))));
 
     std::ofstream of("generated/generated_diffusion.hpp");
+    dump<dawn::codegen::cxxnaiveico::CXXNaiveIcoCodeGen>(of, stencil_instantiation);
+    of.close();
+  }
+
+  {
+    using namespace dawn::iir;
+    using LocType = dawn::ast::Expr::LocationType;
+
+    UnstructuredIIRBuilder b;
+    auto cell_f = b.field("cell_field", LocType::Cells);
+    auto edge_f = b.field("edge_field", LocType::Cells);
+
+    auto stencil_instantiation = b.build(
+        "gradient",
+        b.stencil(b.multistage(
+            dawn::iir::LoopOrderKind::Parallel,
+            b.stage(
+                LocType::Edges,
+                b.vregion(dawn::sir::Interval::Start, dawn::sir::Interval::End,
+                          b.stmt(b.assignExpr(
+                              b.at(edge_f), b.reduceOverNeighborExpr<float>(
+                                                Op::plus, b.at(cell_f, HOffsetType::withOffset, 0),
+                                                b.lit(0.), dawn::ast::Expr::LocationType::Edges,
+                                                dawn::ast::Expr::LocationType::Cells,
+                                                std::vector<float>({1., 1.})))))),
+            b.stage(LocType::Cells,
+                    b.vregion(
+                        dawn::sir::Interval::Start, dawn::sir::Interval::End,
+                        b.stmt(b.assignExpr(
+                            b.at(cell_f), b.reduceOverNeighborExpr<float>(
+                                              Op::plus, b.at(edge_f, HOffsetType::withOffset, 0),
+                                              b.lit(0.), dawn::ast::Expr::LocationType::Cells,
+                                              dawn::ast::Expr::LocationType::Edges,
+                                              std::vector<float>({0.25, 0.25, 0.25, 0.25})))))))));
+
+    std::ofstream of("generated/generated_gradient.hpp");
     dump<dawn::codegen::cxxnaiveico::CXXNaiveIcoCodeGen>(of, stencil_instantiation);
     of.close();
   }

--- a/gtclang/test/atlas-integration-test/reference/reference_gradient.hpp
+++ b/gtclang/test/atlas-integration-test/reference/reference_gradient.hpp
@@ -1,0 +1,72 @@
+#define GRIDTOOLS_CLANG_GENERATED 1
+#define GRIDTOOLS_CLANG_BACKEND_T CXXNAIVEICO
+#include <driver-includes/unstructured_interface.hpp>
+namespace dawn_generated {
+namespace cxxnaiveico {
+template <typename LibTag>
+class gradient {
+private:
+  struct stencil_165 {
+    dawn::mesh_t<LibTag> const& m_mesh;
+    int m_k_size;
+    dawn::cell_field_t<LibTag, double>& m_cell_field;
+    dawn::cell_field_t<LibTag, double>& m_edge_field;
+
+  public:
+    stencil_165(dawn::mesh_t<LibTag> const& mesh, int k_size,
+                dawn::cell_field_t<LibTag, double>& cell_field,
+                dawn::cell_field_t<LibTag, double>& edge_field)
+        : m_mesh(mesh), m_k_size(k_size), m_cell_field(cell_field), m_edge_field(edge_field) {}
+
+    ~stencil_165() {}
+
+    void sync_storages() {}
+
+    void run() {
+      using dawn::deref;
+      ;
+      {
+        for(int k = 0 + 0; k <= (m_k_size == 0 ? 0 : (m_k_size - 1)) + 0 + 0; ++k) {
+          for(auto const& loc : getEdges(LibTag{}, m_mesh)) {
+            m_edge_field(deref(LibTag{}, loc), k + 0) =
+                reduceCellToEdge(LibTag{}, m_mesh, loc, (::dawn::float_type)0.000000,
+                                 [&](auto& lhs, auto const& red_loc, auto const& weight) {
+                                   return lhs +=
+                                          weight * m_cell_field(deref(LibTag{}, red_loc), k + 0);
+                                 },
+                                 std::vector<float>({1.000000, 1.000000}));
+          }
+          for(auto const& loc : getCells(LibTag{}, m_mesh)) {
+            m_cell_field(deref(LibTag{}, loc), k + 0) =
+                reduceEdgeToCell(LibTag{}, m_mesh, loc, (::dawn::float_type)0.000000,
+                                 [&](auto& lhs, auto const& red_loc, auto const& weight) {
+                                   return lhs +=
+                                          weight * m_edge_field(deref(LibTag{}, red_loc), k + 0);
+                                 },
+                                 std::vector<float>({0.250000, 0.250000, 0.250000, 0.250000}));
+          }
+        }
+      }
+      sync_storages();
+    }
+  };
+  static constexpr const char* s_name = "gradient";
+  stencil_165 m_stencil_165;
+
+public:
+  gradient(const gradient&) = delete;
+
+  // Members
+
+  gradient(const dawn::mesh_t<LibTag>& mesh, int k_size,
+           dawn::cell_field_t<LibTag, double>& cell_field,
+           dawn::cell_field_t<LibTag, double>& edge_field)
+      : m_stencil_165(mesh, k_size, cell_field, edge_field) {}
+
+  void run() {
+    m_stencil_165.run();
+    ;
+  }
+};
+} // namespace cxxnaiveico
+} // namespace dawn_generated

--- a/gtclang/test/integration-test/PassStageMerger/Test07_after_ref.json
+++ b/gtclang/test/integration-test/PassStageMerger/Test07_after_ref.json
@@ -160,7 +160,7 @@
                     },
                     {
                       "read_accesses": null,
-                      "stmt": "out[<no_horizontal_offset>,0] = 0;\n",
+                      "stmt": "out[<no_horizontal_offset>,0] = int_type 0;\n",
                       "write_accesses": [
                         {
                           "access_id": 16,

--- a/gtclang/test/integration-test/PassStageMerger/Test07_before_ref.json
+++ b/gtclang/test/integration-test/PassStageMerger/Test07_before_ref.json
@@ -215,7 +215,7 @@
                   "Stmts": [
                     {
                       "read_accesses": null,
-                      "stmt": "out[<no_horizontal_offset>,0] = 0;\n",
+                      "stmt": "out[<no_horizontal_offset>,0] = int_type 0;\n",
                       "write_accesses": [
                         {
                           "access_id": 16,


### PR DESCRIPTION
## Technical Description

Fixes an issues with the replacement of names in `VarAccessExpr`. 

## Example

```
  Do {
    vertical_region(k_start, k_start) {
      double gav = -0.5 * wcon;
      double as = gav * BET_M;
    }
  }
```

used to to lead to wrong names in the IIR:
`float_type __local_as_43 = (gav * (float_type 0.5 * (float_type 1 - float_type 0)));`

this is now correct:
`float_type __local_as_43 = (__local_gav_41 * (float_type 0.5 * (float_type 1 - float_type 0)));`




