### PR TITLE
Add PassSetDependencyGraph call to StageReordering group in CompilerUtil

### DIFF
--- a/dawn/src/dawn/Unittest/CompilerUtil.cpp
+++ b/dawn/src/dawn/Unittest/CompilerUtil.cpp
@@ -27,6 +27,7 @@
 #include "dawn/Optimizer/PassSSA.h"
 #include "dawn/Optimizer/PassSetBlockSize.h"
 #include "dawn/Optimizer/PassSetCaches.h"
+#include "dawn/Optimizer/PassSetDependencyGraph.h"
 #include "dawn/Optimizer/PassSetNonTempCaches.h"
 #include "dawn/Optimizer/PassSetStageGraph.h"
 #include "dawn/Optimizer/PassSetStageName.h"
@@ -181,6 +182,7 @@ CompilerUtil::createGroup(PassGroup group, std::unique_ptr<OptimizerContext>& co
 
   case PassGroup::StageReordering:
     addPass<dawn::PassSetStageGraph>(context, passes);
+    addPass<dawn::PassSetDependencyGraph>(context, passes);
     addPass<dawn::PassStageReordering>(context, passes, reorderStrategy);
     addPass<dawn::PassSetSyncStage>(context, passes);
     addPass<dawn::PassSetStageName>(context, passes);
@@ -334,6 +336,7 @@ bool CompilerUtil::runGroup(PassGroup group, std::unique_ptr<OptimizerContext>& 
   case PassGroup::StageReordering:
     result &= runPass<dawn::PassSetStageName>(context, instantiation);
     result &= runPass<dawn::PassSetStageGraph>(context, instantiation);
+    result &= runPass<dawn::PassSetDependencyGraph>(context, instantiation);
     result &= runPass<dawn::PassStageReordering>(context, instantiation, reorderStrategy);
     result &= runPass<dawn::PassSetSyncStage>(context, instantiation);
     result &= runPass<dawn::PassSetStageName>(context, instantiation);


### PR DESCRIPTION
## Technical Description

Add PassSetDependencyGraph call to StageReordering group in CompilerUtil::runGroup method.

### Resolves / Enhances

Resolves #808 
