### PR TITLE
Split tests using gtest_discover_tests

### DIFF
--- a/dawn/test/integration-test/CMakeLists.txt
+++ b/dawn/test/integration-test/CMakeLists.txt
@@ -11,19 +11,18 @@
 ##  See LICENSE.txt for details.
 ##
 ##===------------------------------------------------------------------------------------------===##
+include(GoogleTest)
 
-add_executable(DawnIntegrationTest
+add_executable(${PROJECT_NAME}IntegrationTest
   TestMain.cpp
   TestIIRDeserializer.cpp
   GenerateInMemoryStencils.cpp
 )
-target_add_dawn_standard_props(DawnIntegrationTest)
-target_link_libraries(DawnIntegrationTest Dawn DawnUnittest gtest)
-set_target_properties(DawnIntegrationTest PROPERTIES
+target_add_dawn_standard_props(${PROJECT_NAME}IntegrationTest)
+target_link_libraries(${PROJECT_NAME}IntegrationTest Dawn DawnUnittest gtest)
+set_target_properties(${PROJECT_NAME}IntegrationTest PROPERTIES
   RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
-add_test(NAME DawnIntegrationTest
-  COMMAND $<TARGET_FILE:DawnIntegrationTest>
-)
+gtest_discover_tests(${PROJECT_NAME}IntegrationTest)
 
 add_executable(DawnUpdateIIRReferences
   RegenerateIIRMain.cpp

--- a/dawn/test/unit-test/dawn-c/CMakeLists.txt
+++ b/dawn/test/unit-test/dawn-c/CMakeLists.txt
@@ -11,13 +11,15 @@
 ##  See LICENSE.txt for details.
 ##
 ##===------------------------------------------------------------------------------------------===##
+include(GoogleTest)
 
-add_executable(DawnCUnittest
+set(executable ${PROJECT_NAME}CUnittest)
+add_executable(${executable}
   TestMain.cpp
   TestOptions.cpp
   TestCompiler.cpp
 )
 
-target_add_dawn_standard_props(DawnCUnittest)
-target_link_libraries(DawnCUnittest DawnC DawnUnittest gtest)
-add_test(NAME DawnCUnittest COMMAND DawnCUnittest)
+target_add_dawn_standard_props(${executable})
+target_link_libraries(${executable} DawnC DawnUnittest gtest)
+gtest_discover_tests(${executable} TEST_PREFIX "${executable}::")

--- a/dawn/test/unit-test/dawn/AST/CMakeLists.txt
+++ b/dawn/test/unit-test/dawn/AST/CMakeLists.txt
@@ -11,9 +11,10 @@
 ##  See LICENSE.txt for details.
 ##
 ##===------------------------------------------------------------------------------------------===##
+include(GoogleTest)
 
 set(executable ${PROJECT_NAME}UnittestAST)
 add_executable(${executable} TestMain.cpp TestOffset.cpp)
 target_link_libraries(${executable} PRIVATE DawnSIR DawnUnittest gtest)
 target_add_dawn_standard_props(${executable})
-add_test(NAME ${executable} COMMAND ${executable})
+gtest_discover_tests(${executable} TEST_PREFIX "${executable}::")

--- a/dawn/test/unit-test/dawn/IIR/CMakeLists.txt
+++ b/dawn/test/unit-test/dawn/IIR/CMakeLists.txt
@@ -11,6 +11,7 @@
 ##  See LICENSE.txt for details.
 ##
 ##===------------------------------------------------------------------------------------------===##
+include(GoogleTest)
 
 set(executable ${PROJECT_NAME}UnittestIIR)
 add_executable(${executable}
@@ -27,4 +28,4 @@ add_executable(${executable}
 )
 target_link_libraries(${executable} PRIVATE DawnIIR DawnSerialization DawnUnittest gtest)
 target_add_dawn_standard_props(${executable})
-add_test(NAME ${executable} COMMAND ${executable})
+gtest_discover_tests(${executable} TEST_PREFIX "${executable}::")

--- a/dawn/test/unit-test/dawn/Optimizer/CMakeLists.txt
+++ b/dawn/test/unit-test/dawn/Optimizer/CMakeLists.txt
@@ -11,6 +11,7 @@
 ##  See LICENSE.txt for details.
 ##
 ##===------------------------------------------------------------------------------------------===##
+include(GoogleTest)
 
 set(executable ${PROJECT_NAME}UnittestOptimizer)
 add_executable(${executable}
@@ -24,7 +25,7 @@ add_executable(${executable}
 )
 target_link_libraries(${executable} PRIVATE DawnOptimizer DawnUnittest gtest)
 target_add_dawn_standard_props(${executable})
-add_test(NAME ${executable} COMMAND ${executable})
+gtest_discover_tests(${executable} TEST_PREFIX "${executable}::")
 
 add_subdirectory(TestsFromSIR)
 add_subdirectory(Passes)

--- a/dawn/test/unit-test/dawn/Optimizer/Passes/CMakeLists.txt
+++ b/dawn/test/unit-test/dawn/Optimizer/Passes/CMakeLists.txt
@@ -11,6 +11,7 @@
 ##  See LICENSE.txt for details.
 ##
 ##===------------------------------------------------------------------------------------------===##
+include(GoogleTest)
 
 set(executable ${PROJECT_NAME}UnittestOptimizerPasses)
 add_executable(${executable}
@@ -26,6 +27,4 @@ target_add_dawn_standard_props(${executable})
 target_include_directories(${executable}
   PRIVATE $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
 )
-add_test(NAME ${executable}
-  COMMAND ${executable} "${CMAKE_CURRENT_LIST_DIR}"
-)
+gtest_discover_tests(${executable} TEST_PREFIX "${executable}::" EXTRA_ARGS ${CMAKE_CURRENT_LIST_DIR})

--- a/dawn/test/unit-test/dawn/Optimizer/Passes/TestMain.cpp
+++ b/dawn/test/unit-test/dawn/Optimizer/Passes/TestMain.cpp
@@ -25,11 +25,13 @@ int main(int argc, char* argv[]) {
   // Initialize gtest
   testing::InitGoogleTest(&argc, argv);
 
-  DAWN_ASSERT_MSG((argc == 2), "wrong number of arguments");
+  if(argc > 1) {
+    DAWN_ASSERT_MSG((argc == 2), "wrong number of arguments");
 
-  std::string path = argv[1];
+    std::string path = argv[1];
 
-  TestEnvironment::path_ = path;
-  ::testing::AddGlobalTestEnvironment(new TestEnvironment());
+    TestEnvironment::path_ = path;
+    ::testing::AddGlobalTestEnvironment(new TestEnvironment());
+  }
   return RUN_ALL_TESTS();
 }

--- a/dawn/test/unit-test/dawn/Optimizer/TestsFromSIR/CMakeLists.txt
+++ b/dawn/test/unit-test/dawn/Optimizer/TestsFromSIR/CMakeLists.txt
@@ -11,6 +11,7 @@
 ##  See LICENSE.txt for details.
 ##
 ##===------------------------------------------------------------------------------------------===##
+include(GoogleTest)
 
 set(executable ${PROJECT_NAME}UnittestOptimizerFromSIR)
 add_executable(${executable}
@@ -24,6 +25,4 @@ target_add_dawn_standard_props(${executable})
 target_include_directories(${executable}
   PRIVATE $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
 )
-add_test(NAME ${executable}
-  COMMAND ${executable} "${CMAKE_CURRENT_LIST_DIR}/../Passes"
-)
+gtest_discover_tests(${executable} TEST_PREFIX "${executable}::" EXTRA_ARGS "${CMAKE_CURRENT_LIST_DIR}/../Passes")

--- a/dawn/test/unit-test/dawn/Optimizer/TestsFromSIR/TestMain.cpp
+++ b/dawn/test/unit-test/dawn/Optimizer/TestsFromSIR/TestMain.cpp
@@ -25,11 +25,14 @@ int main(int argc, char* argv[]) {
   // Initialize gtest
   testing::InitGoogleTest(&argc, argv);
 
-  DAWN_ASSERT_MSG((argc == 2), "wrong number of arguments");
+  if(argc > 1) {
+    DAWN_ASSERT_MSG((argc == 2), "wrong number of arguments");
 
-  std::string path = argv[1];
+    std::string path = argv[1];
 
-  TestEnvironment::path_ = path;
-  ::testing::AddGlobalTestEnvironment(new TestEnvironment());
+    TestEnvironment::path_ = path;
+    ::testing::AddGlobalTestEnvironment(new TestEnvironment());
+  }
+
   return RUN_ALL_TESTS();
 }

--- a/dawn/test/unit-test/dawn/SIR/CMakeLists.txt
+++ b/dawn/test/unit-test/dawn/SIR/CMakeLists.txt
@@ -11,6 +11,7 @@
 ##  See LICENSE.txt for details.
 ##
 ##===------------------------------------------------------------------------------------------===##
+include(GoogleTest)
 
 set(executable ${PROJECT_NAME}UnittestSIR)
 add_executable(${executable}
@@ -22,4 +23,4 @@ add_executable(${executable}
 )
 target_link_libraries(${executable} PRIVATE DawnSIR DawnSerialization DawnUnittest gtest)
 target_add_dawn_standard_props(${executable})
-add_test(NAME ${executable} COMMAND ${executable})
+gtest_discover_tests(${executable} TEST_PREFIX "${executable}::")

--- a/dawn/test/unit-test/dawn/Support/CMakeLists.txt
+++ b/dawn/test/unit-test/dawn/Support/CMakeLists.txt
@@ -11,6 +11,7 @@
 ##  See LICENSE.txt for details.
 ##
 ##===------------------------------------------------------------------------------------------===##
+include(GoogleTest)
 
 set(executable ${PROJECT_NAME}UnittestSupport)
 add_executable(${executable}
@@ -26,4 +27,4 @@ add_executable(${executable}
 )
 target_link_libraries(${executable} DawnSupport DawnUnittest gtest)
 target_add_dawn_standard_props(${executable})
-add_test(NAME ${executable} COMMAND ${executable})
+gtest_discover_tests(${executable} TEST_PREFIX "${executable}::")

--- a/gtclang/test/unit-test/Frontend/CMakeLists.txt
+++ b/gtclang/test/unit-test/Frontend/CMakeLists.txt
@@ -13,6 +13,7 @@
 ##  See LICENSE.txt for details.
 ##
 ##===------------------------------------------------------------------------------------------===##
+include(GoogleTest)
 
 set(test_name ${PROJECT_NAME}UnittestFrontend)
 add_executable(${test_name}
@@ -27,6 +28,4 @@ set_target_properties(${test_name} PROPERTIES
   RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin/unittest
 )
 
-add_test(NAME ${test_name}
-  COMMAND $<TARGET_FILE:${test_name}> --gtest_output=xml:${test_name}_unittest.xml
-)
+gtest_discover_tests(${test_name} TEST_PREFIX "${test_name}::")

--- a/gtclang/test/unit-test/Support/CMakeLists.txt
+++ b/gtclang/test/unit-test/Support/CMakeLists.txt
@@ -13,6 +13,7 @@
 ##  See LICENSE.txt for details.
 ##
 ##===------------------------------------------------------------------------------------------===##
+include(GoogleTest)
 
 set(test_name ${PROJECT_NAME}UnittestSupport)
 add_executable(${test_name}
@@ -27,6 +28,4 @@ set_target_properties(${test_name} PROPERTIES
   RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin/unittest
 )
 
-add_test(NAME ${test_name}
-  COMMAND $<TARGET_FILE:${test_name}> --gtest_output=xml:${test_name}_unittest.xml
-)
+gtest_discover_tests(${test_name} TEST_PREFIX "${test_name}::")

--- a/gtclang/test/unit-test/Unittest/CMakeLists.txt
+++ b/gtclang/test/unit-test/Unittest/CMakeLists.txt
@@ -13,6 +13,7 @@
 ##  See LICENSE.txt for details.
 ##
 ##===------------------------------------------------------------------------------------------===##
+include(GoogleTest)
 
 set(test_name ${PROJECT_NAME}UnittestUnittest)
 add_executable(${test_name}
@@ -27,6 +28,4 @@ set_target_properties(${test_name} PROPERTIES
   RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin/unittest
 )
 
-add_test(NAME ${test_name}
-  COMMAND $<TARGET_FILE:${test_name}> --gtest_output=xml:${test_name}_unittest.xml
-)
+gtest_discover_tests(${test_name} TEST_PREFIX "${test_name}::")


### PR DESCRIPTION
## Technical Description

Adds each individual Google test to ctest.

Gives output like this:

```

   Start 163: DawnUnittestSIR::SIRStencilFunctionTest.AST

...

Total Test time (real) =  13.14 sec

The following tests did not run:
	 64 - DawnUnittestOptimizerPasses::StencilSplitAnalyzer.test_no_bc_inserted (Disabled)
	 65 - DawnUnittestOptimizerPasses::StencilSplitAnalyzer.test_unused_bc (Disabled)
	 66 - DawnUnittestOptimizerPasses::StencilSplitAnalyzer.test_bc_extent_calc (Disabled)
	 67 - DawnUnittestOptimizerPasses::StencilSplitAnalyzer.test_two_bc (Disabled)
	412 - DawnCUnittest::CompilerTest.CodeGenSumEdgeToCells (Disabled)
	413 - DawnCUnittest::CompilerTest.SumVertical (Disabled)
	414 - DawnCUnittest::CompilerTest.CodeGenDiffusion (Disabled)
	415 - DawnCUnittest::CompilerTest.CodeGenTriGradient (Disabled)
	416 - DawnCUnittest::CompilerTest.CodeGenQuadGradient (Disabled)
```