### PR TITLE
Remove redundant IIRSerializer deserialization method

### DIFF
--- a/dawn/src/dawn/Serialization/IIRSerializer.cpp
+++ b/dawn/src/dawn/Serialization/IIRSerializer.cpp
@@ -768,19 +768,13 @@ IIRSerializer::deserializeImpl(const std::string& str, IIRSerializer::Format kin
 std::shared_ptr<iir::StencilInstantiation> IIRSerializer::deserialize(const std::string& file,
                                                                       IIRSerializer::Format kind) {
   std::ifstream ifs(file);
-  if(!ifs.is_open())
+  if(!ifs.is_open()) {
     throw std::runtime_error(
         dawn::format("cannot deserialize IIR: failed to open file \"%s\"", file));
-
+  }
   std::string str((std::istreambuf_iterator<char>(ifs)), std::istreambuf_iterator<char>());
 
   return deserializeImpl(str, kind);
-}
-
-std::shared_ptr<iir::StencilInstantiation>
-IIRSerializer::deserializeFromString(const std::string& str, OptimizerContext* context,
-                                     IIRSerializer::Format kind) {
-  return deserializeFromString(str, kind);
 }
 
 std::shared_ptr<iir::StencilInstantiation>
@@ -792,9 +786,9 @@ void IIRSerializer::serialize(const std::string& file,
                               const std::shared_ptr<iir::StencilInstantiation> instantiation,
                               dawn::IIRSerializer::Format kind) {
   std::ofstream ofs(file);
-  if(!ofs.is_open())
+  if(!ofs.is_open()) {
     throw std::runtime_error(format("cannot serialize IIR: failed to open file \"%s\"", file));
-
+  }
   auto str = serializeImpl(instantiation, kind);
   std::copy(str.begin(), str.end(), std::ostreambuf_iterator<char>(ofs));
 }

--- a/dawn/src/dawn/Serialization/IIRSerializer.h
+++ b/dawn/src/dawn/Serialization/IIRSerializer.h
@@ -52,17 +52,6 @@ public:
   ///
   /// @param str    Byte or JSON string to deserialize
   /// @param kind   The kind of serialization used in `str` (Json or Byte)
-  /// @param context The OptimizerContext in which we register the Instantiation
-  /// @throws std::exception    Failed to deserialize
-  /// @returns newly allocated IIR on success or `NULL`
-  static std::shared_ptr<iir::StencilInstantiation>
-  deserializeFromString(const std::string& str, dawn::OptimizerContext* context,
-                        Format kind = Format::Json);
-
-  /// @brief Deserialize the StencilInstantiation from the given JSON formatted `string`
-  ///
-  /// @param str    Byte or JSON string to deserialize
-  /// @param kind   The kind of serialization used in `str` (Json or Byte)
   /// @throws std::exception    Failed to deserialize
   /// @returns newly allocated IIR on success or `NULL`
   static std::shared_ptr<iir::StencilInstantiation>

--- a/dawn/test/unit-test/dawn/IIR/TestIIRSerializer.cpp
+++ b/dawn/test/unit-test/dawn/IIR/TestIIRSerializer.cpp
@@ -173,7 +173,7 @@ protected:
 
   std::shared_ptr<iir::StencilInstantiation> serializeAndDeserializeRef() {
     return IIRSerializer::deserializeFromString(
-        IIRSerializer::serializeToString(referenceInstantiation), context_.get());
+        IIRSerializer::serializeToString(referenceInstantiation));
   }
 
   std::shared_ptr<iir::StencilInstantiation> referenceInstantiation;
@@ -272,8 +272,8 @@ TEST_F(IIRSerializerTest, IIRTestsReduce) {
                                                   Op::plus, b.at(in_f, HOffsetType::withOffset, 0),
                                                   b.lit(0.), LocType::Cells, LocType::Edges))))))));
 
-  auto deserializedAndSerialized = IIRSerializer::deserializeFromString(
-      IIRSerializer::serializeToString(stencil_instantiation), context_.get());
+  auto deserializedAndSerialized =
+      IIRSerializer::deserializeFromString(IIRSerializer::serializeToString(stencil_instantiation));
 
   IIR_EXPECT_EQ(stencil_instantiation, deserializedAndSerialized);
 }
@@ -307,8 +307,8 @@ TEST_F(IIRSerializerTest, IIRTestsWeightedReduce) {
                                                    b.lit(0.), LocType::Cells, LocType::Edges,
                                                    std::vector<int>({1, 2, 3, 4})))))))));
 
-  auto deserializedAndSerialized = IIRSerializer::deserializeFromString(
-      IIRSerializer::serializeToString(stencil_instantiation), context_.get());
+  auto deserializedAndSerialized =
+      IIRSerializer::deserializeFromString(IIRSerializer::serializeToString(stencil_instantiation));
 
   IIR_EXPECT_EQ(stencil_instantiation, deserializedAndSerialized);
 }


### PR DESCRIPTION
## Technical Description

Removes redundant IIR deserialization methods that accept OptimizerContext parameters that were not used.

### Resolves / Enhances

Resolves #668 
