### PR TITLE
Return StencilInstantiation from IIRBuilder

### DIFF
--- a/dawn/src/dawn/Unittest/CompilerUtil.cpp
+++ b/dawn/src/dawn/Unittest/CompilerUtil.cpp
@@ -14,6 +14,10 @@
 
 #include "dawn/Unittest/CompilerUtil.h"
 
+#include "dawn/CodeGen/CXXNaive-ico/CXXNaiveCodeGen.h"
+#include "dawn/CodeGen/CXXNaive/CXXNaiveCodeGen.h"
+#include "dawn/CodeGen/Cuda/CudaCodeGen.h"
+
 namespace dawn {
 
 const std::shared_ptr<iir::StencilInstantiation>
@@ -53,10 +57,9 @@ stencilInstantiationContext CompilerUtil::compile(const std::string& sirFile) {
   return compile(SIRSerializer::deserialize("input/globals_opt_away.sir"));
 }
 
-void CompilerUtil::dumpNaive(std::ostream& os, dawn::codegen::stencilInstantiationContext& ctx) {
-  using CG = dawn::codegen::cxxnaive::CXXNaiveCodeGen;
-  dawn::DiagnosticsEngine diagnostics;
-  CG generator(ctx, diagnostics, 0);
+namespace {
+template <typename CG>
+void dump(CG& generator, std::ostream& os, std::shared_ptr<iir::StencilInstantiation> si) {
   auto tu = generator.generateCode();
 
   std::ostringstream ss;
@@ -69,20 +72,31 @@ void CompilerUtil::dumpNaive(std::ostream& os, dawn::codegen::stencilInstantiati
   os << ss.str();
 }
 
-void CompilerUtil::dumpCuda(std::ostream& os, dawn::codegen::stencilInstantiationContext& ctx) {
-  using CG = dawn::codegen::cuda::CudaCodeGen;
+dawn::codegen::stencilInstantiationContext
+si_to_context(std::shared_ptr<iir::StencilInstantiation> si) {
+  dawn::codegen::stencilInstantiationContext ctx;
+  ctx[si->getName()] = std::move(si);
+  return ctx;
+}
+
+} // namespace
+
+void CompilerUtil::dumpNaive(std::ostream& os, std::shared_ptr<iir::StencilInstantiation> si) {
   dawn::DiagnosticsEngine diagnostics;
-  CG generator(ctx, diagnostics, 0, 0, 0, {0, 0, 0});
-  auto tu = generator.generateCode();
+  dawn::codegen::cxxnaive::CXXNaiveCodeGen generator(si_to_context(si), diagnostics, 0);
+  dump(generator, os, si);
+}
 
-  std::ostringstream ss;
-  for(auto const& macroDefine : tu->getPPDefines())
-    ss << macroDefine << "\n";
+void CompilerUtil::dumpNaiveIco(std::ostream& os, std::shared_ptr<iir::StencilInstantiation> si) {
+  dawn::DiagnosticsEngine diagnostics;
+  dawn::codegen::cxxnaiveico::CXXNaiveIcoCodeGen generator(si_to_context(si), diagnostics, 0);
+  dump(generator, os, si);
+}
 
-  ss << tu->getGlobals();
-  for(auto const& s : tu->getStencils())
-    ss << s.second;
-  os << ss.str();
+void CompilerUtil::dumpCuda(std::ostream& os, std::shared_ptr<iir::StencilInstantiation> si) {
+  dawn::DiagnosticsEngine diagnostics;
+  dawn::codegen::cuda::CudaCodeGen generator(si_to_context(si), diagnostics, 0, 0, 0, {0, 0, 0});
+  dump(generator, os, si);
 }
 
 } // namespace dawn

--- a/dawn/src/dawn/Unittest/CompilerUtil.cpp
+++ b/dawn/src/dawn/Unittest/CompilerUtil.cpp
@@ -59,7 +59,7 @@ stencilInstantiationContext CompilerUtil::compile(const std::string& sirFile) {
 
 namespace {
 template <typename CG>
-void dump(CG& generator, std::ostream& os, std::shared_ptr<iir::StencilInstantiation> si) {
+void dump(CG& generator, std::ostream& os) {
   auto tu = generator.generateCode();
 
   std::ostringstream ss;
@@ -75,7 +75,7 @@ void dump(CG& generator, std::ostream& os, std::shared_ptr<iir::StencilInstantia
 dawn::codegen::stencilInstantiationContext
 siToContext(std::shared_ptr<iir::StencilInstantiation> si) {
   dawn::codegen::stencilInstantiationContext ctx;
-  ctx[si->getName()] = std::move(si);
+  ctx[si->getName()] = si;
   return ctx;
 }
 
@@ -83,20 +83,23 @@ siToContext(std::shared_ptr<iir::StencilInstantiation> si) {
 
 void CompilerUtil::dumpNaive(std::ostream& os, std::shared_ptr<iir::StencilInstantiation> si) {
   dawn::DiagnosticsEngine diagnostics;
-  dawn::codegen::cxxnaive::CXXNaiveCodeGen generator(siToContext(si), diagnostics, 0);
-  dump(generator, os, si);
+  auto ctx = siToContext(si);
+  dawn::codegen::cxxnaive::CXXNaiveCodeGen generator(ctx, diagnostics, 0);
+  dump(generator, os);
 }
 
 void CompilerUtil::dumpNaiveIco(std::ostream& os, std::shared_ptr<iir::StencilInstantiation> si) {
   dawn::DiagnosticsEngine diagnostics;
-  dawn::codegen::cxxnaiveico::CXXNaiveIcoCodeGen generator(siToContext(si), diagnostics, 0);
-  dump(generator, os, si);
+  auto ctx = siToContext(si);
+  dawn::codegen::cxxnaiveico::CXXNaiveIcoCodeGen generator(ctx, diagnostics, 0);
+  dump(generator, os);
 }
 
 void CompilerUtil::dumpCuda(std::ostream& os, std::shared_ptr<iir::StencilInstantiation> si) {
   dawn::DiagnosticsEngine diagnostics;
-  dawn::codegen::cuda::CudaCodeGen generator(siToContext(si), diagnostics, 0, 0, 0, {0, 0, 0});
-  dump(generator, os, si);
+  auto ctx = siToContext(si);
+  dawn::codegen::cuda::CudaCodeGen generator(ctx, diagnostics, 0, 0, 0, {0, 0, 0});
+  dump(generator, os);
 }
 
 } // namespace dawn

--- a/dawn/src/dawn/Unittest/CompilerUtil.cpp
+++ b/dawn/src/dawn/Unittest/CompilerUtil.cpp
@@ -73,7 +73,7 @@ void dump(CG& generator, std::ostream& os, std::shared_ptr<iir::StencilInstantia
 }
 
 dawn::codegen::stencilInstantiationContext
-si_to_context(std::shared_ptr<iir::StencilInstantiation> si) {
+siToContext(std::shared_ptr<iir::StencilInstantiation> si) {
   dawn::codegen::stencilInstantiationContext ctx;
   ctx[si->getName()] = std::move(si);
   return ctx;
@@ -83,19 +83,19 @@ si_to_context(std::shared_ptr<iir::StencilInstantiation> si) {
 
 void CompilerUtil::dumpNaive(std::ostream& os, std::shared_ptr<iir::StencilInstantiation> si) {
   dawn::DiagnosticsEngine diagnostics;
-  dawn::codegen::cxxnaive::CXXNaiveCodeGen generator(si_to_context(si), diagnostics, 0);
+  dawn::codegen::cxxnaive::CXXNaiveCodeGen generator(siToContext(si), diagnostics, 0);
   dump(generator, os, si);
 }
 
 void CompilerUtil::dumpNaiveIco(std::ostream& os, std::shared_ptr<iir::StencilInstantiation> si) {
   dawn::DiagnosticsEngine diagnostics;
-  dawn::codegen::cxxnaiveico::CXXNaiveIcoCodeGen generator(si_to_context(si), diagnostics, 0);
+  dawn::codegen::cxxnaiveico::CXXNaiveIcoCodeGen generator(siToContext(si), diagnostics, 0);
   dump(generator, os, si);
 }
 
 void CompilerUtil::dumpCuda(std::ostream& os, std::shared_ptr<iir::StencilInstantiation> si) {
   dawn::DiagnosticsEngine diagnostics;
-  dawn::codegen::cuda::CudaCodeGen generator(si_to_context(si), diagnostics, 0, 0, 0, {0, 0, 0});
+  dawn::codegen::cuda::CudaCodeGen generator(siToContext(si), diagnostics, 0, 0, 0, {0, 0, 0});
   dump(generator, os, si);
 }
 

--- a/dawn/src/dawn/Unittest/CompilerUtil.h
+++ b/dawn/src/dawn/Unittest/CompilerUtil.h
@@ -15,16 +15,16 @@
 #ifndef DAWN_UNITTEST_COMPILERUTIL_H
 #define DAWN_UNITTEST_COMPILERUTIL_H
 
-#include "dawn/CodeGen/CXXNaive/CXXNaiveCodeGen.h"
 #include "dawn/CodeGen/CodeGen.h"
-#include "dawn/CodeGen/Cuda/CudaCodeGen.h"
 #include "dawn/Compiler/DawnCompiler.h"
 #include "dawn/Compiler/Options.h"
+#include "dawn/IIR/StencilInstantiation.h"
 #include "dawn/Serialization/IIRSerializer.h"
 #include "dawn/Serialization/SIRSerializer.h"
 
 #include <fstream>
 #include <iostream>
+#include <string>
 
 namespace dawn {
 
@@ -41,8 +41,9 @@ public:
   load(const std::string& iirFilename,
        const dawn::OptimizerContext::OptimizerContextOptions& options,
        std::unique_ptr<OptimizerContext>& context);
-  static void dumpNaive(std::ostream& os, dawn::codegen::stencilInstantiationContext& ctx);
-  static void dumpCuda(std::ostream& os, dawn::codegen::stencilInstantiationContext& ctx);
+  static void dumpNaive(std::ostream& os, std::shared_ptr<iir::StencilInstantiation> si);
+  static void dumpNaiveIco(std::ostream& os, std::shared_ptr<iir::StencilInstantiation> si);
+  static void dumpCuda(std::ostream& os, std::shared_ptr<iir::StencilInstantiation> si);
 };
 
 } // namespace dawn

--- a/dawn/src/dawn/Unittest/IIRBuilder.cpp
+++ b/dawn/src/dawn/Unittest/IIRBuilder.cpp
@@ -55,7 +55,7 @@ Array3i asArray(FieldType ft) {
 }
 } // namespace
 
-dawn::codegen::stencilInstantiationContext
+std::shared_ptr<iir::StencilInstantiation>
 IIRBuilder::build(std::string const& name, std::unique_ptr<iir::Stencil> stencilIIR) {
   DAWN_ASSERT(si_);
   // setup the whole stencil instantiation
@@ -103,9 +103,7 @@ IIRBuilder::build(std::string const& name, std::unique_ptr<iir::Stencil> stencil
   DAWN_ASSERT(gridTypeChecker.checkGridTypeConsistency(*new_si->getIIR().get()));
 
   dawn::codegen::stencilInstantiationContext map;
-  map[new_si->getName()] = std::move(new_si);
-
-  return map;
+  return new_si;
 }
 
 std::shared_ptr<iir::Expr> IIRBuilder::reduceOverNeighborExpr(Op operation,

--- a/dawn/src/dawn/Unittest/IIRBuilder.h
+++ b/dawn/src/dawn/Unittest/IIRBuilder.h
@@ -281,7 +281,7 @@ public:
   }
 
   // generates the final instantiation context
-  dawn::codegen::stencilInstantiationContext build(std::string const& name,
+  std::shared_ptr<iir::StencilInstantiation> build(std::string const& name,
                                                    std::unique_ptr<iir::Stencil> stencil);
 
 protected:

--- a/dawn/test/integration-test/serializer/GenerateInMemoryStencils.cpp
+++ b/dawn/test/integration-test/serializer/GenerateInMemoryStencils.cpp
@@ -351,5 +351,5 @@ createUnstructuredSumEdgeToCellsIIRInMemory(dawn::OptimizerContext& optimizer) {
                                  b.at(out_f), b.reduceOverNeighborExpr(
                                                   Op::plus, b.at(in_f, HOffsetType::withOffset, 0),
                                                   b.lit(0.), LocType::Cells, LocType::Edges))))))));
-  return stencil_instantiation.at("generated");
+  return stencil_instantiation;
 }

--- a/dawn/test/integration-test/unstructured/GenerateUnstructuredStencils.cpp
+++ b/dawn/test/integration-test/unstructured/GenerateUnstructuredStencils.cpp
@@ -16,27 +16,12 @@
 
 #include "dawn/CodeGen/CXXNaive-ico/CXXNaiveCodeGen.h"
 #include "dawn/CodeGen/CXXNaive/CXXNaiveCodeGen.h"
+#include "dawn/Unittest/CompilerUtil.h"
 #include "dawn/Unittest/IIRBuilder.h"
 
 #include <cstring>
 #include <fstream>
 #include <optional>
-
-template <typename CG>
-void dump(std::ostream& os, dawn::codegen::stencilInstantiationContext& ctx) {
-  dawn::DiagnosticsEngine diagnostics;
-  CG generator(ctx, diagnostics, 0);
-  auto tu = generator.generateCode();
-
-  std::ostringstream ss;
-  for(auto const& macroDefine : tu->getPPDefines())
-    ss << macroDefine << "\n";
-
-  ss << tu->getGlobals();
-  for(auto const& s : tu->getStencils())
-    ss << s.second;
-  os << ss.str();
-}
 
 int main() {
 
@@ -55,7 +40,7 @@ int main() {
                                            b.stmt(b.assignExpr(b.at(out_f), b.at(in_f))))))));
 
     std::ofstream of("generated/generated_copyCell.hpp");
-    dump<dawn::codegen::cxxnaiveico::CXXNaiveIcoCodeGen>(of, stencil_instantiation);
+    dawn::CompilerUtil::dumpNaiveIco(of, stencil_instantiation);
     of.close();
   }
 
