### PR TITLE
Add generate method to DawnCompiler

### DIFF
--- a/dawn/src/dawn/CodeGen/CXXNaive-ico/CXXNaiveCodeGen.cpp
+++ b/dawn/src/dawn/CodeGen/CXXNaive-ico/CXXNaiveCodeGen.cpp
@@ -87,8 +87,8 @@ std::string makeKLoop(bool isBackward, iir::Interval const& interval) {
 }
 } // namespace
 
-CXXNaiveIcoCodeGen::CXXNaiveIcoCodeGen(stencilInstantiationContext& ctx, DiagnosticsEngine& engine,
-                                       int maxHaloPoint)
+CXXNaiveIcoCodeGen::CXXNaiveIcoCodeGen(const stencilInstantiationContext& ctx,
+                                       DiagnosticsEngine& engine, int maxHaloPoint)
     : CodeGen(ctx, engine, maxHaloPoint) {}
 
 CXXNaiveIcoCodeGen::~CXXNaiveIcoCodeGen() {}

--- a/dawn/src/dawn/CodeGen/CXXNaive-ico/CXXNaiveCodeGen.h
+++ b/dawn/src/dawn/CodeGen/CXXNaive-ico/CXXNaiveCodeGen.h
@@ -37,7 +37,8 @@ namespace cxxnaiveico {
 class CXXNaiveIcoCodeGen : public CodeGen {
 public:
   ///@brief constructor
-  CXXNaiveIcoCodeGen(stencilInstantiationContext& ctx, DiagnosticsEngine& engine, int maxHaloPoint);
+  CXXNaiveIcoCodeGen(const stencilInstantiationContext& ctx, DiagnosticsEngine& engine,
+                     int maxHaloPoint);
   virtual ~CXXNaiveIcoCodeGen();
   virtual std::unique_ptr<TranslationUnit> generateCode() override;
 

--- a/dawn/src/dawn/CodeGen/CXXNaive/CXXNaiveCodeGen.cpp
+++ b/dawn/src/dawn/CodeGen/CXXNaive/CXXNaiveCodeGen.cpp
@@ -83,7 +83,7 @@ std::string makeKLoop(bool isBackward, iir::Interval const& interval) {
 }
 } // namespace
 
-CXXNaiveCodeGen::CXXNaiveCodeGen(stencilInstantiationContext& ctx, DiagnosticsEngine& engine,
+CXXNaiveCodeGen::CXXNaiveCodeGen(const stencilInstantiationContext& ctx, DiagnosticsEngine& engine,
                                  int maxHaloPoint)
     : CodeGen(ctx, engine, maxHaloPoint) {}
 

--- a/dawn/src/dawn/CodeGen/CXXNaive/CXXNaiveCodeGen.h
+++ b/dawn/src/dawn/CodeGen/CXXNaive/CXXNaiveCodeGen.h
@@ -37,7 +37,8 @@ namespace cxxnaive {
 class CXXNaiveCodeGen : public CodeGen {
 public:
   ///@brief constructor
-  CXXNaiveCodeGen(stencilInstantiationContext& ctx, DiagnosticsEngine& engine, int maxHaloPoint);
+  CXXNaiveCodeGen(const stencilInstantiationContext& ctx, DiagnosticsEngine& engine,
+                  int maxHaloPoint);
   virtual ~CXXNaiveCodeGen();
   virtual std::unique_ptr<TranslationUnit> generateCode() override;
 

--- a/dawn/src/dawn/CodeGen/CodeGen.cpp
+++ b/dawn/src/dawn/CodeGen/CodeGen.cpp
@@ -24,7 +24,7 @@ size_t CodeGen::getVerticalTmpHaloSizeForMultipleStencils(
   return fullIntervals ? std::max(fullIntervals->overEnd(), fullIntervals->belowBegin()) : 0;
 }
 
-std::string CodeGen::generateGlobals(stencilInstantiationContext& context,
+std::string CodeGen::generateGlobals(const stencilInstantiationContext& context,
                                      std::string outer_namespace_, std::string inner_namespace_) {
 
   std::stringstream ss;
@@ -37,7 +37,8 @@ std::string CodeGen::generateGlobals(stencilInstantiationContext& context,
   return ss.str();
 }
 
-std::string CodeGen::generateGlobals(stencilInstantiationContext& context, std::string namespace_) {
+std::string CodeGen::generateGlobals(const stencilInstantiationContext& context,
+                                     std::string namespace_) {
   if(context.size() > 0) {
     const auto& globalsMap = context.begin()->second->getIIR()->getGlobalVariableMap();
     return generateGlobals(globalsMap, namespace_);

--- a/dawn/src/dawn/CodeGen/CodeGen.h
+++ b/dawn/src/dawn/CodeGen/CodeGen.h
@@ -33,7 +33,7 @@ using stencilInstantiationContext =
 /// @ingroup codegen
 class CodeGen {
 protected:
-  stencilInstantiationContext context_;
+  const stencilInstantiationContext context_;
   DiagnosticsEngine& diagEngine;
   struct codeGenOption {
     int MaxHaloPoints;
@@ -72,7 +72,7 @@ protected:
   const std::string bigWrapperMetadata_ = "m_meta_data";
 
 public:
-  CodeGen(stencilInstantiationContext& ctx, DiagnosticsEngine& engine, int maxHaloPoints)
+  CodeGen(const stencilInstantiationContext& ctx, DiagnosticsEngine& engine, int maxHaloPoints)
       : context_(ctx), diagEngine(engine), codeGenOptions{maxHaloPoints} {};
   virtual ~CodeGen() {}
 
@@ -94,8 +94,9 @@ public:
                                   Class& stencilWrapperClass,
                                   const sir::GlobalVariableMap& globalsMap,
                                   const CodeGenProperties& codeGenProperties) const;
-  virtual std::string generateGlobals(stencilInstantiationContext& context, std::string namespace_);
-  virtual std::string generateGlobals(stencilInstantiationContext& context,
+  virtual std::string generateGlobals(const stencilInstantiationContext& context,
+                                      std::string namespace_);
+  virtual std::string generateGlobals(const stencilInstantiationContext& context,
                                       std::string outer_namespace_, std::string inner_namespace_);
   virtual std::string generateGlobals(const sir::GlobalVariableMap& globalsMaps,
                                       std::string namespace_) const;

--- a/dawn/src/dawn/CodeGen/Cuda/CudaCodeGen.cpp
+++ b/dawn/src/dawn/CodeGen/Cuda/CudaCodeGen.cpp
@@ -51,7 +51,7 @@ std::string makeIntervalBoundExplicit(std::string dim, const iir::Interval& inte
 }
 } // namespace
 
-CudaCodeGen::CudaCodeGen(stencilInstantiationContext& ctx, DiagnosticsEngine& engine,
+CudaCodeGen::CudaCodeGen(const stencilInstantiationContext& ctx, DiagnosticsEngine& engine,
                          int maxHaloPoints, int nsms, int maxBlocksPerSM, const Array3i& domainSize)
     : CodeGen(ctx, engine, maxHaloPoints), codeGenOptions_{nsms, maxBlocksPerSM, domainSize} {}
 

--- a/dawn/src/dawn/CodeGen/Cuda/CudaCodeGen.h
+++ b/dawn/src/dawn/CodeGen/Cuda/CudaCodeGen.h
@@ -37,7 +37,7 @@ class CudaCodeGen : public CodeGen {
 
 public:
   ///@brief constructor
-  CudaCodeGen(stencilInstantiationContext& ctx, DiagnosticsEngine& engine, int maxHaloPoints,
+  CudaCodeGen(const stencilInstantiationContext& ctx, DiagnosticsEngine& engine, int maxHaloPoints,
               int nsms, int maxBlocksPerSM, const Array3i& domainSize);
   virtual ~CudaCodeGen();
   virtual std::unique_ptr<TranslationUnit> generateCode() override;

--- a/dawn/src/dawn/CodeGen/GridTools/GTCodeGen.cpp
+++ b/dawn/src/dawn/CodeGen/GridTools/GTCodeGen.cpp
@@ -34,7 +34,7 @@ namespace dawn {
 namespace codegen {
 namespace gt {
 
-GTCodeGen::GTCodeGen(stencilInstantiationContext& ctx, DiagnosticsEngine& engine,
+GTCodeGen::GTCodeGen(const stencilInstantiationContext& ctx, DiagnosticsEngine& engine,
                      bool useParallelEP, int maxHaloPoints)
     : CodeGen(ctx, engine, maxHaloPoints),
       mplContainerMaxSize_(20), codeGenOptions_{useParallelEP} {}

--- a/dawn/src/dawn/CodeGen/GridTools/GTCodeGen.h
+++ b/dawn/src/dawn/CodeGen/GridTools/GTCodeGen.h
@@ -37,7 +37,7 @@ namespace gt {
 /// @ingroup gt
 class GTCodeGen : public CodeGen {
 public:
-  GTCodeGen(stencilInstantiationContext& ctx, DiagnosticsEngine& engine, bool useParallelEP,
+  GTCodeGen(const stencilInstantiationContext& ctx, DiagnosticsEngine& engine, bool useParallelEP,
             int maxHaloPoints);
   virtual ~GTCodeGen();
 

--- a/dawn/src/dawn/Compiler/DawnCompiler.cpp
+++ b/dawn/src/dawn/Compiler/DawnCompiler.cpp
@@ -265,6 +265,48 @@ std::unique_ptr<OptimizerContext> DawnCompiler::runOptimizer(std::shared_ptr<SIR
   return optimizer;
 }
 
+std::unique_ptr<codegen::TranslationUnit>
+DawnCompiler::generate(const std::map<std::string, std::shared_ptr<iir::StencilInstantiation>>&
+                           stencilInstantiationMap) {
+  // Generate code
+  try {
+    BackendType backend = parseBackendString(options_.Backend);
+    switch(backend) {
+    case BackendType::GridTools: {
+      codegen::gt::GTCodeGen CG(stencilInstantiationMap, diagnostics_, options_.UseParallelEP,
+                                options_.MaxHaloPoints);
+      return CG.generateCode();
+    }
+    case BackendType::CXXNaive: {
+      codegen::cxxnaive::CXXNaiveCodeGen CG(stencilInstantiationMap, diagnostics_,
+                                            options_.MaxHaloPoints);
+      return CG.generateCode();
+    }
+    case BackendType::CUDA: {
+      const Array3i domain_size{options_.domain_size_i, options_.domain_size_j,
+                                options_.domain_size_k};
+      codegen::cuda::CudaCodeGen CG(stencilInstantiationMap, diagnostics_, options_.MaxHaloPoints,
+                                    options_.nsms, options_.maxBlocksPerSM, domain_size);
+      return CG.generateCode();
+    }
+    case BackendType::CXXNaiveIco: {
+      codegen::cxxnaiveico::CXXNaiveIcoCodeGen CG(stencilInstantiationMap, diagnostics_,
+                                                  options_.MaxHaloPoints);
+
+      return CG.generateCode();
+    }
+    case BackendType::CXXOpt:
+      dawn_unreachable("GTClangOptCXX not supported yet");
+    }
+  } catch(...) {
+    diagnostics_.report(buildDiag("-backend", options_.Backend,
+                                  "backend options must be : " +
+                                      dawn::RangeToString(", ", "", "")(std::vector<std::string>{
+                                          "gridtools", "c++-naive", "c++-opt", "c++-naive-ico"})));
+    return nullptr;
+  }
+}
+
 std::unique_ptr<codegen::TranslationUnit> DawnCompiler::compile(const std::shared_ptr<SIR>& SIR) {
   diagnostics_.clear();
   diagnostics_.setFilename(SIR->Filename);
@@ -299,46 +341,11 @@ std::unique_ptr<codegen::TranslationUnit> DawnCompiler::compile(const std::share
   if(diagnostics_.hasErrors()) {
     DAWN_LOG(INFO) << "Errors occurred. Skipping code generation.";
     return nullptr;
+  } else {
+    DAWN_ASSERT_MSG(optimizer, "No errors, but optimizer context fails to exist!");
   }
 
-  // Generate code
-  try {
-    BackendType backend = parseBackendString(options_.Backend);
-    switch(backend) {
-    case BackendType::GridTools: {
-      codegen::gt::GTCodeGen CG(optimizer->getStencilInstantiationMap(), diagnostics_,
-                                options_.UseParallelEP, options_.MaxHaloPoints);
-      return CG.generateCode();
-    }
-    case BackendType::CXXNaive: {
-      codegen::cxxnaive::CXXNaiveCodeGen CG(optimizer->getStencilInstantiationMap(), diagnostics_,
-                                            options_.MaxHaloPoints);
-      return CG.generateCode();
-    }
-    case BackendType::CUDA: {
-      const Array3i domain_size{options_.domain_size_i, options_.domain_size_j,
-                                options_.domain_size_k};
-      codegen::cuda::CudaCodeGen CG(optimizer->getStencilInstantiationMap(), diagnostics_,
-                                    options_.MaxHaloPoints, options_.nsms, options_.maxBlocksPerSM,
-                                    domain_size);
-      return CG.generateCode();
-    }
-    case BackendType::CXXNaiveIco: {
-      codegen::cxxnaiveico::CXXNaiveIcoCodeGen CG(optimizer->getStencilInstantiationMap(),
-                                                  diagnostics_, options_.MaxHaloPoints);
-
-      return CG.generateCode();
-    }
-    case BackendType::CXXOpt:
-      dawn_unreachable("GTClangOptCXX not supported yet");
-    }
-  } catch(...) {
-    diagnostics_.report(buildDiag("-backend", options_.Backend,
-                                  "backend options must be : " +
-                                      dawn::RangeToString(", ", "", "")(std::vector<std::string>{
-                                          "gridtools", "c++-naive", "c++-opt", "c++-naive-ico"})));
-    return nullptr;
-  }
+  return generate(optimizer->getStencilInstantiationMap());
 }
 
 const DiagnosticsEngine& DawnCompiler::getDiagnostics() const { return diagnostics_; }

--- a/dawn/src/dawn/Compiler/DawnCompiler.h
+++ b/dawn/src/dawn/Compiler/DawnCompiler.h
@@ -43,6 +43,10 @@ public:
 
   std::unique_ptr<OptimizerContext> runOptimizer(std::shared_ptr<SIR> const& SIR);
 
+  std::unique_ptr<codegen::TranslationUnit>
+  generate(const std::map<std::string, std::shared_ptr<iir::StencilInstantiation>>&
+               stencilInstantiationMap);
+
   /// @brief Get options
   const Options& getOptions() const;
   Options& getOptions();


### PR DESCRIPTION
## Technical Description

Adds a generate method to DawnCompiler and calls it from compile(). This is in preparation for splitting code generation tests from the gtclang integration tests. 

### Resolves / Enhances

Part of #625.

### Testing

This is implicitly tested because compile() calls it.
