### PR TITLE
Fix gtclang dawn call

### DIFF
--- a/dawn/src/dawn/Compiler/DawnCompiler.cpp
+++ b/dawn/src/dawn/Compiler/DawnCompiler.cpp
@@ -432,35 +432,28 @@ DawnCompiler::generate(const std::map<std::string, std::shared_ptr<iir::StencilI
 
 std::unique_ptr<codegen::TranslationUnit>
 DawnCompiler::compile(const std::shared_ptr<SIR>& stencilIR, std::list<PassGroup> groups) {
-  diagnostics_.clear();
-  diagnostics_.setFilename(stencilIR->Filename);
-
   if(groups.empty())
     groups = defaultPassGroups();
 
   // Parallelize the SIR
-  std::map<std::string, std::shared_ptr<iir::StencilInstantiation>> stencilInstantiation;
+  std::map<std::string, std::shared_ptr<iir::StencilInstantiation>> SIM, optimizedSIM;
   try {
-    stencilInstantiation = lowerToIIR(stencilIR);
+    SIM = lowerToIIR(stencilIR);
   } catch(...) {
     DAWN_LOG(INFO) << "Errors occurred. Skipping optimisation and code generation.";
     return nullptr;
   }
 
-  if(diagnostics_.hasErrors()) {
-    DAWN_LOG(INFO) << "Errors occurred. Skipping optimisation and code generation.";
-    return nullptr;
-  }
-
   // Optimize the IIR
-  auto optimizedStencilInstantiation = optimize(stencilInstantiation, groups);
-
-  if(diagnostics_.hasErrors()) {
+  try {
+    optimizedSIM = optimize(SIM, groups);
+  } catch(...) {
     DAWN_LOG(INFO) << "Errors occurred. Skipping code generation.";
     return nullptr;
   }
+
   // Generate the Code
-  return generate(optimizedStencilInstantiation);
+  return generate(optimizedSIM);
 }
 
 const DiagnosticsEngine& DawnCompiler::getDiagnostics() const { return diagnostics_; }

--- a/gtclang/src/gtclang/Frontend/GTClangASTConsumer.cpp
+++ b/gtclang/src/gtclang/Frontend/GTClangASTConsumer.cpp
@@ -193,13 +193,10 @@ void GTClangASTConsumer::HandleTranslationUnit(clang::ASTContext& ASTContext) {
       Compiler.generate(Compiler.optimize(Compiler.lowerToIIR(SIR), PassGroups));
 
   // Report diagnostics from Dawn
-  if(Compiler.getDiagnostics().hasDiags()) {
+  if(!DawnTranslationUnit || Compiler.getDiagnostics().hasErrors()) {
     for(const auto& diags : Compiler.getDiagnostics().getQueue()) {
       context_->getDiagnostics().report(*diags);
     }
-  }
-
-  if(!DawnTranslationUnit || Compiler.getDiagnostics().hasErrors()) {
     DAWN_LOG(INFO) << "Errors in Dawn. Aborting";
     return;
   }
@@ -243,7 +240,6 @@ void GTClangASTConsumer::HandleTranslationUnit(clang::ASTContext& ASTContext) {
   std::string code;
   if(context_->getOptions().Serialized) {
     DAWN_LOG(INFO) << "Data was loaded from serialized IR, codegen ";
-    std::cout << "Data was loaded from serialized IR, codegen " << std::endl;
 
     code += DawnTranslationUnit->getGlobals();
 

--- a/gtclang/src/gtclang/Frontend/GTClangASTConsumer.cpp
+++ b/gtclang/src/gtclang/Frontend/GTClangASTConsumer.cpp
@@ -190,7 +190,7 @@ void GTClangASTConsumer::HandleTranslationUnit(clang::ASTContext& ASTContext) {
 
   dawn::DawnCompiler Compiler(makeDAWNOptions(context_->getOptions()));
   std::unique_ptr<dawn::codegen::TranslationUnit> DawnTranslationUnit =
-      Compiler.compile(SIR, PassGroups);
+      Compiler.generate(Compiler.optimize(Compiler.lowerToIIR(SIR), PassGroups));
 
   // Report diagnostics from Dawn
   if(Compiler.getDiagnostics().hasDiags()) {


### PR DESCRIPTION
## Technical Description

Calls dawn components separately from gtclang, in order to recognize the `-disable-optimization` gtclang flag, since calling separately does not add default pass groups when none are present.

Also deletes a bit of unnecessary code.