@@ -75,7 +60,7 @@ int main() {
                                                b.stmt(b.assignExpr(b.at(out_f), b.at(in_f))))))));
 
     std::ofstream of("generated/generated_copyEdge.hpp");
-    dump<dawn::codegen::cxxnaiveico::CXXNaiveIcoCodeGen>(of, stencil_instantiation);
+    dawn::CompilerUtil::dumpNaiveIco(of, stencil_instantiation);
     of.close();
   }
 
@@ -99,7 +84,7 @@ int main() {
                                                 b.lit(0.), LocType::Cells, LocType::Edges))))))));
 
     std::ofstream of("generated/generated_accumulateEdgeToCell.hpp");
-    dump<dawn::codegen::cxxnaiveico::CXXNaiveIcoCodeGen>(of, stencil_instantiation);
+    dawn::CompilerUtil::dumpNaiveIco(of, stencil_instantiation);
     of.close();
   }
 
@@ -123,7 +108,7 @@ int main() {
                                                              Op::plus))))))));
 
     std::ofstream of("generated/generated_verticalSum.hpp");
-    dump<dawn::codegen::cxxnaiveico::CXXNaiveIcoCodeGen>(of, stencil_instantiation);
+    dawn::CompilerUtil::dumpNaiveIco(of, stencil_instantiation);
     of.close();
   }
 
