### PR TITLE
Fix Dawn4Py SIR serialization utils to work with GTPy

### DIFF
--- a/dawn/src/dawn4py/serialization/utils.py
+++ b/dawn/src/dawn4py/serialization/utils.py
@@ -365,7 +365,7 @@ def make_block_stmt(statements: List[StmtType]) -> BlockStmt:
     """
     stmt = BlockStmt()
     if isinstance(statements, Iterable):
-        stmt.statements.extend([make_stmt(s) for s in statements])
+        stmt.statements.extend([make_stmt(s) for s in statements if not isinstance(s, Field)])
     else:
         stmt.statements.extend([make_stmt(statements)])
     return stmt
@@ -718,7 +718,8 @@ def make_literal_access_expr(value: str, type: BuiltinType.TypeID) -> LiteralAcc
     :param type:    Builtin type id of the literal.
     """
     builtin_type = BuiltinType()
-    builtin_type.type_id = type
+    if builtin_type.type_id != type:
+        builtin_type.type_id = type
 
     expr = LiteralAccessExpr()
     expr.value = value


### PR DESCRIPTION
## Technical Description

This PR resolves the following GT4Py errors in the SIR serialization step in the Dawn4Py integration that occur in the FV3 stencils:

```python
  File "/home/eddied/Work/dawn/dawn/src/dawn4py/serialization/utils.py", line 357, in make_stmt
    raise SIRError("cannot create Stmt from type {}".format(type(stmt)))
dawn4py.serialization.error.SIRError: cannot create Stmt from type <class 'SIR.statements_pb2.Field'>
```

... and ...

```python
File "/home/eddied/Work/dawn/dawn/src/dawn4py/serialization/utils.py", line 722, in make_literal_access_expr
  builtin_type.type_id = type
  AttributeError: 'BuiltinType' object attribute 'type_id' is read-only
```