### PR TITLE
Add stage location type consistency checks to validation pass

### DIFF
--- a/dawn/src/dawn/Optimizer/PassValidation.cpp
+++ b/dawn/src/dawn/Optimizer/PassValidation.cpp
@@ -40,23 +40,21 @@ bool PassValidation::run(const std::shared_ptr<iir::StencilInstantiation>& insta
   }
 
   if(iir->getGridType() == ast::GridType::Unstructured) {
-    UnstructuredDimensionChecker dimensionsChecker;
     auto [dimsConsistent, dimsConsistencyErrorLocation] =
-        dimensionsChecker.checkDimensionsConsistency(*iir, metadata);
+        UnstructuredDimensionChecker::checkDimensionsConsistency(*iir, metadata);
     DAWN_ASSERT_MSG(dimsConsistent,
                     ("Dimensions consistency check failed at line " +
                      std::to_string(dimsConsistencyErrorLocation.Line) + " " + description)
                         .c_str());
     auto [stageConsistent, stageConsistencyErrorLocation] =
-        dimensionsChecker.checkStageLocTypeConsistency(*iir, metadata);
+        UnstructuredDimensionChecker::checkStageLocTypeConsistency(*iir, metadata);
     DAWN_ASSERT_MSG(stageConsistent,
                     ("Stage location type consistency check failed at line " +
                      std::to_string(stageConsistencyErrorLocation.Line) + " " + description)
                         .c_str());
   }
 
