### PR TITLE
Update loop orders in IIR reference files

### DIFF
--- a/dawn/CMakeLists.txt
+++ b/dawn/CMakeLists.txt
@@ -114,12 +114,6 @@ set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 find_package(Python3 COMPONENTS Interpreter)
 
-# Set PYTHON_EXECUTABLE to the Python3_EXECUTABLE if not manually specified,
-# otherwise pybind11 may find the wrong python library.
-if (NOT PYTHON_EXECUTABLE)
-  set(PYTHON_EXECUTABLE ${Python3_EXECUTABLE})
-endif()
-
 # Add cxx standard, include directories, and properties
 function(target_add_dawn_standard_props target)
   target_include_directories(${target}

--- a/gtclang/test/integration-test/IIRSerializer/AccessTest_ref.iir
+++ b/gtclang/test/integration-test/IIRSerializer/AccessTest_ref.iir
@@ -400,7 +400,7 @@
         "locationType": "LocationTypeUnknown"
        }
       ],
-      "loopOrder": "Parallel",
+      "loopOrder": "Forward",
       "multiStageID": 43,
       "Caches": {}
      }

--- a/gtclang/test/integration-test/IIRSerializer/CopyTest_ref.iir
+++ b/gtclang/test/integration-test/IIRSerializer/CopyTest_ref.iir
@@ -196,7 +196,7 @@
         "locationType": "LocationTypeUnknown"
        }
       ],
-      "loopOrder": "Parallel",
+      "loopOrder": "Forward",
       "multiStageID": 23,
       "Caches": {}
      }

--- a/gtclang/test/integration-test/IIRSerializer/NestedStencils_ref.iir
+++ b/gtclang/test/integration-test/IIRSerializer/NestedStencils_ref.iir
@@ -196,7 +196,7 @@
         "locationType": "LocationTypeUnknown"
        }
       ],
-      "loopOrder": "Parallel",
+      "loopOrder": "Forward",
       "multiStageID": 108,
       "Caches": {}
      }

--- a/gtclang/test/integration-test/IIRSerializer/StencilFnCallTest_ref.iir
+++ b/gtclang/test/integration-test/IIRSerializer/StencilFnCallTest_ref.iir
@@ -257,7 +257,7 @@
         "locationType": "LocationTypeUnknown"
        }
       ],
-      "loopOrder": "Parallel",
+      "loopOrder": "Forward",
       "multiStageID": 35,
       "Caches": {}
      }

--- a/gtclang/test/integration-test/Regression/globals_dependencies_issue401_ref.0.iir
+++ b/gtclang/test/integration-test/Regression/globals_dependencies_issue401_ref.0.iir
@@ -258,7 +258,7 @@
         "locationType": "LocationTypeUnknown"
        }
       ],
-      "loopOrder": "Parallel",
+      "loopOrder": "Forward",
       "multiStageID": 75,
       "Caches": {}
      }
@@ -424,7 +424,7 @@
         "locationType": "LocationTypeUnknown"
        }
       ],
-      "loopOrder": "Parallel",
+      "loopOrder": "Forward",
       "multiStageID": 76,
       "Caches": {}
      }


### PR DESCRIPTION
## Technical Description

Updates IIR reference files in the `GTClang::Integration` tests to reflect the change that the default multistage loop order is specified by the user.


