### PR TITLE
Implementation of PassLocalVarType

### DIFF
--- a/dawn/src/dawn/Compiler/DawnCompiler.cpp
+++ b/dawn/src/dawn/Compiler/DawnCompiler.cpp
@@ -25,6 +25,7 @@
 #include "dawn/Optimizer/PassFixVersionedInputFields.h"
 #include "dawn/Optimizer/PassInlining.h"
 #include "dawn/Optimizer/PassIntervalPartitioner.h"
+#include "dawn/Optimizer/PassLocalVarType.h"
 #include "dawn/Optimizer/PassMultiStageSplitter.h"
 #include "dawn/Optimizer/PassPrintStencilGraph.h"
 #include "dawn/Optimizer/PassSSA.h"
@@ -194,16 +195,19 @@ std::unique_ptr<OptimizerContext> DawnCompiler::runOptimizer(std::shared_ptr<SIR
     //  optimizer->checkAndPushBack<PassTemporaryFirstAccss>();
     optimizer->checkAndPushBack<PassFieldVersioning>();
     optimizer->checkAndPushBack<PassSSA>();
+    optimizer->checkAndPushBack<PassLocalVarType>(); // Needs to be run before splitters.
     optimizer->checkAndPushBack<PassMultiStageSplitter>(mssSplitStrategy);
     optimizer->checkAndPushBack<PassStageSplitter>();
     optimizer->checkAndPushBack<PassPrintStencilGraph>();
     optimizer->checkAndPushBack<PassTemporaryType>();
+    optimizer->checkAndPushBack<PassLocalVarType>(); // Needs to be run after temporary type.
     optimizer->checkAndPushBack<PassSetStageName>();
     optimizer->checkAndPushBack<PassSetStageGraph>();
     optimizer->checkAndPushBack<PassStageReordering>(reorderStrategy);
     optimizer->checkAndPushBack<PassStageMerger>();
     optimizer->checkAndPushBack<PassStencilSplitter>(maxFields);
     optimizer->checkAndPushBack<PassTemporaryType>();
+    optimizer->checkAndPushBack<PassLocalVarType>(); // Needs to be run after temporary type.
     optimizer->checkAndPushBack<PassTemporaryMerger>();
     optimizer->checkAndPushBack<PassInlining>(
         (getOptions().InlineSF || getOptions().PassTmpToFunction),

--- a/dawn/src/dawn/IIR/CMakeLists.txt
+++ b/dawn/src/dawn/IIR/CMakeLists.txt
@@ -112,6 +112,8 @@ add_library(DawnIIR
   IIR.h
   IIRNode.h
   IIRNodeIterator.h
+  LocalVariable.cpp
+  LocalVariable.h
   LoopOrder.cpp
   LoopOrder.h
   MultiInterval.cpp

--- a/dawn/src/dawn/IIR/LocalVariable.cpp
+++ b/dawn/src/dawn/IIR/LocalVariable.cpp
@@ -32,8 +32,9 @@ LocalVariableType LocalVariableData::getType() const {
 
 ast::LocationType LocalVariableData::getLocationType() const {
   DAWN_ASSERT_MSG(type_.has_value(), "Must run PassLocalVarType first.");
-  DAWN_ASSERT_MSG(!type_->isScalar(), "Variable must not be scalar.");
-  DAWN_ASSERT_MSG(*type != LocalVariableType::OnIJ, "Variable is defined on cartesian dimensions.");
+  DAWN_ASSERT_MSG(!isScalar(), "Variable must not be scalar.");
+  DAWN_ASSERT_MSG(*type_ != LocalVariableType::OnIJ,
+                  "Variable is defined on cartesian dimensions.");
 
   switch(*type_) {
   case LocalVariableType::OnCells:

--- a/dawn/src/dawn/IIR/LocalVariable.cpp
+++ b/dawn/src/dawn/IIR/LocalVariable.cpp
@@ -1,0 +1,51 @@
+//===--------------------------------------------------------------------------------*- C++ -*-===//
+//                          _
+//                         | |
+//                       __| | __ ___      ___ ___
+//                      / _` |/ _` \ \ /\ / / '_  |
+//                     | (_| | (_| |\ V  V /| | | |
+//                      \__,_|\__,_| \_/\_/ |_| |_| - Compiler Toolchain
+//
+//
+//  This file is distributed under the MIT License (MIT).
+//  See LICENSE.txt for details.
+//
+//===------------------------------------------------------------------------------------------===//
+
+#pragma once
+
+#include "LocalVariable.h"
+#include "dawn/Support/Assert.h"
+#include "dawn/Support/Unreachable.h"
+
+namespace dawn {
+namespace iir {
+
+bool LocalVariableData::isScalar() const {
+  DAWN_ASSERT_MSG(type_.has_value(), "Must run PassLocalVarType first.");
+  return *type_ == LocalVariableType::Scalar;
+}
+LocalVariableType LocalVariableData::getType() const {
+  DAWN_ASSERT_MSG(type_.has_value(), "Must run PassLocalVarType first.");
+  return *type_;
+}
+
+ast::LocationType LocalVariableData::getLocationType() const {
+  DAWN_ASSERT_MSG(type_.has_value(), "Must run PassLocalVarType first.");
+  DAWN_ASSERT_MSG(!type_->isScalar(), "Variable must not be scalar.");
+  DAWN_ASSERT_MSG(*type != LocalVariableType::OnIJ, "Variable is defined on cartesian dimensions.");
+
+  switch(*type_) {
+  case LocalVariableType::OnCells:
+    return ast::LocationType::Cells;
+  case LocalVariableType::OnEdges:
+    return ast::LocationType::Edges;
+  case LocalVariableType::OnVertices:
+    return ast::LocationType::Vertices;
+  default:
+    dawn_unreachable("It should be an unstructured horizontal dimension.");
+  }
+}
+
+} // namespace iir
+} // namespace dawn

--- a/dawn/src/dawn/IIR/LocalVariable.cpp
+++ b/dawn/src/dawn/IIR/LocalVariable.cpp
@@ -12,8 +12,6 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
-#pragma once
-
 #include "LocalVariable.h"
 #include "dawn/Support/Assert.h"
 #include "dawn/Support/Unreachable.h"

--- a/dawn/src/dawn/IIR/LocalVariable.h
+++ b/dawn/src/dawn/IIR/LocalVariable.h
@@ -1,0 +1,56 @@
+//===--------------------------------------------------------------------------------*- C++ -*-===//
+//                          _
+//                         | |
+//                       __| | __ ___      ___ ___
+//                      / _` |/ _` \ \ /\ / / '_  |
+//                     | (_| | (_| |\ V  V /| | | |
+//                      \__,_|\__,_| \_/\_/ |_| |_| - Compiler Toolchain
+//
+//
+//  This file is distributed under the MIT License (MIT).
+//  See LICENSE.txt for details.
+//
+//===------------------------------------------------------------------------------------------===//
+
+#pragma once
+
+#include "dawn/AST/LocationType.h"
+#include <optional>
+
+namespace dawn {
+namespace iir {
+
+/// @brief A variable can be a scalar (we want to remove scalar variables to get to valid IIR),
+/// or it can have the same horizontal dimensions as a field (IJ for cartesian, location types for
+/// unstructured).
+///
+/// @ingroup optimizer
+enum class LocalVariableType { Scalar, OnCells, OnEdges, OnVertices, OnIJ };
+
+/// @brief Contains information about a local variable
+///
+/// @ingroup optimizer
+class LocalVariableData {
+
+  // Type of the variable. std::nullopt means not computed yet.
+  std::optional<LocalVariableType> type_;
+
+public:
+  /// @brief returns whether the type is set or not
+  bool isTypeSet() const { return type_.has_value(); }
+  /// @brief returns whether the variable is adimensional (must be called once the type has
+  /// been computed by PassLocalVarType)
+  bool isScalar() const;
+  /// @brief returns the computed variable type (must be called once the type has
+  /// been computed by PassLocalVarType)
+  LocalVariableType getType() const;
+  /// @brief returns the ast::LocationType that corresponds to the variable type in the unstructured
+  /// case (must be called once the type has been computed by PassLocalVarType and for a
+  /// non-scalar variable)
+  ast::LocationType getLocationType() const;
+
+  void setType(LocalVariableType type) { type_ = type; }
+};
+
+} // namespace iir
+} // namespace dawn

--- a/dawn/src/dawn/IIR/StencilMetaInformation.cpp
+++ b/dawn/src/dawn/IIR/StencilMetaInformation.cpp
@@ -281,11 +281,11 @@ void StencilMetaInformation::insertAccessOfType(FieldAccessType type, int Access
   }
 }
 
-int StencilMetaInformation::addStmt(bool keepVarNames, const std::shared_ptr<VarDeclStmt>& stmt) {
+int StencilMetaInformation::addStmt(bool keepVarName, const std::shared_ptr<VarDeclStmt>& stmt) {
   int accessID = UIDGenerator::getInstance()->get();
 
   std::string globalName;
-  if(keepVarNames) {
+  if(keepVarName) {
     globalName = stmt->getName();
   } else {
     globalName = InstantiationHelper::makeLocalVariablename(stmt->getName(), accessID);
@@ -299,6 +299,33 @@ int StencilMetaInformation::addStmt(bool keepVarNames, const std::shared_ptr<Var
   stmt->getData<iir::VarDeclStmtData>().AccessID = std::make_optional(accessID);
 
   return accessID;
+}
+
+std::shared_ptr<VarDeclStmt>
+StencilMetaInformation::declareVar(bool keepVarName, std::string varName, Type type, int accessID) {
+  declareVar(keepVarName, varName, type, nullptr, accessID);
+}
+std::shared_ptr<VarDeclStmt> StencilMetaInformation::declareVar(bool keepVarName,
+                                                                std::string varName, Type type,
+                                                                std::shared_ptr<Expr> rhs,
+                                                                int accessID) {
+  // TODO: find a way to reuse code from addStmt
+  std::string globalName =
+      keepVarName ? varName : InstantiationHelper::makeLocalVariablename(varName, accessID);
+  // Construct the variable declaration
+  std::vector<std::shared_ptr<iir::Expr>> initList;
+  if(rhs != nullptr) { // If nullptr, declaration without initialization (overload)
+    initList.push_back(rhs);
+  }
+  auto varDeclStmt = iir::makeVarDeclStmt(type, globalName, 0, "=", std::move(initList));
+  // Update id to name map
+  addAccessIDNamePair(accessID, globalName);
+  // Add empty data object for local variable
+  addAccessIDToLocalVariableDataPair(accessID, LocalVariableData{});
+  // Update varDeclStmt's data
+  varDeclStmt->getData<iir::VarDeclStmtData>().AccessID = std::make_optional(accessID);
+
+  return varDeclStmt;
 }
 
 bool StencilMetaInformation::isFieldType(FieldAccessType accessType) const {

--- a/dawn/src/dawn/IIR/StencilMetaInformation.cpp
+++ b/dawn/src/dawn/IIR/StencilMetaInformation.cpp
@@ -303,7 +303,7 @@ int StencilMetaInformation::addStmt(bool keepVarName, const std::shared_ptr<VarD
 
 std::shared_ptr<VarDeclStmt>
 StencilMetaInformation::declareVar(bool keepVarName, std::string varName, Type type, int accessID) {
-  declareVar(keepVarName, varName, type, nullptr, accessID);
+  return declareVar(keepVarName, varName, type, nullptr, accessID);
 }
 std::shared_ptr<VarDeclStmt> StencilMetaInformation::declareVar(bool keepVarName,
                                                                 std::string varName, Type type,
@@ -418,6 +418,10 @@ void StencilMetaInformation::removeAccessID(int AccessID) {
   // literals
   DAWN_ASSERT(isAccessType(FieldAccessType::Field, AccessID) ||
               isAccessType(FieldAccessType::LocalVariable, AccessID));
+
+  if(isAccessType(FieldAccessType::LocalVariable, AccessID)) {
+    accessIDToLocalVariableDataMap_.erase(AccessID);
+  }
 
   fieldAccessMetadata_.FieldAccessIDSet_.erase(AccessID);
   if(isAccessType(FieldAccessType::InterStencilTemporary, AccessID)) {

--- a/dawn/src/dawn/IIR/StencilMetaInformation.cpp
+++ b/dawn/src/dawn/IIR/StencilMetaInformation.cpp
@@ -292,6 +292,8 @@ int StencilMetaInformation::addStmt(bool keepVarNames, const std::shared_ptr<Var
   }
 
   addAccessIDNamePair(accessID, globalName);
+  // Add empty data object for local variable
+  addAccessIDToLocalVariableDataPair(accessID, LocalVariableData{});
 
   DAWN_ASSERT(!stmt->getData<iir::VarDeclStmtData>().AccessID);
   stmt->getData<iir::VarDeclStmtData>().AccessID = std::make_optional(accessID);
@@ -529,6 +531,25 @@ int StencilMetaInformation::getStencilIDFromStencilCallStmt(
 void StencilMetaInformation::addStencilCallStmt(std::shared_ptr<StencilCallDeclStmt> stmt,
                                                 int stencilID) {
   StencilIDToStencilCallMap_.add(stencilID, stmt);
+}
+
+void StencilMetaInformation::addAccessIDToLocalVariableDataPair(int accessID,
+                                                                LocalVariableData&& data) {
+  DAWN_ASSERT(isAccessType(FieldAccessType::LocalVariable, accessID));
+  accessIDToLocalVariableDataMap_.emplace(accessID, std::move(data));
+}
+
+iir::LocalVariableData& StencilMetaInformation::getLocalVariableDataFromAccessID(int accessID) {
+  DAWN_ASSERT(isAccessType(FieldAccessType::LocalVariable, accessID));
+  DAWN_ASSERT(accessIDToLocalVariableDataMap_.count(accessID));
+  return accessIDToLocalVariableDataMap_.at(accessID);
+}
+
+const iir::LocalVariableData&
+StencilMetaInformation::getLocalVariableDataFromAccessID(int accessID) const {
+  DAWN_ASSERT(isAccessType(FieldAccessType::LocalVariable, accessID));
+  DAWN_ASSERT(accessIDToLocalVariableDataMap_.count(accessID));
+  return accessIDToLocalVariableDataMap_.at(accessID);
 }
 
 } // namespace iir

--- a/dawn/src/dawn/IIR/StencilMetaInformation.cpp
+++ b/dawn/src/dawn/IIR/StencilMetaInformation.cpp
@@ -583,5 +583,11 @@ StencilMetaInformation::getLocalVariableDataFromAccessID(int accessID) const {
   return accessIDToLocalVariableDataMap_.at(accessID);
 }
 
+void StencilMetaInformation::resetLocalVarTypes() {
+  for(auto& pair : accessIDToLocalVariableDataMap_) {
+    pair.second = iir::LocalVariableData{};
+  }
+}
+
 } // namespace iir
 } // namespace dawn

--- a/dawn/src/dawn/IIR/StencilMetaInformation.h
+++ b/dawn/src/dawn/IIR/StencilMetaInformation.h
@@ -158,7 +158,27 @@ public:
                   sir::FieldDimensions&& fieldDimensions,
                   std::optional<int> accessID = std::nullopt);
 
-  int addStmt(bool keepVarNames, const std::shared_ptr<VarDeclStmt>& stmt);
+  /// @brief Adds an existing variable declaration to the metadata: assigns an accessID to the
+  /// variable, fixes the ID to name map, the ID to LocalVariableData map and the AccessID in the
+  /// `VarDeclStmt`'s data.
+  /// @param keepVarName: whether to keep the current name or complete it with the accessID
+  /// @param stmt: the variable declaration statement
+  /// @returns the access id of the variable
+  int addStmt(bool keepVarName, const std::shared_ptr<VarDeclStmt>& stmt);
+
+  /// @brief Adds an new variable declaration to the metadata: constructs a `VarDeclStmt`, assigns
+  /// an accessID to the variable, fixes the ID to name map, the ID to LocalVariableData map and the
+  /// AccessID in the `VarDeclStmt`'s data.
+  /// @param keepVarName: whether to keep the provided name or complete it with the accessID
+  /// @param varName: the variable's name
+  /// @param type: the variable's type (double, const int, ...)
+  /// @param rhs: the expression to initialize the variable (optional)
+  /// @returns the variable declaration statement
+  std::shared_ptr<VarDeclStmt> declareVar(bool keepVarName, std::string varName, Type type,
+                                          int accessID = UIDGenerator::getInstance()->get());
+  std::shared_ptr<VarDeclStmt> declareVar(bool keepVarName, std::string varName, Type type,
+                                          std::shared_ptr<Expr> rhs,
+                                          int accessID = UIDGenerator::getInstance()->get());
 
   void eraseStencilFunctionInstantiation(
       const std::shared_ptr<StencilFunctionInstantiation>& stencilFun) {

--- a/dawn/src/dawn/IIR/StencilMetaInformation.h
+++ b/dawn/src/dawn/IIR/StencilMetaInformation.h
@@ -19,6 +19,7 @@
 #include "dawn/IIR/Extents.h"
 #include "dawn/IIR/Field.h"
 #include "dawn/IIR/FieldAccessMetadata.h"
+#include "dawn/IIR/LocalVariable.h"
 #include "dawn/SIR/SIR.h"
 #include "dawn/Support/DoubleSidedMap.h"
 #include "dawn/Support/NonCopyable.h"
@@ -350,6 +351,10 @@ public:
     return StencilIDToStencilCallMap_;
   }
 
+  void addAccessIDToLocalVariableDataPair(int accessID, LocalVariableData&& data);
+  iir::LocalVariableData& getLocalVariableDataFromAccessID(int accessID);
+  const iir::LocalVariableData& getLocalVariableDataFromAccessID(int accessID) const;
+
   dawn::ast::LocationType getDenseLocationTypeFromAccessID(int ID) const;
 
 private:
@@ -389,6 +394,9 @@ private:
   /// BoundaryConditionCall to Extent Map. Filled my `PassSetBoundaryCondition`
   std::unordered_map<std::shared_ptr<iir::BoundaryConditionDeclStmt>, Extents>
       boundaryConditionToExtentsMap_;
+
+  /// Map from AccessID (of a local variable) to the data of such variable.
+  std::unordered_map<int, iir::LocalVariableData> accessIDToLocalVariableDataMap_;
 
   SourceLocation stencilLocation_;
   std::string stencilName_;

--- a/dawn/src/dawn/IIR/StencilMetaInformation.h
+++ b/dawn/src/dawn/IIR/StencilMetaInformation.h
@@ -377,6 +377,8 @@ public:
   const std::unordered_map<int, iir::LocalVariableData>& getAccessIDToLocalVariableDataMap() const {
     return accessIDToLocalVariableDataMap_;
   }
+  /// @brief Resets types of all variables to "not computed" (type_ = std::nullopt)
+  void resetLocalVarTypes();
 
   dawn::ast::LocationType getDenseLocationTypeFromAccessID(int ID) const;
 

--- a/dawn/src/dawn/IIR/StencilMetaInformation.h
+++ b/dawn/src/dawn/IIR/StencilMetaInformation.h
@@ -354,6 +354,9 @@ public:
   void addAccessIDToLocalVariableDataPair(int accessID, LocalVariableData&& data);
   iir::LocalVariableData& getLocalVariableDataFromAccessID(int accessID);
   const iir::LocalVariableData& getLocalVariableDataFromAccessID(int accessID) const;
+  const std::unordered_map<int, iir::LocalVariableData>& getAccessIDToLocalVariableDataMap() const {
+    return accessIDToLocalVariableDataMap_;
+  }
 
   dawn::ast::LocationType getDenseLocationTypeFromAccessID(int ID) const;
 

--- a/dawn/src/dawn/Optimizer/CMakeLists.txt
+++ b/dawn/src/dawn/Optimizer/CMakeLists.txt
@@ -30,6 +30,8 @@ add_library(DawnOptimizer
   PassInlining.h
   PassIntervalPartitioner.cpp
   PassIntervalPartitioner.h
+  PassLocalVarType.h
+  PassLocalVarType.cpp
   PassManager.cpp
   PassManager.h
   PassMultiStageSplitter.cpp

--- a/dawn/src/dawn/Optimizer/PassInlining.cpp
+++ b/dawn/src/dawn/Optimizer/PassInlining.cpp
@@ -119,7 +119,8 @@ public:
       // return value in a local variable.
 
       // Declare and register the variable
-      auto newStmt = metadata_.declareVar(false, curStencilFunctioninstantiation_->getName(),
+      const bool keepVarName = false; // We want the full name (completed with access ID)
+      auto newStmt = metadata_.declareVar(keepVarName, curStencilFunctioninstantiation_->getName(),
                                           dawn::Type(BuiltinTypeID::Float, CVQualifier::Const),
                                           stmt->getExpr());
       // Add it to the AST

--- a/dawn/src/dawn/Optimizer/PassInlining.cpp
+++ b/dawn/src/dawn/Optimizer/PassInlining.cpp
@@ -117,23 +117,20 @@ public:
     if(AccessIDOfCaller_ == 0) {
       // We are *not* called within an arugment list of a stencil function, meaning we can store the
       // return value in a local variable.
-      int AccessID = instantiation_->nextUID();
-      auto returnVarName = iir::InstantiationHelper::makeLocalVariablename(
-          curStencilFunctioninstantiation_->getName(), AccessID);
 
-      newExpr_ = std::make_shared<iir::VarAccessExpr>(returnVarName);
-      auto newStmt =
-          iir::makeVarDeclStmt(dawn::Type(BuiltinTypeID::Float, CVQualifier::Const), returnVarName,
-                               0, "=", std::vector<std::shared_ptr<iir::Expr>>{stmt->getExpr()});
+      // Declare and register the variable
+      auto newStmt = metadata_.declareVar(false, curStencilFunctioninstantiation_->getName(),
+                                          dawn::Type(BuiltinTypeID::Float, CVQualifier::Const),
+                                          stmt->getExpr());
+      // Add it to the AST
       appendNewStatement(newStmt);
 
-      // Register the variable
-      metadata_.addAccessIDNamePair(AccessID, returnVarName);
-      newStmt->getData<iir::VarDeclStmtData>().AccessID = std::make_optional(AccessID);
-      // TODO recheck this
-      std::dynamic_pointer_cast<iir::VarAccessExpr>(newExpr_)
-          ->getData<iir::IIRAccessExprData>()
-          .AccessID = std::make_optional(AccessID);
+      // Set the access ID to the access expression
+      auto varAccessExpr = std::make_shared<iir::VarAccessExpr>(newStmt->getName());
+      varAccessExpr->getData<iir::IIRAccessExprData>().AccessID =
+          std::make_optional(iir::getAccessID(newStmt));
+
+      newExpr_ = varAccessExpr;
 
     } else {
       // We are called within an arugment list of a stencil function, we thus need to store the
@@ -184,6 +181,7 @@ public:
     int AccessID = iir::getAccessID(stmt);
     const std::string& name = curStencilFunctioninstantiation_->getFieldNameFromAccessID(AccessID);
     metadata_.addAccessIDNamePair(AccessID, name);
+    metadata_.addAccessIDToLocalVariableDataPair(AccessID, iir::LocalVariableData{});
 
     // Push back the statement and move on
     appendNewStatement(stmt);

--- a/dawn/src/dawn/Optimizer/PassLocalVarType.cpp
+++ b/dawn/src/dawn/Optimizer/PassLocalVarType.cpp
@@ -1,0 +1,142 @@
+//===--------------------------------------------------------------------------------*- C++ -*-===//
+//                          _
+//                         | |
+//                       __| | __ ___      ___ ___
+//                      / _` |/ _` \ \ /\ / / '_  |
+//                     | (_| | (_| |\ V  V /| | | |
+//                      \__,_|\__,_| \_/\_/ |_| |_| - Compiler Toolchain
+//
+//
+//  This file is distributed under the MIT License (MIT).
+//  See LICENSE.txt for details.
+//
+//===------------------------------------------------------------------------------------------===//
+
+#include "PassLocalVarType.h"
+#include "dawn/IIR/ASTExpr.h"
+#include "dawn/IIR/ASTStmt.h"
+#include "dawn/IIR/DoMethod.h"
+#include "dawn/IIR/StencilInstantiation.h"
+#include "dawn/IIR/StencilMetaInformation.h"
+
+namespace dawn {
+namespace {
+class VarTypeFinder : public ast::ASTVisitorForwarding {
+  iir::StencilMetaInformation& metadata_;
+
+  // Currently determined variable type.
+  // Unset if visitor is not inside a `VarDeclStmt` or an `AssignmentExpr` to a local variable.
+  std::optional<iir::LocalVariableType> curVarType_;
+
+  void updateVariableType(int accessID, SourceLocation sourceLocation) {
+
+    // Set the variable type (could still be changed when visiting another assignment)
+    iir::LocalVariableData& data = metadata_.getLocalVariableDataFromAccessID(accessID);
+
+    if(data.isTypeSet()) {
+      iir::LocalVariableType previouslyComputedType = data.getType();
+
+      if(previouslyComputedType == iir::LocalVariableType::Scalar) {
+        data.setType(*curVarType_);
+      } else if(previouslyComputedType != *curVarType_) {
+
+        throw std::runtime_error(
+            dawn::format("Invalid assignment to variable at line %d: rhs differs in location type",
+                         sourceLocation.Line));
+      }
+    } else {
+      data.setType(*curVarType_);
+    }
+  }
+
+  void updateCurrentType(iir::LocalVariableType newType, SourceLocation sourceLocation) {
+    if(curVarType_.has_value() && *curVarType_ != iir::LocalVariableType::Scalar &&
+       *curVarType_ != newType) {
+
+      throw std::runtime_error(
+          dawn::format("Invalid assignment to variable at line %d: rhs differs in location type",
+                       sourceLocation.Line));
+    }
+    curVarType_ = newType;
+  }
+
+public:
+  void visit(const std::shared_ptr<iir::FieldAccessExpr>& expr) override {
+    if(curVarType_.has_value()) { // We are inside an assignment to variable / variable declaration
+      iir::LocalVariableType newType;
+      switch(metadata_.getDenseLocationTypeFromAccessID(iir::getAccessID(expr))) {
+      case ast::LocationType::Cells:
+        newType = iir::LocalVariableType::OnCells;
+        break;
+      case ast::LocationType::Edges:
+        newType = iir::LocalVariableType::OnEdges;
+        break;
+      case ast::LocationType::Vertices:
+        newType = iir::LocalVariableType::OnVertices;
+        break;
+      }
+
+      updateCurrentType(newType, expr->getSourceLocation());
+    }
+  }
+  void visit(const std::shared_ptr<iir::VarAccessExpr>& expr) override {
+    if(curVarType_.has_value()) { // We are inside an assignment / variable declaration
+      const iir::LocalVariableData& data =
+          metadata_.getLocalVariableDataFromAccessID(iir::getAccessID(expr));
+      DAWN_ASSERT_MSG(data.isTypeSet(), "Variable accessed before being declared.");
+      iir::LocalVariableType newType = data.getType();
+
+      updateCurrentType(newType, expr->getSourceLocation());
+    }
+  }
+  void visit(const std::shared_ptr<iir::AssignmentExpr>& expr) override {
+    if(expr->getLeft()->getKind() == ast::Expr::Kind::VarAccessExpr) {
+
+      if(curVarType_
+             .has_value()) { // Variable assignment inside variable assignment, not supported.
+        throw std::runtime_error(dawn::format(
+            "Variable assignment inside rhs of variable assignment is not supported. Line %d.",
+            expr->getSourceLocation().Line));
+      }
+
+      // Assume scalar if nothing proves the opposite during the visit
+      curVarType_ = iir::LocalVariableType::Scalar;
+
+      // Visit rhs
+      expr->getRight()->accept(*this);
+
+      updateVariableType(iir::getAccessID(expr->getLeft()), expr->getSourceLocation());
+
+      // Unset varType_ as we are exiting the AssignmentExpr's visit
+      curVarType_ = std::nullopt;
+    }
+  }
+  void visit(const std::shared_ptr<iir::VarDeclStmt>& stmt) override {
+
+    // Assume scalar if nothing proves the opposite during the visit
+    curVarType_ = iir::LocalVariableType::Scalar;
+
+    // Visit rhs
+    ast::ASTVisitorForwarding::visit(stmt);
+
+    updateVariableType(iir::getAccessID(stmt), stmt->getSourceLocation());
+
+    // Unset varType_ as we are exiting the VarDeclStmt's visit
+    curVarType_ = std::nullopt;
+  }
+  VarTypeFinder(iir::StencilMetaInformation& metadata) : metadata_(metadata) {}
+}; // namespace
+} // namespace
+
+bool PassLocalVarType::run(const std::shared_ptr<iir::StencilInstantiation>& stencilInstantiation) {
+  // Loop over all the statements of each stencil
+  for(const auto& stencilPtr : stencilInstantiation->getStencils()) {
+    VarTypeFinder varTypeFinder(stencilInstantiation->getMetaData());
+    for(const auto& stmt : iterateIIROverStmt(*stencilPtr)) {
+      stmt->accept(varTypeFinder);
+    }
+  }
+  return true;
+}
+
+} // namespace dawn

--- a/dawn/src/dawn/Optimizer/PassLocalVarType.cpp
+++ b/dawn/src/dawn/Optimizer/PassLocalVarType.cpp
@@ -49,15 +49,16 @@ class VarTypeFinder : public ast::ASTVisitorForwarding {
 
     iir::LocalVariableData& data = metadata_.getLocalVariableDataFromAccessID(varID);
     if(data.isTypeSet()) {
-      iir::LocalVariableType previouslyComputedType = data.getType();
+      if(newType != iir::LocalVariableType::Scalar) {
+        iir::LocalVariableType previouslyComputedType = data.getType();
 
-      if(previouslyComputedType == iir::LocalVariableType::Scalar) {
-        data.setType(newType);
-      } else if(previouslyComputedType != newType) {
-
-        throw std::runtime_error(
-            dawn::format("Invalid assignment to variable at line %d: rhs differs in location type",
-                         sourceLocation.Line));
+        if(previouslyComputedType == iir::LocalVariableType::Scalar) {
+          data.setType(newType);
+        } else if(previouslyComputedType != newType) {
+          throw std::runtime_error(dawn::format(
+              "Invalid assignment to variable at line %d: rhs differs in location type",
+              sourceLocation.Line));
+        }
       }
     } else {
       data.setType(newType);

--- a/dawn/src/dawn/Optimizer/PassLocalVarType.cpp
+++ b/dawn/src/dawn/Optimizer/PassLocalVarType.cpp
@@ -22,14 +22,6 @@
 namespace dawn {
 namespace {
 
-// Resets types of all variables to "not computed" (type_ = std::nullopt)
-void resetVarTypes(iir::StencilMetaInformation& metadata) {
-  for(const auto& pair : metadata.getAccessIDToLocalVariableDataMap()) {
-    auto& data = metadata.getLocalVariableDataFromAccessID(pair.first);
-    data = iir::LocalVariableData{};
-  }
-}
-
 class VarTypeFinder : public ast::ASTVisitorForwarding {
 
   iir::StencilMetaInformation& metadata_;
@@ -198,7 +190,7 @@ bool PassLocalVarType::run(const std::shared_ptr<iir::StencilInstantiation>& ste
 
     // As this might not be the first run of this pass, need to clear the variables' types in order
     // to recompute them
-    resetVarTypes(stencilInstantiation->getMetaData());
+    stencilInstantiation->getMetaData().resetLocalVarTypes();
 
     for(const auto& doMethod : iterateIIROver<iir::DoMethod>(*stencilPtr)) {
       // Local variables are local to a DoMethod. VarTypeFinder needs to be applied to each DoMethod

--- a/dawn/src/dawn/Optimizer/PassLocalVarType.cpp
+++ b/dawn/src/dawn/Optimizer/PassLocalVarType.cpp
@@ -127,7 +127,9 @@ public:
     }
   }
   void visit(const std::shared_ptr<iir::VarAccessExpr>& expr) override {
-    if(curVarID_.has_value()) { // We are inside an assignment / variable declaration
+    // We are inside an assignment / variable declaration and the current variable accessed is not a
+    // global variable
+    if(curVarID_.has_value() && expr->isLocal()) {
       int accessedVariableID = iir::getAccessID(expr);
       // No self-dependencies
       if(accessedVariableID != *curVarID_) {
@@ -152,7 +154,9 @@ public:
     }
   }
   void visit(const std::shared_ptr<iir::AssignmentExpr>& expr) override {
-    if(expr->getLeft()->getKind() == ast::Expr::Kind::VarAccessExpr) {
+    // Run only when lhs is a local variable
+    if(expr->getLeft()->getKind() == ast::Expr::Kind::VarAccessExpr &&
+       std::dynamic_pointer_cast<iir::VarAccessExpr>(expr->getLeft())->isLocal()) {
 
       if(curVarID_.has_value()) { // Variable assignment inside variable assignment, not supported.
         throw std::runtime_error(dawn::format(

--- a/dawn/src/dawn/Optimizer/PassLocalVarType.cpp
+++ b/dawn/src/dawn/Optimizer/PassLocalVarType.cpp
@@ -132,6 +132,10 @@ public:
       // No self-dependencies
       if(accessedVariableID != *curVarID_) {
 
+        // If the set of dependers for this variable is not there, it means the variable hasn't been
+        // declared
+        DAWN_ASSERT_MSG(dependencyMap_.count(accessedVariableID),
+                        "Variable accessed before being declared.");
         // Need to register a dependency. Pair to be added is from dependency (variable accessed in
         // the rhs) to dependent (lhs).
         dependencyMap_.at(accessedVariableID).insert(*curVarID_);

--- a/dawn/src/dawn/Optimizer/PassLocalVarType.cpp
+++ b/dawn/src/dawn/Optimizer/PassLocalVarType.cpp
@@ -191,10 +191,9 @@ bool PassLocalVarType::run(const std::shared_ptr<iir::StencilInstantiation>& ste
     // to recompute them
     resetVarTypes(stencilInstantiation->getMetaData());
 
-    VarTypeFinder varTypeFinder(stencilInstantiation->getMetaData());
-    // TODO scope of varTypeFinder should be DoMethod's
-    for(const auto& stmt : iterateIIROverStmt(*stencilPtr)) {
-      stmt->accept(varTypeFinder);
+    for(const auto& doMethod : iterateIIROver<iir::DoMethod>(*stencilPtr)) {
+      VarTypeFinder varTypeFinder(stencilInstantiation->getMetaData());
+      doMethod->getAST().accept(varTypeFinder);
     }
   }
   return true;

--- a/dawn/src/dawn/Optimizer/PassLocalVarType.cpp
+++ b/dawn/src/dawn/Optimizer/PassLocalVarType.cpp
@@ -192,6 +192,8 @@ bool PassLocalVarType::run(const std::shared_ptr<iir::StencilInstantiation>& ste
     resetVarTypes(stencilInstantiation->getMetaData());
 
     for(const auto& doMethod : iterateIIROver<iir::DoMethod>(*stencilPtr)) {
+      // Local variables are local to a DoMethod. VarTypeFinder needs to be applied to each DoMethod
+      // separately.
       VarTypeFinder varTypeFinder(stencilInstantiation->getMetaData());
       doMethod->getAST().accept(varTypeFinder);
     }

--- a/dawn/src/dawn/Optimizer/PassLocalVarType.cpp
+++ b/dawn/src/dawn/Optimizer/PassLocalVarType.cpp
@@ -33,105 +33,109 @@ void resetVarTypes(iir::StencilMetaInformation& metadata) {
 class VarTypeFinder : public ast::ASTVisitorForwarding {
   iir::StencilMetaInformation& metadata_;
 
-  // Currently determined variable type.
+  // AccessID of variable being processed.
   // Unset if visitor is not inside a `VarDeclStmt` or an `AssignmentExpr` to a local variable.
-  std::optional<iir::LocalVariableType> curVarType_;
+  std::optional<int> curVarID_;
+  // When assigning to or declaring variable A, each other variable that appears on the rhs is a
+  // dependence of A. This map is from a variable B to all variables that depend on B. A variable
+  // cannot depend on itself.
+  std::unordered_map<int, std::vector<int>> dependencyMap_;
 
-  void updateVariableType(int accessID, SourceLocation sourceLocation) {
+  void updateVariableType(iir::LocalVariableType newType, SourceLocation sourceLocation) {
+    DAWN_ASSERT(curVarID_.has_value());
 
     // Set the variable type (could still be changed when visiting another assignment)
-    iir::LocalVariableData& data = metadata_.getLocalVariableDataFromAccessID(accessID);
+    iir::LocalVariableData& data = metadata_.getLocalVariableDataFromAccessID(*curVarID_);
 
     if(data.isTypeSet()) {
       iir::LocalVariableType previouslyComputedType = data.getType();
 
       if(previouslyComputedType == iir::LocalVariableType::Scalar) {
-        data.setType(*curVarType_);
-      } else if(previouslyComputedType != *curVarType_) {
+        data.setType(newType);
+      } else if(previouslyComputedType != newType) {
 
         throw std::runtime_error(
             dawn::format("Invalid assignment to variable at line %d: rhs differs in location type",
                          sourceLocation.Line));
       }
     } else {
-      data.setType(*curVarType_);
+      data.setType(newType);
     }
-  }
-
-  void updateCurrentType(iir::LocalVariableType newType, SourceLocation sourceLocation) {
-    if(curVarType_.has_value() && *curVarType_ != iir::LocalVariableType::Scalar &&
-       *curVarType_ != newType) {
-
-      throw std::runtime_error(
-          dawn::format("Invalid assignment to variable at line %d: rhs differs in location type",
-                       sourceLocation.Line));
-    }
-    curVarType_ = newType;
   }
 
 public:
   void visit(const std::shared_ptr<iir::FieldAccessExpr>& expr) override {
-    if(curVarType_.has_value()) { // We are inside an assignment to variable / variable declaration
+    if(curVarID_.has_value()) { // We are inside an assignment to variable / variable declaration
       iir::LocalVariableType newType;
-      switch(metadata_.getDenseLocationTypeFromAccessID(iir::getAccessID(expr))) {
-      case ast::LocationType::Cells:
-        newType = iir::LocalVariableType::OnCells;
-        break;
-      case ast::LocationType::Edges:
-        newType = iir::LocalVariableType::OnEdges;
-        break;
-      case ast::LocationType::Vertices:
-        newType = iir::LocalVariableType::OnVertices;
-        break;
+
+      if(sir::dimension_isa<sir::CartesianFieldDimension>(
+             metadata_.getFieldDimensions(iir::getAccessID(expr)).getHorizontalFieldDimension())) {
+        // Cartesian case
+        newType = iir::LocalVariableType::OnIJ;
+      } else {
+        // Unstructured case
+        switch(metadata_.getDenseLocationTypeFromAccessID(iir::getAccessID(expr))) {
+        case ast::LocationType::Cells:
+          newType = iir::LocalVariableType::OnCells;
+          break;
+        case ast::LocationType::Edges:
+          newType = iir::LocalVariableType::OnEdges;
+          break;
+        case ast::LocationType::Vertices:
+          newType = iir::LocalVariableType::OnVertices;
+          break;
+        }
       }
 
-      updateCurrentType(newType, expr->getSourceLocation());
+      updateVariableType(newType, expr->getSourceLocation());
     }
   }
   void visit(const std::shared_ptr<iir::VarAccessExpr>& expr) override {
-    if(curVarType_.has_value()) { // We are inside an assignment / variable declaration
+    if(curVarID_.has_value()) { // We are inside an assignment / variable declaration
+
+      // Need to map dependency between lhs variable and accessed variable
+      // TODO...
+
+      // Retrieve the type of the accessed variable
       const iir::LocalVariableData& data =
           metadata_.getLocalVariableDataFromAccessID(iir::getAccessID(expr));
       DAWN_ASSERT_MSG(data.isTypeSet(), "Variable accessed before being declared.");
       iir::LocalVariableType newType = data.getType();
 
-      updateCurrentType(newType, expr->getSourceLocation());
+      updateVariableType(newType, expr->getSourceLocation());
     }
   }
   void visit(const std::shared_ptr<iir::AssignmentExpr>& expr) override {
     if(expr->getLeft()->getKind() == ast::Expr::Kind::VarAccessExpr) {
 
-      if(curVarType_
-             .has_value()) { // Variable assignment inside variable assignment, not supported.
+      if(curVarID_.has_value()) { // Variable assignment inside variable assignment, not supported.
         throw std::runtime_error(dawn::format(
             "Variable assignment inside rhs of variable assignment is not supported. Line %d.",
             expr->getSourceLocation().Line));
       }
 
       // Assume scalar if nothing proves the opposite during the visit
-      curVarType_ = iir::LocalVariableType::Scalar;
+      curVarID_ = iir::getAccessID(expr->getLeft());
+      updateVariableType(iir::LocalVariableType::Scalar, expr->getSourceLocation());
 
       // Visit rhs
       expr->getRight()->accept(*this);
 
-      updateVariableType(iir::getAccessID(expr->getLeft()), expr->getSourceLocation());
-
-      // Unset varType_ as we are exiting the AssignmentExpr's visit
-      curVarType_ = std::nullopt;
+      // Unset curVarID_ as we are exiting the AssignmentExpr's visit
+      curVarID_ = std::nullopt;
     }
   }
   void visit(const std::shared_ptr<iir::VarDeclStmt>& stmt) override {
 
     // Assume scalar if nothing proves the opposite during the visit
-    curVarType_ = iir::LocalVariableType::Scalar;
+    curVarID_ = iir::getAccessID(stmt);
+    updateVariableType(iir::LocalVariableType::Scalar, stmt->getSourceLocation());
 
     // Visit rhs
     ast::ASTVisitorForwarding::visit(stmt);
 
-    updateVariableType(iir::getAccessID(stmt), stmt->getSourceLocation());
-
-    // Unset varType_ as we are exiting the VarDeclStmt's visit
-    curVarType_ = std::nullopt;
+    // Unset curVarID_ as we are exiting the VarDeclStmt's visit
+    curVarID_ = std::nullopt;
   }
   VarTypeFinder(iir::StencilMetaInformation& metadata) : metadata_(metadata) {}
 };

--- a/dawn/src/dawn/Optimizer/PassLocalVarType.h
+++ b/dawn/src/dawn/Optimizer/PassLocalVarType.h
@@ -24,9 +24,7 @@ namespace dawn {
 /// For unstructured grids this dimension (dense) can be either cells, vertices or edges.
 /// For cartesian grids it's IJ.
 /// @see LocalVariableType
-/// * Input: IIR with unsplit stencils and types of local variables not computed, i.e. unset
-///          (LocalVariableData::type_ == std::nullopt). Map from access id to LocalVariableData
-///          must be filled.
+/// * Input: any IIR. Map from access id to LocalVariableData must be filled.
 /// * Output: same as input but types of all local variables computed (LocalVariableData::type_ !=
 ///           std::nullopt)
 /// @ingroup optimizer

--- a/dawn/src/dawn/Optimizer/PassLocalVarType.h
+++ b/dawn/src/dawn/Optimizer/PassLocalVarType.h
@@ -1,0 +1,43 @@
+//===--------------------------------------------------------------------------------*- C++ -*-===//
+//                          _
+//                         | |
+//                       __| | __ ___      ___ ___
+//                      / _` |/ _` \ \ /\ / / '_  |
+//                     | (_| | (_| |\ V  V /| | | |
+//                      \__,_|\__,_| \_/\_/ |_| |_| - Compiler Toolchain
+//
+//
+//  This file is distributed under the MIT License (MIT).
+//  See LICENSE.txt for details.
+//
+//===------------------------------------------------------------------------------------------===//
+
+#pragma once
+
+#include "Pass.h"
+
+namespace dawn {
+
+/// @brief PassLocalVarType will compute the type of the variable
+/// determining whether it is a scalar or it has an horizontal dimension and,
+/// in the latter case, which dimension it is.
+/// For unstructured grids this dimension (dense) can be either cells, vertices or edges.
+/// For cartesian grids it's IJ.
+/// @see LocalVariableType
+/// * Input: IIR with unsplit stencils and types of local variables not computed, i.e. unset
+///          (LocalVariableData::type_ == std::nullopt). Map from access id to LocalVariableData
+///          must be filled.
+/// * Output: same as input but types of all local variables computed (LocalVariableData::type_ !=
+///           std::nullopt)
+/// @ingroup optimizer
+///
+/// This pass is necessary to generate legal IIR
+class PassLocalVarType : public Pass {
+public:
+  PassLocalVarType(OptimizerContext& context) : Pass(context, "PassLocalVarType") {}
+
+  /// @brief Pass implementation
+  bool run(const std::shared_ptr<iir::StencilInstantiation>& stencilInstantiation) override;
+};
+
+} // namespace dawn

--- a/dawn/src/dawn/Optimizer/PassLocalVarType.h
+++ b/dawn/src/dawn/Optimizer/PassLocalVarType.h
@@ -18,7 +18,7 @@
 
 namespace dawn {
 
-/// @brief PassLocalVarType will compute the type of the variable
+/// @brief PassLocalVarType will compute, for each variable, its type
 /// determining whether it is a scalar or it has an horizontal dimension and,
 /// in the latter case, which dimension it is.
 /// For unstructured grids this dimension (dense) can be either cells, vertices or edges.

--- a/dawn/src/dawn/Optimizer/PassLocalVarType.h
+++ b/dawn/src/dawn/Optimizer/PassLocalVarType.h
@@ -24,7 +24,7 @@ namespace dawn {
 /// For unstructured grids this dimension (dense) can be either cells, vertices or edges.
 /// For cartesian grids it's IJ.
 /// @see LocalVariableType
-/// * Input: any IIR. Map from access id to LocalVariableData must be filled.
+/// * Input:  any IIR. Map from access id to LocalVariableData must be filled.
 /// * Output: same as input but types of all local variables computed (LocalVariableData::type_ !=
 ///           std::nullopt)
 /// @ingroup optimizer

--- a/dawn/src/dawn/Optimizer/StatementMapper.cpp
+++ b/dawn/src/dawn/Optimizer/StatementMapper.cpp
@@ -94,8 +94,12 @@ void StatementMapper::visit(const std::shared_ptr<iir::VarDeclStmt>& stmt) {
   DAWN_ASSERT(initializedWithBlockStmt_);
 
   if(!stmt->getData<iir::VarDeclStmtData>().AccessID) {
-    // This is the first time we encounter this variable. We have to make sure the name is not
-    // already used in another scope!
+    // TODO: this code is almost a duplicate of `StencilMetaInformation::addStmt()`, but here it
+    // differs because it considers also the stencil function case. A common solution should be
+    // found.
+
+    // This is the first time we encounter this variable. We have to make sure the name is
+    // not already used in another scope!
     int accessID = instantiation_->nextUID();
 
     std::string globalName;
@@ -106,10 +110,12 @@ void StatementMapper::visit(const std::shared_ptr<iir::VarDeclStmt>& stmt) {
 
     // We generate a new AccessID and insert it into the AccessMaps (using the global name)
     auto& function = scope_.top()->FunctionInstantiation;
-    if(function)
+    if(function) {
       function->getAccessIDToNameMap().emplace(accessID, globalName);
-    else
+    } else {
       metadata_.addAccessIDNamePair(accessID, globalName);
+      metadata_.addAccessIDToLocalVariableDataPair(accessID, iir::LocalVariableData{});
+    }
 
     stmt->getData<iir::VarDeclStmtData>().AccessID = std::make_optional(accessID);
 

--- a/dawn/src/dawn/Unittest/IIRBuilder.cpp
+++ b/dawn/src/dawn/Unittest/IIRBuilder.cpp
@@ -157,9 +157,10 @@ std::shared_ptr<iir::Expr> IIRBuilder::assignExpr(std::shared_ptr<iir::Expr>&& l
   binop->setID(si_->nextUID());
   return binop;
 }
-IIRBuilder::LocalVar IIRBuilder::localvar(std::string const& name, BuiltinTypeID type) {
+IIRBuilder::LocalVar IIRBuilder::localvar(std::string const& name, BuiltinTypeID type,
+                                          std::vector<std::shared_ptr<iir::Expr>>&& initList) {
   DAWN_ASSERT(si_);
-  auto iirStmt = makeVarDeclStmt(Type{type}, name, 0, "=", std::vector<std::shared_ptr<Expr>>{});
+  auto iirStmt = makeVarDeclStmt(Type{type}, name, 0, "=", std::move(initList));
   int id = si_->getMetaData().addStmt(true, iirStmt);
   return {id, name, iirStmt};
 }

--- a/dawn/src/dawn/Unittest/IIRBuilder.h
+++ b/dawn/src/dawn/Unittest/IIRBuilder.h
@@ -107,14 +107,14 @@ public:
   IIRBuilder(const ast::GridType gridType)
       : si_(std::make_shared<iir::StencilInstantiation>(gridType)) {}
 
-  LocalVar localvar(std::string const& name, BuiltinTypeID = BuiltinTypeID::Float);
+  LocalVar localvar(std::string const& name, BuiltinTypeID = BuiltinTypeID::Float,
+                    std::vector<std::shared_ptr<iir::Expr>>&& initList = {});
 
   template <class TWeight>
-  std::shared_ptr<iir::Expr> reduceOverNeighborExpr(Op operation, std::shared_ptr<iir::Expr>&& rhs,
-                                                    std::shared_ptr<iir::Expr>&& init,
-                                                    ast::LocationType lhs_location,
-                                                    ast::LocationType rhs_location,
-                                                    const std::vector<TWeight>&& weights) {
+  std::shared_ptr<iir::Expr>
+  reduceOverNeighborExpr(Op operation, std::shared_ptr<iir::Expr>&& rhs,
+                         std::shared_ptr<iir::Expr>&& init, ast::LocationType lhs_location,
+                         ast::LocationType rhs_location, const std::vector<TWeight>&& weights) {
     static_assert(std::is_arithmetic<TWeight>::value, "weights need to be of arithmetic type!\n");
 
     std::vector<sir::Value> vWeights;

--- a/dawn/test/unit-test/dawn/Optimizer/Passes/CMakeLists.txt
+++ b/dawn/test/unit-test/dawn/Optimizer/Passes/CMakeLists.txt
@@ -19,6 +19,7 @@ add_executable(${executable}
   TestPassComputeStageExtents.cpp
   TestComputeMaxExtent.cpp
   TestPassCaching.cpp
+  TestPassLocalVarType.cpp
   TestPassSetBoundaryCondition.cpp
   TestFieldAccessIntervals.cpp
   TestTemporaryToFunction.cpp

--- a/dawn/test/unit-test/dawn/Optimizer/Passes/TestPassLocalVarType.cpp
+++ b/dawn/test/unit-test/dawn/Optimizer/Passes/TestPassLocalVarType.cpp
@@ -1,0 +1,59 @@
+//===--------------------------------------------------------------------------------*- C++ -*-===//
+//                          _
+//                         | |
+//                       __| | __ ___      ___ ___
+//                      / _` |/ _` \ \ /\ / / '_  |
+//                     | (_| | (_| |\ V  V /| | | |
+//                      \__,_|\__,_| \_/\_/ |_| |_| - Compiler Toolchain
+//
+//
+//  This file is distributed under the MIT License (MIT).
+//  See LICENSE.txt for details.
+//
+//===------------------------------------------------------------------------------------------===//
+#include "dawn/Compiler/DawnCompiler.h"
+#include "dawn/Optimizer/OptimizerContext.h"
+#include "dawn/Optimizer/PassLocalVarType.h"
+#include "dawn/Unittest/IIRBuilder.h"
+
+#include <gtest/gtest.h>
+
+using namespace dawn;
+
+namespace {
+
+TEST(TestLocalVarType, test_cartesian_01) {
+  using namespace dawn::iir;
+
+  CartesianIIRBuilder b;
+  auto fIJ = b.field("f_ij", FieldType::ij);
+  auto varA = b.localvar("varA", dawn::BuiltinTypeID::Double, {b.lit(3.0)});
+
+  /// storage_ij f_ij;
+  /// double varA = 3.0;
+  /// f_ij = varA;
+
+  auto stencilInstantiationContext = b.build(
+      "generated",
+      b.stencil(b.multistage(
+          dawn::iir::LoopOrderKind::Forward,
+          b.stage(b.doMethod(dawn::sir::Interval::Start, dawn::sir::Interval::End,
+                             b.declareVar(varA), b.stmt(b.assignExpr(b.at(fIJ), b.at(varA))))))));
+  auto stencil = stencilInstantiationContext.at("generated");
+
+  OptimizerContext::OptimizerContextOptions optimizerOptions;
+
+  DawnCompiler compiler;
+  OptimizerContext optimizer(compiler.getDiagnostics(), optimizerOptions,
+                             std::make_shared<dawn::SIR>(ast::GridType::Cartesian));
+
+  // run single pass (PassLocalVarType)
+  PassLocalVarType passLocalVarType(optimizer);
+  passLocalVarType.run(stencil);
+
+  // Need to check that varA has been flagged as scalar
+  int varAID = stencil->getMetaData().getAccessIDFromName("varA");
+  ASSERT_TRUE(stencil->getMetaData().getLocalVariableDataFromAccessID(varAID).isScalar());
+}
+
+} // namespace

--- a/dawn/test/unit-test/dawn/Optimizer/Passes/TestPassLocalVarType.cpp
+++ b/dawn/test/unit-test/dawn/Optimizer/Passes/TestPassLocalVarType.cpp
@@ -52,12 +52,48 @@ TEST(TestLocalVarType, test_cartesian_01) {
   passLocalVarType.run(stencil);
 
   int varAID = stencil->getMetaData().getAccessIDFromName("varA");
-  ASSERT_TRUE(stencil->getMetaData().getLocalVariableDataFromAccessID(varAID).isTypeSet());
   // Need to check that varA has been flagged as scalar
   ASSERT_TRUE(stencil->getMetaData().getLocalVariableDataFromAccessID(varAID).isScalar());
 }
 
 TEST(TestLocalVarType, test_cartesian_02) {
+  using namespace dawn::iir;
+
+  CartesianIIRBuilder b;
+  auto fIJ = b.field("f_ij", FieldType::ij);
+  auto varA = b.localvar("varA", dawn::BuiltinTypeID::Double, {b.lit(3.0)});
+
+  /// storage_ij f_ij;
+  /// double varA = 3.0;
+  /// varA = f_ij;
+  /// f_ij = varA;
+
+  auto stencilInstantiationContext = b.build(
+      "generated",
+      b.stencil(b.multistage(
+          dawn::iir::LoopOrderKind::Forward,
+          b.stage(b.doMethod(dawn::sir::Interval::Start, dawn::sir::Interval::End,
+                             b.declareVar(varA), b.stmt(b.assignExpr(b.at(varA), b.at(fIJ))),
+                             b.stmt(b.assignExpr(b.at(fIJ), b.at(varA))))))));
+  auto stencil = stencilInstantiationContext.at("generated");
+
+  OptimizerContext::OptimizerContextOptions optimizerOptions;
+
+  DawnCompiler compiler;
+  OptimizerContext optimizer(compiler.getDiagnostics(), optimizerOptions,
+                             std::make_shared<dawn::SIR>(ast::GridType::Cartesian));
+
+  // run single pass (PassLocalVarType)
+  PassLocalVarType passLocalVarType(optimizer);
+  passLocalVarType.run(stencil);
+
+  int varAID = stencil->getMetaData().getAccessIDFromName("varA");
+  // Need to check that varA has been flagged as OnIJ
+  ASSERT_TRUE(stencil->getMetaData().getLocalVariableDataFromAccessID(varAID).getType() ==
+              iir::LocalVariableType::OnIJ);
+}
+
+TEST(TestLocalVarType, test_cartesian_propagation_01) {
   using namespace dawn::iir;
 
   CartesianIIRBuilder b;
@@ -90,14 +126,13 @@ TEST(TestLocalVarType, test_cartesian_02) {
 
   int varAID = stencil->getMetaData().getAccessIDFromName("varA");
   int varBID = stencil->getMetaData().getAccessIDFromName("varB");
-  ASSERT_TRUE(stencil->getMetaData().getLocalVariableDataFromAccessID(varAID).isTypeSet());
   // Need to check that varA has been flagged as scalar
   ASSERT_TRUE(stencil->getMetaData().getLocalVariableDataFromAccessID(varAID).isScalar());
   // Need to check that varB has been flagged as scalar
   ASSERT_TRUE(stencil->getMetaData().getLocalVariableDataFromAccessID(varBID).isScalar());
 }
 
-TEST(TestLocalVarType, test_cartesian_03) {
+TEST(TestLocalVarType, test_cartesian_propagation_02) {
   using namespace dawn::iir;
 
   CartesianIIRBuilder b;
@@ -132,7 +167,6 @@ TEST(TestLocalVarType, test_cartesian_03) {
 
   int varAID = stencil->getMetaData().getAccessIDFromName("varA");
   int varBID = stencil->getMetaData().getAccessIDFromName("varB");
-  ASSERT_TRUE(stencil->getMetaData().getLocalVariableDataFromAccessID(varAID).isTypeSet());
   // Need to check that varA has been flagged as IJ
   ASSERT_TRUE(stencil->getMetaData().getLocalVariableDataFromAccessID(varAID).getType() ==
               iir::LocalVariableType::OnIJ);
@@ -141,4 +175,287 @@ TEST(TestLocalVarType, test_cartesian_03) {
               iir::LocalVariableType::OnIJ);
 }
 
+TEST(TestLocalVarType, test_cartesian_propagation_03) {
+  using namespace dawn::iir;
+
+  CartesianIIRBuilder b;
+  auto fIJ = b.field("f_ij", FieldType::ij);
+  auto varA = b.localvar("varA", dawn::BuiltinTypeID::Double, {b.lit(3.0)});
+  auto varB = b.localvar("varB", dawn::BuiltinTypeID::Double, {b.lit(1.0)});
+  auto varC = b.localvar("varC", dawn::BuiltinTypeID::Double, {b.lit(2.0)});
+  auto varD = b.localvar("varD", dawn::BuiltinTypeID::Double, {b.at(varC)});
+
+  /// storage_ij f_ij;
+  /// double varA = 3.0;
+  /// double varB = 1.0;
+  /// double varC = 2.0;
+  /// double varD = varC;
+  /// varB = varA;
+  /// varD = varB;
+  /// f_ij = varD;
+
+  auto stencilInstantiationContext = b.build(
+      "generated",
+      b.stencil(b.multistage(
+          dawn::iir::LoopOrderKind::Forward,
+          b.stage(b.doMethod(dawn::sir::Interval::Start, dawn::sir::Interval::End,
+                             b.declareVar(varA), b.declareVar(varB), b.declareVar(varC),
+                             b.declareVar(varD), b.stmt(b.assignExpr(b.at(varB), b.at(varA))),
+                             b.stmt(b.assignExpr(b.at(varD), b.at(varB))),
+                             b.stmt(b.assignExpr(b.at(fIJ), b.at(varD))))))));
+  auto stencil = stencilInstantiationContext.at("generated");
+
+  OptimizerContext::OptimizerContextOptions optimizerOptions;
+
+  DawnCompiler compiler;
+  OptimizerContext optimizer(compiler.getDiagnostics(), optimizerOptions,
+                             std::make_shared<dawn::SIR>(ast::GridType::Cartesian));
+
+  // run single pass (PassLocalVarType)
+  PassLocalVarType passLocalVarType(optimizer);
+  passLocalVarType.run(stencil);
+
+  int varAID = stencil->getMetaData().getAccessIDFromName("varA");
+  int varBID = stencil->getMetaData().getAccessIDFromName("varB");
+  int varCID = stencil->getMetaData().getAccessIDFromName("varC");
+  int varDID = stencil->getMetaData().getAccessIDFromName("varD");
+  // Need to check that varA has been flagged as scalar
+  ASSERT_TRUE(stencil->getMetaData().getLocalVariableDataFromAccessID(varAID).isScalar());
+  // Need to check that varB has been flagged as scalar
+  ASSERT_TRUE(stencil->getMetaData().getLocalVariableDataFromAccessID(varBID).isScalar());
+  // Need to check that varC has been flagged as scalar
+  ASSERT_TRUE(stencil->getMetaData().getLocalVariableDataFromAccessID(varCID).isScalar());
+  // Need to check that varD has been flagged as scalar
+  ASSERT_TRUE(stencil->getMetaData().getLocalVariableDataFromAccessID(varDID).isScalar());
+}
+
+TEST(TestLocalVarType, test_cartesian_propagation_04) {
+  using namespace dawn::iir;
+
+  CartesianIIRBuilder b;
+  auto fIJ = b.field("f_ij", FieldType::ij);
+  auto varA = b.localvar("varA", dawn::BuiltinTypeID::Double, {b.lit(3.0)});
+  auto varB = b.localvar("varB", dawn::BuiltinTypeID::Double, {b.lit(1.0)});
+  auto varC = b.localvar("varC", dawn::BuiltinTypeID::Double, {b.lit(2.0)});
+  auto varD = b.localvar("varD", dawn::BuiltinTypeID::Double, {b.at(varC)});
+
+  /// storage_ij f_ij;
+  /// double varA = 3.0;
+  /// double varB = 1.0;
+  /// double varC = 2.0;
+  /// double varD = varC;
+  /// varB = varA;
+  /// varD = varB;
+  /// varB = f_ij;
+  /// f_ij = varD;
+
+  auto stencilInstantiationContext = b.build(
+      "generated",
+      b.stencil(b.multistage(
+          dawn::iir::LoopOrderKind::Forward,
+          b.stage(b.doMethod(dawn::sir::Interval::Start, dawn::sir::Interval::End,
+                             b.declareVar(varA), b.declareVar(varB), b.declareVar(varC),
+                             b.declareVar(varD), b.stmt(b.assignExpr(b.at(varB), b.at(varA))),
+                             b.stmt(b.assignExpr(b.at(varD), b.at(varB))),
+                             b.stmt(b.assignExpr(b.at(varB), b.at(fIJ))),
+                             b.stmt(b.assignExpr(b.at(fIJ), b.at(varD))))))));
+  auto stencil = stencilInstantiationContext.at("generated");
+
+  OptimizerContext::OptimizerContextOptions optimizerOptions;
+
+  DawnCompiler compiler;
+  OptimizerContext optimizer(compiler.getDiagnostics(), optimizerOptions,
+                             std::make_shared<dawn::SIR>(ast::GridType::Cartesian));
+
+  // run single pass (PassLocalVarType)
+  PassLocalVarType passLocalVarType(optimizer);
+  passLocalVarType.run(stencil);
+
+  int varAID = stencil->getMetaData().getAccessIDFromName("varA");
+  int varBID = stencil->getMetaData().getAccessIDFromName("varB");
+  int varCID = stencil->getMetaData().getAccessIDFromName("varC");
+  int varDID = stencil->getMetaData().getAccessIDFromName("varD");
+  // Need to check that varA has been flagged as scalar
+  ASSERT_TRUE(stencil->getMetaData().getLocalVariableDataFromAccessID(varAID).isScalar());
+  // Need to check that varB has been flagged as OnIJ
+  ASSERT_TRUE(stencil->getMetaData().getLocalVariableDataFromAccessID(varBID).getType() ==
+              iir::LocalVariableType::OnIJ);
+  // Need to check that varC has been flagged as scalar
+  ASSERT_TRUE(stencil->getMetaData().getLocalVariableDataFromAccessID(varCID).isScalar());
+  // Need to check that varD has been flagged as OnIJ
+  ASSERT_TRUE(stencil->getMetaData().getLocalVariableDataFromAccessID(varDID).getType() ==
+              iir::LocalVariableType::OnIJ);
+}
+
+TEST(TestLocalVarType, test_unstructured_propagation_01) {
+  using namespace dawn::iir;
+
+  UnstructuredIIRBuilder b;
+  auto f_c = b.field("f_c", ast::LocationType::Cells);
+  auto f_e = b.field("f_e", ast::LocationType::Edges);
+  auto varA = b.localvar("varA", dawn::BuiltinTypeID::Double, {b.lit(3.0)});
+  auto varB = b.localvar("varB", dawn::BuiltinTypeID::Double, {b.lit(2.0)});
+  auto varC = b.localvar("varC", dawn::BuiltinTypeID::Double, {b.at(f_e)});
+  auto varD = b.localvar("varD", dawn::BuiltinTypeID::Double, {b.lit(3.0)});
+
+  /// field(cells) f_c;
+  /// field(edges) f_e;
+  /// double varA = 3.0;
+  /// double varB = 2.0;
+  /// double varC = f_e;
+  /// double varD = 3.0;
+  /// varA = varB;
+  /// varB = varD;
+  /// varD = f_c;
+
+  auto stencilInstantiationContext = b.build(
+      "generated",
+      b.stencil(b.multistage(
+          dawn::iir::LoopOrderKind::Forward,
+          b.stage(b.doMethod(dawn::sir::Interval::Start, dawn::sir::Interval::End,
+                             b.declareVar(varA), b.declareVar(varB), b.declareVar(varC),
+                             b.declareVar(varD), b.stmt(b.assignExpr(b.at(varA), b.at(varB))),
+                             b.stmt(b.assignExpr(b.at(varB), b.at(varD))),
+                             b.stmt(b.assignExpr(b.at(varD), b.at(f_c))))))));
+  auto stencil = stencilInstantiationContext.at("generated");
+
+  OptimizerContext::OptimizerContextOptions optimizerOptions;
+
+  DawnCompiler compiler;
+  OptimizerContext optimizer(compiler.getDiagnostics(), optimizerOptions,
+                             std::make_shared<dawn::SIR>(ast::GridType::Unstructured));
+
+  // run single pass (PassLocalVarType) and expect exception to be thrown
+  PassLocalVarType passLocalVarType(optimizer);
+  passLocalVarType.run(stencil);
+
+  int varAID = stencil->getMetaData().getAccessIDFromName("varA");
+  int varBID = stencil->getMetaData().getAccessIDFromName("varB");
+  int varCID = stencil->getMetaData().getAccessIDFromName("varC");
+  int varDID = stencil->getMetaData().getAccessIDFromName("varD");
+  // Need to check that varA has been flagged as OnCells
+  ASSERT_TRUE(stencil->getMetaData().getLocalVariableDataFromAccessID(varAID).getLocationType() ==
+              ast::LocationType::Cells);
+  // Need to check that varB has been flagged as OnCells
+  ASSERT_TRUE(stencil->getMetaData().getLocalVariableDataFromAccessID(varBID).getLocationType() ==
+              ast::LocationType::Cells);
+  // Need to check that varC has been flagged as OnEdges
+  ASSERT_TRUE(stencil->getMetaData().getLocalVariableDataFromAccessID(varCID).getLocationType() ==
+              ast::LocationType::Edges);
+  // Need to check that varD has been flagged as OnCells
+  ASSERT_TRUE(stencil->getMetaData().getLocalVariableDataFromAccessID(varDID).getLocationType() ==
+              ast::LocationType::Cells);
+}
+
+TEST(TestLocalVarType, test_throw_unstructured_01) {
+  using namespace dawn::iir;
+
+  UnstructuredIIRBuilder b;
+  auto f_c = b.field("f_c", ast::LocationType::Cells);
+  auto f_e = b.field("f_e", ast::LocationType::Edges);
+  auto varA = b.localvar("varA", dawn::BuiltinTypeID::Double, {b.at(f_c)});
+
+  /// field(cells) f_c;
+  /// field(edges) f_e;
+  /// double varA = f_c;
+  /// varA = f_e;
+
+  auto stencilInstantiationContext = b.build(
+      "generated",
+      b.stencil(b.multistage(
+          dawn::iir::LoopOrderKind::Forward,
+          b.stage(b.doMethod(dawn::sir::Interval::Start, dawn::sir::Interval::End,
+                             b.declareVar(varA), b.stmt(b.assignExpr(b.at(varA), b.at(f_e))))))));
+  auto stencil = stencilInstantiationContext.at("generated");
+
+  OptimizerContext::OptimizerContextOptions optimizerOptions;
+
+  DawnCompiler compiler;
+  OptimizerContext optimizer(compiler.getDiagnostics(), optimizerOptions,
+                             std::make_shared<dawn::SIR>(ast::GridType::Unstructured));
+
+  // run single pass (PassLocalVarType) and expect exception to be thrown
+  PassLocalVarType passLocalVarType(optimizer);
+  EXPECT_THROW(passLocalVarType.run(stencil), std::runtime_error);
+}
+
+TEST(TestLocalVarType, test_throw_unstructured_02) {
+  using namespace dawn::iir;
+
+  UnstructuredIIRBuilder b;
+  auto f_c = b.field("f_c", ast::LocationType::Cells);
+  auto f_e = b.field("f_e", ast::LocationType::Edges);
+  auto varA = b.localvar("varA", dawn::BuiltinTypeID::Double, {b.lit(3.0)});
+  auto varB = b.localvar("varB", dawn::BuiltinTypeID::Double, {b.lit(2.0)});
+
+  /// field(cells) f_c;
+  /// field(edges) f_e;
+  /// double varA = 3.0;
+  /// double varB = 2.0;
+  /// varB = f_e + varA;
+  /// varA = f_c;
+
+  auto stencilInstantiationContext = b.build(
+      "generated",
+      b.stencil(b.multistage(
+          dawn::iir::LoopOrderKind::Forward,
+          b.stage(b.doMethod(dawn::sir::Interval::Start, dawn::sir::Interval::End,
+                             b.declareVar(varA), b.declareVar(varB),
+                             b.stmt(b.assignExpr(b.at(varB), b.binaryExpr(b.at(f_e), b.at(varA)))),
+                             b.stmt(b.assignExpr(b.at(varA), b.at(f_c))))))));
+  auto stencil = stencilInstantiationContext.at("generated");
+
+  OptimizerContext::OptimizerContextOptions optimizerOptions;
+
+  DawnCompiler compiler;
+  OptimizerContext optimizer(compiler.getDiagnostics(), optimizerOptions,
+                             std::make_shared<dawn::SIR>(ast::GridType::Unstructured));
+
+  // run single pass (PassLocalVarType) and expect exception to be thrown
+  PassLocalVarType passLocalVarType(optimizer);
+  EXPECT_THROW(passLocalVarType.run(stencil), std::runtime_error);
+}
+
+TEST(TestLocalVarType, test_throw_unstructured_03) {
+  using namespace dawn::iir;
+
+  UnstructuredIIRBuilder b;
+  auto f_c = b.field("f_c", ast::LocationType::Cells);
+  auto f_e = b.field("f_e", ast::LocationType::Edges);
+  auto varA = b.localvar("varA", dawn::BuiltinTypeID::Double, {b.lit(3.0)});
+  auto varB = b.localvar("varB", dawn::BuiltinTypeID::Double, {b.lit(2.0)});
+  auto varC = b.localvar("varC", dawn::BuiltinTypeID::Double, {b.lit(1.0)});
+
+  /// field(cells) f_c;
+  /// field(edges) f_e;
+  /// double varA = 3.0;
+  /// double varB = 2.0;
+  /// double varC = 1.0;
+  /// varB = varA;
+  /// varC = varB;
+  /// varA = f_c;
+  /// varC = f_e;
+
+  auto stencilInstantiationContext =
+      b.build("generated",
+              b.stencil(b.multistage(
+                  dawn::iir::LoopOrderKind::Forward,
+                  b.stage(b.doMethod(dawn::sir::Interval::Start, dawn::sir::Interval::End,
+                                     b.declareVar(varA), b.declareVar(varB), b.declareVar(varC),
+                                     b.stmt(b.assignExpr(b.at(varB), b.at(varA))),
+                                     b.stmt(b.assignExpr(b.at(varC), b.at(varB))),
+                                     b.stmt(b.assignExpr(b.at(varA), b.at(f_c))),
+                                     b.stmt(b.assignExpr(b.at(varC), b.at(f_e))))))));
+  auto stencil = stencilInstantiationContext.at("generated");
+
+  OptimizerContext::OptimizerContextOptions optimizerOptions;
+
+  DawnCompiler compiler;
+  OptimizerContext optimizer(compiler.getDiagnostics(), optimizerOptions,
+                             std::make_shared<dawn::SIR>(ast::GridType::Unstructured));
+
+  // run single pass (PassLocalVarType) and expect exception to be thrown
+  PassLocalVarType passLocalVarType(optimizer);
+  EXPECT_THROW(passLocalVarType.run(stencil), std::runtime_error);
+}
 } // namespace

--- a/dawn/test/unit-test/dawn/Optimizer/Passes/TestPassLocalVarType.cpp
+++ b/dawn/test/unit-test/dawn/Optimizer/Passes/TestPassLocalVarType.cpp
@@ -51,9 +51,94 @@ TEST(TestLocalVarType, test_cartesian_01) {
   PassLocalVarType passLocalVarType(optimizer);
   passLocalVarType.run(stencil);
 
-  // Need to check that varA has been flagged as scalar
   int varAID = stencil->getMetaData().getAccessIDFromName("varA");
+  ASSERT_TRUE(stencil->getMetaData().getLocalVariableDataFromAccessID(varAID).isTypeSet());
+  // Need to check that varA has been flagged as scalar
   ASSERT_TRUE(stencil->getMetaData().getLocalVariableDataFromAccessID(varAID).isScalar());
+}
+
+TEST(TestLocalVarType, test_cartesian_02) {
+  using namespace dawn::iir;
+
+  CartesianIIRBuilder b;
+  auto fIJ = b.field("f_ij", FieldType::ij);
+  auto varA = b.localvar("varA", dawn::BuiltinTypeID::Double, {b.lit(3.0)});
+  auto varB = b.localvar("varB", dawn::BuiltinTypeID::Double, {b.at(varA)});
+
+  /// storage_ij f_ij;
+  /// double varA = 3.0;
+  /// double varB = varA;
+  /// f_ij = varB;
+
+  auto stencilInstantiationContext = b.build(
+      "generated", b.stencil(b.multistage(
+                       dawn::iir::LoopOrderKind::Forward,
+                       b.stage(b.doMethod(dawn::sir::Interval::Start, dawn::sir::Interval::End,
+                                          b.declareVar(varA), b.declareVar(varB),
+                                          b.stmt(b.assignExpr(b.at(fIJ), b.at(varB))))))));
+  auto stencil = stencilInstantiationContext.at("generated");
+
+  OptimizerContext::OptimizerContextOptions optimizerOptions;
+
+  DawnCompiler compiler;
+  OptimizerContext optimizer(compiler.getDiagnostics(), optimizerOptions,
+                             std::make_shared<dawn::SIR>(ast::GridType::Cartesian));
+
+  // run single pass (PassLocalVarType)
+  PassLocalVarType passLocalVarType(optimizer);
+  passLocalVarType.run(stencil);
+
+  int varAID = stencil->getMetaData().getAccessIDFromName("varA");
+  int varBID = stencil->getMetaData().getAccessIDFromName("varB");
+  ASSERT_TRUE(stencil->getMetaData().getLocalVariableDataFromAccessID(varAID).isTypeSet());
+  // Need to check that varA has been flagged as scalar
+  ASSERT_TRUE(stencil->getMetaData().getLocalVariableDataFromAccessID(varAID).isScalar());
+  // Need to check that varB has been flagged as scalar
+  ASSERT_TRUE(stencil->getMetaData().getLocalVariableDataFromAccessID(varBID).isScalar());
+}
+
+TEST(TestLocalVarType, test_cartesian_03) {
+  using namespace dawn::iir;
+
+  CartesianIIRBuilder b;
+  auto fIJ = b.field("f_ij", FieldType::ij);
+  auto varA = b.localvar("varA", dawn::BuiltinTypeID::Double, {b.lit(3.0)});
+  auto varB = b.localvar("varB", dawn::BuiltinTypeID::Double, {b.at(varA)});
+
+  /// storage_ij f_ij;
+  /// double varA = 3.0;
+  /// double varB = varA;
+  /// varA = f_ij;
+  /// f_ij = varB;
+
+  auto stencilInstantiationContext = b.build(
+      "generated", b.stencil(b.multistage(
+                       dawn::iir::LoopOrderKind::Forward,
+                       b.stage(b.doMethod(dawn::sir::Interval::Start, dawn::sir::Interval::End,
+                                          b.declareVar(varA), b.declareVar(varB),
+                                          b.stmt(b.assignExpr(b.at(varA), b.at(fIJ))),
+                                          b.stmt(b.assignExpr(b.at(fIJ), b.at(varB))))))));
+  auto stencil = stencilInstantiationContext.at("generated");
+
+  OptimizerContext::OptimizerContextOptions optimizerOptions;
+
+  DawnCompiler compiler;
+  OptimizerContext optimizer(compiler.getDiagnostics(), optimizerOptions,
+                             std::make_shared<dawn::SIR>(ast::GridType::Cartesian));
+
+  // run single pass (PassLocalVarType)
+  PassLocalVarType passLocalVarType(optimizer);
+  passLocalVarType.run(stencil);
+
+  int varAID = stencil->getMetaData().getAccessIDFromName("varA");
+  int varBID = stencil->getMetaData().getAccessIDFromName("varB");
+  ASSERT_TRUE(stencil->getMetaData().getLocalVariableDataFromAccessID(varAID).isTypeSet());
+  // Need to check that varA has been flagged as IJ
+  ASSERT_TRUE(stencil->getMetaData().getLocalVariableDataFromAccessID(varAID).getType() ==
+              iir::LocalVariableType::OnIJ);
+  // Need to check that varB has been flagged as IJ
+  ASSERT_TRUE(stencil->getMetaData().getLocalVariableDataFromAccessID(varBID).getType() ==
+              iir::LocalVariableType::OnIJ);
 }
 
 } // namespace

--- a/dawn/test/unit-test/dawn/Validator/TestGridTypeChecker.cpp
+++ b/dawn/test/unit-test/dawn/Validator/TestGridTypeChecker.cpp
@@ -58,4 +58,37 @@ TEST(GridTypeCheckerTest, MixedGridTypes) {
   bool consistent = checker.checkGridTypeConsistency(*si->getIIR());
   ASSERT_FALSE(consistent);
 }
+
+TEST(GridTypeCheckerTest, LocalVariableDataMixed) {
+  using namespace dawn::iir;
+  using LocType = dawn::ast::LocationType;
+
+  std::string stencilName("LocalVariableDataMixed");
+
+  UnstructuredIIRBuilder b;
+  auto cell_fA = b.field("cell_field_a", LocType::Cells);
+  auto cell_fB = b.field("cell_field_b", LocType::Cells);
+  auto varA = b.localvar("varA");
+
+  // lets build a consistent stencil
+  auto stencilContext =
+      b.build(stencilName.c_str(),
+              b.stencil(b.multistage(
+                  LoopOrderKind::Parallel,
+                  b.stage(b.doMethod(dawn::sir::Interval::Start, dawn::sir::Interval::End,
+                                     b.declareVar(varA),
+                                     b.stmt(b.assignExpr(b.at(cell_fA), b.at(cell_fB))))))));
+
+  // extract the stencil instantiation
+  auto si = stencilContext[stencilName.c_str()];
+
+  // lets manually add a LocalVariableData with a cartesian type (OnIJ)
+  si->getMetaData().addAccessIDToLocalVariableDataPair(varA.id, iir::LocalVariableData{});
+  si->getMetaData().getLocalVariableDataFromAccessID(varA.id).setType(iir::LocalVariableType::OnIJ);
+
+  // lets ensure that the grid type checking now fails
+  GridTypeChecker checker;
+  bool consistent = checker.checkGridTypeConsistency(*si->getIIR());
+  ASSERT_FALSE(consistent);
+}
 } // namespace


### PR DESCRIPTION
## Technical Description

- Add `LocalVariableData` (data container for a local variable) and `LocalVariableType` which can be `Scalar, OnCells, OnEdges, OnVertices, OnIJ`.
- Add pass (and unit tests) `PassLocalVariableType` to determine the type of a local variable.
- Add map from access ID of variable to `LocalVariableData` in metadata (not serialized).
- Add helper method `StencilMetaInformation::declareVar()` to declare a variable (same as `StencilMetaInformation::addStmt()` but doesn't require a `VarDeclStmt` in input).
- In `GridTypeChecker` check if all variable types match the grid type.

### Resolves / Enhances

resolves #669 