@@ -187,7 +172,7 @@ int main() {
                                                 Op::minus))))))));
 
     std::ofstream of("generated/generated_verticalSolver.hpp");
-    dump<dawn::codegen::cxxnaiveico::CXXNaiveIcoCodeGen>(of, stencil_instantiation);
+    dawn::CompilerUtil::dumpNaiveIco(of, stencil_instantiation);
     of.close();
   }
 
@@ -223,7 +208,7 @@ int main() {
                                  Op::plus))))))));
 
     std::ofstream of("generated/generated_diffusion.hpp");
-    dump<dawn::codegen::cxxnaiveico::CXXNaiveIcoCodeGen>(of, stencil_instantiation);
+    dawn::CompilerUtil::dumpNaiveIco(of, stencil_instantiation);
     of.close();
   }
 
@@ -259,7 +244,7 @@ int main() {
                                    std::vector<float>({0.5, 0., 0., 0.5})))))))));
 
     std::ofstream of("generated/generated_gradient.hpp");
-    dump<dawn::codegen::cxxnaiveico::CXXNaiveIcoCodeGen>(of, stencil_instantiation);
+    dawn::CompilerUtil::dumpNaiveIco(of, stencil_instantiation);
     of.close();
   }
 
@@ -291,7 +276,7 @@ int main() {
                                        std::vector<float>({1., 1., 1., 1})))))))));
 
     std::ofstream of("generated/generated_sparseDimension.hpp");
-    dump<dawn::codegen::cxxnaiveico::CXXNaiveIcoCodeGen>(of, stencil_instantiation);
+    dawn::CompilerUtil::dumpNaiveIco(of, stencil_instantiation);
     of.close();
   }
 
@@ -332,7 +317,7 @@ int main() {
                             std::vector<float>({1., 1., 1., 1})))))))));
 
     std::ofstream of("generated/generated_sparseDimensionTwice.hpp");
-    dump<dawn::codegen::cxxnaiveico::CXXNaiveIcoCodeGen>(of, stencil_instantiation);
+    dawn::CompilerUtil::dumpNaiveIco(of, stencil_instantiation);
     of.close();
   }
 
@@ -363,7 +348,7 @@ int main() {
                                        dawn::ast::LocationType::Edges))))))));
 
     std::ofstream of("generated/generated_NestedSimple.hpp");
-    dump<dawn::codegen::cxxnaiveico::CXXNaiveIcoCodeGen>(of, stencil_instantiation);
+    dawn::CompilerUtil::dumpNaiveIco(of, stencil_instantiation);
     of.close();
   }
 
@@ -397,7 +382,7 @@ int main() {
                                                dawn::ast::LocationType::Edges))))))));
 
     std::ofstream of("generated/generated_NestedWithField.hpp");
-    dump<dawn::codegen::cxxnaiveico::CXXNaiveIcoCodeGen>(of, stencil_instantiation);
+    dawn::CompilerUtil::dumpNaiveIco(of, stencil_instantiation);
     of.close();
   }
 

