### PR TITLE
Remove extra include in dawn4py

### DIFF
--- a/dawn/src/dawn4py/_dawn4py.cpp
+++ b/dawn/src/dawn4py/_dawn4py.cpp
@@ -304,9 +304,6 @@ PYBIND11_MODULE(_dawn4py, m) {
                  if(export_info)
                    pp_defines_list.append(py::str(macroDefine));
                }
-               ss << "\n//---- Includes ----\n"
-                  << "#include \"driver-includes/gridtools_includes.hpp\"\n"
-                  << "using namespace gridtools::dawn;\n";
                ss << "\n//---- Globals ----\n";
                ss << translationUnit->getGlobals();
                ss << "\n//---- Stencils ----\n";

--- a/dawn/test/integration-test/dawn4py-tests/data/copy_stencil_ref.cpp
+++ b/dawn/test/integration-test/dawn4py-tests/data/copy_stencil_ref.cpp
@@ -38,10 +38,6 @@
 #include <driver-includes/gridtools_includes.hpp>
 using namespace gridtools::dawn;
 
-//---- Includes ----
-#include "driver-includes/gridtools_includes.hpp"
-using namespace gridtools::dawn;
-
 //---- Globals ----
 
 //---- Stencils ----

--- a/dawn/test/integration-test/dawn4py-tests/data/hori_diff_stencil_ref.cpp
+++ b/dawn/test/integration-test/dawn4py-tests/data/hori_diff_stencil_ref.cpp
@@ -38,10 +38,6 @@
 #include <driver-includes/gridtools_includes.hpp>
 using namespace gridtools::dawn;
 
-//---- Includes ----
-#include "driver-includes/gridtools_includes.hpp"
-using namespace gridtools::dawn;
-
 //---- Globals ----
 
 //---- Stencils ----

--- a/dawn/test/integration-test/dawn4py-tests/data/tridiagonal_solve_stencil_ref.cpp
+++ b/dawn/test/integration-test/dawn4py-tests/data/tridiagonal_solve_stencil_ref.cpp
@@ -38,10 +38,6 @@
 #include <driver-includes/gridtools_includes.hpp>
 using namespace gridtools::dawn;
 
-//---- Includes ----
-#include "driver-includes/gridtools_includes.hpp"
-using namespace gridtools::dawn;
-
 //---- Globals ----
 
 //---- Stencils ----


### PR DESCRIPTION
## Technical Description

The include is already part of the pp_defines_list. Especially adding the explicit include here breaks unstructured (introduces unnecessary dependency to gridtools).
