### PR TITLE
Correctly install IIR and SIR generated proto headers

### DIFF
--- a/dawn/src/CMakeLists.txt
+++ b/dawn/src/CMakeLists.txt
@@ -21,6 +21,6 @@ endif()
 
 # install headers
 foreach(dir IN ITEMS dawn dawn-c)
-  install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/${dir} ${CMAKE_CURRENT_BINARY_DIR}/${dir} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+  install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/${dir} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
     FILES_MATCHING PATTERN "*.h" PATTERN "*.hpp" PATTERN "*.inc")
 endforeach()

--- a/dawn/src/dawn/IIR/CMakeLists.txt
+++ b/dawn/src/dawn/IIR/CMakeLists.txt
@@ -24,6 +24,9 @@ dawn_protobuf_generate(
   PACKG IIR
   LANGUAGE cpp
 )
+set(iir_proto_header_files ${iir_proto_cpp_files})
+list(FILTER iir_proto_header_files INCLUDE REGEX ".+\\.h?h$")
+install(FILES ${iir_proto_header_files} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/dawn/IIR/IIR)
 
 add_library(DawnIIRProto OBJECT ${iir_proto_cpp_files})
 target_compile_features(DawnIIRProto PUBLIC cxx_std_11)
@@ -115,6 +118,10 @@ add_library(DawnIIR
 
 target_add_dawn_standard_props(DawnIIR)
 target_link_libraries(DawnIIR PUBLIC DawnSupport DawnSIR DawnIIRProto)
+# The include path below is necessary for the C++ proto headers
+target_include_directories(DawnIIR
+  PUBLIC $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/dawn/IIR>
+)
 
 # TODO add this if CLAW needs it (-> Matthias)
 # if(DAWN_JAVA)

--- a/dawn/src/dawn/SIR/CMakeLists.txt
+++ b/dawn/src/dawn/SIR/CMakeLists.txt
@@ -23,6 +23,9 @@ dawn_protobuf_generate(
   PACKG SIR
   LANGUAGE cpp
 )
+set(sir_proto_header_files ${sir_proto_cpp_files})
+list(FILTER sir_proto_header_files INCLUDE REGEX ".+\\.h?h$")
+install(FILES ${sir_proto_header_files} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/dawn/SIR/SIR)
 
 add_library(DawnSIRProto OBJECT ${sir_proto_cpp_files})
 target_compile_features(DawnSIRProto PUBLIC cxx_std_11)
@@ -55,3 +58,7 @@ add_library(DawnSIR
 
 target_add_dawn_standard_props(DawnSIR)
 target_link_libraries(DawnSIR PUBLIC DawnSupport DawnAST DawnSIRProto)
+# The include path below is necessary for the C++ proto headers
+target_include_directories(DawnSIR
+  PUBLIC $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/dawn/SIR>
+)


### PR DESCRIPTION
## Technical Description

The proto header files were still not being correctly installed. This PR fixes that.