### PR TITLE
Skip serialization in certain cases

### DIFF
--- a/dawn/src/dawn/dawn-opt.cpp
+++ b/dawn/src/dawn/dawn-opt.cpp
@@ -242,7 +242,7 @@ int main(int argc, char* argv[]) {
 
       std::cout << dawn::IIRSerializer::serializeToString(instantiation, iirFormat);
     } else {
-      DAWN_LOG(INFO) << "Option dump-si was present. Skipping serialization...";
+      DAWN_LOG(INFO) << "dump-si present. Skipping serialization.";
     }
   }
 

--- a/dawn/src/dawn/dawn-opt.cpp
+++ b/dawn/src/dawn/dawn-opt.cpp
@@ -160,7 +160,7 @@ int main(int argc, char* argv[]) {
     ("input", "Input file. If unset, reads from stdin.", cxxopts::value<std::string>())
     ("o,out", "Output IIR filename. If unset, writes IIR to stdout.", cxxopts::value<std::string>())
     ("v,verbose", "Set verbosity level to info. If set, use -o or --out to redirect IIR.")
-    ("default-groups", "Add default groups before those in --pass-groups.")
+    ("default-opt", "Add default groups before those in --pass-groups.")
     ("p,pass-groups",
         "Comma-separated ordered list of pass groups to run. See DawnCompiler.h for list. If unset, runs the basic, default groups.",
         cxxopts::value<std::vector<std::string>>()->default_value({}))
@@ -197,7 +197,7 @@ int main(int argc, char* argv[]) {
 
   // Determine the list of pass groups to run
   std::list<dawn::PassGroup> passGroups;
-  if(result.count("default-groups") > 0) {
+  if(result.count("default-opt") > 0) {
     passGroups = dawn::DawnCompiler::defaultPassGroups();
   }
   for(auto pg : result["pass-groups"].as<std::vector<std::string>>()) {
@@ -238,8 +238,12 @@ int main(int argc, char* argv[]) {
                                                 : dawn::IIRSerializer::Format::Json;
     if(result.count("out"))
       dawn::IIRSerializer::serialize(result["out"].as<std::string>(), instantiation, iirFormat);
-    else
+    else if(!dawnOptions.DumpStencilInstantiation) {
+
       std::cout << dawn::IIRSerializer::serializeToString(instantiation, iirFormat);
+    } else {
+      DAWN_LOG(INFO) << "Option dump-si was present. Skipping serialization...";
+    }
   }
 
   return 0;

--- a/gtclang/src/gtclang/gtc-parse.cpp
+++ b/gtclang/src/gtclang/gtc-parse.cpp
@@ -126,7 +126,9 @@ int main(int argc, char* argv[]) {
   }
 
   // Write SIR to stdout or file
-  if(result.count("out")) {
+  if(result.count("DumpAST") > 0 || result.count("DumpPP") > 0) {
+    DAWN_INFO(WARN) << "dump-ast or dump-pp present. Skipping serialization.";
+  } else if(result.count("out")) {
     dawn::SIRSerializer::serialize(result["out"].as<std::string>(), returnSIR.get(), format);
   } else {
     const std::string sirString = dawn::SIRSerializer::serializeToString(returnSIR.get(), format);

--- a/gtclang/src/gtclang/gtc-parse.cpp
+++ b/gtclang/src/gtclang/gtc-parse.cpp
@@ -126,10 +126,10 @@ int main(int argc, char* argv[]) {
   }
 
   // Write SIR to stdout or file
-  if(result.count("DumpAST") > 0 || result.count("DumpPP") > 0) {
-    DAWN_LOG(INFO) << "dump-ast or dump-pp present. Skipping serialization.";
-  } else if(result.count("out")) {
+  if(result.count("out") > 0) {
     dawn::SIRSerializer::serialize(result["out"].as<std::string>(), returnSIR.get(), format);
+  } else if(result.count("dump-ast") > 0 || result.count("dump-pp") > 0) {
+    DAWN_LOG(INFO) << "dump-ast or dump-pp present. Skipping serialization.";
   } else {
     const std::string sirString = dawn::SIRSerializer::serializeToString(returnSIR.get(), format);
     std::cout << sirString;

--- a/gtclang/src/gtclang/gtc-parse.cpp
+++ b/gtclang/src/gtclang/gtc-parse.cpp
@@ -127,7 +127,7 @@ int main(int argc, char* argv[]) {
 
   // Write SIR to stdout or file
   if(result.count("DumpAST") > 0 || result.count("DumpPP") > 0) {
-    DAWN_INFO(WARN) << "dump-ast or dump-pp present. Skipping serialization.";
+    DAWN_LOG(WARNING) << "dump-ast or dump-pp present. Skipping serialization.";
   } else if(result.count("out")) {
     dawn::SIRSerializer::serialize(result["out"].as<std::string>(), returnSIR.get(), format);
   } else {

--- a/gtclang/src/gtclang/gtc-parse.cpp
+++ b/gtclang/src/gtclang/gtc-parse.cpp
@@ -127,7 +127,7 @@ int main(int argc, char* argv[]) {
 
   // Write SIR to stdout or file
   if(result.count("DumpAST") > 0 || result.count("DumpPP") > 0) {
-    DAWN_LOG(WARNING) << "dump-ast or dump-pp present. Skipping serialization.";
+    DAWN_LOG(INFO) << "dump-ast or dump-pp present. Skipping serialization.";
   } else if(result.count("out")) {
     dawn::SIRSerializer::serialize(result["out"].as<std::string>(), returnSIR.get(), format);
   } else {


### PR DESCRIPTION
## Technical Description

Skip serialization if certain options are present in separate executables. Mimics the existing gtclang behavior.