### PR TITLE
Use experimental::fs if fs is not supported

### DIFF
--- a/dawn/src/dawn/Compiler/DawnCompiler.cpp
+++ b/dawn/src/dawn/Compiler/DawnCompiler.cpp
@@ -48,14 +48,13 @@
 #include "dawn/Serialization/IIRSerializer.h"
 #include "dawn/Support/Array.h"
 #include "dawn/Support/EditDistance.h"
+#include "dawn/Support/FileSystem.h"
 #include "dawn/Support/Logging.h"
 #include "dawn/Support/StringSwitch.h"
 #include "dawn/Support/StringUtil.h"
 #include "dawn/Support/Unreachable.h"
 #include "dawn/Validator/GridTypeChecker.h"
 #include "dawn/Validator/LocationTypeChecker.h"
-
-#include <filesystem>
 
 namespace dawn {
 
@@ -236,9 +235,8 @@ std::unique_ptr<OptimizerContext> DawnCompiler::runOptimizer(std::shared_ptr<SIR
                      << instantiation->getName() << "`";
 
       if(options_->SerializeIIR) {
-        const std::filesystem::path p(options_->OutputFile.empty()
-                                          ? instantiation->getMetaData().getFileName()
-                                          : options_->OutputFile);
+        const fs::path p(options_->OutputFile.empty() ? instantiation->getMetaData().getFileName()
+                                                      : options_->OutputFile);
         IIRSerializer::serialize(static_cast<std::string>(p.stem()) + "." + std::to_string(i) +
                                      ".iir",
                                  instantiation, serializationKind);

--- a/dawn/src/dawn/Support/FileSystem.h
+++ b/dawn/src/dawn/Support/FileSystem.h
@@ -1,0 +1,26 @@
+//===--------------------------------------------------------------------------------*- C++ -*-===//
+//                          _
+//                         | |
+//                       __| | __ ___      ___ ___
+//                      / _` |/ _` \ \ /\ / / '_  |
+//                     | (_| | (_| |\ V  V /| | | |
+//                      \__,_|\__,_| \_/\_/ |_| |_| - Compiler Toolchain
+//
+//
+//  This file is distributed under the MIT License (MIT).
+//  See LICENSE.txt for details.
+//
+//===------------------------------------------------------------------------------------------===//
+
+#ifndef DAWN_SUPPORT_FILESYSTEM_H
+#define DAWN_SUPPORT_FILESYSTEM_H
+
+#if __has_include(<filesystem>)
+#include <filesystem>
+namespace fs = std::filesystem;
+#elif __has_include(<experimental/filesystem>)
+#include <experimental/filesystem>
+namespace fs = std::experimental::filesystem;
+#endif
+
+#endif


### PR DESCRIPTION
## Technical Description

Use std::experimental::filesystem if std::filesystem is not supported, i.e. gcc < 8.