### PR TITLE
Quick fix of PassTemporaryMerger

### DIFF
--- a/dawn/src/dawn/Optimizer/Renaming.cpp
+++ b/dawn/src/dawn/Optimizer/Renaming.cpp
@@ -41,8 +41,9 @@ public:
 
   virtual void visit(const std::shared_ptr<iir::VarDeclStmt>& stmt) override {
     int& varAccessID = *stmt->getData<iir::VarDeclStmtData>().AccessID;
-    if(varAccessID == oldAccessID_)
+    if(varAccessID == oldAccessID_) {
       varAccessID = newAccessID_;
+    }
     iir::ASTVisitorForwarding::visit(stmt);
     stmt->getName() = instantiation_->getNameFromAccessID(varAccessID);
   }
@@ -56,8 +57,9 @@ public:
 
   void visit(const std::shared_ptr<iir::VarAccessExpr>& expr) override {
     int& varAccessID = *expr->getData<iir::IIRAccessExprData>().AccessID;
-    if(varAccessID == oldAccessID_)
+    if(varAccessID == oldAccessID_) {
       varAccessID = newAccessID_;
+    }
     expr->setName(instantiation_->getNameFromAccessID(varAccessID));
   }
 
@@ -65,8 +67,8 @@ public:
     int& fieldAccessID = *expr->getData<iir::IIRAccessExprData>().AccessID;
     if(fieldAccessID == oldAccessID_) {
       fieldAccessID = newAccessID_;
-      expr->setName(instantiation_->getNameFromAccessID(fieldAccessID));
     }
+    expr->setName(instantiation_->getNameFromAccessID(fieldAccessID));
   }
 };
 

--- a/dawn/test/unit-test/dawn/Optimizer/Passes/TestPassTemporaryMerger.cpp
+++ b/dawn/test/unit-test/dawn/Optimizer/Passes/TestPassTemporaryMerger.cpp
@@ -57,8 +57,8 @@ protected:
 
       std::unordered_set<std::string> fieldNames;
       for(const auto& access : accessExprs) {
-        const auto& field = std::dynamic_pointer_cast<ast::FieldAccessExpr>(access);
-        fieldNames.insert(field->getName());
+        const auto& fieldAccessExpr = std::dynamic_pointer_cast<ast::FieldAccessExpr>(access);
+        fieldNames.insert(fieldAccessExpr->getName());
       }
 
       // Assert that merged fields are no longer accessed
@@ -78,7 +78,7 @@ TEST_F(TestPassTemporaryMerger, MergeTest3) { runTest("input/MergeTest03.sir", {
 TEST_F(TestPassTemporaryMerger, MergeTest4) { runTest("input/MergeTest04.sir", {"tmp_b"}); }
 
 TEST_F(TestPassTemporaryMerger, MergeTest5) {
-  runTest("input/MergeTest05.sir", {"tmp_1", "tmp_2", "tmp_4", "tmp_5"});
+  runTest("input/MergeTest05.sir", {"tmp_2", "tmp_3", "tmp_4", "tmp_5"});
 }
 
 } // anonymous namespace


### PR DESCRIPTION
## Technical Description

`PassTemporaryMerger` merges temporaries into the one with lowest access id. Since access ids vary from compiler to compiler, tests failed on some dev setups (e.g. gcc 9.2.1). This PR fixes this by selecting the first temporary in alphabetical order as the target one.
