### PR TITLE
Add ENABLE_CUDA_IF_FOUND option

### DIFF
--- a/gtclang/CMakeLists.txt
+++ b/gtclang/CMakeLists.txt
@@ -149,7 +149,7 @@ if(${PROJECT_NAME}_TESTING)
 
   cmake_dependent_option(GTCLANG_BUILD_TESTING_GT_MC
     "Build integration tests with the GridTools MC backend"
-    ON "BUILD_TESTING;NOT ENABLE_CUDA_IF_FOUND" OFF
+    ON "BUILD_TESTING" OFF
   )
   cmake_dependent_option(GTCLANG_BUILD_TESTING_GT_CUDA
     "Build integration tests with the GridTools CUDA backend"

--- a/gtclang/CMakeLists.txt
+++ b/gtclang/CMakeLists.txt
@@ -39,6 +39,7 @@ unset(__GTCLANG_VERSION)
 # Other options
 include(CMakeDependentOption)
 option(BUILD_EXAMPLES "Build examples" ON)
+option(ENABLE_CUDA_IF_FOUND "Enable CUDA if it is detected" ON)
 option(GTCLANG_BUILD_TESTING "Override BUILD_TESTING if part of a multi-project build." OFF)
 # By default unstructured integration tests are not built if atlas or eckit is not found.
 # GTCLANG_REQUIRE_UNSTRUCTURED_TESTING=ON will force an error if atlas or eckit are not found.
@@ -146,9 +147,18 @@ if(${PROJECT_NAME}_TESTING)
     message(STATUS "Could NOT find CUDA compiler. Disabling GPU integration tests.")
   endif()
 
-  cmake_dependent_option(GTCLANG_BUILD_TESTING_GT_MC "Build integration tests with the GridTools MC backend" ON "BUILD_TESTING" OFF)
-  cmake_dependent_option(GTCLANG_BUILD_TESTING_GT_CUDA "Build integration tests with the GridTools CUDA backend" ON "BUILD_TESTING;CMAKE_CUDA_COMPILER" OFF)
-  cmake_dependent_option(GTCLANG_BUILD_TESTING_PLAIN_CUDA "Build integration tests with the plain CUDA backend" ON "BUILD_TESTING;CMAKE_CUDA_COMPILER" OFF)
+  cmake_dependent_option(GTCLANG_BUILD_TESTING_GT_MC
+    "Build integration tests with the GridTools MC backend"
+    ON "BUILD_TESTING;NOT ENABLE_CUDA_IF_FOUND" OFF
+  )
+  cmake_dependent_option(GTCLANG_BUILD_TESTING_GT_CUDA
+    "Build integration tests with the GridTools CUDA backend"
+    ON "BUILD_TESTING;CMAKE_CUDA_COMPILER;NOT ENABLE_CUDA_IF_FOUND" OFF
+  )
+  cmake_dependent_option(GTCLANG_BUILD_TESTING_PLAIN_CUDA
+    "Build integration tests with the plain CUDA backend"
+    ON "BUILD_TESTING;CMAKE_CUDA_COMPILER;NOT ENABLE_CUDA_IF_FOUND" OFF
+  )
 
   add_subdirectory(test)
 endif()


### PR DESCRIPTION
## Technical Description

If you have the CUDA toolkit but no GPU, certain tests are failing. Setting this option in CMake allows you to disable CUDA tests.