--- a/dawn/test/integration-test/unstructured/GenerateUnstructuredStencils.cpp
+++ b/dawn/test/integration-test/unstructured/GenerateUnstructuredStencils.cpp
@@ -41,7 +41,6 @@ int main() {
 
     std::ofstream of("generated/generated_copyCell.hpp");
     dawn::CompilerUtil::dumpNaiveIco(of, stencil_instantiation);
-    of.close();
   }
 
   {
@@ -61,7 +60,6 @@ int main() {
 
     std::ofstream of("generated/generated_copyEdge.hpp");
     dawn::CompilerUtil::dumpNaiveIco(of, stencil_instantiation);
-    of.close();
   }
 
   {
@@ -85,7 +83,6 @@ int main() {
 
     std::ofstream of("generated/generated_accumulateEdgeToCell.hpp");
     dawn::CompilerUtil::dumpNaiveIco(of, stencil_instantiation);
-    of.close();
   }
 
   {
@@ -109,7 +106,6 @@ int main() {
 
     std::ofstream of("generated/generated_verticalSum.hpp");
     dawn::CompilerUtil::dumpNaiveIco(of, stencil_instantiation);
-    of.close();
   }
 
   {
@@ -173,7 +169,6 @@ int main() {
 
     std::ofstream of("generated/generated_verticalSolver.hpp");
     dawn::CompilerUtil::dumpNaiveIco(of, stencil_instantiation);
-    of.close();
   }
 
   {
@@ -209,7 +204,6 @@ int main() {
 
     std::ofstream of("generated/generated_diffusion.hpp");
     dawn::CompilerUtil::dumpNaiveIco(of, stencil_instantiation);
-    of.close();
   }
 
   {
@@ -245,7 +239,6 @@ int main() {
 
     std::ofstream of("generated/generated_gradient.hpp");
     dawn::CompilerUtil::dumpNaiveIco(of, stencil_instantiation);
-    of.close();
   }
 
   {
@@ -277,7 +270,6 @@ int main() {
 
     std::ofstream of("generated/generated_sparseDimension.hpp");
     dawn::CompilerUtil::dumpNaiveIco(of, stencil_instantiation);
-    of.close();
   }
 
   {
@@ -318,7 +310,6 @@ int main() {
 
     std::ofstream of("generated/generated_sparseDimensionTwice.hpp");
     dawn::CompilerUtil::dumpNaiveIco(of, stencil_instantiation);
-    of.close();
   }
 
   {
@@ -349,7 +340,6 @@ int main() {
 
     std::ofstream of("generated/generated_NestedSimple.hpp");
     dawn::CompilerUtil::dumpNaiveIco(of, stencil_instantiation);
-    of.close();
   }
 
   {
@@ -383,7 +373,6 @@ int main() {
 
     std::ofstream of("generated/generated_NestedWithField.hpp");
     dawn::CompilerUtil::dumpNaiveIco(of, stencil_instantiation);
-    of.close();
   }
 
   {
@@ -434,7 +423,6 @@ int main() {
     // Code generation deactivated for the reasons stated above
     // std::ofstream of("generated/generated_NestedSparse.hpp");
     // dump<dawn::codegen::cxxnaiveico::CXXNaiveIcoCodeGen>(of, stencil_instantiation);
-    // of.close();
   }
 
   return 0;

--- a/dawn/test/unit-test/dawn-c/TestCompiler.cpp
+++ b/dawn/test/unit-test/dawn-c/TestCompiler.cpp
@@ -17,10 +17,12 @@
 #include "dawn/CodeGen/CXXNaive-ico/CXXNaiveCodeGen.h"
 #include "dawn/CodeGen/CXXNaive/CXXNaiveCodeGen.h"
 #include "dawn/CodeGen/CodeGen.h"
+#include "dawn/IIR/StencilInstantiation.h"
 #include "dawn/Optimizer/OptimizerContext.h"
 #include "dawn/SIR/SIR.h"
 #include "dawn/Serialization/SIRSerializer.h"
 #include "dawn/Support/DiagnosticsEngine.h"
+#include "dawn/Unittest/CompilerUtil.h"
 #include "dawn/Unittest/IIRBuilder.h"
 
 #include <gtest/gtest.h>
@@ -51,21 +53,6 @@ TEST(CompilerTest, CompileEmptySIR) {
   freeCharArray(ppDefines, size);
   dawnTranslationUnitDestroy(TU);
 }
-template <typename CG>
-void dump(std::ostream& os, dawn::codegen::stencilInstantiationContext& ctx) {
-  dawn::DiagnosticsEngine diagnostics;
-  CG generator(ctx, diagnostics, 0);
-  auto tu = generator.generateCode();
-
-  std::ostringstream ss;
-  for(auto const& macroDefine : tu->getPPDefines())
-    ss << macroDefine << "\n";
-
-  ss << tu->getGlobals();
-  for(auto const& s : tu->getStencils())
-    ss << s.second;
-  os << ss.str();
-}
 
 TEST(CompilerTest, CompileCopyStencil) {
   using namespace dawn::iir;
@@ -81,7 +68,7 @@ TEST(CompilerTest, CompileCopyStencil) {
                   b.stage(b.doMethod(dawn::sir::Interval::Start, dawn::sir::Interval::End,
                                      b.block(b.stmt(b.assignExpr(b.at(out_f), b.at(in_f)))))))));
   std::ofstream of("/dev/null");
-  dump<dawn::codegen::cxxnaive::CXXNaiveCodeGen>(of, stencil_instantiation);
+  dawn::CompilerUtil::dumpNaive(of, stencil_instantiation);
 }
 
 TEST(CompilerTest, DISABLED_CodeGenSumEdgeToCells) {
@@ -107,7 +94,7 @@ TEST(CompilerTest, DISABLED_CodeGenSumEdgeToCells) {
 
   std::ofstream of("prototype/generated_copyEdgeToCell.hpp");
   DAWN_ASSERT_MSG(of, "file could not be opened. Binary must be called from dawn/dawn");
-  dump<dawn::codegen::cxxnaiveico::CXXNaiveIcoCodeGen>(of, stencil_instantiation);
+  dawn::CompilerUtil::dumpNaiveIco(of, stencil_instantiation);
   of.close();
 }
 
@@ -132,7 +119,7 @@ TEST(CompilerTest, DISABLED_SumVertical) {
 
   std::ofstream of("prototype/generated_verticalSum.hpp");
   DAWN_ASSERT_MSG(of, "file could not be opened. Binary must be called from dawn/dawn");
-  dump<dawn::codegen::cxxnaiveico::CXXNaiveIcoCodeGen>(of, stencil_instantiation);
+  dawn::CompilerUtil::dumpNaiveIco(of, stencil_instantiation);
   of.close();
 }
 
@@ -169,7 +156,7 @@ TEST(CompilerTest, DISABLED_CodeGenDiffusion) {
 
   std::ofstream of("prototype/generated_Diffusion.hpp");
   DAWN_ASSERT_MSG(of, "file could not be opened. Binary must be called from dawn/dawn");
-  dump<dawn::codegen::cxxnaiveico::CXXNaiveIcoCodeGen>(of, stencil_instantiation);
+  dawn::CompilerUtil::dumpNaiveIco(of, stencil_instantiation);
   of.close();
 }
 
@@ -204,7 +191,7 @@ TEST(CompilerTest, DISABLED_CodeGenTriGradient) {
 
   std::ofstream of("prototype/generated_triGradient.hpp");
   DAWN_ASSERT_MSG(of, "file could not be opened. Binary must be called from dawn/dawn");
-  dump<dawn::codegen::cxxnaiveico::CXXNaiveIcoCodeGen>(of, stencil_instantiation);
+  dawn::CompilerUtil::dumpNaiveIco(of, stencil_instantiation);
   of.close();
 }
 
@@ -239,7 +226,7 @@ TEST(CompilerTest, DISABLED_CodeGenQuadGradient) {
 
   std::ofstream of("prototype/generated_quadGradient.hpp");
   DAWN_ASSERT_MSG(of, "file could not be opened. Binary must be called from dawn/dawn");
-  dump<dawn::codegen::cxxnaiveico::CXXNaiveIcoCodeGen>(of, stencil_instantiation);
+  dawn::CompilerUtil::dumpNaiveIco(of, stencil_instantiation);
   of.close();
 }
 
@@ -271,7 +258,7 @@ TEST(CompilerTest, DISABLED_SparseDimension) {
                           std::vector<float>({1., 1., 1., 1})))))))));
 
   std::ofstream of("prototype/generated_sparseDimension.hpp");
-  dump<dawn::codegen::cxxnaiveico::CXXNaiveIcoCodeGen>(of, stencil_instantiation);
+  dawn::CompilerUtil::dumpNaiveIco(of, stencil_instantiation);
   of.close();
 }
 
@@ -301,7 +288,7 @@ TEST(CompilerTest, DISABLED_NestedReduce) {
                                      dawn::ast::LocationType::Edges))))))));
 
   std::ofstream of("prototype/generated_NestedSimple.hpp");
