### PR TITLE
Move clang-tidy and remove 'User' key

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -4,7 +4,6 @@ WarningsAsErrors: ''
 HeaderFilterRegex: ''
 AnalyzeTemporaryDtors: false
 FormatStyle:     none
-User:
 CheckOptions:
   - key:             cert-dcl16-c.NewSuffixes
     value:           'L;LL;LU;LLU'


### PR DESCRIPTION
## Technical Description

Clang 9 complains about the 'User' key not having a value. For example, from the vscode log:

```YAML:8:1: error: unexpected scalar
CheckOptions:
^
Error parsing /Users/johannd/Code/dawn/dawn/.clang-tidy: Invalid argument
```

Is there a reason not to have this in the root directory? This PR moves it there.
