### PR TITLE
fixed VarDeclStmt visitor

### DIFF
--- a/dawn/src/dawn/IIR/DoMethod.cpp
+++ b/dawn/src/dawn/IIR/DoMethod.cpp
@@ -51,6 +51,8 @@ public:
     DAWN_ASSERT_MSG(accessmap.size() == 1, "can only be one write access");
     std::string realName = metadata_.getNameFromAccessID(accessmap.begin()->first);
     stmt->getName() = realName;
+    for(const auto& expr : stmt->getInitList())
+      expr->accept(*this);
   }
   void visit(const std::shared_ptr<VarAccessExpr>& expr) override {
     auto data = expr->getData<iir::IIRAccessExprData>();


### PR DESCRIPTION
## Technical Description

Fixes an issues with the replacement of names in `VarAccessExpr`. 

## Example

```
  Do {
    vertical_region(k_start, k_start) {
      double gav = -0.5 * wcon;
      double as = gav * BET_M;
    }
  }
```

used to to lead to wrong names in the IIR:
`float_type __local_as_43 = (gav * (float_type 0.5 * (float_type 1 - float_type 0)));`

this is now correct:
`float_type __local_as_43 = (__local_gav_41 * (float_type 0.5 * (float_type 1 - float_type 0)));`