-  GridTypeChecker gridChecker;
-  DAWN_ASSERT_MSG(gridChecker.checkGridTypeConsistency(*iir),
+  DAWN_ASSERT_MSG(GridTypeChecker::checkGridTypeConsistency(*iir),
                   ("Grid type consistency check failed " + description).c_str());
 
   IntegrityChecker checker(instantiation.get());
@@ -76,15 +74,14 @@ bool PassValidation::run(const std::shared_ptr<iir::StencilInstantiation>& insta
 
 bool PassValidation::run(const std::shared_ptr<dawn::SIR>& sir) {
   if(sir->GridType == ast::GridType::Unstructured) {
-    UnstructuredDimensionChecker dimensionsChecker;
-    auto [checkResult, errorLocation] = dimensionsChecker.checkDimensionsConsistency(*sir);
+    auto [checkResult, errorLocation] =
+        UnstructuredDimensionChecker::checkDimensionsConsistency(*sir);
     DAWN_ASSERT_MSG(checkResult, ("Dimensions in SIR are not consistent at line " +
                                   std::to_string(errorLocation.Line))
                                      .c_str());
   }
 
-  GridTypeChecker gridChecker;
-  DAWN_ASSERT_MSG(gridChecker.checkGridTypeConsistency(*sir),
+  DAWN_ASSERT_MSG(GridTypeChecker::checkGridTypeConsistency(*sir),
                   "Grid types in SIR are not consistent");
 
   return true;

--- a/dawn/src/dawn/Optimizer/TemporaryHandling.cpp
+++ b/dawn/src/dawn/Optimizer/TemporaryHandling.cpp
@@ -27,7 +27,7 @@ namespace dawn {
 
 namespace {
 sir::HorizontalFieldDimension
-getHorizontalFieldDimensions(iir::StencilInstantiation const* instantiation, int accessID) {
+getHorizontalFieldDimensionFromVar(iir::StencilInstantiation const* instantiation, int accessID) {
   auto cartesian = instantiation->getIIR()->getGridType() == ast::GridType::Cartesian;
   if(cartesian) {
     return sir::HorizontalFieldDimension(ast::cartesian, {true, true});
@@ -47,7 +47,7 @@ void promoteLocalVariableToTemporaryField(iir::StencilInstantiation* instantiati
 
   // Figure out dimensions
   sir::FieldDimensions fieldDims =
-      sir::FieldDimensions{getHorizontalFieldDimensions(instantiation, accessID), true};
+      sir::FieldDimensions{getHorizontalFieldDimensionFromVar(instantiation, accessID), true};
 
   // Compute name of field
   std::string fieldname = iir::InstantiationHelper::makeTemporaryFieldname(

--- a/dawn/src/dawn/Unittest/IIRBuilder.cpp
+++ b/dawn/src/dawn/Unittest/IIRBuilder.cpp
@@ -97,8 +97,9 @@ IIRBuilder::build(std::string const& name, std::unique_ptr<iir::Stencil> stencil
   UnstructuredDimensionChecker dimensionsChecker;
   GridTypeChecker gridTypeChecker;
   if(new_si->getIIR()->getGridType() == ast::GridType::Unstructured) {
-    DAWN_ASSERT(dimensionsChecker.checkDimensionsConsistency(*new_si->getIIR().get(),
-                                                             new_si->getMetaData()));
+    auto [checkResult, errorLoc] = dimensionsChecker.checkDimensionsConsistency(
+        *new_si->getIIR().get(), new_si->getMetaData());
+    DAWN_ASSERT_MSG(checkResult, "Dimensions consistency check failed.");
   }
   DAWN_ASSERT(gridTypeChecker.checkGridTypeConsistency(*new_si->getIIR().get()));
 

--- a/dawn/src/dawn/Unittest/IIRBuilder.cpp
+++ b/dawn/src/dawn/Unittest/IIRBuilder.cpp
@@ -94,14 +94,12 @@ IIRBuilder::build(std::string const& name, std::unique_ptr<iir::Stencil> stencil
   optimizer->restoreIIR("<restored>", std::move(si_));
   auto new_si = optimizer->getStencilInstantiationMap()["<restored>"];
 
-  UnstructuredDimensionChecker dimensionsChecker;
-  GridTypeChecker gridTypeChecker;
   if(new_si->getIIR()->getGridType() == ast::GridType::Unstructured) {
-    auto [checkResult, errorLoc] = dimensionsChecker.checkDimensionsConsistency(
+    auto [checkResult, errorLoc] = UnstructuredDimensionChecker::checkDimensionsConsistency(
         *new_si->getIIR().get(), new_si->getMetaData());
     DAWN_ASSERT_MSG(checkResult, "Dimensions consistency check failed.");
   }
-  DAWN_ASSERT(gridTypeChecker.checkGridTypeConsistency(*new_si->getIIR().get()));
+  DAWN_ASSERT(GridTypeChecker::checkGridTypeConsistency(*new_si->getIIR().get()));
 
   dawn::codegen::stencilInstantiationContext map;
   return new_si;

--- a/dawn/src/dawn/Validator/GridTypeChecker.h
+++ b/dawn/src/dawn/Validator/GridTypeChecker.h
@@ -43,7 +43,7 @@ private:
   };
 
 public:
-  bool checkGridTypeConsistency(const dawn::SIR&);
-  bool checkGridTypeConsistency(const dawn::iir::IIR&);
+  static bool checkGridTypeConsistency(const dawn::SIR&);
+  static bool checkGridTypeConsistency(const dawn::iir::IIR&);
 };
 } // namespace dawn

--- a/dawn/src/dawn/Validator/UnstructuredDimensionChecker.h
+++ b/dawn/src/dawn/Validator/UnstructuredDimensionChecker.h
@@ -63,10 +63,10 @@ public:
   /// inconsistency is found, the second element indicates its location in the source.
   using ConsistencyResult = std::tuple<bool, SourceLocation>;
 
-  ConsistencyResult checkDimensionsConsistency(const dawn::SIR&);
-  ConsistencyResult checkDimensionsConsistency(const dawn::iir::IIR&,
-                                               const iir::StencilMetaInformation&);
-  ConsistencyResult checkStageLocTypeConsistency(const dawn::iir::IIR&,
-                                                 const iir::StencilMetaInformation&);
+  static ConsistencyResult checkDimensionsConsistency(const dawn::SIR&);
+  static ConsistencyResult checkDimensionsConsistency(const dawn::iir::IIR&,
+                                                      const iir::StencilMetaInformation&);
+  static ConsistencyResult checkStageLocTypeConsistency(const dawn::iir::IIR&,
+                                                        const iir::StencilMetaInformation&);
 };
 } // namespace dawn

--- a/dawn/src/dawn/Validator/UnstructuredDimensionChecker.h
+++ b/dawn/src/dawn/Validator/UnstructuredDimensionChecker.h
@@ -20,6 +20,7 @@
 #include "dawn/IIR/IIR.h"
 #include "dawn/IIR/IIRNodeIterator.h"
 #include "dawn/IIR/StencilMetaInformation.h"
+#include "dawn/Support/SourceLocation.h"
 #include <memory>
 
 namespace dawn {
@@ -58,7 +59,14 @@ private:
   };
 
 public:
-  bool checkDimensionsConsistency(const dawn::SIR&);
-  bool checkDimensionsConsistency(const dawn::iir::IIR&, const iir::StencilMetaInformation&);
+  /// @brief Result of check. First element indicates whether the check passed. When an
+  /// inconsistency is found, the second element indicates its location in the source.
+  using ConsistencyResult = std::tuple<bool, SourceLocation>;
+
+  ConsistencyResult checkDimensionsConsistency(const dawn::SIR&);
+  ConsistencyResult checkDimensionsConsistency(const dawn::iir::IIR&,
+                                               const iir::StencilMetaInformation&);
+  ConsistencyResult checkStageLocTypeConsistency(const dawn::iir::IIR&,
+                                                 const iir::StencilMetaInformation&);
 };
 } // namespace dawn

--- a/dawn/test/unit-test/dawn/Validator/TestUnstructuredDimensionChecker.cpp
+++ b/dawn/test/unit-test/dawn/Validator/TestUnstructuredDimensionChecker.cpp
@@ -35,7 +35,7 @@ TEST(UnstructuredDimensionCheckerTest, AssignmentCase0_0) {
                           b.stage(b.doMethod(
                               dawn::sir::Interval::Start, dawn::sir::Interval::End,
                               b.stmt(b.assignExpr(b.at(sparse_field1), b.at(sparse_field2)))))))),
-      ".*checkDimensionsConsistency.*");
+      ".*Dimensions consistency check failed.*");
 }
 TEST(UnstructuredDimensionCheckerTest, AssignmentCase0_1) {
   using namespace dawn::iir;
@@ -51,7 +51,7 @@ TEST(UnstructuredDimensionCheckerTest, AssignmentCase0_1) {
                           b.stage(b.doMethod(
                               dawn::sir::Interval::Start, dawn::sir::Interval::End,
                               b.stmt(b.assignExpr(b.at(sparse_field1), b.at(sparse_field2)))))))),
-      ".*checkDimensionsConsistency.*");
+      ".*Dimensions consistency check failed.*");
 }
 TEST(UnstructuredDimensionCheckerTest, AssignmentCase1_0) {
   using namespace dawn::iir;
@@ -68,7 +68,7 @@ TEST(UnstructuredDimensionCheckerTest, AssignmentCase1_0) {
               LoopOrderKind::Parallel,
               b.stage(b.doMethod(dawn::sir::Interval::Start, dawn::sir::Interval::End,
                                  b.stmt(b.assignExpr(b.at(sparse_field), b.at(dense_field)))))))),