-  dump<dawn::codegen::cxxnaiveico::CXXNaiveIcoCodeGen>(of, stencil_instantiation);
+  dawn::CompilerUtil::dumpNaiveIco(of, stencil_instantiation);
   of.close();
 }
 
@@ -335,7 +322,7 @@ TEST(CompilerTest, DISABLED_NestedReduceField) {
                                               dawn::ast::LocationType::Edges))))))));
 
   std::ofstream of("prototype/generated_NestedWithField.hpp");
-  dump<dawn::codegen::cxxnaiveico::CXXNaiveIcoCodeGen>(of, stencil_instantiation);
+  dawn::CompilerUtil::dumpNaiveIco(of, stencil_instantiation);
   of.close();
 }
 } // anonymous namespace

--- a/dawn/test/unit-test/dawn-c/TestCompiler.cpp
+++ b/dawn/test/unit-test/dawn-c/TestCompiler.cpp
@@ -95,7 +95,6 @@ TEST(CompilerTest, DISABLED_CodeGenSumEdgeToCells) {
   std::ofstream of("prototype/generated_copyEdgeToCell.hpp");
   DAWN_ASSERT_MSG(of, "file could not be opened. Binary must be called from dawn/dawn");
   dawn::CompilerUtil::dumpNaiveIco(of, stencil_instantiation);
-  of.close();
 }
 
 TEST(CompilerTest, DISABLED_SumVertical) {
@@ -120,7 +119,6 @@ TEST(CompilerTest, DISABLED_SumVertical) {
   std::ofstream of("prototype/generated_verticalSum.hpp");
   DAWN_ASSERT_MSG(of, "file could not be opened. Binary must be called from dawn/dawn");
   dawn::CompilerUtil::dumpNaiveIco(of, stencil_instantiation);
-  of.close();
 }
 
 TEST(CompilerTest, DISABLED_CodeGenDiffusion) {
@@ -157,7 +155,6 @@ TEST(CompilerTest, DISABLED_CodeGenDiffusion) {
   std::ofstream of("prototype/generated_Diffusion.hpp");
   DAWN_ASSERT_MSG(of, "file could not be opened. Binary must be called from dawn/dawn");
   dawn::CompilerUtil::dumpNaiveIco(of, stencil_instantiation);
-  of.close();
 }
 
 TEST(CompilerTest, DISABLED_CodeGenTriGradient) {
@@ -192,7 +189,6 @@ TEST(CompilerTest, DISABLED_CodeGenTriGradient) {
   std::ofstream of("prototype/generated_triGradient.hpp");
   DAWN_ASSERT_MSG(of, "file could not be opened. Binary must be called from dawn/dawn");
   dawn::CompilerUtil::dumpNaiveIco(of, stencil_instantiation);
-  of.close();
 }
 
 TEST(CompilerTest, DISABLED_CodeGenQuadGradient) {
@@ -227,7 +223,6 @@ TEST(CompilerTest, DISABLED_CodeGenQuadGradient) {
   std::ofstream of("prototype/generated_quadGradient.hpp");
   DAWN_ASSERT_MSG(of, "file could not be opened. Binary must be called from dawn/dawn");
   dawn::CompilerUtil::dumpNaiveIco(of, stencil_instantiation);
-  of.close();
 }
 
 TEST(CompilerTest, DISABLED_SparseDimension) {
@@ -259,7 +254,6 @@ TEST(CompilerTest, DISABLED_SparseDimension) {
 
   std::ofstream of("prototype/generated_sparseDimension.hpp");
   dawn::CompilerUtil::dumpNaiveIco(of, stencil_instantiation);
-  of.close();
 }
 
 TEST(CompilerTest, DISABLED_NestedReduce) {
@@ -289,7 +283,6 @@ TEST(CompilerTest, DISABLED_NestedReduce) {
 
   std::ofstream of("prototype/generated_NestedSimple.hpp");
   dawn::CompilerUtil::dumpNaiveIco(of, stencil_instantiation);
-  of.close();
 }
 
 TEST(CompilerTest, DISABLED_NestedReduceField) {
@@ -323,6 +316,5 @@ TEST(CompilerTest, DISABLED_NestedReduceField) {
 
   std::ofstream of("prototype/generated_NestedWithField.hpp");
   dawn::CompilerUtil::dumpNaiveIco(of, stencil_instantiation);
-  of.close();
 }
 } // anonymous namespace

--- a/dawn/test/unit-test/dawn/IIR/TestIIRSerializer.cpp
+++ b/dawn/test/unit-test/dawn/IIR/TestIIRSerializer.cpp
@@ -280,9 +280,9 @@ TEST_F(IIRSerializerTest, IIRTestsReduce) {
                                                   b.lit(0.), LocType::Cells, LocType::Edges))))))));
 
   auto deserializedAndSerialized = IIRSerializer::deserializeFromString(
-      IIRSerializer::serializeToString(stencil_instantiation[stencilName.c_str()]), context_.get());
+      IIRSerializer::serializeToString(stencil_instantiation), context_.get());
 
