### PR TITLE
Fixing flag usage in gtclang

### DIFF
--- a/dawn/src/dawn/Optimizer/PassOptions.inc
+++ b/dawn/src/dawn/Optimizer/PassOptions.inc
@@ -34,10 +34,6 @@
 
 // Boolean parameters that turn on and off passes and specific pass reports. These will be removed.
 
-OPT(bool, DefaultNone, false, "default-none", "",
-    "Selectively run passes", "", false, true)
-OPT(bool, Parallel, false, "parallel", "",
-    "Run parallel pass group", "", false, true)
 OPT(bool, SSA, false, "ssa", "",
     "Transform all statements into static single assignment (SSA) form", "", false, false)
 OPT(bool, PrintStencilGraph, false, "print-stencil-graph", "",

--- a/dawn/src/dawn4py/_dawn4py.cpp
+++ b/dawn/src/dawn4py/_dawn4py.cpp
@@ -27,16 +27,16 @@ PYBIND11_MODULE(_dawn4py, m) {
                   bool UseNonTempCaches, bool KeepVarnames, bool PassVerbose, bool ReportAccesses,
                   bool DumpSplitGraphs, bool DumpStageGraph, bool DumpTemporaryGraphs,
                   bool DumpRaceConditionGraph, bool DumpStencilInstantiation, bool DumpStencilGraph,
-                  bool DefaultNone, bool Parallel, bool SSA, bool PrintStencilGraph,
-                  bool SetStageName, bool StageReordering, bool StageMerger, bool TemporaryMerger,
-                  bool Inlining, bool IntervalPartitioning, bool TmpToStencilFunction,
-                  bool SetNonTempCaches, bool SetCaches, bool SetBlockSize, bool DataLocalityMetric,
-                  bool ReportBoundaryConditions, bool ReportDataLocalityMetric,
-                  bool ReportPassTmpToFunction, bool ReportPassRemoveScalars,
-                  bool ReportPassStageSplit, bool ReportPassMultiStageSplit,
-                  bool ReportPassFieldVersioning, bool ReportPassTemporaryMerger,
-                  bool ReportPassTemporaryType, bool ReportPassStageReodering,
-                  bool ReportPassStageMerger, bool ReportPassSetCaches, bool ReportPassSetBlockSize,
+                  bool SSA, bool PrintStencilGraph, bool SetStageName, bool StageReordering,
+                  bool StageMerger, bool TemporaryMerger, bool Inlining, bool IntervalPartitioning,
+                  bool TmpToStencilFunction, bool SetNonTempCaches, bool SetCaches,
+                  bool SetBlockSize, bool DataLocalityMetric, bool ReportBoundaryConditions,
+                  bool ReportDataLocalityMetric, bool ReportPassTmpToFunction,
+                  bool ReportPassRemoveScalars, bool ReportPassStageSplit,
+                  bool ReportPassMultiStageSplit, bool ReportPassFieldVersioning,
+                  bool ReportPassTemporaryMerger, bool ReportPassTemporaryType,
+                  bool ReportPassStageReodering, bool ReportPassStageMerger,
+                  bool ReportPassSetCaches, bool ReportPassSetBlockSize,
                   bool ReportPassSetNonTempCaches) {
                  return dawn::Options{MaxBlocksPerSM,
                                       nsms,
@@ -69,8 +69,6 @@ PYBIND11_MODULE(_dawn4py, m) {
                                       DumpRaceConditionGraph,
                                       DumpStencilInstantiation,
                                       DumpStencilGraph,
-                                      DefaultNone,
-                                      Parallel,
                                       SSA,
                                       PrintStencilGraph,
                                       SetStageName,
@@ -114,14 +112,13 @@ PYBIND11_MODULE(_dawn4py, m) {
            py::arg("dump_stage_graph") = false, py::arg("dump_temporary_graphs") = false,
            py::arg("dump_race_condition_graph") = false,
            py::arg("dump_stencil_instantiation") = false, py::arg("dump_stencil_graph") = false,
-           py::arg("default_none") = false, py::arg("parallel") = false, py::arg("ssa") = false,
-           py::arg("print_stencil_graph") = false, py::arg("set_stage_name") = false,
-           py::arg("stage_reordering") = false, py::arg("stage_merger") = false,
-           py::arg("temporary_merger") = false, py::arg("inlining") = false,
-           py::arg("interval_partitioning") = false, py::arg("tmp_to_stencil_function") = false,
-           py::arg("set_non_temp_caches") = false, py::arg("set_caches") = false,
-           py::arg("set_block_size") = false, py::arg("data_locality_metric") = false,
-           py::arg("report_boundary_conditions") = false,
+           py::arg("ssa") = false, py::arg("print_stencil_graph") = false,
+           py::arg("set_stage_name") = false, py::arg("stage_reordering") = false,
+           py::arg("stage_merger") = false, py::arg("temporary_merger") = false,
+           py::arg("inlining") = false, py::arg("interval_partitioning") = false,
+           py::arg("tmp_to_stencil_function") = false, py::arg("set_non_temp_caches") = false,
+           py::arg("set_caches") = false, py::arg("set_block_size") = false,
+           py::arg("data_locality_metric") = false, py::arg("report_boundary_conditions") = false,
            py::arg("report_data_locality_metric") = false,
            py::arg("report_pass_tmp_to_function") = false,
            py::arg("report_pass_remove_scalars") = false,
@@ -165,8 +162,6 @@ PYBIND11_MODULE(_dawn4py, m) {
       .def_readwrite("dump_race_condition_graph", &dawn::Options::DumpRaceConditionGraph)
       .def_readwrite("dump_stencil_instantiation", &dawn::Options::DumpStencilInstantiation)
       .def_readwrite("dump_stencil_graph", &dawn::Options::DumpStencilGraph)
-      .def_readwrite("default_none", &dawn::Options::DefaultNone)
-      .def_readwrite("parallel", &dawn::Options::Parallel)
       .def_readwrite("ssa", &dawn::Options::SSA)
       .def_readwrite("print_stencil_graph", &dawn::Options::PrintStencilGraph)
       .def_readwrite("set_stage_name", &dawn::Options::SetStageName)
@@ -237,8 +232,6 @@ PYBIND11_MODULE(_dawn4py, m) {
            << "dump_race_condition_graph=" << self.DumpRaceConditionGraph << ",\n    "
            << "dump_stencil_instantiation=" << self.DumpStencilInstantiation << ",\n    "
            << "dump_stencil_graph=" << self.DumpStencilGraph << ",\n    "
-           << "default_none=" << self.DefaultNone << ",\n    "
-           << "parallel=" << self.Parallel << ",\n    "
            << "ssa=" << self.SSA << ",\n    "
            << "print_stencil_graph=" << self.PrintStencilGraph << ",\n    "
            << "set_stage_name=" << self.SetStageName << ",\n    "
@@ -304,6 +297,9 @@ PYBIND11_MODULE(_dawn4py, m) {
                  if(export_info)
                    pp_defines_list.append(py::str(macroDefine));
                }
+               ss << "\n//---- Includes ----\n"
+                  << "#include \"driver-includes/gridtools_includes.hpp\"\n"
+                  << "using namespace gridtools::dawn;\n";
                ss << "\n//---- Globals ----\n";
                ss << translationUnit->getGlobals();
                ss << "\n//---- Stencils ----\n";

--- a/dawn/test/integration-test/dawn4py-tests/data/copy_stencil_ref.cpp
+++ b/dawn/test/integration-test/dawn4py-tests/data/copy_stencil_ref.cpp
@@ -38,6 +38,10 @@
 #include <driver-includes/gridtools_includes.hpp>
 using namespace gridtools::dawn;
 
+//---- Includes ----
+#include "driver-includes/gridtools_includes.hpp"
+using namespace gridtools::dawn;
+
 //---- Globals ----
 
 //---- Stencils ----

--- a/dawn/test/integration-test/dawn4py-tests/data/hori_diff_stencil_ref.cpp
+++ b/dawn/test/integration-test/dawn4py-tests/data/hori_diff_stencil_ref.cpp
@@ -38,6 +38,10 @@
 #include <driver-includes/gridtools_includes.hpp>
 using namespace gridtools::dawn;
 
+//---- Includes ----
+#include "driver-includes/gridtools_includes.hpp"
+using namespace gridtools::dawn;
+
 //---- Globals ----
 
 //---- Stencils ----

--- a/dawn/test/integration-test/dawn4py-tests/data/tridiagonal_solve_stencil_ref.cpp
+++ b/dawn/test/integration-test/dawn4py-tests/data/tridiagonal_solve_stencil_ref.cpp
@@ -38,6 +38,10 @@
 #include <driver-includes/gridtools_includes.hpp>
 using namespace gridtools::dawn;
 
+//---- Includes ----
+#include "driver-includes/gridtools_includes.hpp"
+using namespace gridtools::dawn;
+
 //---- Globals ----
 
 //---- Stencils ----

--- a/gtclang/src/gtclang/Driver/Options.inc
+++ b/gtclang/src/gtclang/Driver/Options.inc
@@ -49,7 +49,9 @@ OPT(bool, ClangFormat, true, "clang-format", "", "Run clang-format on the genera
 OPT(bool, ReportPassPreprocessor, false, "report-pass-preprocessor", "",
     "Print each line of the preprocessed source prepended by the line number (comments and indentation are removed)", "", false, true)
 OPT(bool, Serialized, false, "loaded-serialized", "", "is the passed file serialized data", "", false, true)
-OPT(bool, DisableOptimization, false, "disable-optimization", "",
-    "If true, disables all default pass groups", "", false, false)
+OPT(bool, DisableOptimization, false, "no-opt", "",
+    "Disables all optimisation", "", false, true)
+OPT(bool, DefaultOptimization, false, "default-opt", "",
+    "Runs all the default optimization", "", false, true)
 
 // clang-format on

--- a/gtclang/src/gtclang/Driver/Options.inc
+++ b/gtclang/src/gtclang/Driver/Options.inc
@@ -50,8 +50,8 @@ OPT(bool, ReportPassPreprocessor, false, "report-pass-preprocessor", "",
     "Print each line of the preprocessed source prepended by the line number (comments and indentation are removed)", "", false, true)
 OPT(bool, Serialized, false, "loaded-serialized", "", "is the passed file serialized data", "", false, true)
 OPT(bool, DisableOptimization, false, "no-opt", "",
-    "Disables all optimisation", "", false, true)
+    "Disables all optimisation", "", false, false)
 OPT(bool, DefaultOptimization, false, "default-opt", "",
-    "Runs all the default optimization", "", false, true)
+    "Runs all the default optimization", "", false, false)
 
 // clang-format on

--- a/gtclang/src/gtclang/Frontend/GTClangASTConsumer.cpp
+++ b/gtclang/src/gtclang/Frontend/GTClangASTConsumer.cpp
@@ -142,55 +142,69 @@ void GTClangASTConsumer::HandleTranslationUnit(clang::ASTContext& ASTContext) {
     return;
 
   // Compile the SIR using Dawn
-  std::list<dawn::PassGroup> PassGroups;
+  std::list<dawn::PassGroup> passGroup;
 
   if(context_->getOptions().SSA)
-    PassGroups.push_back(dawn::PassGroup::SSA);
+    passGroup.push_back(dawn::PassGroup::SSA);
 
   if(context_->getOptions().PrintStencilGraph)
-    PassGroups.push_back(dawn::PassGroup::PrintStencilGraph);
+    passGroup.push_back(dawn::PassGroup::PrintStencilGraph);
 
-  if(!context_->getOptions().DisableOptimization)
-    PassGroups.push_back(dawn::PassGroup::SetStageName);
+  if(context_->getOptions().SetStageName || context_->getOptions().DefaultOptimization)
+    passGroup.push_back(dawn::PassGroup::SetStageName);
 
-  if(!context_->getOptions().DisableOptimization)
-    PassGroups.push_back(dawn::PassGroup::StageReordering);
+  if(context_->getOptions().StageReordering || context_->getOptions().DefaultOptimization)
+    passGroup.push_back(dawn::PassGroup::StageReordering);
 
-  if(!context_->getOptions().DisableOptimization)
-    PassGroups.push_back(dawn::PassGroup::StageMerger);
+  if(context_->getOptions().StageMerger || context_->getOptions().DefaultOptimization)
+    passGroup.push_back(dawn::PassGroup::StageMerger);
 
   if(std::any_of(SIR->Stencils.begin(), SIR->Stencils.end(),
                  [](const std::shared_ptr<dawn::sir::Stencil>& stencilPtr) {
                    return stencilPtr->Attributes.has(dawn::sir::Attr::Kind::MergeTemporaries);
                  }) ||
      context_->getOptions().TemporaryMerger) {
-    PassGroups.push_back(dawn::PassGroup::TemporaryMerger);
+    passGroup.push_back(dawn::PassGroup::TemporaryMerger);
   }
 
   if(context_->getOptions().Inlining)
-    PassGroups.push_back(dawn::PassGroup::Inlining);
+    passGroup.push_back(dawn::PassGroup::Inlining);
 
   if(context_->getOptions().IntervalPartitioning)
-    PassGroups.push_back(dawn::PassGroup::IntervalPartitioning);
+    passGroup.push_back(dawn::PassGroup::IntervalPartitioning);
 
   if(context_->getOptions().TmpToStencilFunction)
-    PassGroups.push_back(dawn::PassGroup::TmpToStencilFunction);
+    passGroup.push_back(dawn::PassGroup::TmpToStencilFunction);
 
   if(context_->getOptions().SetNonTempCaches)
-    PassGroups.push_back(dawn::PassGroup::SetNonTempCaches);
+    passGroup.push_back(dawn::PassGroup::SetNonTempCaches);
 
-  if(!context_->getOptions().DisableOptimization)
-    PassGroups.push_back(dawn::PassGroup::SetCaches);
+  if(context_->getOptions().SetCaches || context_->getOptions().DefaultOptimization)
+    passGroup.push_back(dawn::PassGroup::SetCaches);
 
-  if(!context_->getOptions().DisableOptimization)
-    PassGroups.push_back(dawn::PassGroup::SetBlockSize);
+  if(context_->getOptions().SetBlockSize || context_->getOptions().DefaultOptimization)
+    passGroup.push_back(dawn::PassGroup::SetBlockSize);
 
   if(context_->getOptions().DataLocalityMetric)
-    PassGroups.push_back(dawn::PassGroup::DataLocalityMetric);
+    passGroup.push_back(dawn::PassGroup::DataLocalityMetric);
+
+  // if nothing is passed, we fill the group with the default if no-optimization is not specified
+  if(!context_->getOptions().DisableOptimization && passGroup.size() == 0) {
+    passGroup.push_back(dawn::PassGroup::SetStageName);
+    passGroup.push_back(dawn::PassGroup::StageReordering);
+    passGroup.push_back(dawn::PassGroup::StageMerger);
+    passGroup.push_back(dawn::PassGroup::SetCaches);
+    passGroup.push_back(dawn::PassGroup::SetBlockSize);
+  }
+
+  if(context_->getOptions().DisableOptimization && passGroup.size() > 0) {
+    DAWN_ASSERT_MSG(false,
+                    "Inconsistent arguments: no optimisation as well as optimization specified");
+  }
 
   dawn::DawnCompiler Compiler(makeDAWNOptions(context_->getOptions()));
   std::unique_ptr<dawn::codegen::TranslationUnit> DawnTranslationUnit =
-      Compiler.generate(Compiler.optimize(Compiler.lowerToIIR(SIR), PassGroups));
+      Compiler.generate(Compiler.optimize(Compiler.lowerToIIR(SIR), passGroup));
 
   // Report diagnostics from Dawn
   if(!DawnTranslationUnit || Compiler.getDiagnostics().hasErrors()) {


### PR DESCRIPTION
## Technical Description

This ensures the use of `-no-opt` and `-default-opt` do the correct thing. 
The new interface does:
- run the default group if nothing is specified
- run only the selected passes if they are specified
- run nothing if `-no-opt` is specified
- run default plus passes if both are specified
- asserts if `no-opt` and optimization is specified


### Resolves / Enhances

Issues with current implementation of the flag check while maintaining backwards compatibility.

## Testing

This requires the default flag to be set in one of Clang-GT's tests, so testing is here:
http://localhost:8080/job/dawn_gtclang_clang-gridtools_PR/415/