-      ".*checkDimensionsConsistency.*");
+      ".*Dimensions consistency check failed.*");
 }
 TEST(UnstructuredDimensionCheckerTest, AssignmentCase2_0) {
   using namespace dawn::iir;
@@ -83,7 +83,7 @@ TEST(UnstructuredDimensionCheckerTest, AssignmentCase2_0) {
                           LoopOrderKind::Parallel,
                           b.stage(b.doMethod(dawn::sir::Interval::Start, dawn::sir::Interval::End,
                                              b.stmt(b.assignExpr(b.at(cell_f), b.at(edge_f)))))))),
-      ".*checkDimensionsConsistency.*");
+      ".*Dimensions consistency check failed.*");
 }
 TEST(UnstructuredDimensionCheckerTest, AssignmentNoCase_0) {
   using namespace dawn::iir;
@@ -100,7 +100,7 @@ TEST(UnstructuredDimensionCheckerTest, AssignmentNoCase_0) {
               LoopOrderKind::Parallel,
               b.stage(b.doMethod(dawn::sir::Interval::Start, dawn::sir::Interval::End,
                                  b.stmt(b.assignExpr(b.at(dense_field), b.at(sparse_field)))))))),
-      ".*checkDimensionsConsistency.*");
+      ".*Dimensions consistency check failed.*");
 }
 TEST(UnstructuredDimensionCheckerTest, BinaryOpCase0_0) {
   using namespace dawn::iir;
@@ -118,7 +118,7 @@ TEST(UnstructuredDimensionCheckerTest, BinaryOpCase0_0) {
                   b.stage(b.doMethod(
                       dawn::sir::Interval::Start, dawn::sir::Interval::End,
                       b.stmt(b.binaryExpr(b.at(sparse_field1), b.at(sparse_field2), Op::plus))))))),
-      ".*checkDimensionsConsistency.*");
+      ".*Dimensions consistency check failed.*");
 }
 TEST(UnstructuredDimensionCheckerTest, BinaryOpCase0_1) {
   using namespace dawn::iir;
@@ -135,7 +135,7 @@ TEST(UnstructuredDimensionCheckerTest, BinaryOpCase0_1) {
                   b.stage(b.doMethod(
                       dawn::sir::Interval::Start, dawn::sir::Interval::End,
                       b.stmt(b.binaryExpr(b.at(sparse_field1), b.at(sparse_field2), Op::plus))))))),