-  IIR_EXPECT_EQ(stencil_instantiation[stencilName.c_str()], deserializedAndSerialized);
+  IIR_EXPECT_EQ(stencil_instantiation, deserializedAndSerialized);
 }
 
 TEST_F(IIRSerializerTest, IIRTestsWeightedReduce) {
@@ -315,9 +315,9 @@ TEST_F(IIRSerializerTest, IIRTestsWeightedReduce) {
                                                    std::vector<int>({1, 2, 3, 4})))))))));
 
   auto deserializedAndSerialized = IIRSerializer::deserializeFromString(
-      IIRSerializer::serializeToString(stencil_instantiation[stencilName.c_str()]), context_.get());
+      IIRSerializer::serializeToString(stencil_instantiation), context_.get());
 
-  IIR_EXPECT_EQ(stencil_instantiation[stencilName.c_str()], deserializedAndSerialized);
+  IIR_EXPECT_EQ(stencil_instantiation, deserializedAndSerialized);
 }
 
 TEST_F(IIRSerializerTest, IIRTests) {

--- a/dawn/test/unit-test/dawn/Optimizer/Passes/TestPassCaching.cpp
+++ b/dawn/test/unit-test/dawn/Optimizer/Passes/TestPassCaching.cpp
@@ -42,7 +42,7 @@ TEST(TestCaching, test_global_iteration_space_01) {
   auto in = b.field("in_field", FieldType::ijk);
   auto tmp = b.tmpField("tmp", FieldType::ijk);
 
-  auto stencilInstantiationContext =
+  auto stencil =
       b.build(stencilName.c_str(),
               b.stencil(b.multistage(
                   dawn::iir::LoopOrderKind::Forward,
@@ -50,7 +50,6 @@ TEST(TestCaching, test_global_iteration_space_01) {
                                      b.stmt(b.assignExpr(b.at(tmp), b.at(in))))),
                   b.stage(b.doMethod(dawn::sir::Interval::Start, dawn::sir::Interval::End, 1, 0,
                                      b.stmt(b.assignExpr(b.at(out), b.at(tmp, {0, 0, -1}))))))));
-  auto stencil = stencilInstantiationContext.at(stencilName.c_str());
 
   // dummy options
   OptimizerContext::OptimizerContextOptions optimizerOptions;
@@ -86,7 +85,7 @@ TEST(TestCaching, test_global_iteration_space_02) {
   auto in = b.field("in_field", FieldType::ijk);
   auto tmp = b.tmpField("tmp", FieldType::ijk);
 
-  auto stencilInstantiationContext =
+  auto stencil =
       b.build(stencilName.c_str(),
               b.stencil(b.multistage(
                   dawn::iir::LoopOrderKind::Forward,
@@ -96,7 +95,6 @@ TEST(TestCaching, test_global_iteration_space_02) {
                   b.stage(Interval(2, 8), Interval(3, 10),
                           b.doMethod(dawn::sir::Interval::Start, dawn::sir::Interval::End, 1, 0,
                                      b.stmt(b.assignExpr(b.at(out), b.at(tmp, {0, 0, -1}))))))));
-  auto stencil = stencilInstantiationContext.at(stencilName.c_str());
 
   // dummy options
   OptimizerContext::OptimizerContextOptions optimizerOptions;
@@ -133,7 +131,7 @@ TEST(TestCaching, test_global_iteration_space_03) {
   auto in = b.field("in_field", FieldType::ijk);
   auto tmp = b.tmpField("tmp", FieldType::ijk);
 
-  auto stencilInstantiationContext =
+  auto stencil =
       b.build(stencilName.c_str(),
               b.stencil(b.multistage(
                   dawn::iir::LoopOrderKind::Forward,
@@ -143,7 +141,6 @@ TEST(TestCaching, test_global_iteration_space_03) {
                   b.stage(Interval(2, 12), Interval(10, 13),
                           b.doMethod(dawn::sir::Interval::Start, dawn::sir::Interval::End, 1, 0,
                                      b.stmt(b.assignExpr(b.at(out), b.at(tmp, {0, 0, -1}))))))));
-  auto stencil = stencilInstantiationContext.at(stencilName.c_str());
 
   // dummy options
   Options compileOptions;
@@ -178,7 +175,7 @@ TEST(TestCaching, test_global_iteration_space_04) {
   auto in = b.field("in_field", FieldType::ijk);
   auto tmp = b.tmpField("tmp", FieldType::ijk);
 
-  auto stencilInstantiationContext =
+  auto stencil =
       b.build(stencilName.c_str(),
               b.stencil(b.multistage(
                   dawn::iir::LoopOrderKind::Forward,
@@ -187,7 +184,6 @@ TEST(TestCaching, test_global_iteration_space_04) {
                                      b.stmt(b.assignExpr(b.at(tmp), b.at(in))))),
                   b.stage(b.doMethod(dawn::sir::Interval::Start, dawn::sir::Interval::End, 1, 0,
                                      b.stmt(b.assignExpr(b.at(out), b.at(tmp, {0, 0, -1}))))))));
-  auto stencil = stencilInstantiationContext.at(stencilName.c_str());
 
   // dummy options
   OptimizerContext::OptimizerContextOptions optimizerOptions;
@@ -221,7 +217,7 @@ TEST(TestCaching, test_global_iteration_space_05) {
   auto in = b.field("in_field", FieldType::ijk);
   auto tmp = b.tmpField("tmp", FieldType::ijk);
 
-  auto stencilInstantiationContext =
+  auto stencil =
       b.build(stencilName.c_str(),
               b.stencil(b.multistage(
                   dawn::iir::LoopOrderKind::Forward,
@@ -230,7 +226,6 @@ TEST(TestCaching, test_global_iteration_space_05) {
                   b.stage(Interval(0, 10), Interval(0, 10),
                           b.doMethod(dawn::sir::Interval::Start, dawn::sir::Interval::End, 1, 0,
                                      b.stmt(b.assignExpr(b.at(out), b.at(tmp, {0, 0, -1}))))))));
-  auto stencil = stencilInstantiationContext.at(stencilName.c_str());
 
   // dummy options
   OptimizerContext::OptimizerContextOptions optimizerOptions;

--- a/dawn/test/unit-test/dawn/Optimizer/Passes/TestPassLocalVarType.cpp
+++ b/dawn/test/unit-test/dawn/Optimizer/Passes/TestPassLocalVarType.cpp
@@ -33,13 +33,12 @@ TEST(TestLocalVarType, test_cartesian_01) {
   /// double varA = 3.0;
   /// f_ij = varA;
 
-  auto stencilInstantiationContext = b.build(
+  auto stencil = b.build(
       "generated",
       b.stencil(b.multistage(
           dawn::iir::LoopOrderKind::Forward,
           b.stage(b.doMethod(dawn::sir::Interval::Start, dawn::sir::Interval::End,
                              b.declareVar(varA), b.stmt(b.assignExpr(b.at(fIJ), b.at(varA))))))));
-  auto stencil = stencilInstantiationContext.at("generated");
 
   OptimizerContext::OptimizerContextOptions optimizerOptions;
 
@@ -68,14 +67,13 @@ TEST(TestLocalVarType, test_cartesian_02) {
   /// varA = f_ij;
   /// f_ij = varA;
 
-  auto stencilInstantiationContext = b.build(
+  auto stencil = b.build(
       "generated",
       b.stencil(b.multistage(
           dawn::iir::LoopOrderKind::Forward,
           b.stage(b.doMethod(dawn::sir::Interval::Start, dawn::sir::Interval::End,
                              b.declareVar(varA), b.stmt(b.assignExpr(b.at(varA), b.at(fIJ))),
                              b.stmt(b.assignExpr(b.at(fIJ), b.at(varA))))))));
-  auto stencil = stencilInstantiationContext.at("generated");
 
   OptimizerContext::OptimizerContextOptions optimizerOptions;
 
@@ -106,13 +104,12 @@ TEST(TestLocalVarType, test_cartesian_propagation_01) {
   /// double varB = varA;
   /// f_ij = varB;
 
-  auto stencilInstantiationContext = b.build(
+  auto stencil = b.build(
       "generated", b.stencil(b.multistage(
                        dawn::iir::LoopOrderKind::Forward,
                        b.stage(b.doMethod(dawn::sir::Interval::Start, dawn::sir::Interval::End,
                                           b.declareVar(varA), b.declareVar(varB),
                                           b.stmt(b.assignExpr(b.at(fIJ), b.at(varB))))))));
-  auto stencil = stencilInstantiationContext.at("generated");
 
   OptimizerContext::OptimizerContextOptions optimizerOptions;
 
@@ -146,14 +143,13 @@ TEST(TestLocalVarType, test_cartesian_propagation_02) {
   /// varA = f_ij;
   /// f_ij = varB;
 
-  auto stencilInstantiationContext = b.build(
+  auto stencil = b.build(
       "generated", b.stencil(b.multistage(
                        dawn::iir::LoopOrderKind::Forward,
                        b.stage(b.doMethod(dawn::sir::Interval::Start, dawn::sir::Interval::End,
                                           b.declareVar(varA), b.declareVar(varB),
                                           b.stmt(b.assignExpr(b.at(varA), b.at(fIJ))),
                                           b.stmt(b.assignExpr(b.at(fIJ), b.at(varB))))))));
-  auto stencil = stencilInstantiationContext.at("generated");
 
   OptimizerContext::OptimizerContextOptions optimizerOptions;
 
@@ -194,7 +190,7 @@ TEST(TestLocalVarType, test_cartesian_propagation_03) {
   /// varD = varB;
   /// f_ij = varD;
 
-  auto stencilInstantiationContext = b.build(
+  auto stencil = b.build(
       "generated",
       b.stencil(b.multistage(
           dawn::iir::LoopOrderKind::Forward,
@@ -203,7 +199,6 @@ TEST(TestLocalVarType, test_cartesian_propagation_03) {
                              b.declareVar(varD), b.stmt(b.assignExpr(b.at(varB), b.at(varA))),
                              b.stmt(b.assignExpr(b.at(varD), b.at(varB))),
                              b.stmt(b.assignExpr(b.at(fIJ), b.at(varD))))))));
-  auto stencil = stencilInstantiationContext.at("generated");
 
   OptimizerContext::OptimizerContextOptions optimizerOptions;
 
@@ -249,7 +244,7 @@ TEST(TestLocalVarType, test_cartesian_propagation_04) {
   /// varB = f_ij;
   /// f_ij = varD;
 
-  auto stencilInstantiationContext = b.build(
+  auto stencil = b.build(
       "generated",
       b.stencil(b.multistage(
           dawn::iir::LoopOrderKind::Forward,
@@ -259,7 +254,6 @@ TEST(TestLocalVarType, test_cartesian_propagation_04) {
                              b.stmt(b.assignExpr(b.at(varD), b.at(varB))),
                              b.stmt(b.assignExpr(b.at(varB), b.at(fIJ))),
                              b.stmt(b.assignExpr(b.at(fIJ), b.at(varD))))))));
-  auto stencil = stencilInstantiationContext.at("generated");
 
   OptimizerContext::OptimizerContextOptions optimizerOptions;
 
@@ -308,7 +302,7 @@ TEST(TestLocalVarType, test_unstructured_propagation_01) {
   /// varB = varD;
   /// varD = f_c;
 
-  auto stencilInstantiationContext = b.build(
+  auto stencil = b.build(
       "generated",
       b.stencil(b.multistage(
           dawn::iir::LoopOrderKind::Forward,
@@ -317,7 +311,6 @@ TEST(TestLocalVarType, test_unstructured_propagation_01) {
                              b.declareVar(varD), b.stmt(b.assignExpr(b.at(varA), b.at(varB))),
                              b.stmt(b.assignExpr(b.at(varB), b.at(varD))),
                              b.stmt(b.assignExpr(b.at(varD), b.at(f_c))))))));
-  auto stencil = stencilInstantiationContext.at("generated");
 
   OptimizerContext::OptimizerContextOptions optimizerOptions;
 
@@ -363,7 +356,7 @@ TEST(TestLocalVarType, test_unstructured_propagation_02) {
   /// varA = varB;
   /// varB = varC;
 
-  auto stencilInstantiationContext =
+  auto stencil =
       b.build("generated",
               b.stencil(b.multistage(
                   dawn::iir::LoopOrderKind::Forward,
@@ -371,7 +364,6 @@ TEST(TestLocalVarType, test_unstructured_propagation_02) {
                                      b.declareVar(varA), b.declareVar(varB), b.declareVar(varC),
                                      b.stmt(b.assignExpr(b.at(varA), b.at(varB))),
                                      b.stmt(b.assignExpr(b.at(varB), b.at(varC))))))));
-  auto stencil = stencilInstantiationContext.at("generated");
 
   OptimizerContext::OptimizerContextOptions optimizerOptions;
 
@@ -408,13 +400,12 @@ TEST(TestLocalVarType, test_throw_unstructured_01) {
   /// double varA = f_c;
   /// varA = f_e;
 
-  auto stencilInstantiationContext = b.build(
+  auto stencil = b.build(
       "generated",
       b.stencil(b.multistage(
           dawn::iir::LoopOrderKind::Forward,
           b.stage(b.doMethod(dawn::sir::Interval::Start, dawn::sir::Interval::End,
                              b.declareVar(varA), b.stmt(b.assignExpr(b.at(varA), b.at(f_e))))))));
-  auto stencil = stencilInstantiationContext.at("generated");
 
   OptimizerContext::OptimizerContextOptions optimizerOptions;
 
@@ -443,7 +434,7 @@ TEST(TestLocalVarType, test_throw_unstructured_02) {
   /// varB = f_e + varA;
   /// varA = f_c;
 
-  auto stencilInstantiationContext = b.build(
+  auto stencil = b.build(
       "generated",
       b.stencil(b.multistage(
           dawn::iir::LoopOrderKind::Forward,
@@ -451,7 +442,6 @@ TEST(TestLocalVarType, test_throw_unstructured_02) {
                              b.declareVar(varA), b.declareVar(varB),
                              b.stmt(b.assignExpr(b.at(varB), b.binaryExpr(b.at(f_e), b.at(varA)))),
                              b.stmt(b.assignExpr(b.at(varA), b.at(f_c))))))));
-  auto stencil = stencilInstantiationContext.at("generated");
 
   OptimizerContext::OptimizerContextOptions optimizerOptions;
 
@@ -484,7 +474,7 @@ TEST(TestLocalVarType, test_throw_unstructured_03) {
   /// varA = f_c;
   /// varC = f_e;
 
-  auto stencilInstantiationContext =
+  auto stencil =
       b.build("generated",
               b.stencil(b.multistage(
                   dawn::iir::LoopOrderKind::Forward,
@@ -494,7 +484,6 @@ TEST(TestLocalVarType, test_throw_unstructured_03) {
                                      b.stmt(b.assignExpr(b.at(varC), b.at(varB))),
                                      b.stmt(b.assignExpr(b.at(varA), b.at(f_c))),
                                      b.stmt(b.assignExpr(b.at(varC), b.at(f_e))))))));
-  auto stencil = stencilInstantiationContext.at("generated");
 
   OptimizerContext::OptimizerContextOptions optimizerOptions;
 

--- a/dawn/test/unit-test/dawn/Validator/TestGridTypeChecker.cpp
+++ b/dawn/test/unit-test/dawn/Validator/TestGridTypeChecker.cpp
@@ -35,15 +35,11 @@ TEST(GridTypeCheckerTest, MixedGridTypes) {
   auto cell_fB = b.field("cell_field_b", LocType::Cells);
 
   // lets build a consistent stencil
-  auto stencilContext =
-      b.build(stencilName.c_str(),
-              b.stencil(b.multistage(
-                  LoopOrderKind::Parallel,
-                  b.stage(b.doMethod(dawn::sir::Interval::Start, dawn::sir::Interval::End,
-                                     b.stmt(b.assignExpr(b.at(cell_fA), b.at(cell_fB))))))));
-
-  // extract the stencil instantiation
-  auto si = stencilContext[stencilName.c_str()];
+  auto si = b.build(stencilName.c_str(),
+                    b.stencil(b.multistage(
+                        LoopOrderKind::Parallel,
+                        b.stage(b.doMethod(dawn::sir::Interval::Start, dawn::sir::Interval::End,
+                                           b.stmt(b.assignExpr(b.at(cell_fA), b.at(cell_fB))))))));
 
   // lets manually add a field access of the wrong type to the IIR
   ast::Offsets offsets(ast::cartesian_{}, 0, 0, 0);
@@ -71,16 +67,12 @@ TEST(GridTypeCheckerTest, LocalVariableDataMixed) {
   auto varA = b.localvar("varA");
 
   // lets build a consistent stencil
-  auto stencilContext =
-      b.build(stencilName.c_str(),
-              b.stencil(b.multistage(
-                  LoopOrderKind::Parallel,
-                  b.stage(b.doMethod(dawn::sir::Interval::Start, dawn::sir::Interval::End,
-                                     b.declareVar(varA),
-                                     b.stmt(b.assignExpr(b.at(cell_fA), b.at(cell_fB))))))));
-
-  // extract the stencil instantiation
-  auto si = stencilContext[stencilName.c_str()];
+  auto si = b.build(stencilName.c_str(),
+                    b.stencil(b.multistage(
+                        LoopOrderKind::Parallel,
+                        b.stage(b.doMethod(dawn::sir::Interval::Start, dawn::sir::Interval::End,
+                                           b.declareVar(varA),
+                                           b.stmt(b.assignExpr(b.at(cell_fA), b.at(cell_fB))))))));
 
   // lets manually add a LocalVariableData with a cartesian type (OnIJ)
   si->getMetaData().addAccessIDToLocalVariableDataPair(varA.id, iir::LocalVariableData{});


### PR DESCRIPTION
## Technical Description

Return `shared_ptr<StencilInstantiation>` from `IIRBuilder.build()`.

Reason:
- By design of the `IIRBuilder.build()`, the `StencilInstantiationContext` always contained exactly one `StencilInstantiation`. 
- The `shared_ptr<>` should be removed.