### PR TITLE
Declare cuda globals once

### DIFF
--- a/dawn/src/dawn/CodeGen/Cuda/MSCodeGen.cpp
+++ b/dawn/src/dawn/CodeGen/Cuda/MSCodeGen.cpp
@@ -27,6 +27,9 @@
 namespace dawn {
 namespace codegen {
 namespace cuda {
+
+std::unordered_set<std::string> MSCodeGen::globalNames_;
+
 MSCodeGen::MSCodeGen(std::stringstream& ss, const std::unique_ptr<iir::MultiStage>& ms,
                      const std::shared_ptr<iir::StencilInstantiation>& stencilInstantiation,
                      const CacheProperties& cacheProperties,
@@ -714,6 +717,7 @@ void MSCodeGen::generateCudaKernelCode() {
         }
       }
     }
+
     if(globalNames_.find("globalOffsets") == globalNames_.end()) {
       ss_ << "__constant__ unsigned globalOffsets_[2];\n";
       globalNames_.insert("globalOffsets");

--- a/dawn/src/dawn/CodeGen/Cuda/MSCodeGen.h
+++ b/dawn/src/dawn/CodeGen/Cuda/MSCodeGen.h
@@ -16,6 +16,7 @@
 #define DAWN_CODEGEN_CUDA_MSCODEGEN_H
 
 #include <sstream>
+#include <unordered_set>
 
 #include "dawn/CodeGen/CXXUtil.h"
 #include "dawn/CodeGen/Cuda/CacheProperties.h"
@@ -58,6 +59,7 @@ private:
   const bool solveKLoopInParallel_;
   CudaCodeGen::CudaCodeGenOptions options_;
   bool iterationSpaceSet_;
+  std::unordered_set<std::string> globalNames_;
 
 public:
   MSCodeGen(std::stringstream& ss, const std::unique_ptr<iir::MultiStage>& ms,

--- a/dawn/src/dawn/CodeGen/Cuda/MSCodeGen.h
+++ b/dawn/src/dawn/CodeGen/Cuda/MSCodeGen.h
@@ -59,7 +59,7 @@ private:
   const bool solveKLoopInParallel_;
   CudaCodeGen::CudaCodeGenOptions options_;
   bool iterationSpaceSet_;
-  std::unordered_set<std::string> globalNames_;
+  static std::unordered_set<std::string> globalNames_;
 
 public:
   MSCodeGen(std::stringstream& ss, const std::unique_ptr<iir::MultiStage>& ms,


### PR DESCRIPTION
## Technical Description

This PR modifies the `MSCodeGen` class to only declare global CUDA variables and functions once per translation unit, rather than once per kernel.

### Resolves / Enhances

Resolves #939