-      ".*checkDimensionsConsistency.*");
+      ".*Dimensions consistency check failed.*");
 }
 TEST(UnstructuredDimensionCheckerTest, BinaryOpCase1_0) {
   using namespace dawn::iir;
@@ -152,7 +152,7 @@ TEST(UnstructuredDimensionCheckerTest, BinaryOpCase1_0) {
                   b.stage(b.doMethod(
                       dawn::sir::Interval::Start, dawn::sir::Interval::End,
                       b.stmt(b.binaryExpr(b.at(dense_field), b.at(sparse_field), Op::plus))))))),
-      ".*checkDimensionsConsistency.*");
+      ".*Dimensions consistency check failed.*");
 }
 TEST(UnstructuredDimensionCheckerTest, BinaryOpCase2_0) {
   using namespace dawn::iir;
@@ -168,7 +168,7 @@ TEST(UnstructuredDimensionCheckerTest, BinaryOpCase2_0) {
                           b.stage(b.doMethod(dawn::sir::Interval::Start, dawn::sir::Interval::End,
                                              b.stmt(b.binaryExpr(b.at(sparse_field),
                                                                  b.at(dense_field), Op::plus))))))),
-      ".*checkDimensionsConsistency.*");
+      ".*Dimensions consistency check failed.*");
 }
 TEST(UnstructuredDimensionCheckerTest, BinaryOpCase3_0) {
   using namespace dawn::iir;
@@ -185,7 +185,7 @@ TEST(UnstructuredDimensionCheckerTest, BinaryOpCase3_0) {
               LoopOrderKind::Parallel,
               b.stage(b.doMethod(dawn::sir::Interval::Start, dawn::sir::Interval::End,
                                  b.stmt(b.binaryExpr(b.at(cell_f), b.at(edge_f), Op::plus))))))),
-      ".*checkDimensionsConsistency.*");
+      ".*Dimensions consistency check failed.*");
 }
 TEST(UnstructuredDimensionCheckerTest, ReduceDense_0) {
   using namespace dawn::iir;
@@ -205,7 +205,7 @@ TEST(UnstructuredDimensionCheckerTest, ReduceDense_0) {
                                          b.reduceOverNeighborExpr(
                                              Op::plus, b.at(edge_field, HOffsetType::withOffset, 0),
                                              b.lit(0.), LocType::Edges, LocType::Cells)))))))),
-      ".*checkDimensionsConsistency.*");
+      ".*Dimensions consistency check failed.*");
 }
 TEST(UnstructuredDimensionCheckerTest, ReduceDense_1) {
   using namespace dawn::iir;
@@ -225,7 +225,7 @@ TEST(UnstructuredDimensionCheckerTest, ReduceDense_1) {
                                          b.reduceOverNeighborExpr(
                                              Op::plus, b.at(cell_field, HOffsetType::withOffset, 0),
                                              b.lit(0.), LocType::Cells, LocType::Edges)))))))),
-      ".*checkDimensionsConsistency.*");
+      ".*Dimensions consistency check failed.*");
 }
 TEST(UnstructuredDimensionCheckerTest, ReduceSparse_0) {
   using namespace dawn::iir;
@@ -246,7 +246,7 @@ TEST(UnstructuredDimensionCheckerTest, ReduceSparse_0) {
                                       b.reduceOverNeighborExpr(
                                           Op::plus, b.at(sparse_field, HOffsetType::withOffset, 0),
                                           b.lit(0.), LocType::Cells, LocType::Vertices)))))))),
-      ".*checkDimensionsConsistency.*");
+      ".*Dimensions consistency check failed.*");
 }
 TEST(UnstructuredDimensionCheckerTest, ReduceSparse_1) {
   using namespace dawn::iir;
@@ -267,6 +267,6 @@ TEST(UnstructuredDimensionCheckerTest, ReduceSparse_1) {
                                       b.reduceOverNeighborExpr(
                                           Op::plus, b.at(sparse_field, HOffsetType::withOffset, 0),
                                           b.lit(0.), LocType::Edges, LocType::Cells)))))))),
-      ".*checkDimensionsConsistency.*");
+      ".*Dimensions consistency check failed.*");
 }
 } // namespace


### PR DESCRIPTION
## Technical Description

- Add stage location type consistency check in `UnstructuredDimensionChecker` to check stage's location type consistency w.r.t. the statements inside the stage.
- Make methods of `UnstructuredDimensionChecker` and `GridTypeChecker` static.
- Improve error reporting of `UnstructuredDimensionChecker` (line number reporting).

### Resolves / Enhances

resolves #592 
