### PR TITLE
stages with defined extents do not extend their computational domain

### DIFF
--- a/dawn/src/dawn/Optimizer/PassComputeStageExtents.cpp
+++ b/dawn/src/dawn/Optimizer/PassComputeStageExtents.cpp
@@ -14,6 +14,7 @@
 
 #include "dawn/Optimizer/PassComputeStageExtents.h"
 #include "dawn/IIR/DependencyGraphStage.h"
+#include "dawn/IIR/Extents.h"
 #include "dawn/IIR/IIRNodeIterator.h"
 #include "dawn/IIR/StencilInstantiation.h"
 #include "dawn/Optimizer/OptimizerContext.h"
@@ -36,6 +37,12 @@ bool PassComputeStageExtents::run(
     // backward loop over stages
     for(int i = numStages - 1; i >= 0; --i) {
       iir::Stage& fromStage = *(stencil.getStage(i));
+      for(auto globalIterationSpace : fromStage.getIterationSpace()) {
+        if(globalIterationSpace) {
+          fromStage.setExtents(iir::Extents());
+          continue;
+        }
+      }
 
       iir::Extents const& stageExtent = fromStage.getExtents();
 

--- a/dawn/src/dawn/Optimizer/PassComputeStageExtents.cpp
+++ b/dawn/src/dawn/Optimizer/PassComputeStageExtents.cpp
@@ -37,7 +37,7 @@ bool PassComputeStageExtents::run(
     // backward loop over stages
     for(int i = numStages - 1; i >= 0; --i) {
       iir::Stage& fromStage = *(stencil.getStage(i));
-      // If the stage has a global interationspace set, we should never extend it since is is user
+      // If the stage has a global iterationspace set, we should never extend it since it is user
       // defined where this computation should happen
       if(std::any_of(fromStage.getIterationSpace().cbegin(), fromStage.getIterationSpace().cend(),
                      [](const auto& p) { return p.has_value(); })) {

--- a/dawn/src/dawn/Optimizer/PassComputeStageExtents.cpp
+++ b/dawn/src/dawn/Optimizer/PassComputeStageExtents.cpp
@@ -37,11 +37,10 @@ bool PassComputeStageExtents::run(
     // backward loop over stages
     for(int i = numStages - 1; i >= 0; --i) {
       iir::Stage& fromStage = *(stencil.getStage(i));
-      for(auto globalIterationSpace : fromStage.getIterationSpace()) {
-        if(globalIterationSpace) {
-          fromStage.setExtents(iir::Extents());
-          continue;
-        }
+      if(std::any_of(fromStage.getIterationSpace().cbegin(), fromStage.getIterationSpace().cend(),
+                     [](const auto& p) -> bool { return p.has_value(); })) {
+        fromStage.setExtents(iir::Extents());
+        continue;
       }
 
       iir::Extents const& stageExtent = fromStage.getExtents();

--- a/dawn/src/dawn/Optimizer/PassComputeStageExtents.cpp
+++ b/dawn/src/dawn/Optimizer/PassComputeStageExtents.cpp
@@ -37,8 +37,10 @@ bool PassComputeStageExtents::run(
     // backward loop over stages
     for(int i = numStages - 1; i >= 0; --i) {
       iir::Stage& fromStage = *(stencil.getStage(i));
+      // If the stage has a global interationspace set, we should never extend it since is is user
+      // defined where this computation should happen
       if(std::any_of(fromStage.getIterationSpace().cbegin(), fromStage.getIterationSpace().cend(),
-                     [](const auto& p) -> bool { return p.has_value(); })) {
+                     [](const auto& p) { return p.has_value(); })) {
         fromStage.setExtents(iir::Extents());
         continue;
       }


### PR DESCRIPTION
## Technical Description

Discussions showed that Stages that have a specified horizontal extent should never be extended to fit for additional computation

### Resolves / Enhances

Fixes #472

### Example

```
#include "gtclang_dsl_defs/gtclang_dsl.hpp"
using namespace gtclang::dsl;

stencil Test {
  storage in, out, out2;
  void Do() {
    iteration_space() {
      // computation
      out = in;
    }
    iteration_space(i_start, i_start + 1) {
      // correction term
      out = 3;
    }
    vertical_region(k_start, k_end) {
      // use of conputed value
      out2 = out[i + 1] + out[i - 1] + out[j - 1] + out[j + 1];
    }
  }
};
```

### Dependencies
This PR is independent, for the test, use the front end branch https://github.com/MeteoSwiss-APN/dawn/pull/531


