### PR TITLE
Add iteration space ranges to IIR stage prototypes

### DIFF
--- a/dawn/src/dawn/IIR/Stage.cpp
+++ b/dawn/src/dawn/IIR/Stage.cpp
@@ -32,8 +32,8 @@
 namespace dawn {
 namespace iir {
 
-Stage::Stage(const StencilMetaInformation& metaData, int StageID)
-    : metaData_(metaData), StageID_(StageID), iterationSpace_() {}
+Stage::Stage(const StencilMetaInformation& metaData, int StageID, IterationSpace iterationSpace)
+    : metaData_(metaData), StageID_(StageID), iterationSpace_(iterationSpace) {}
 
 Stage::Stage(const StencilMetaInformation& metaData, int StageID, const Interval& interval,
              IterationSpace iterationSpace)

--- a/dawn/src/dawn/IIR/Stage.h
+++ b/dawn/src/dawn/IIR/Stage.h
@@ -85,9 +85,11 @@ public:
 
   /// @name Constructors and Assignment
   /// @{
+  Stage(const StencilMetaInformation& metaData, int StageID,
+        IterationSpace iterationspace = {std::optional<Interval>(), std::optional<Interval>()});
+
   Stage(const StencilMetaInformation& metaData, int StageID, const Interval& interval,
         IterationSpace iterationspace = {std::optional<Interval>(), std::optional<Interval>()});
-  Stage(const StencilMetaInformation& metaData, int StageID);
 
   Stage(Stage&&) = default;
   /// @}

--- a/dawn/src/dawn/IIR/proto/IIR/IIR.proto
+++ b/dawn/src/dawn/IIR/proto/IIR/IIR.proto
@@ -77,7 +77,8 @@ message DoMethod {
 message Stage {
     repeated DoMethod doMethods = 1;
     int32 stageID = 2;
-
+    dawn.proto.statements.Interval i_range = 3; // Global index space in the I dimension
+    dawn.proto.statements.Interval j_range = 4; // Global index space in the J dimension
 }
 
 // @brief The Protobuf description of all the required members to describe a MultiStage of the IIR

--- a/dawn/src/dawn/Serialization/IIRSerializer.cpp
+++ b/dawn/src/dawn/Serialization/IIRSerializer.cpp
@@ -354,6 +354,19 @@ void IIRSerializer::serializeIIR(proto::iir::StencilInstantiation& target,
         // Information other than the children
         protoStage->set_stageid(stages->getStageID());
 
+        // Add iteration space
+        if(stages->hasIterationSpace()) {
+          auto iterationSpace = stages->getIterationSpace();
+          if(iterationSpace[0].has_value()) {
+            dawn::sir::Interval interval = iterationSpace[0].value().asSIRInterval();
+            setInterval(protoStage->mutable_i_range(), &interval);
+          }
+          if(iterationSpace[1].has_value()) {
+            dawn::sir::Interval interval = iterationSpace[1].value().asSIRInterval();
+            setInterval(protoStage->mutable_j_range(), &interval);
+          }
+        }
+
         // adding it's children
         for(const auto& domethod : stages->getChildren()) {
           auto protoDoMethod = protoStage->add_domethods();
@@ -678,7 +691,14 @@ void IIRSerializer::deserializeIIR(std::shared_ptr<iir::StencilInstantiation>& t
         int stageID = protoStage.stageid();
         maxID = std::max(std::abs(stageID), maxID);
 
-        IIRMSS->insertChild(std::make_unique<iir::Stage>(target->getMetaData(), stageID));
+        std::array<std::optional<iir::Interval>, 2> iterationSpace;
+        if(protoStage.has_i_range())
+          iterationSpace[0] = *makeInterval(protoStage.i_range());
+        if(protoStage.has_j_range())
+          iterationSpace[1] = *makeInterval(protoStage.j_range());
+
+        IIRMSS->insertChild(
+            std::make_unique<iir::Stage>(target->getMetaData(), stageID, iterationSpace));
         const auto& IIRStage = IIRMSS->getChild(stagePos++);
 
         for(const auto& protoDoMethod : protoStage.domethods()) {


### PR DESCRIPTION
## Technical Description

This PR updates the Protobuf definitions for IIR stages to include i-range and j-range intervals for global iteration spaces, and modifies the IIRSerializer accordingly.

### Resolves / Enhances

Resolves #819 



