### PR TITLE
fix pip calls to use the venv

### DIFF
--- a/dawn/scripts/jenkins/build.sh
+++ b/dawn/scripts/jenkins/build.sh
@@ -54,6 +54,7 @@ bash run.sh
 python -m pytest -v ${base_dir}/test/unit-test/test_dawn4py/
 
 # clean up the build directory for the c++ tests
+deactivate
 rm -rf $build_dir
 rm -rf ${base_dir}/bundle/install
 rm -rf ${base_dir}/bundle/yoda

--- a/dawn/scripts/jenkins/build.sh
+++ b/dawn/scripts/jenkins/build.sh
@@ -45,13 +45,13 @@ export TMPDIR=${build_dir}/temp
 mkdir -p $TMPDIR
 python -m venv dawn_venv
 source dawn_venv/bin/activate
-pip install --upgrade pip
-pip install wheel
-pip install -e ${base_dir} -v
+python -m pip install --upgrade pip
+python -m pip install wheel
+python -m pip install -e ${base_dir} -v
 
 cd ${base_dir}/examples/python
 bash run.sh
-pytest -v ${base_dir}/test/unit-test/test_dawn4py/
+python -m pytest -v ${base_dir}/test/unit-test/test_dawn4py/
 
 # clean up the build directory for the c++ tests
 rm -rf $build_dir


### PR DESCRIPTION
## Technical Description

Jenkins used to use the standard pip instead of the one in the virtual environment which led to permission errors

### Resolves

Fixes the currently broken plans on master

### Dependencies

This is independent


