### PR TITLE
Change global variable map from unordered to ordered

### DIFF
--- a/dawn/src/dawn/SIR/SIR.h
+++ b/dawn/src/dawn/SIR/SIR.h
@@ -559,6 +559,7 @@ public:
   Global(Kind type) : Value(type) {}
 };
 
+// Using ordered map to guarantee the same backend code will be generated
 using GlobalVariableMap = std::map<std::string, Global>;
 
 } // namespace sir

--- a/dawn/src/dawn/SIR/SIR.h
+++ b/dawn/src/dawn/SIR/SIR.h
@@ -31,7 +31,7 @@
 #include <memory>
 #include <optional>
 #include <string>
-#include <unordered_map>
+#include <map>
 #include <variant>
 #include <vector>
 
@@ -559,7 +559,7 @@ public:
   Global(Kind type) : Value(type) {}
 };
 
-using GlobalVariableMap = std::unordered_map<std::string, Global>;
+using GlobalVariableMap = std::map<std::string, Global>;
 
 } // namespace sir
 

--- a/dawn/test/unit-test/dawn/CodeGen/reference/conditional_stencil.cpp
+++ b/dawn/test/unit-test/dawn/CodeGen/reference/conditional_stencil.cpp
@@ -40,8 +40,8 @@ namespace dawn_generated{
 namespace cxxnaive{
 
 struct globals {
-  bool var2;
   int var1;
+  bool var2;
 
   globals() : var1(1){
   }
@@ -124,20 +124,20 @@ public:
 
   // Access-wrapper for globally defined variables
 
-  bool get_var2() {
-    return m_globals.var2;
-  }
-
-  void set_var2(bool var2) {
-    m_globals.var2=var2;
-  }
-
   int get_var1() {
     return m_globals.var1;
   }
 
   void set_var1(int var1) {
     m_globals.var1=var1;
+  }
+
+  bool get_var2() {
+    return m_globals.var2;
+  }
+
+  void set_var2(bool var2) {
+    m_globals.var2=var2;
   }
 
   void run(storage_ijk_t in, storage_ijk_t out) {

--- a/dawn/test/unit-test/dawn/CodeGen/reference/conditional_stencil.cu
+++ b/dawn/test/unit-test/dawn/CodeGen/reference/conditional_stencil.cu
@@ -40,8 +40,8 @@ namespace dawn_generated{
 namespace cuda{
 
 struct globals {
-  bool var2;
   int var1;
+  bool var2;
 
   globals() : var1(1){
   }
@@ -188,20 +188,20 @@ public:
 
   // Access-wrapper for globally defined variables
 
-  bool get_var2() {
-    return m_globals.var2;
-  }
-
-  void set_var2(bool var2) {
-    m_globals.var2=var2;
-  }
-
   int get_var1() {
     return m_globals.var1;
   }
 
   void set_var1(int var1) {
     m_globals.var1=var1;
+  }
+
+  bool get_var2() {
+    return m_globals.var2;
+  }
+
+  void set_var2(bool var2) {
+    m_globals.var2=var2;
   }
 
   template<typename S>


### PR DESCRIPTION
## Technical Description

This PR changes the SIR global variables map from unordered to ordered to ensure that the same backend code is always generated.

