### PR TITLE
Fix for GCC on MacOS

### DIFF
--- a/gtclang/src/gtclang/Driver/CompilerInstance.cpp
+++ b/gtclang/src/gtclang/Driver/CompilerInstance.cpp
@@ -91,8 +91,8 @@ clang::CompilerInstance* createCompilerInstance(llvm::SmallVectorImpl<const char
 
 #ifdef __APPLE__
   // Set the root where system headers are located.
-  // ccArgs.push_back("-internal-isystem");
-  // ccArgs.push_back(GTCLANG_CLANG_RESSOURCE_INCLUDE_PATH "/../../../../include/c++/v1/");
+  ccArgs.push_back("-internal-isystem");
+  ccArgs.push_back(GTCLANG_CLANG_RESSOURCE_INCLUDE_PATH "/../../../../include/c++/v1/");
   ccArgs.push_back("-internal-isystem");
   ccArgs.push_back("/Library/Developer/CommandLineTools/usr/include/c++/v1");
   // 20191208: -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk does not work, so we

--- a/gtclang/src/gtclang/Driver/CompilerInstance.cpp
+++ b/gtclang/src/gtclang/Driver/CompilerInstance.cpp
@@ -91,8 +91,10 @@ clang::CompilerInstance* createCompilerInstance(llvm::SmallVectorImpl<const char
 
 #ifdef __APPLE__
   // Set the root where system headers are located.
+  // ccArgs.push_back("-internal-isystem");
+  // ccArgs.push_back(GTCLANG_CLANG_RESSOURCE_INCLUDE_PATH "/../../../../include/c++/v1/");
   ccArgs.push_back("-internal-isystem");
-  ccArgs.push_back(GTCLANG_CLANG_RESSOURCE_INCLUDE_PATH "/../../../../include/c++/v1/");
+  ccArgs.push_back("/Library/Developer/CommandLineTools/usr/include/c++/v1");
   // 20191208: -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk does not work, so we
   // add the full path manually
   ccArgs.push_back("-internal-isystem");


### PR DESCRIPTION
## Technical Description

Adds correct include path for GCC on MacOS. Code is only changed inside an __APPLE__ macro check.