### PR TITLE
Try-catch correctly with dawn-opt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,3 @@ _local_/*
 
 # Ignore python editable installs
 *.egg-info/
-
-# Python venvs
-.venv/

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ _local_/*
 
 # Ignore python editable installs
 *.egg-info/
+
+# Python venvs
+.venv/

--- a/dawn/src/dawn/Compiler/DawnCompiler.cpp
+++ b/dawn/src/dawn/Compiler/DawnCompiler.cpp
@@ -195,10 +195,6 @@ DawnCompiler::lowerToIIR(const std::shared_ptr<SIR>& stencilIR) {
       throw std::runtime_error("An error occurred.");
 
     DAWN_LOG(INFO) << "Done with parallelization passes for `" << instantiation->getName() << "`";
-
-    if(options_.DumpStencilInstantiation) {
-      instantiation->dump();
-    }
   }
 
   return optimizer.getStencilInstantiationMap();

--- a/dawn/src/dawn/Serialization/SIRSerializer.cpp
+++ b/dawn/src/dawn/Serialization/SIRSerializer.cpp
@@ -28,6 +28,7 @@
 #include <list>
 #include <memory>
 #include <stack>
+#include <stdexcept>
 #include <tuple>
 
 namespace dawn {
@@ -116,8 +117,6 @@ static std::string serializeImpl(const SIR* sir, SIRSerializer::Format kind) {
   case ast::GridType::Unstructured:
     sirProto.set_gridtype(proto::enums::GridType::Unstructured);
     break;
-  default:
-    dawn_unreachable("invalid grid type");
   }
 
   // SIR.Filename
@@ -163,7 +162,7 @@ static std::string serializeImpl(const SIR* sir, SIRSerializer::Format kind) {
       } else if(sir::Offset* offset = dyn_cast<sir::Offset>(arg.get())) {
         setOffset(argProto->mutable_offset_value(), offset);
       } else {
-        dawn_unreachable("invalid argument");
+        throw std::invalid_argument("Invalid argument: StencilFunction.Args");
       }
     }
 
@@ -230,8 +229,6 @@ static std::string serializeImpl(const SIR* sir, SIRSerializer::Format kind) {
           "cannot deserialize SIR: %s", ProtobufLogger::getInstance().getErrorMessagesAndReset()));
     break;
   }
-  default:
-    dawn_unreachable("invalid SerializationKind");
   }
 
   return str;
@@ -471,7 +468,7 @@ static std::shared_ptr<sir::Expr> makeExpr(const dawn::proto::statements::Expr& 
       offset = ast::Offsets{ast::HorizontalOffset{}, exprProto.vertical_offset()};
       break;
     default:
-      dawn_unreachable("unknown offset");
+      throw std::invalid_argument("Unknown offset");
     }
 
     Array3i argumentOffset{{0, 0, 0}};
@@ -519,11 +516,12 @@ static std::shared_ptr<sir::Expr> makeExpr(const dawn::proto::statements::Expr& 
         weights.push_back(dawn::sir::Value(weightProto.integer_value()));
         break;
       case proto::statements::Weight::kStringValue:
-        dawn_unreachable("string type for weight encountered in serialization (weights need to be "
-                         "of arithmetic type)\n");
+        throw std::invalid_argument(
+            "string type for weight encountered in serialization (weights need to be "
+            "of arithmetic type)\n");
         break;
       case proto::statements::Weight::VALUE_NOT_SET:
-        dawn_unreachable("weight with undefined value encountered!\n");
+        throw std::invalid_argument("weight with undefined value encountered!\n");
         break;
       }
     }
@@ -542,7 +540,7 @@ static std::shared_ptr<sir::Expr> makeExpr(const dawn::proto::statements::Expr& 
   }
   case dawn::proto::statements::Expr::EXPR_NOT_SET:
   default:
-    dawn_unreachable("expr not set");
+    throw std::out_of_range("expr not set");
   }
   return nullptr;
 }
@@ -610,7 +608,7 @@ static std::shared_ptr<sir::Stmt> makeStmt(const dawn::proto::statements::Stmt& 
   }
   case dawn::proto::statements::Stmt::STMT_NOT_SET:
   default:
-    dawn_unreachable("stmt not set");
+    throw std::out_of_range("stmt not set");
   }
   return nullptr;
 }
@@ -644,7 +642,7 @@ static std::shared_ptr<SIR> deserializeImpl(const std::string& str, SIRSerialize
     break;
   }
   default:
-    dawn_unreachable("invalid serialization Kind");
+    throw std::invalid_argument("invalid serialization Kind");
   }
 
   // Convert protobuf SIR to SIR
@@ -661,7 +659,7 @@ static std::shared_ptr<SIR> deserializeImpl(const std::string& str, SIRSerialize
       sir = std::make_shared<SIR>(ast::GridType::Unstructured);
       break;
     default:
-      dawn_unreachable("unknown grid type");
+      throw std::out_of_range("Unknown grid type");
     }
 
     // SIR.Filename
@@ -712,7 +710,7 @@ static std::shared_ptr<SIR> deserializeImpl(const std::string& str, SIRSerialize
           break;
         case dawn::proto::statements::StencilFunctionArg::ARG_NOT_SET:
         default:
-          dawn_unreachable("argument not set");
+          throw std::out_of_range("argument not set");
         }
       }
 
@@ -753,7 +751,7 @@ static std::shared_ptr<SIR> deserializeImpl(const std::string& str, SIRSerialize
         break;
       case sir::proto::GlobalVariableValue::VALUE_NOT_SET:
       default:
-        dawn_unreachable("value not set");
+        throw std::out_of_range("value not set");
       }
 
       sir->GlobalVariableMap->emplace(sirName, std::move(*value));

--- a/dawn/src/dawn/dawn-opt.cpp
+++ b/dawn/src/dawn/dawn-opt.cpp
@@ -191,6 +191,8 @@ int main(int argc, char* argv[]) {
   dawnOptions.NAME = result[OPTION].as<TYPE>();
 #include "dawn/Optimizer/Options.inc"
 #undef OPT
+  // Never serialize IIR here
+  dawnOptions.SerializeIIR = false;
   dawn::DawnCompiler compiler(dawnOptions);
 
   // Determine the list of pass groups to run

--- a/dawn/src/dawn/dawn-opt.cpp
+++ b/dawn/src/dawn/dawn-opt.cpp
@@ -91,7 +91,7 @@ deserializeInput(const std::string& input) {
           dawn::SIRSerializer::deserializeFromString(input, dawn::SIRSerializer::Format::Byte);
       format = SerializationFormat::Byte;
     } catch(...) {
-      // Do nothing
+      stencilIR = nullptr;
     }
   }
   if(!stencilIR) {
@@ -100,7 +100,7 @@ deserializeInput(const std::string& input) {
           dawn::SIRSerializer::deserializeFromString(input, dawn::SIRSerializer::Format::Json);
       format = SerializationFormat::Json;
     } catch(...) {
-      // Do nothing
+      stencilIR = nullptr;
     }
   }
   // Then try IIR
@@ -111,7 +111,7 @@ deserializeInput(const std::string& input) {
           dawn::IIRSerializer::deserializeFromString(input, dawn::IIRSerializer::Format::Byte);
       format = SerializationFormat::Byte;
     } catch(...) {
-      // Do nothing
+      internalIR = nullptr;
     }
   }
   if(!internalIR && !stencilIR) {
@@ -120,7 +120,7 @@ deserializeInput(const std::string& input) {
           dawn::IIRSerializer::deserializeFromString(input, dawn::IIRSerializer::Format::Json);
       format = SerializationFormat::Json;
     } catch(...) {
-      // Do nothing
+      internalIR = nullptr;
     }
   }
 
@@ -134,6 +134,7 @@ deserializeInput(const std::string& input) {
       stencilIR =
           dawn::SIRSerializer::deserializeFromString(input, dawn::SIRSerializer::Format::Json);
     }
+    break;
   }
   case IRType::IIR: {
     if(format == SerializationFormat::Byte) {
@@ -143,6 +144,7 @@ deserializeInput(const std::string& input) {
       internalIR =
           dawn::IIRSerializer::deserializeFromString(input, dawn::IIRSerializer::Format::Json);
     }
+    break;
   }
   }
 


### PR DESCRIPTION
## Technical Description

Correctly try-catch with dawn-opt. Involves removing incorrect `dawn_unreachable(...)` calls and replacing these with throws. The serialization functions should no longer use `dawn_unreachable(...)` in the future.
