### PR TITLE
Add Cuda Code Gen for Unstructured Meshes 

### DIFF
--- a/dawn/src/dawn/CodeGen/CMakeLists.txt
+++ b/dawn/src/dawn/CodeGen/CMakeLists.txt
@@ -50,6 +50,8 @@ add_library(DawnCodeGen
   Cuda/ASTStencilFunctionParamVisitor.h
   Cuda/MSCodeGen.cpp
   Cuda/MSCodeGen.h
+  Cuda-ico/ASTStencilBody.h
+  Cuda-ico/ASTStencilBody.cpp
   Cuda-ico/CudaIcoCodeGen.h
   Cuda-ico/CudaIcoCodeGen.cpp
   Driver.cpp

--- a/dawn/src/dawn/CodeGen/CMakeLists.txt
+++ b/dawn/src/dawn/CodeGen/CMakeLists.txt
@@ -50,6 +50,8 @@ add_library(DawnCodeGen
   Cuda/ASTStencilFunctionParamVisitor.h
   Cuda/MSCodeGen.cpp
   Cuda/MSCodeGen.h
+  Cuda-ico/CudaIcoCodeGen.h
+  Cuda-ico/CudaIcoCodeGen.cpp
   Driver.cpp
   Driver.h
   GridTools/ASTStencilBody.cpp

--- a/dawn/src/dawn/CodeGen/CMakeLists.txt
+++ b/dawn/src/dawn/CodeGen/CMakeLists.txt
@@ -54,6 +54,8 @@ add_library(DawnCodeGen
   Cuda-ico/ASTStencilBody.cpp
   Cuda-ico/CudaIcoCodeGen.h
   Cuda-ico/CudaIcoCodeGen.cpp
+  Cuda-ico/LocToStringUtils.h
+  Cuda-ico/LocToStringUtils.cpp
   Driver.cpp
   Driver.h
   GridTools/ASTStencilBody.cpp

--- a/dawn/src/dawn/CodeGen/Cuda-ico/ASTStencilBody.cpp
+++ b/dawn/src/dawn/CodeGen/Cuda-ico/ASTStencilBody.cpp
@@ -1,0 +1,232 @@
+//===--------------------------------------------------------------------------------*- C++ -*-===//
+//                          _
+//                         | |
+//                       __| | __ ___      ___ ___
+//                      / _` |/ _` \ \ /\ / / '_  |
+//                     | (_| | (_| |\ V  V /| | | |
+//                      \__,_|\__,_| \_/\_/ |_| |_| - Compiler Toolchain
+//
+//
+//  This file is distributed under the MIT License (MIT).
+//  See LICENSE.txt for details.
+//
+//===------------------------------------------------------------------------------------------===//
+
+#include "ASTStencilBody.h"
+#include "dawn/AST/LocationType.h"
+#include "dawn/IIR/AST.h"
+#include "dawn/IIR/ASTExpr.h"
+#include <sstream>
+
+namespace dawn {
+namespace codegen {
+namespace cudaico {
+
+static std::string sparseSizeString(const std::vector<ast::LocationType>& locs) {
+  std::stringstream ss;
+  for(auto loc : locs) {
+    switch(loc) {
+    case ast::LocationType::Cells:
+      ss << "C_";
+      break;
+    case ast::LocationType::Edges:
+      ss << "E_";
+      break;
+    case ast::LocationType::Vertices:
+      ss << "V_";
+      break;
+    }
+  }
+  ss << "SIZE";
+  return ss.str();
+}
+static std::string tableString(const std::vector<ast::LocationType>& locs) {
+  std::stringstream ss;
+  for(auto loc : locs) {
+    switch(loc) {
+    case ast::LocationType::Cells:
+      ss << "c";
+      break;
+    case ast::LocationType::Edges:
+      ss << "e";
+      break;
+    case ast::LocationType::Vertices:
+      ss << "v";
+      break;
+    }
+  }
+  ss << "Table";
+  return ss.str();
+}
+static std::string numLocString(ast::LocationType loc) {
+  std::stringstream ss;
+  switch(loc) {
+  case ast::LocationType::Cells:
+    ss << "NumCells";
+    break;
+  case ast::LocationType::Edges:
+    ss << "NumEdges";
+    break;
+  case ast::LocationType::Vertices:
+    ss << "NumVertices";
+    break;
+  }
+  return ss.str();
+}
+
+namespace {
+class FindReduceOverNeighborExpr : public dawn::ast::ASTVisitorForwarding {
+  std::optional<std::shared_ptr<dawn::iir::ReductionOverNeighborExpr>> foundReduction_ =
+      std::nullopt;
+
+public:
+  void visit(const std::shared_ptr<dawn::iir::ReductionOverNeighborExpr>& stmt) override {
+    foundReduction_ = stmt;
+    return;
+  }
+  bool hasReduceOverNeighborExpr() const { return foundReduction_.has_value(); }
+};
+} // namespace
+
+void ASTStencilBody::visit(const std::shared_ptr<iir::BlockStmt>& stmt) {
+  indent_ += DAWN_PRINT_INDENT;
+  auto indent = std::string(indent_, ' ');
+  for(const auto& s : stmt->getStatements()) {
+    ss_ << indent;
+    s->accept(*this);
+  }
+  indent_ -= DAWN_PRINT_INDENT;
+}
+void ASTStencilBody::visit(const std::shared_ptr<iir::ReturnStmt>& stmt) {
+  if(scopeDepth_ == 0)
+    ss_ << std::string(indent_, ' ');
+
+  ss_ << "return ";
+
+  stmt->getExpr()->accept(*this);
+  ss_ << ";\n";
+}
+void ASTStencilBody::visit(const std::shared_ptr<iir::LoopStmt>& stmt) {
+  const auto maybeChainPtr =
+      dynamic_cast<const ast::ChainIterationDescr*>(stmt->getIterationDescrPtr());
+  DAWN_ASSERT_MSG(maybeChainPtr, "general loop concept not implemented yet!\n");
+
+  ss_ << "for (int nbhIter = 0; nbhIter < " << sparseSizeString(maybeChainPtr->getChain())
+      << "; nbhIter++)";
+  parentIsForLoop_ = true;
+
+  ss_ << "{\n";
+  ss_ << "int nbhIdx = __ldg(&" << tableString(maybeChainPtr->getChain()) << "["
+      << "pidx * " << sparseSizeString(maybeChainPtr->getChain()) << " + nbhIter"
+      << "]);\n";
+  ss_ << "if (nbh_idx == DEVICE_MISSING_VALUE) { continue; }";
+
+  stmt->getBlockStmt()->accept(*this);
+
+  ss_ << "}\n";
+  parentIsForLoop_ = false;
+}
+void ASTStencilBody::visit(const std::shared_ptr<iir::VerticalRegionDeclStmt>& stmt) {
+  DAWN_ASSERT_MSG(0, "VerticalRegionDeclStmt not allowed in this context");
+}
+void ASTStencilBody::visit(const std::shared_ptr<iir::StencilCallDeclStmt>& stmt) {
+  DAWN_ASSERT_MSG(0, "StencilCallDeclStmt not allowed in this context");
+}
+void ASTStencilBody::visit(const std::shared_ptr<iir::BoundaryConditionDeclStmt>& stmt) {
+  DAWN_ASSERT_MSG(0, "BoundaryConditionDeclStmt not allowed in this context");
+}
+
+void ASTStencilBody::visit(const std::shared_ptr<iir::StencilFunCallExpr>& expr) {
+  DAWN_ASSERT_MSG(0, "StencilFunCallExpr not allowed in this context");
+}
+void ASTStencilBody::visit(const std::shared_ptr<iir::StencilFunArgExpr>& expr) {
+  DAWN_ASSERT_MSG(0, "StencilFunArgExpr not allowed in this context");
+}
+void ASTStencilBody::visit(const std::shared_ptr<iir::VarAccessExpr>& expr) {}
+
+void ASTStencilBody::visit(const std::shared_ptr<iir::AssignmentExpr>& expr) {
+  FindReduceOverNeighborExpr reductionFinder;
+  expr->getRight()->accept(reductionFinder);
+  if(reductionFinder.hasReduceOverNeighborExpr()) {
+    expr->getRight()->accept(*this);
+    expr->getLeft()->accept(*this);
+    ss_ << expr->getOp() << "lhs";
+  } else {
+    expr->getLeft()->accept(*this);
+    ss_ << " " << expr->getOp() << " ";
+    expr->getRight()->accept(*this);
+  }
+}
+
+void ASTStencilBody::visit(const std::shared_ptr<iir::FieldAccessExpr>& expr) {
+  auto unstrDims = sir::dimension_cast<const sir::UnstructuredFieldDimension&>(
+      metadata_.getFieldDimensions(iir::getAccessID(expr)).getHorizontalFieldDimension());
+  std::string denseOffset = "kIter * " + numLocString(unstrDims.getDenseLocationType());
+  if(unstrDims.isDense()) {
+    std::string resArgName;
+    if(!parentIsReduction_ && parentIsForLoop_ &&
+       ast::offset_cast<const ast::UnstructuredOffset&>(expr->getOffset().horizontalOffset())
+           .hasOffset()) {
+      resArgName = denseOffset + " + nbhIdx";
+    } else {
+      resArgName = denseOffset + " + pidx";
+    }
+    ss_ << getName(expr) << "[" << resArgName << "]";
+  } else {
+    DAWN_ASSERT_MSG(parentIsForLoop_ || parentIsReduction_,
+                    "Sparse Field Access not allowed in this context");
+
+    std::string sparseSize = sparseSizeString(unstrDims.getNeighborChain());
+    std::string resArgName = denseOffset + " * " + sparseSize + "+ nbhIter * " +
+                             numLocString(unstrDims.getDenseLocationType()) + "+ pidx";
+    ss_ << getName(expr) << "[" << resArgName << "]";
+  }
+}
+void ASTStencilBody::visit(const std::shared_ptr<iir::ReductionOverNeighborExpr>& expr) {
+  ss_ << "::dawn::float_type lhs = ";
+  expr->getInit()->accept(*this);
+  ss_ << ";\n";
+  auto weights = expr->getWeights();
+  if(weights.has_value()) {
+    ss_ << "::dawn::float_type weights[" << weights->size() << "] = {";
+    bool first = true;
+    for(auto weight : *weights) {
+      if(!first) {
+        ss_ << ", ";
+      }
+      weight->accept(*this);
+      first = false;
+    }
+    ss_ << "};";
+  }
+  ss_ << "for (int nbhIter = 0; nbhIter < " << sparseSizeString(expr->getNbhChain())
+      << "; nbhIter++)";
+
+  parentIsReduction_ = true;
+  ss_ << "{\n";
+  ss_ << "int nbhIdx = __ldg(&" << tableString(expr->getNbhChain()) << "["
+      << "pidx * " << sparseSizeString(expr->getNbhChain()) << " + nbhIter"
+      << "]);\n";
+  ss_ << "if (nbh_idx == DEVICE_MISSING_VALUE) { continue; }";
+  ss_ << "lhs " << expr->getOp() << "=";
+  if(weights.has_value()) {
+    ss_ << " weights[nbhIter] * ";
+  }
+  expr->getRhs()->accept(*this);
+  ss_ << "}\n";
+  parentIsReduction_ = false;
+}
+
+std::string ASTStencilBody::getName(const std::shared_ptr<iir::VarDeclStmt>& stmt) const {
+  return metadata_.getFieldNameFromAccessID(iir::getAccessID(stmt));
+}
+std::string ASTStencilBody::getName(const std::shared_ptr<iir::Expr>& expr) const {
+  return metadata_.getFieldNameFromAccessID(iir::getAccessID(expr));
+}
+
+ASTStencilBody::ASTStencilBody(const iir::StencilMetaInformation& metadata) : metadata_(metadata) {}
+ASTStencilBody::~ASTStencilBody() {}
+
+} // namespace cudaico
+} // namespace codegen
+} // namespace dawn

--- a/dawn/src/dawn/CodeGen/Cuda-ico/ASTStencilBody.cpp
+++ b/dawn/src/dawn/CodeGen/Cuda-ico/ASTStencilBody.cpp
@@ -111,9 +111,9 @@ void ASTStencilBody::visit(const std::shared_ptr<iir::FieldAccessExpr>& expr) {
       metadata_.getFieldDimensions(iir::getAccessID(expr)).getHorizontalFieldDimension());
   std::string denseOffset =
       "kIter * " + locToDenseSizeStringGpuMesh(unstrDims.getDenseLocationType());
-  if(unstrDims.isDense()) {
+  if(unstrDims.isDense()) { // dense field accesses
     std::string resArgName;
-    if(!parentIsReduction_ && parentIsForLoop_ &&
+    if((parentIsReduction_ || parentIsForLoop_) &&
        ast::offset_cast<const ast::UnstructuredOffset&>(expr->getOffset().horizontalOffset())
            .hasOffset()) {
       resArgName = denseOffset + " + nbhIdx";
@@ -121,7 +121,7 @@ void ASTStencilBody::visit(const std::shared_ptr<iir::FieldAccessExpr>& expr) {
       resArgName = denseOffset + " + pidx";
     }
     ss_ << getName(expr) << "[" << resArgName << "]";
-  } else {
+  } else { // sparse field accesses
     DAWN_ASSERT_MSG(parentIsForLoop_ || parentIsReduction_,
                     "Sparse Field Access not allowed in this context");
 

--- a/dawn/src/dawn/CodeGen/Cuda-ico/ASTStencilBody.h
+++ b/dawn/src/dawn/CodeGen/Cuda-ico/ASTStencilBody.h
@@ -1,0 +1,113 @@
+//===--------------------------------------------------------------------------------*- C++ -*-===//
+//                          _
+//                         | |
+//                       __| | __ ___      ___ ___
+//                      / _` |/ _` \ \ /\ / / '_  |
+//                     | (_| | (_| |\ V  V /| | | |
+//                      \__,_|\__,_| \_/\_/ |_| |_| - Compiler Toolchain
+//
+//
+//  This file is distributed under the MIT License (MIT).
+//  See LICENSE.txt for details.
+//
+//===------------------------------------------------------------------------------------------===//
+
+#pragma once
+
+#include "dawn/CodeGen/ASTCodeGenCXX.h"
+#include "dawn/CodeGen/CodeGenProperties.h"
+#include "dawn/IIR/ASTFwd.h"
+#include "dawn/IIR/Interval.h"
+#include "dawn/Support/StringUtil.h"
+#include <stack>
+#include <unordered_map>
+
+namespace dawn {
+
+namespace iir {
+class StencilFunctionInstantiation;
+class StencilMetaInformation;
+} // namespace iir
+
+namespace codegen {
+namespace cudaico {
+
+// // quick visitor to check whether a statement contains a reduceOverNeighborExpr
+// class FindReduceOverNeighborExpr : public ast::ASTVisitorForwarding {
+//   std::optional<std::shared_ptr<iir::ReductionOverNeighborExpr>> foundReduction_ = std::nullopt;
+
+// public:
+//   void visit(const std::shared_ptr<iir::ReductionOverNeighborExpr>& stmt) override {
+//     foundReduction_ = stmt;
+//     return;
+//   }
+//   bool hasReduceOverNeighborExpr() const { return foundReduction_.has_value(); }
+//   const iir::ReductionOverNeighborExpr& foundReduceOverNeighborExpr() {
+//     DAWN_ASSERT(foundReduction_.has_value());
+//     return *foundReduction_.value();
+//   }
+// };
+
+/// @brief ASTVisitor to generate C++ naive code for the stencil and stencil function bodies
+/// @ingroup cxxnaiveico
+class ASTStencilBody : public ASTCodeGenCXX {
+protected:
+  const iir::StencilMetaInformation& metadata_;
+
+  // arg names for field access exprs
+  std::string denseArgName_ = "loc";
+  std::string sparseArgName_ = "loc";
+
+  bool parentIsReduction_ = false;
+  bool parentIsForLoop_ = false;
+
+  /// Nesting level of argument lists of stencil function *calls*
+  int nestingOfStencilFunArgLists_;
+
+public:
+  using Base = ASTCodeGenCXX;
+  using Base::visit;
+
+  // static std::string LoopLinearIndexVarName() { return "for_loop_idx"; }
+  // static std::string LoopNeighborIndexVarName() { return "inner_loc"; }
+  // static std::string ReductionIndexVarName(size_t level) {
+  //   return "red_loc" + std::to_string(level);
+  // }
+  // static std::string ReductionSparseIndexVarName(size_t level) {
+  //   return "sparse_dimension_idx" + std::to_string(level);
+  // }
+  // static std::string StageIndexVarName() { return "loc"; }
+
+  /// @brief constructor
+  ASTStencilBody(const iir::StencilMetaInformation& metadata);
+
+  virtual ~ASTStencilBody();
+
+  /// @name Statement implementation
+  /// @{
+  void visit(const std::shared_ptr<iir::BlockStmt>& stmt) override;
+  void visit(const std::shared_ptr<iir::ReturnStmt>& stmt) override;
+  void visit(const std::shared_ptr<iir::LoopStmt>& stmt) override;
+  void visit(const std::shared_ptr<iir::VerticalRegionDeclStmt>& stmt) override;
+  void visit(const std::shared_ptr<iir::StencilCallDeclStmt>& stmt) override;
+  void visit(const std::shared_ptr<iir::BoundaryConditionDeclStmt>& stmt) override;
+  /// @}
+
+  /// @name Expression implementation
+  /// @{
+  void visit(const std::shared_ptr<iir::StencilFunCallExpr>& expr) override;
+  void visit(const std::shared_ptr<iir::StencilFunArgExpr>& expr) override;
+  void visit(const std::shared_ptr<iir::VarAccessExpr>& expr) override;
+  void visit(const std::shared_ptr<iir::FieldAccessExpr>& expr) override;
+  void visit(const std::shared_ptr<iir::ReductionOverNeighborExpr>& expr) override;
+  void visit(const std::shared_ptr<iir::AssignmentExpr>& expr) override;
+  /// @}
+
+  /// @brief Mapping of VarDeclStmt and Var/FieldAccessExpr to their name
+  std::string getName(const std::shared_ptr<iir::Expr>& expr) const override;
+  std::string getName(const std::shared_ptr<iir::VarDeclStmt>& stmt) const override;
+};
+
+} // namespace cudaico
+} // namespace codegen
+} // namespace dawn

--- a/dawn/src/dawn/CodeGen/Cuda-ico/ASTStencilBody.h
+++ b/dawn/src/dawn/CodeGen/Cuda-ico/ASTStencilBody.h
@@ -19,8 +19,11 @@
 #include "dawn/IIR/ASTFwd.h"
 #include "dawn/IIR/Interval.h"
 #include "dawn/Support/StringUtil.h"
+
 #include <stack>
 #include <unordered_map>
+
+#include "LocToStringUtils.h"
 
 namespace dawn {
 

--- a/dawn/src/dawn/CodeGen/Cuda-ico/ASTStencilBody.h
+++ b/dawn/src/dawn/CodeGen/Cuda-ico/ASTStencilBody.h
@@ -95,6 +95,7 @@ public:
 
   /// @name Expression implementation
   /// @{
+  void visit(const std::shared_ptr<iir::FunCallExpr>& expr) override;
   void visit(const std::shared_ptr<iir::StencilFunCallExpr>& expr) override;
   void visit(const std::shared_ptr<iir::StencilFunArgExpr>& expr) override;
   void visit(const std::shared_ptr<iir::VarAccessExpr>& expr) override;

--- a/dawn/src/dawn/CodeGen/Cuda-ico/ASTStencilBody.h
+++ b/dawn/src/dawn/CodeGen/Cuda-ico/ASTStencilBody.h
@@ -35,22 +35,6 @@ class StencilMetaInformation;
 namespace codegen {
 namespace cudaico {
 
-// // quick visitor to check whether a statement contains a reduceOverNeighborExpr
-// class FindReduceOverNeighborExpr : public ast::ASTVisitorForwarding {
-//   std::optional<std::shared_ptr<iir::ReductionOverNeighborExpr>> foundReduction_ = std::nullopt;
-
-// public:
-//   void visit(const std::shared_ptr<iir::ReductionOverNeighborExpr>& stmt) override {
-//     foundReduction_ = stmt;
-//     return;
-//   }
-//   bool hasReduceOverNeighborExpr() const { return foundReduction_.has_value(); }
-//   const iir::ReductionOverNeighborExpr& foundReduceOverNeighborExpr() {
-//     DAWN_ASSERT(foundReduction_.has_value());
-//     return *foundReduction_.value();
-//   }
-// };
-
 /// @brief ASTVisitor to generate C++ naive code for the stencil and stencil function bodies
 /// @ingroup cxxnaiveico
 class ASTStencilBody : public ASTCodeGenCXX {
@@ -70,16 +54,6 @@ protected:
 public:
   using Base = ASTCodeGenCXX;
   using Base::visit;
-
-  // static std::string LoopLinearIndexVarName() { return "for_loop_idx"; }
-  // static std::string LoopNeighborIndexVarName() { return "inner_loc"; }
-  // static std::string ReductionIndexVarName(size_t level) {
-  //   return "red_loc" + std::to_string(level);
-  // }
-  // static std::string ReductionSparseIndexVarName(size_t level) {
-  //   return "sparse_dimension_idx" + std::to_string(level);
-  // }
-  // static std::string StageIndexVarName() { return "loc"; }
 
   /// @brief constructor
   ASTStencilBody(const iir::StencilMetaInformation& metadata);

--- a/dawn/src/dawn/CodeGen/Cuda-ico/CudaIcoCodeGen.cpp
+++ b/dawn/src/dawn/CodeGen/Cuda-ico/CudaIcoCodeGen.cpp
@@ -30,6 +30,101 @@
 #include <string>
 #include <vector>
 
+static std::string chainToTableString(std::vector<dawn::ast::LocationType> locs) {
+  std::stringstream ss;
+  for(auto loc : locs) {
+    switch(loc) {
+    case dawn::ast::LocationType::Cells:
+      ss << "c";
+      break;
+    case dawn::ast::LocationType::Edges:
+      ss << "e";
+      break;
+    case dawn::ast::LocationType::Vertices:
+      ss << "v";
+      break;
+    }
+  }
+  ss << "Table";
+  return ss.str();
+}
+
+static std::string chainToSparseSizeString(std::vector<dawn::ast::LocationType> locs) {
+  std::stringstream ss;
+  for(auto loc : locs) {
+    switch(loc) {
+    case dawn::ast::LocationType::Cells:
+      ss << "C_";
+      break;
+    case dawn::ast::LocationType::Edges:
+      ss << "E_";
+      break;
+    case dawn::ast::LocationType::Vertices:
+      ss << "V_";
+      break;
+    }
+  }
+  ss << "SIZE";
+  return ss.str();
+}
+
+static std::string chainToDenseSizeString(std::vector<dawn::ast::LocationType> locs) {
+  std::stringstream ss;
+  switch(locs[0]) {
+  case dawn::ast::LocationType::Cells:
+    ss << "mesh.cells().size()";
+    break;
+  case dawn::ast::LocationType::Edges:
+    ss << "mesh.edges().size()";
+    break;
+  case dawn::ast::LocationType::Vertices:
+    ss << "mesh.nodes().size()";
+    break;
+  }
+  return ss.str();
+}
+
+static std::string chainToVectorString(std::vector<dawn::ast::LocationType> locs) {
+  std::stringstream ss;
+  ss << "{";
+  bool first = true;
+  for(auto loc : locs) {
+    if(!first) {
+      ss << ", ";
+    }
+    switch(loc) {
+    case dawn::ast::LocationType::Cells:
+      ss << "dawn::LocationType::Cells";
+      break;
+    case dawn::ast::LocationType::Edges:
+      ss << "dawn::LocationType::Edges";
+      break;
+    case dawn::ast::LocationType::Vertices:
+      ss << "dawn::LocationType::Vertices";
+      break;
+    }
+    first = false;
+  }
+  ss << "}";
+  return ss.str();
+}
+
+static std::string locToArgString(dawn::ast::LocationType loc) {
+  switch(loc) {
+  case dawn::ast::LocationType::Cells:
+    return "NumCells";
+    break;
+  case dawn::ast::LocationType::Edges:
+    return "NumEdges";
+    break;
+  case dawn::ast::LocationType::Vertices:
+    return "NumVertices";
+    break;
+  default:
+    dawn_unreachable("");
+  }
+}
+
 namespace dawn {
 namespace codegen {
 namespace cudaico {
@@ -53,37 +148,17 @@ run(const std::map<std::string, std::shared_ptr<iir::StencilInstantiation>>&
 CudaIcoCodeGen::CudaIcoCodeGen(const StencilInstantiationContext& ctx, DiagnosticsEngine& engine,
                                int maxHaloPoints, int nsms, int maxBlocksPerSM,
                                const Array3i& domainSize)
-    : CodeGen(ctx, engine, maxHaloPoints) {
-  DAWN_ASSERT_MSG(ctx.size() == 1,
-                  "cuda code genreation currently only supports a single stencil!");
-}
+    : CodeGen(ctx, engine, maxHaloPoints) {}
 
 CudaIcoCodeGen::~CudaIcoCodeGen() {}
 
 class CollectChainStrings : public iir::ASTVisitorForwarding {
 private:
-  std::set<std::string> chainStrings_;
-  std::string chainToString(std::vector<ast::LocationType> locs) {
-    std::stringstream ss;
-    for(auto loc : locs) {
-      switch(loc) {
-      case ast::LocationType::Cells:
-        ss << "c";
-        break;
-      case ast::LocationType::Edges:
-        ss << "e";
-        break;
-      case ast::LocationType::Vertices:
-        ss << "v";
-        break;
-      }
-    }
-    return ss.str();
-  }
+  std::set<std::vector<ast::LocationType>> chains_;
 
 public:
   void visit(const std::shared_ptr<iir::ReductionOverNeighborExpr>& expr) override {
-    chainStrings_.insert(chainToString(expr->getNbhChain()));
+    chains_.insert(expr->getNbhChain());
     for(auto c : expr->getChildren()) {
       c->accept(*this);
     }
@@ -91,14 +166,276 @@ public:
 
   void visit(const std::shared_ptr<iir::LoopStmt>& stmt) override {
     auto chainDescr = dynamic_cast<const ast::ChainIterationDescr*>(stmt->getIterationDescrPtr());
-    chainStrings_.insert(chainToString(chainDescr->getChain()));
+    chains_.insert(chainDescr->getChain());
     for(auto c : stmt->getChildren()) {
       c->accept(*this);
     }
   }
 
-  const std::set<std::string>& getChainStrings() const { return chainStrings_; }
+  const std::set<std::vector<ast::LocationType>>& getChains() const { return chains_; }
 };
+
+void CudaIcoCodeGen::generateGpuMesh(
+    const std::shared_ptr<iir::StencilInstantiation>& stencilInstantiation,
+    Class& stencilWrapperClass, CodeGenProperties& codeGenProperties) {
+  Structure gpuMeshClass = stencilWrapperClass.addStruct("GpuTriMesh");
+
+  gpuMeshClass.addMember("int", "NumNodes");
+  gpuMeshClass.addMember("int", "NumEdges");
+  gpuMeshClass.addMember("int", "NumCells");
+
+  CollectChainStrings chainCollector;
+  std::set<std::vector<ast::LocationType>> chains;
+  for(const auto& doMethod : iterateIIROver<iir::DoMethod>(*(stencilInstantiation->getIIR()))) {
+    doMethod->getAST().accept(chainCollector);
+    chains.insert(chainCollector.getChains().begin(), chainCollector.getChains().end());
+  }
+  for(auto chain : chains) {
+    gpuMeshClass.addMember("int*", chainToTableString(chain));
+  }
+
+  auto gpuMeshClassCtor = gpuMeshClass.addConstructor();
+  gpuMeshClassCtor.addArg("const atlas::Mesh& mesh");
+  gpuMeshClassCtor.addStatement("NumNodes = mesh.nodes.size()");
+  gpuMeshClassCtor.addStatement("NumCells = mesh.cells.size()");
+  gpuMeshClassCtor.addStatement("NumEdges = mesh.edges.size()");
+  for(auto chain : chains) {
+    gpuMeshClassCtor.addStatement("gpuErrchk(cudaMalloc((void**)" + chainToTableString(chain) +
+                                  "* sizeof(int) * " + chainToDenseSizeString(chain) + "* " +
+                                  chainToSparseSizeString(chain) + "))");
+    gpuMeshClassCtor.addStatement("generateNbhTable(mesh, " + chainToVectorString(chain) + ", " +
+                                  chainToDenseSizeString(chain) + ", " +
+                                  chainToSparseSizeString(chain) + ", " +
+                                  chainToTableString(chain) + ")");
+  }
+}
+
+void CudaIcoCodeGen::generateRunFun(
+    const std::shared_ptr<iir::StencilInstantiation>& stencilInstantiation, MemberFunction& runFun,
+    CodeGenProperties& codeGenProperties) {
+
+  // find block sizes to generate
+  std::set<ast::LocationType> stageLocType;
+  for(const auto& ms : iterateIIROver<iir::MultiStage>(*(stencilInstantiation->getIIR()))) {
+    for(const auto& stage : ms->getChildren()) {
+      stageLocType.insert(*stage->getLocationType());
+    }
+  }
+  for(auto stageLoc : stageLocType) {
+    switch(stageLoc) {
+    case ast::LocationType::Cells:
+      runFun.addStatement("dim3 dGC((mesh_.NumCells() + BLOCK_SIZE - 1) / BLOCK_SIZE)");
+      break;
+    case ast::LocationType::Edges:
+      runFun.addStatement("dim3 dGE((mesh_.NumEdges() + BLOCK_SIZE - 1) / BLOCK_SIZE)");
+      break;
+    case ast::LocationType::Vertices:
+      runFun.addStatement("dim3 dGV((mesh_.NumNodes() + BLOCK_SIZE - 1) / BLOCK_SIZE)");
+      break;
+    }
+  }
+  runFun.addStatement("dim3 DB(BLOCK_SIZE)");
+
+  // start timers
+  runFun.addStatement("start()");
+
+  for(const auto& ms : iterateIIROver<iir::MultiStage>(*(stencilInstantiation->getIIR()))) {
+    for(const auto& stage : ms->getChildren()) {
+
+      // fields used in the stencil
+      const auto fields = support::orderMap(stage->getFields());
+      auto nonTempFields = makeRange(fields, [&](std::pair<int, iir::Field> const& p) {
+        return !stencilInstantiation->getMetaData().isAccessType(
+            iir::FieldAccessType::StencilTemporary, p.second.getAccessID());
+      });
+
+      //--------------------------------------
+      // signature of kernel
+      //--------------------------------------
+      std::stringstream kernelCall;
+      std::string kName =
+          cuda::CodeGeneratorHelper::buildCudaKernelName(stencilInstantiation, ms, stage);
+      kernelCall << kName;
+      switch(*stage->getLocationType()) {
+      case ast::LocationType::Cells:
+        kernelCall << "<<<"
+                   << "dGC,dB"
+                   << ">>>(";
+        break;
+      case ast::LocationType::Edges:
+        kernelCall << "<<<"
+                   << "dGE,dB"
+                   << ">>>(";
+        break;
+      case ast::LocationType::Vertices:
+        kernelCall << "<<<"
+                   << "dGV,dB"
+                   << ">>>(";
+        break;
+      }
+
+      // which loc args (int CellIdx, int EdgeIdx, int CellIdx) need to be passed?
+      std::set<std::string> locArgs;
+      for(auto field : fields) {
+        auto dims = sir::dimension_cast<sir::UnstructuredFieldDimension const&>(
+            field.second.getFieldDimensions().getHorizontalFieldDimension());
+        locArgs.insert(locToArgString(dims.getDenseLocationType()));
+      }
+      auto loc = *stage->getLocationType();
+      locArgs.insert(locToArgString(loc));
+      for(auto arg : locArgs) {
+        kernelCall << "mesh_." + arg + ", ";
+      }
+
+      // we always need the k size
+      kernelCall << "kSize, ";
+
+      // which nbh tables need to be passed?
+      CollectChainStrings chainStringCollector;
+      for(const auto& doMethod : stage->getChildren()) {
+        doMethod->getAST().accept(chainStringCollector);
+      }
+      auto chains = chainStringCollector.getChains();
+      for(auto chain : chains) {
+        kernelCall << "mesh_." + chainToTableString(chain) + ", ";
+      }
+
+      // field arguments (correct cv specifier)
+      bool first = true;
+      for(const auto& fieldPair : nonTempFields) {
+        if(!first) {
+          kernelCall << ", ";
+        }
+        kernelCall << stencilInstantiation->getMetaData().getFieldNameFromAccessID(
+                          fieldPair.second.getAccessID()) +
+                          "_";
+        first = false;
+      }
+      kernelCall << ")";
+      runFun.addStatement(kernelCall.str());
+      runFun.addStatement("cudaPeekAtLastError()");
+      runFun.addStatement("cudaDeviceSynchronize()");
+    }
+  }
+
+  // stop timers
+  runFun.addStatement("pause()");
+}
+
+void CudaIcoCodeGen::generateStencilClassCtr(MemberFunction& ctor, const iir::Stencil& stencil,
+                                             CodeGenProperties& codeGenProperties) const {
+  std::string stencilName =
+      codeGenProperties.getStencilName(StencilContext::SC_Stencil, stencil.getStencilID());
+  ctor.addInit("sbase(\"" + stencilName + "\")");
+  ctor.addInit("mesh_(mesh)");
+  ctor.addInit("kSize_(kSize)");
+
+  for(auto field : support::orderMap(stencil.getFields())) {
+    auto dims = sir::dimension_cast<sir::UnstructuredFieldDimension const&>(
+        field.second.field.getFieldDimensions().getHorizontalFieldDimension());
+    if(dims.isDense()) {
+      ctor.addStatement("initField(" + field.second.Name + ", " + "&" + field.second.Name + "_, " +
+                        chainToDenseSizeString({dims.getDenseLocationType()}) + ", kSize)");
+    } else {
+      ctor.addStatement("initSparseField(" + field.second.Name + ", " + "&" + field.second.Name +
+                        "_, " + chainToDenseSizeString(dims.getNeighborChain()) +
+                        chainToSparseSizeString(dims.getNeighborChain()) + ", kSize)");
+    }
+  }
+}
+
+void CudaIcoCodeGen::generateCopyBackFun(MemberFunction& copyBackFun,
+                                         const iir::Stencil& stencil) const {
+  for(auto field : support::orderMap(stencil.getFields())) {
+    if(field.second.field.getIntend() == dawn::iir::Field::IntendKind::Output ||
+       field.second.field.getIntend() == dawn::iir::Field::IntendKind::InputOutput) {
+      auto dims = sir::dimension_cast<sir::UnstructuredFieldDimension const&>(
+          field.second.field.getFieldDimensions().getHorizontalFieldDimension());
+
+      copyBackFun.addBlockStatement("", [&]() {
+        copyBackFun.addStatement("dawn::float_type* host_buf = new float[" + field.second.Name +
+                                 ".numElements()" + "]");
+        copyBackFun.addStatement("gpuErrchk(cudaMemcpy((dawn::float_type*) host_buf, " +
+                                 field.second.Name + "_, " + field.second.Name +
+                                 ".numElements(), cudaMemcpyDeviceToHost)");
+        if(dims.isDense()) {
+          copyBackFun.addStatement("reshape_back(host_buf, " + field.second.Name +
+                                   ".data(), kSize, mesh_." +
+                                   chainToDenseSizeString({dims.getDenseLocationType()}));
+        } else {
+          copyBackFun.addStatement("reshape_back(host_buf, " + field.second.Name +
+                                   ".data(), kSize, mesh_." +
+                                   chainToDenseSizeString({dims.getDenseLocationType()}) + ", " +
+                                   chainToSparseSizeString(dims.getNeighborChain()));
+        }
+        copyBackFun.addStatement("delete[] host_buf");
+      });
+    }
+  }
+}
+
+void CudaIcoCodeGen::generateStencilClasses(
+    const std::shared_ptr<iir::StencilInstantiation>& stencilInstantiation,
+    Class& stencilWrapperClass, CodeGenProperties& codeGenProperties) {
+
+  const auto& stencils = stencilInstantiation->getStencils();
+
+  // Stencil members:
+  // generate the code for each of the stencils
+  for(std::size_t stencilIdx = 0; stencilIdx < stencils.size(); ++stencilIdx) {
+    const auto& stencil = *stencils[stencilIdx];
+
+    std::string stencilName =
+        codeGenProperties.getStencilName(StencilContext::SC_Stencil, stencil.getStencilID());
+
+    Structure stencilClass = stencilWrapperClass.addStruct(stencilName, "", "sbase");
+    stencilClass.changeAccessibility("private");
+    for(auto field : support::orderMap(stencil.getFields())) {
+      stencilClass.addMember("dawn::float_type*", field.second.Name + "_");
+    }
+    stencilClass.addMember("int", "kSize_ = 0");
+    stencilClass.addMember("GpuTriMesh", "mesh_ = 0");
+
+    stencilClass.changeAccessibility("public");
+
+    auto stencilClassConstructor = stencilClass.addConstructor();
+    stencilClassConstructor.addArg("const atlas::Mesh& mesh");
+    stencilClassConstructor.addArg("int kSize");
+    for(auto field : support::orderMap(stencil.getFields())) {
+      auto dims = sir::dimension_cast<sir::UnstructuredFieldDimension const&>(
+          field.second.field.getFieldDimensions().getHorizontalFieldDimension());
+      if(dims.isDense()) {
+        stencilClassConstructor.addArg("const atlasInterface::Field<dawn::float_type>& " +
+                                       field.second.Name);
+      } else {
+        stencilClassConstructor.addArg("const atlasInterface::SparseDimension<dawn::float_type> " +
+                                       field.second.Name);
+      }
+    }
+    generateStencilClassCtr(stencilClassConstructor, stencil, codeGenProperties);
+    stencilClassConstructor.commit();
+
+    auto runFun = stencilClass.addMemberFunction("void", "run(");
+    generateRunFun(stencilInstantiation, runFun, codeGenProperties);
+    runFun.commit();
+
+    auto copyBackFun = stencilClass.addMemberFunction("void", "CopyResultToHost");
+    for(auto field : support::orderMap(stencil.getFields())) {
+      if(field.second.field.getIntend() == dawn::iir::Field::IntendKind::Output ||
+         field.second.field.getIntend() == dawn::iir::Field::IntendKind::InputOutput) {
+        auto dims = sir::dimension_cast<sir::UnstructuredFieldDimension const&>(
+            field.second.field.getFieldDimensions().getHorizontalFieldDimension());
+        if(dims.isDense()) {
+          copyBackFun.addArg("atlasInterface::Field<dawn::float_type>& " + field.second.Name);
+        } else {
+          copyBackFun.addArg("atlasInterface::SparseDimension<dawn::float_type> " +
+                             field.second.Name);
+        }
+      }
+    }
+    generateCopyBackFun(copyBackFun, stencil);
+  }
+}
 
 void CudaIcoCodeGen::generateAllCudaKernels(
     std::stringstream& ssSW,
@@ -125,21 +462,6 @@ void CudaIcoCodeGen::generateAllCudaKernels(
 
       // which loc args (int CellIdx, int EdgeIdx, int CellIdx) need to be passed?
       std::set<std::string> locArgs;
-      auto locToArgString = [](ast::LocationType loc) {
-        switch(loc) {
-        case ast::LocationType::Cells:
-          return "int NumCells";
-          break;
-        case ast::LocationType::Edges:
-          return "int NumEdges";
-          break;
-        case ast::LocationType::Vertices:
-          return "int NumVertices";
-          break;
-        default:
-          dawn_unreachable("");
-        }
-      };
       for(auto field : fields) {
         auto dims = sir::dimension_cast<sir::UnstructuredFieldDimension const&>(
             field.second.getFieldDimensions().getHorizontalFieldDimension());
@@ -148,7 +470,7 @@ void CudaIcoCodeGen::generateAllCudaKernels(
       auto loc = *stage->getLocationType();
       locArgs.insert(locToArgString(loc));
       for(auto arg : locArgs) {
-        cudaKernel.addArg(arg);
+        cudaKernel.addArg("int " + arg);
       }
 
       // we always need the k size
@@ -159,9 +481,9 @@ void CudaIcoCodeGen::generateAllCudaKernels(
       for(const auto& doMethod : stage->getChildren()) {
         doMethod->getAST().accept(chainStringCollector);
       }
-      auto chainStrings = chainStringCollector.getChainStrings();
-      for(auto chainString : chainStrings) {
-        cudaKernel.addArg("const int *" + chainString + "Table");
+      auto chains = chainStringCollector.getChains();
+      for(auto chain : chains) {
+        cudaKernel.addArg("const int *" + chainToTableString(chain));
       }
 
       // field arguments (correct cv specifier)
@@ -238,9 +560,12 @@ std::string CudaIcoCodeGen::generateStencilInstantiation(
 
   sbase.commit();
 
-  // generateStencilClasses(stencilInstantiation, stencilWrapperClass, codeGenProperties);
+  generateStencilClasses(stencilInstantiation, stencilWrapperClass, codeGenProperties);
 
-  // generateStencilWrapperMembers(stencilWrapperClass, stencilInstantiation, codeGenProperties);
+  generateGpuMesh(stencilInstantiation, stencilWrapperClass, codeGenProperties);
+
+  // generateStencilWrapperMembers(stencilWrapperClass, stencilInstantiation,
+  // codeGenProperties);
 
   // generateStencilWrapperCtr(stencilWrapperClass, stencilInstantiation, codeGenProperties);
 

--- a/dawn/src/dawn/CodeGen/Cuda-ico/CudaIcoCodeGen.cpp
+++ b/dawn/src/dawn/CodeGen/Cuda-ico/CudaIcoCodeGen.cpp
@@ -14,6 +14,9 @@
 
 #include "dawn/CodeGen/Cuda-ico/CudaIcoCodeGen.h"
 
+#include "dawn/CodeGen/Cuda/CodeGeneratorHelper.h"
+#include "dawn/IIR/Field.h"
+#include "dawn/IIR/MultiStage.h"
 #include "dawn/Support/Logging.h"
 
 #include <algorithm>
@@ -45,18 +48,172 @@ run(const std::map<std::string, std::shared_ptr<iir::StencilInstantiation>>&
 CudaIcoCodeGen::CudaIcoCodeGen(const StencilInstantiationContext& ctx, DiagnosticsEngine& engine,
                                int maxHaloPoints, int nsms, int maxBlocksPerSM,
                                const Array3i& domainSize)
-    : CodeGen(ctx, engine, maxHaloPoints) {}
+    : CodeGen(ctx, engine, maxHaloPoints) {
+  DAWN_ASSERT_MSG(ctx.size() == 1,
+                  "cuda code genreation currently only supports a single stencil!");
+}
 
 CudaIcoCodeGen::~CudaIcoCodeGen() {}
 
+void CudaIcoCodeGen::generateAllCudaKernels(
+    std::stringstream& ssSW,
+    const std::shared_ptr<iir::StencilInstantiation>& stencilInstantiation) {
+
+  // for(const auto& ms : iterateIIROver<iir::MultiStage>(*(stencilInstantiation->getIIR()))) {
+
+  //   // fields used in the stencil
+  //   const auto fields = support::orderMap(ms->getFields());
+  //   auto nonTempFields = makeRange(fields, [&](std::pair<int, iir::Field> const& p) {
+  //     return !stencilInstantiation->getMetaData().isAccessType(
+  //         iir::FieldAccessType::StencilTemporary, p.second.getAccessID());
+  //   });
+
+  //   MemberFunction cudaKernel(
+  //       "__global__ void", cuda::CodeGeneratorHelper::buildCudaKernelName(stencilInstantiation,
+  //       ms), ssSW);
+
+  //   for(const auto& fieldPair : nonTempFields) {
+  //     std::string cvstr = fieldPair.second.getIntend() == dawn::iir::Field::IntendKind::Input
+  //                             ? "const ::dawn::float_type * "
+  //                             : "::dawn::float_type * ";
+  //     cudaKernel.addArg(cvstr + stencilInstantiation->getMetaData().getFieldNameFromAccessID(
+  //                                   fieldPair.second.getAccessID()));
+  //   }
+  // }
+
+  for(const auto& ms : iterateIIROver<iir::MultiStage>(*(stencilInstantiation->getIIR()))) {
+    for(const auto& stage : ms->getChildren()) {
+
+      // fields used in the stencil
+      const auto fields = support::orderMap(stage->getFields());
+      auto nonTempFields = makeRange(fields, [&](std::pair<int, iir::Field> const& p) {
+        return !stencilInstantiation->getMetaData().isAccessType(
+            iir::FieldAccessType::StencilTemporary, p.second.getAccessID());
+      });
+
+      // signature of kernel
+      MemberFunction cudaKernel(
+          "__global__ void",
+          cuda::CodeGeneratorHelper::buildCudaKernelName(stencilInstantiation, ms, stage), ssSW);
+
+      auto loc = *stage->getLocationType();
+      switch(loc) {
+      case ast::LocationType::Cells:
+        cudaKernel.addArg("int NumCells");
+        break;
+      case ast::LocationType::Edges:
+        cudaKernel.addArg("int NumEdges");
+        break;
+      case ast::LocationType::Vertices:
+        cudaKernel.addArg("int NumVertices");
+        break;
+      }
+
+      for(const auto& fieldPair : nonTempFields) {
+        std::string cvstr = fieldPair.second.getIntend() == dawn::iir::Field::IntendKind::Input
+                                ? "const ::dawn::float_type * "
+                                : "::dawn::float_type * ";
+        cudaKernel.addArg(cvstr + stencilInstantiation->getMetaData().getFieldNameFromAccessID(
+                                      fieldPair.second.getAccessID()));
+      }
+
+      // pidx
+      cudaKernel.addStatement("unsigned int pidx = blockIdx.x * blockDim.x + threadIdx.x");
+      switch(loc) {
+      case ast::LocationType::Cells:
+        cudaKernel.addBlockStatement("if (pidx >= NumCells)",
+                                     [&]() { cudaKernel.addStatement("return"); });
+        break;
+      case ast::LocationType::Edges:
+        cudaKernel.addBlockStatement("if (pidx >= NumEdges)",
+                                     [&]() { cudaKernel.addStatement("return"); });
+        break;
+      case ast::LocationType::Vertices:
+        cudaKernel.addBlockStatement("if (pidx >= NumVertices)",
+                                     [&]() { cudaKernel.addStatement("return"); });
+        break;
+      }
+    }
+  }
+}
+
+std::string CudaIcoCodeGen::generateStencilInstantiation(
+    const std::shared_ptr<iir::StencilInstantiation>& stencilInstantiation) {
+
+  using namespace codegen;
+
+  std::stringstream ssSW;
+
+  Namespace dawnNamespace("dawn_generated", ssSW);
+  Namespace cudaNamespace("cuda", ssSW);
+
+  generateAllCudaKernels(ssSW, stencilInstantiation);
+
+  Class stencilWrapperClass(stencilInstantiation->getName(), ssSW);
+  stencilWrapperClass.changeAccessibility("public");
+
+  CodeGenProperties codeGenProperties = computeCodeGenProperties(stencilInstantiation.get());
+
+  // generate code for base class of all the inner stencils
+  Structure sbase = stencilWrapperClass.addStruct("sbase", "", "timer_cuda");
+  auto baseCtr = sbase.addConstructor();
+  baseCtr.addArg("std::string name");
+  baseCtr.addInit("timer_cuda(name)");
+  baseCtr.commit();
+  MemberFunction gettime = sbase.addMemberFunction("double", "get_time");
+  gettime.addStatement("return total_time()");
+  gettime.commit();
+
+  sbase.commit();
+
+  // generateStencilClasses(stencilInstantiation, stencilWrapperClass, codeGenProperties);
+
+  // generateStencilWrapperMembers(stencilWrapperClass, stencilInstantiation, codeGenProperties);
+
+  // generateStencilWrapperCtr(stencilWrapperClass, stencilInstantiation, codeGenProperties);
+
+  // generateStencilWrapperRun(stencilWrapperClass, stencilInstantiation, codeGenProperties);
+
+  // generateStencilWrapperPublicMemberFunctions(stencilWrapperClass, codeGenProperties);
+
+  stencilWrapperClass.commit();
+
+  cudaNamespace.commit();
+  dawnNamespace.commit();
+
+  return ssSW.str();
+}
+
 std::unique_ptr<TranslationUnit> CudaIcoCodeGen::generateCode() {
-  std::vector<std::string> ppDefines;
+
+  DAWN_LOG(INFO) << "Starting code generation for GTClang ...";
+
+  // Generate code for StencilInstantiations
   std::map<std::string, std::string> stencils;
+  for(const auto& nameStencilCtxPair : context_) {
+    std::shared_ptr<iir::StencilInstantiation> origSI = nameStencilCtxPair.second;
+    // TODO the clone seems to be broken
+    //    std::shared_ptr<iir::StencilInstantiation> stencilInstantiation = origSI->clone();
+    std::shared_ptr<iir::StencilInstantiation> stencilInstantiation = origSI;
 
-  std::cout << "in cuda ico codegen\n";
+    std::string code = generateStencilInstantiation(stencilInstantiation);
+    if(code.empty())
+      return nullptr;
+    stencils.emplace(nameStencilCtxPair.first, std::move(code));
+  }
 
-  return std::make_unique<TranslationUnit>("todo.txt", std::move(ppDefines), std::move(stencils),
-                                           "");
+  // currently no pp defines are required
+  std::vector<std::string> ppDefines;
+
+  // globals not yet supported
+  std::string globals = "";
+
+  DAWN_LOG(INFO) << "Done generating code";
+
+  std::string filename = generateFileName(context_);
+
+  return std::make_unique<TranslationUnit>(filename, std::move(ppDefines), std::move(stencils),
+                                           std::move(globals));
 }
 
 } // namespace cudaico

--- a/dawn/src/dawn/CodeGen/Cuda-ico/CudaIcoCodeGen.cpp
+++ b/dawn/src/dawn/CodeGen/Cuda-ico/CudaIcoCodeGen.cpp
@@ -1,0 +1,64 @@
+//===--------------------------------------------------------------------------------*- C++ -*-===//
+//                          _
+//                         | |
+//                       __| | __ ___      ___ ___
+//                      / _` |/ _` \ \ /\ / / '_  |
+//                     | (_| | (_| |\ V  V /| | | |
+//                      \__,_|\__,_| \_/\_/ |_| |_| - Compiler Toolchain
+//
+//
+//  This file is distributed under the MIT License (MIT).
+//  See LICENSE.txt for details.
+//
+//===------------------------------------------------------------------------------------------===//
+
+#include "dawn/CodeGen/Cuda-ico/CudaIcoCodeGen.h"
+
+#include "dawn/Support/Logging.h"
+
+#include <algorithm>
+#include <memory>
+#include <numeric>
+#include <string>
+#include <vector>
+
+namespace dawn {
+namespace codegen {
+namespace cudaico {
+std::unique_ptr<TranslationUnit>
+run(const std::map<std::string, std::shared_ptr<iir::StencilInstantiation>>&
+        stencilInstantiationMap,
+    const Options& options) {
+  DiagnosticsEngine diagnostics;
+  const Array3i domain_size{options.DomainSizeI, options.DomainSizeJ, options.DomainSizeK};
+  CudaIcoCodeGen CG(stencilInstantiationMap, diagnostics, options.MaxHaloSize, options.nsms,
+                    options.MaxBlocksPerSM, domain_size);
+  if(diagnostics.hasDiags()) {
+    for(const auto& diag : diagnostics.getQueue())
+      DAWN_LOG(INFO) << diag->getMessage();
+    throw std::runtime_error("An error occured in code generation");
+  }
+
+  return CG.generateCode();
+}
+
+CudaIcoCodeGen::CudaIcoCodeGen(const StencilInstantiationContext& ctx, DiagnosticsEngine& engine,
+                               int maxHaloPoints, int nsms, int maxBlocksPerSM,
+                               const Array3i& domainSize)
+    : CodeGen(ctx, engine, maxHaloPoints) {}
+
+CudaIcoCodeGen::~CudaIcoCodeGen() {}
+
+std::unique_ptr<TranslationUnit> CudaIcoCodeGen::generateCode() {
+  std::vector<std::string> ppDefines;
+  std::map<std::string, std::string> stencils;
+
+  std::cout << "in cuda ico codegen\n";
+
+  return std::make_unique<TranslationUnit>("todo.txt", std::move(ppDefines), std::move(stencils),
+                                           "");
+}
+
+} // namespace cudaico
+} // namespace codegen
+} // namespace dawn

--- a/dawn/src/dawn/CodeGen/Cuda-ico/CudaIcoCodeGen.cpp
+++ b/dawn/src/dawn/CodeGen/Cuda-ico/CudaIcoCodeGen.cpp
@@ -574,7 +574,6 @@ std::unique_ptr<TranslationUnit> CudaIcoCodeGen::generateCode() {
       "#include \"driver-includes/math.hpp\"",
       "#include \"driver-includes/timer_cuda.hpp\"",
       "#define BLOCK_SIZE 16",
-      "#define DEVICE_MISSING_VALUE -1",
       "#define LEVELS_PER_THREAD 1",
       "using namespace gridtools::dawn;",
   };

--- a/dawn/src/dawn/CodeGen/Cuda-ico/CudaIcoCodeGen.h
+++ b/dawn/src/dawn/CodeGen/Cuda-ico/CudaIcoCodeGen.h
@@ -22,6 +22,8 @@
 #include "dawn/Support/IndexRange.h"
 #include <unordered_map>
 
+#include "LocToStringUtils.h"
+
 namespace dawn {
 namespace iir {
 class StencilInstantiation;

--- a/dawn/src/dawn/CodeGen/Cuda-ico/CudaIcoCodeGen.h
+++ b/dawn/src/dawn/CodeGen/Cuda-ico/CudaIcoCodeGen.h
@@ -1,0 +1,61 @@
+//===--------------------------------------------------------------------------------*- C++ -*-===//
+//                          _
+//                         | |
+//                       __| | __ ___      ___ ___
+//                      / _` |/ _` \ \ /\ / / '_  |
+//                     | (_| | (_| |\ V  V /| | | |
+//                      \__,_|\__,_| \_/\_/ |_| |_| - Compiler Toolchain
+//
+//
+//  This file is distributed under the MIT License (MIT).
+//  See LICENSE.txt for details.
+//
+//===------------------------------------------------------------------------------------------===//
+
+#pragma once
+
+#include "dawn/CodeGen/CodeGen.h"
+#include "dawn/CodeGen/CodeGenProperties.h"
+#include "dawn/CodeGen/Cuda/CacheProperties.h"
+#include "dawn/CodeGen/Options.h"
+#include "dawn/Support/Array.h"
+#include "dawn/Support/IndexRange.h"
+#include <unordered_map>
+
+namespace dawn {
+namespace iir {
+class StencilInstantiation;
+}
+
+namespace codegen {
+namespace cudaico {
+
+/// @brief Run the Cuda code generation
+std::unique_ptr<TranslationUnit>
+run(const std::map<std::string, std::shared_ptr<iir::StencilInstantiation>>&
+        stencilInstantiationMap,
+    const Options& options = {});
+
+/// @brief CUDA code generation for cartesian grids
+/// @ingroup cxxnaive cartesian
+class CudaIcoCodeGen : public CodeGen {
+
+public:
+  ///@brief constructor
+  CudaIcoCodeGen(const StencilInstantiationContext& ctx, DiagnosticsEngine& engine,
+                 int maxHaloPoints, int nsms, int maxBlocksPerSM, const Array3i& domainSize);
+  virtual ~CudaIcoCodeGen();
+  virtual std::unique_ptr<TranslationUnit> generateCode() override;
+
+  struct CudaCodeGenOptions {
+    int nsms;
+    int maxBlocksPerSM;
+    Array3i domainSize;
+  };
+
+private:
+};
+
+} // namespace cudaico
+} // namespace codegen
+} // namespace dawn

--- a/dawn/src/dawn/CodeGen/Cuda-ico/CudaIcoCodeGen.h
+++ b/dawn/src/dawn/CodeGen/Cuda-ico/CudaIcoCodeGen.h
@@ -54,6 +54,64 @@ public:
   };
 
 private:
+private:
+  static std::string
+  buildCudaKernelName(const std::shared_ptr<iir::StencilInstantiation>& instantiation,
+                      const std::unique_ptr<iir::MultiStage>& ms);
+
+  void
+  generateCudaKernelCode(std::stringstream& ssSW,
+                         const std::shared_ptr<iir::StencilInstantiation>& stencilInstantiation,
+                         const std::unique_ptr<iir::MultiStage>& ms);
+  void
+  generateAllCudaKernels(std::stringstream& ssSW,
+                         const std::shared_ptr<iir::StencilInstantiation>& stencilInstantiation);
+
+  void
+  generateStencilRunMethod(Structure& stencilClass, const iir::Stencil& stencil,
+                           const std::shared_ptr<StencilProperties>& stencilProperties,
+                           const std::shared_ptr<iir::StencilInstantiation>& stencilInstantiation,
+                           const std::unordered_map<std::string, std::string>& paramNameToType,
+                           const sir::GlobalVariableMap& globalsMap) const;
+
+  void
+  generateStencilClasses(const std::shared_ptr<iir::StencilInstantiation>& stencilInstantiation,
+                         Class& stencilWrapperClass, CodeGenProperties& codeGenProperties);
+  void
+  generateStencilWrapperCtr(Class& stencilWrapperClass,
+                            const std::shared_ptr<iir::StencilInstantiation>& stencilInstantiation,
+                            const CodeGenProperties& codeGenProperties) const;
+
+  void generateStencilWrapperMembers(
+      Class& stencilWrapperClass,
+      const std::shared_ptr<iir::StencilInstantiation>& stencilInstantiation,
+      CodeGenProperties& codeGenProperties) const;
+
+  void
+  generateStencilWrapperRun(Class& stencilWrapperClass,
+                            const std::shared_ptr<iir::StencilInstantiation>& stencilInstantiation,
+                            const CodeGenProperties& codeGenProperties) const;
+
+  void
+  generateStencilWrapperPublicMemberFunctions(Class& stencilWrapperClass,
+                                              const CodeGenProperties& codeGenProperties) const;
+
+  void
+  generateStencilClassCtr(Structure& stencilClass, const iir::Stencil& stencil,
+                          const sir::GlobalVariableMap& globalsMap,
+                          IndexRange<const std::map<int, iir::Stencil::FieldInfo>>& nonTempFields,
+                          IndexRange<const std::map<int, iir::Stencil::FieldInfo>>& tempFields,
+                          std::shared_ptr<StencilProperties> stencilProperties) const;
+
+  void generateStencilClassMembers(
+      Structure& stencilClass, const iir::Stencil& stencil,
+      const sir::GlobalVariableMap& globalsMap,
+      IndexRange<const std::map<int, iir::Stencil::FieldInfo>>& nonTempFields,
+      IndexRange<const std::map<int, iir::Stencil::FieldInfo>>& tempFields,
+      std::shared_ptr<StencilProperties> stencilProperties) const;
+
+  std::string generateStencilInstantiation(
+      const std::shared_ptr<iir::StencilInstantiation>& stencilInstantiation);
 };
 
 } // namespace cudaico

--- a/dawn/src/dawn/CodeGen/Cuda-ico/CudaIcoCodeGen.h
+++ b/dawn/src/dawn/CodeGen/Cuda-ico/CudaIcoCodeGen.h
@@ -54,15 +54,6 @@ public:
   };
 
 private:
-private:
-  static std::string
-  buildCudaKernelName(const std::shared_ptr<iir::StencilInstantiation>& instantiation,
-                      const std::unique_ptr<iir::MultiStage>& ms);
-
-  void
-  generateCudaKernelCode(std::stringstream& ssSW,
-                         const std::shared_ptr<iir::StencilInstantiation>& stencilInstantiation,
-                         const std::unique_ptr<iir::MultiStage>& ms);
   void
   generateAllCudaKernels(std::stringstream& ssSW,
                          const std::shared_ptr<iir::StencilInstantiation>& stencilInstantiation);
@@ -77,38 +68,17 @@ private:
   void
   generateStencilClasses(const std::shared_ptr<iir::StencilInstantiation>& stencilInstantiation,
                          Class& stencilWrapperClass, CodeGenProperties& codeGenProperties);
-  void
-  generateStencilWrapperCtr(Class& stencilWrapperClass,
-                            const std::shared_ptr<iir::StencilInstantiation>& stencilInstantiation,
-                            const CodeGenProperties& codeGenProperties) const;
 
-  void generateStencilWrapperMembers(
-      Class& stencilWrapperClass,
-      const std::shared_ptr<iir::StencilInstantiation>& stencilInstantiation,
-      CodeGenProperties& codeGenProperties) const;
+  void generateGpuMesh(const std::shared_ptr<iir::StencilInstantiation>& stencilInstantiation,
+                       Class& stencilWrapperClass, CodeGenProperties& codeGenProperties);
 
-  void
-  generateStencilWrapperRun(Class& stencilWrapperClass,
-                            const std::shared_ptr<iir::StencilInstantiation>& stencilInstantiation,
-                            const CodeGenProperties& codeGenProperties) const;
+  void generateRunFun(const std::shared_ptr<iir::StencilInstantiation>& stencilInstantiation,
+                      MemberFunction& runFun, CodeGenProperties& codeGenProperties);
 
-  void
-  generateStencilWrapperPublicMemberFunctions(Class& stencilWrapperClass,
-                                              const CodeGenProperties& codeGenProperties) const;
+  void generateStencilClassCtr(MemberFunction& stencilClassCtor, const iir::Stencil& stencil,
+                               CodeGenProperties& codeGenProperties) const;
 
-  void
-  generateStencilClassCtr(Structure& stencilClass, const iir::Stencil& stencil,
-                          const sir::GlobalVariableMap& globalsMap,
-                          IndexRange<const std::map<int, iir::Stencil::FieldInfo>>& nonTempFields,
-                          IndexRange<const std::map<int, iir::Stencil::FieldInfo>>& tempFields,
-                          std::shared_ptr<StencilProperties> stencilProperties) const;
-
-  void generateStencilClassMembers(
-      Structure& stencilClass, const iir::Stencil& stencil,
-      const sir::GlobalVariableMap& globalsMap,
-      IndexRange<const std::map<int, iir::Stencil::FieldInfo>>& nonTempFields,
-      IndexRange<const std::map<int, iir::Stencil::FieldInfo>>& tempFields,
-      std::shared_ptr<StencilProperties> stencilProperties) const;
+  void generateCopyBackFun(MemberFunction& copyBackFun, const iir::Stencil& stencil) const;
 
   std::string generateStencilInstantiation(
       const std::shared_ptr<iir::StencilInstantiation>& stencilInstantiation);

--- a/dawn/src/dawn/CodeGen/Cuda-ico/LocToStringUtils.cpp
+++ b/dawn/src/dawn/CodeGen/Cuda-ico/LocToStringUtils.cpp
@@ -1,0 +1,150 @@
+//===--------------------------------------------------------------------------------*- C++ -*-===//
+//                          _
+//                         | |
+//                       __| | __ ___      ___ ___
+//                      / _` |/ _` \ \ /\ / / '_  |
+//                     | (_| | (_| |\ V  V /| | | |
+//                      \__,_|\__,_| \_/\_/ |_| |_| - Compiler Toolchain
+//
+//
+//  This file is distributed under the MIT License (MIT).
+//  See LICENSE.txt for details.
+//
+//===------------------------------------------------------------------------------------------===//
+
+#include "LocToStringUtils.h"
+
+#include "dawn/Support/Unreachable.h"
+
+#include <sstream>
+
+namespace dawn {
+namespace codegen {
+namespace cudaico {
+
+std::string chainToTableString(std::vector<dawn::ast::LocationType> locs) {
+  std::stringstream ss;
+  for(auto loc : locs) {
+    switch(loc) {
+    case dawn::ast::LocationType::Cells:
+      ss << "c";
+      break;
+    case dawn::ast::LocationType::Edges:
+      ss << "e";
+      break;
+    case dawn::ast::LocationType::Vertices:
+      ss << "v";
+      break;
+    }
+  }
+  ss << "Table";
+  return ss.str();
+}
+
+std::string chainToSparseSizeString(std::vector<dawn::ast::LocationType> locs) {
+  std::stringstream ss;
+  for(auto loc : locs) {
+    switch(loc) {
+    case dawn::ast::LocationType::Cells:
+      ss << "C_";
+      break;
+    case dawn::ast::LocationType::Edges:
+      ss << "E_";
+      break;
+    case dawn::ast::LocationType::Vertices:
+      ss << "V_";
+      break;
+    }
+  }
+  ss << "SIZE";
+  return ss.str();
+}
+
+std::string chainToDenseSizeStringHostMesh(std::vector<dawn::ast::LocationType> locs) {
+  std::stringstream ss;
+  switch(locs[0]) {
+  case dawn::ast::LocationType::Cells:
+    ss << "mesh.cells().size()";
+    break;
+  case dawn::ast::LocationType::Edges:
+    ss << "mesh.edges().size()";
+    break;
+  case dawn::ast::LocationType::Vertices:
+    ss << "mesh.nodes().size()";
+    break;
+  }
+  return ss.str();
+}
+
+std::string chainToVectorString(std::vector<dawn::ast::LocationType> locs) {
+  std::stringstream ss;
+  ss << "{";
+  bool first = true;
+  for(auto loc : locs) {
+    if(!first) {
+      ss << ", ";
+    }
+    switch(loc) {
+    case dawn::ast::LocationType::Cells:
+      ss << "dawn::LocationType::Cells";
+      break;
+    case dawn::ast::LocationType::Edges:
+      ss << "dawn::LocationType::Edges";
+      break;
+    case dawn::ast::LocationType::Vertices:
+      ss << "dawn::LocationType::Vertices";
+      break;
+    }
+    first = false;
+  }
+  ss << "}";
+  return ss.str();
+}
+std::string locToDenseSizeStringGpuMesh(dawn::ast::LocationType loc) {
+  switch(loc) {
+  case dawn::ast::LocationType::Cells:
+    return "NumCells";
+    break;
+  case dawn::ast::LocationType::Edges:
+    return "NumEdges";
+    break;
+  case dawn::ast::LocationType::Vertices:
+    return "NumVertices";
+    break;
+  default:
+    dawn_unreachable("");
+  }
+}
+std::string locToDenseTypeString(dawn::ast::LocationType loc) {
+  switch(loc) {
+  case dawn::ast::LocationType::Cells:
+    return "dawn::cell_field_t<LibTag, dawn::float_type>";
+    break;
+  case dawn::ast::LocationType::Edges:
+    return "dawn::edge_field_t<LibTag, dawn::float_type>";
+    break;
+  case dawn::ast::LocationType::Vertices:
+    return "dawn::vertex_field_t<LibTag, dawn::float_type>";
+    break;
+  default:
+    dawn_unreachable("");
+  }
+}
+std::string locToSparseTypeString(dawn::ast::LocationType loc) {
+  switch(loc) {
+  case dawn::ast::LocationType::Cells:
+    return "dawn::sparse_cell_field_t<LibTag, dawn::float_type>";
+    break;
+  case dawn::ast::LocationType::Edges:
+    return "dawn::sparse_edge_field_t<LibTag, dawn::float_type>";
+    break;
+  case dawn::ast::LocationType::Vertices:
+    return "dawn::sparse_vertex_field_t<LibTag, dawn::float_type>";
+    break;
+  default:
+    dawn_unreachable("");
+  }
+}
+} // namespace cudaico
+} // namespace codegen
+} // namespace dawn

--- a/dawn/src/dawn/CodeGen/Cuda-ico/LocToStringUtils.cpp
+++ b/dawn/src/dawn/CodeGen/Cuda-ico/LocToStringUtils.cpp
@@ -118,13 +118,13 @@ std::string locToDenseSizeStringGpuMesh(dawn::ast::LocationType loc) {
 std::string locToDenseTypeString(dawn::ast::LocationType loc) {
   switch(loc) {
   case dawn::ast::LocationType::Cells:
-    return "dawn::cell_field_t<LibTag, dawn::float_type>";
+    return "dawn::cell_field_t<LibTag, ::dawn::float_type>";
     break;
   case dawn::ast::LocationType::Edges:
-    return "dawn::edge_field_t<LibTag, dawn::float_type>";
+    return "dawn::edge_field_t<LibTag, ::dawn::float_type>";
     break;
   case dawn::ast::LocationType::Vertices:
-    return "dawn::vertex_field_t<LibTag, dawn::float_type>";
+    return "dawn::vertex_field_t<LibTag, ::dawn::float_type>";
     break;
   default:
     dawn_unreachable("");
@@ -133,13 +133,13 @@ std::string locToDenseTypeString(dawn::ast::LocationType loc) {
 std::string locToSparseTypeString(dawn::ast::LocationType loc) {
   switch(loc) {
   case dawn::ast::LocationType::Cells:
-    return "dawn::sparse_cell_field_t<LibTag, dawn::float_type>";
+    return "dawn::sparse_cell_field_t<LibTag, ::dawn::float_type>";
     break;
   case dawn::ast::LocationType::Edges:
-    return "dawn::sparse_edge_field_t<LibTag, dawn::float_type>";
+    return "dawn::sparse_edge_field_t<LibTag, ::dawn::float_type>";
     break;
   case dawn::ast::LocationType::Vertices:
-    return "dawn::sparse_vertex_field_t<LibTag, dawn::float_type>";
+    return "dawn::sparse_vertex_field_t<LibTag, ::dawn::float_type>";
     break;
   default:
     dawn_unreachable("");

--- a/dawn/src/dawn/CodeGen/Cuda-ico/LocToStringUtils.h
+++ b/dawn/src/dawn/CodeGen/Cuda-ico/LocToStringUtils.h
@@ -1,0 +1,42 @@
+//===--------------------------------------------------------------------------------*- C++ -*-===//
+//                          _
+//                         | |
+//                       __| | __ ___      ___ ___
+//                      / _` |/ _` \ \ /\ / / '_  |
+//                     | (_| | (_| |\ V  V /| | | |
+//                      \__,_|\__,_| \_/\_/ |_| |_| - Compiler Toolchain
+//
+//
+//  This file is distributed under the MIT License (MIT).
+//  See LICENSE.txt for details.
+//
+//===------------------------------------------------------------------------------------------===//
+
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include "dawn/AST/LocationType.h"
+
+namespace dawn {
+namespace codegen {
+namespace cudaico {
+
+std::string chainToTableString(std::vector<dawn::ast::LocationType> locs);
+
+std::string chainToSparseSizeString(std::vector<dawn::ast::LocationType> locs);
+
+std::string chainToDenseSizeStringHostMesh(std::vector<dawn::ast::LocationType> locs);
+
+std::string chainToVectorString(std::vector<dawn::ast::LocationType> locs);
+
+std::string locToDenseSizeStringGpuMesh(dawn::ast::LocationType loc);
+
+std::string locToDenseTypeString(dawn::ast::LocationType loc);
+
+std::string locToSparseTypeString(dawn::ast::LocationType loc);
+
+} // namespace cudaico
+} // namespace codegen
+} // namespace dawn

--- a/dawn/src/dawn/CodeGen/Cuda/CodeGeneratorHelper.cpp
+++ b/dawn/src/dawn/CodeGen/Cuda/CodeGeneratorHelper.cpp
@@ -42,6 +42,14 @@ std::string CodeGeneratorHelper::buildCudaKernelName(
          "_ms" + std::to_string(ms->getID()) + "_kernel";
 }
 
+std::string CodeGeneratorHelper::buildCudaKernelName(
+    const std::shared_ptr<iir::StencilInstantiation>& instantiation,
+    const std::unique_ptr<iir::MultiStage>& ms, const std::unique_ptr<iir::Stage>& stage) {
+  return instantiation->getName() + "_stencil" + std::to_string(ms->getParent()->getStencilID()) +
+         "_ms" + std::to_string(ms->getID()) + "_s" + std::to_string(stage->getStageID()) +
+         "_kernel";
+}
+
 std::vector<std::string> CodeGeneratorHelper::generateStrideArguments(
     const IndexRange<const std::map<int, iir::Field>>& nonTempFields,
     const IndexRange<const std::map<int, iir::Field>>& tempFields,

--- a/dawn/src/dawn/CodeGen/Cuda/CodeGeneratorHelper.h
+++ b/dawn/src/dawn/CodeGen/Cuda/CodeGeneratorHelper.h
@@ -16,6 +16,7 @@
 #define DAWN_CODEGEN_CUDA_CODEGENERATORHELPER_H
 
 #include "dawn/IIR/Cache.h"
+#include "dawn/IIR/Stage.h"
 #include "dawn/Support/Array.h"
 #include "dawn/Support/IndexRange.h"
 #include <map>
@@ -84,6 +85,12 @@ public:
   static std::string
   buildCudaKernelName(const std::shared_ptr<iir::StencilInstantiation>& instantiation,
                       const std::unique_ptr<iir::MultiStage>& ms);
+
+  /// @brief compose the cuda kernel name of a stencil instantiation
+  static std::string
+  buildCudaKernelName(const std::shared_ptr<iir::StencilInstantiation>& instantiation,
+                      const std::unique_ptr<iir::MultiStage>& ms,
+                      const std::unique_ptr<iir::Stage>& stage);
 };
 
 } // namespace cuda

--- a/dawn/src/dawn/CodeGen/Driver.cpp
+++ b/dawn/src/dawn/CodeGen/Driver.cpp
@@ -15,6 +15,7 @@
 #include "dawn/CodeGen/Driver.h"
 #include "dawn/CodeGen/CXXNaive-ico/CXXNaiveCodeGen.h"
 #include "dawn/CodeGen/CXXNaive/CXXNaiveCodeGen.h"
+#include "dawn/CodeGen/Cuda-ico/CudaIcoCodeGen.h"
 #include "dawn/CodeGen/Cuda/CudaCodeGen.h"
 #include "dawn/CodeGen/GridTools/GTCodeGen.h"
 #include "dawn/Serialization/IIRSerializer.h"
@@ -33,6 +34,9 @@ codegen::Backend parseBackendString(const std::string& backendStr) {
     return codegen::Backend::CXXNaiveIco;
   } else if(backendStr == "cuda" || backendStr == "CUDA") {
     return codegen::Backend::CUDA;
+  } else if(backendStr == "cuda-ico" || backendStr == "CUDAIco" || backendStr == "CUDA-Ico" ||
+            backendStr == "CUDA-ICO") {
+    return codegen::Backend::CUDAIco;
   } else {
     throw std::invalid_argument("Backend not supported");
   }
@@ -50,6 +54,8 @@ run(const std::map<std::string, std::shared_ptr<iir::StencilInstantiation>>& con
     return cxxnaiveico::run(context, options);
   case Backend::GridTools:
     return gt::run(context, options);
+  case Backend::CUDAIco:
+    return cudaico::run(context, options);
   case Backend::CXXOpt:
     throw std::invalid_argument("Backend not supported");
   }

--- a/dawn/src/dawn/CodeGen/Options.h
+++ b/dawn/src/dawn/CodeGen/Options.h
@@ -19,7 +19,7 @@ namespace dawn {
 namespace codegen {
 
 /// @brief CodeGen backends
-enum class Backend { GridTools, CXXNaive, CXXNaiveIco, CUDA, CXXOpt };
+enum class Backend { GridTools, CXXNaive, CXXNaiveIco, CUDAIco, CUDA, CXXOpt };
 
 /// @brief Options for all codegen backends combined.
 ///

--- a/dawn/src/dawn/dawn-codegen.cpp
+++ b/dawn/src/dawn/dawn-codegen.cpp
@@ -76,7 +76,7 @@ int main(int argc, char* argv[]) {
     ("i,input", "Input IIR file. If unset, uses stdin.", cxxopts::value<std::string>())
     ("o,out", "Output filename. If unset, writes code to stdout.", cxxopts::value<std::string>())
     ("v,verbose", "Set verbosity level to info. If set, use -o or --out to redirect code to file.")
-    ("b,backend", "Backend code generator: [gridtools|gt, c++-naive|naive, cxx-naive-ico|naive-ico, cuda, cxx-opt].",
+    ("b,backend", "Backend code generator: [gridtools|gt, c++-naive|naive, cxx-naive-ico|naive-ico, cuda, cuda-ico, cxx-opt].",
         cxxopts::value<std::string>()->default_value("c++-naive"))
     ("h,help", "Display usage.");
 

--- a/dawn/src/driver-includes/cuda_utils.hpp
+++ b/dawn/src/driver-includes/cuda_utils.hpp
@@ -19,6 +19,13 @@
 #include <cuda.h>
 #include <cuda_runtime.h>
 
+#include "unstructured_interface.hpp"
+
+#include <assert.h>
+#include <vector>
+
+#define DEVICE_MISSING_VALUE -1
+
 #define gpuErrchk(ans)                                                                             \
   { gpuAssert((ans), __FILE__, __LINE__); }
 inline void gpuAssert(cudaError_t code, const char* file, int line, bool abort = true) {
@@ -28,6 +35,8 @@ inline void gpuAssert(cudaError_t code, const char* file, int line, bool abort =
       exit(code);
   }
 }
+
+namespace dawn {
 
 void reshape(const dawn::float_type* input, dawn::float_type* output, int kSize, int numEdges,
              int sparseSize) {
@@ -62,6 +71,18 @@ void reshape_back(const dawn::float_type* input, dawn::float_type* output, int k
       output[edgeIdx * kSize + kLevel] = input[kLevel * numEdges + edgeIdx];
     }
 }
+void reshape_back(const dawn::float_type* input, dawn::float_type* output, int kSize, int numEdges,
+                  int sparseSize) {
+  // In: klevels, sparse, edges
+  // Out: edges, klevels, sparse
+  for(int edgeIdx = 0; edgeIdx < numEdges; edgeIdx++)
+    for(int kLevel = 0; kLevel < kSize; kLevel++)
+      for(int sparseIdx = 0; sparseIdx < sparseSize; sparseIdx++) {
+        output[edgeIdx * kSize * sparseSize + kLevel * sparseSize + sparseIdx] =
+            input[kLevel * numEdges * sparseSize + sparseIdx * numEdges + edgeIdx];
+      }
+}
+
 template <class FieldT>
 void initField(const FieldT& field, dawn::float_type** cudaStorage, int denseSize, int kSize) {
   dawn::float_type* reshaped = new dawn::float_type[field.numElements()];
@@ -81,3 +102,48 @@ void initSparseField(const SparseFieldT& field, dawn::float_type** cudaStorage, 
                        cudaMemcpyHostToDevice));
   delete[] reshaped;
 }
+
+template <typename LibTag>
+void generateNbhTable(dawn::mesh_t<LibTag> const& mesh, std::vector<dawn::LocationType> chain,
+                      int numElements, int numNbhPerElement, int* target) {
+  std::vector<dawn::nbh_table_index_t<LibTag>> elems;
+  switch(chain.front()) {
+  case dawn::LocationType::Cells: {
+    for(auto cell : getCells(LibTag{}, mesh)) {
+      elems.push_back(cell);
+    }
+    break;
+  }
+  case dawn::LocationType::Edges: {
+    for(auto edge : getEdges(LibTag{}, mesh)) {
+      elems.push_back(edge);
+    }
+    break;
+  }
+  case dawn::LocationType::Vertices: {
+    for(auto vertex : getVertices(LibTag{}, mesh)) {
+      elems.push_back(vertex);
+    }
+    break;
+  }
+  }
+
+  assert(elems.size() == numElements);
+
+  std::vector<int> hostTable;
+  for(int elem : elems) {
+    auto neighbors = getNeighbors(LibTag{}, mesh, chain, elem);
+    for(int nbhIdx = 0; nbhIdx < numNbhPerElement; nbhIdx++) {
+      if(nbhIdx < neighbors.size()) {
+        hostTable.push_back(neighbors[nbhIdx]);
+      } else {
+        hostTable.push_back(DEVICE_MISSING_VALUE);
+      }
+    }
+  }
+
+  assert(hostTable.size() == numElements * numNbhPerElement);
+  gpuErrchk(cudaMemcpy(target, hostTable.data(), sizeof(int) * numElements * numNbhPerElement,
+                       cudaMemcpyHostToDevice));
+}
+} // namespace dawn

--- a/dawn/src/driver-includes/cuda_utils.hpp
+++ b/dawn/src/driver-includes/cuda_utils.hpp
@@ -1,0 +1,83 @@
+//===--------------------------------------------------------------------------------*- C++ -*-===//
+//                          _
+//                         | |
+//                       __| | __ ___      ___ ___
+//                      / _` |/ _` \ \ /\ / / '_  |
+//                     | (_| | (_| |\ V  V /| | | |
+//                      \__,_|\__,_| \_/\_/ |_| |_| - Compiler Toolchain
+//
+//
+//  This file is distributed under the MIT License (MIT).
+//  See LICENSE.txt for details.
+//
+//===------------------------------------------------------------------------------------------===//
+
+#pragma once
+
+#include "defs.hpp"
+
+#include <cuda.h>
+#include <cuda_runtime.h>
+
+#define gpuErrchk(ans)                                                                             \
+  { gpuAssert((ans), __FILE__, __LINE__); }
+inline void gpuAssert(cudaError_t code, const char* file, int line, bool abort = true) {
+  if(code != cudaSuccess) {
+    fprintf(stderr, "GPUassert: %s %s %d\n", cudaGetErrorString(code), file, line);
+    if(abort)
+      exit(code);
+  }
+}
+
+void reshape(const dawn::float_type* input, dawn::float_type* output, int kSize, int numEdges,
+             int sparseSize) {
+  // In: edges, klevels, sparse
+  // Out: klevels, sparse, edges
+
+  for(int edgeIdx = 0; edgeIdx < numEdges; edgeIdx++)
+    for(int kLevel = 0; kLevel < kSize; kLevel++)
+      for(int sparseIdx = 0; sparseIdx < sparseSize; sparseIdx++) {
+        output[kLevel * numEdges * sparseSize + sparseIdx * numEdges + edgeIdx] =
+            input[edgeIdx * kSize * sparseSize + kLevel * sparseSize + sparseIdx];
+      }
+}
+
+void reshape(const dawn::float_type* input, dawn::float_type* output, int kSize, int numEdges) {
+  // In: edges, klevels
+  // Out: klevels, edges
+
+  for(int edgeIdx = 0; edgeIdx < numEdges; edgeIdx++)
+    for(int kLevel = 0; kLevel < kSize; kLevel++) {
+      output[kLevel * numEdges + edgeIdx] = input[edgeIdx * kSize + kLevel];
+    }
+}
+
+void reshape_back(const dawn::float_type* input, dawn::float_type* output, int kSize,
+                  int numEdges) {
+  // In: klevels, edges
+  // Out: edges, klevels
+
+  for(int edgeIdx = 0; edgeIdx < numEdges; edgeIdx++)
+    for(int kLevel = 0; kLevel < kSize; kLevel++) {
+      output[edgeIdx * kSize + kLevel] = input[kLevel * numEdges + edgeIdx];
+    }
+}
+template <class FieldT>
+void initField(const FieldT& field, dawn::float_type** cudaStorage, int denseSize, int kSize) {
+  dawn::float_type* reshaped = new dawn::float_type[field.numElements()];
+  reshape(field.data(), reshaped, kSize, denseSize);
+  gpuErrchk(cudaMalloc((void**)cudaStorage, sizeof(dawn::float_type) * field.numElements()));
+  gpuErrchk(cudaMemcpy(*cudaStorage, reshaped, sizeof(dawn::float_type) * field.numElements(),
+                       cudaMemcpyHostToDevice));
+  delete[] reshaped;
+}
+template <class SparseFieldT>
+void initSparseField(const SparseFieldT& field, dawn::float_type** cudaStorage, int denseSize,
+                     int sparseSize, int kSize) {
+  dawn::float_type* reshaped = new dawn::float_type[field.numElements()];
+  reshape(field.data(), reshaped, kSize, denseSize, sparseSize);
+  gpuErrchk(cudaMalloc((void**)cudaStorage, sizeof(dawn::float_type) * field.numElements()));
+  gpuErrchk(cudaMemcpy(*cudaStorage, reshaped, sizeof(dawn::float_type) * field.numElements(),
+                       cudaMemcpyHostToDevice));
+  delete[] reshaped;
+}


### PR DESCRIPTION
## Technical Description

This PR introduces a simple code gen for unstructured (icosahedral) cuda code. The code gen only supports the feature set used by the two ICON Laplacians so far, which can roughly be summarized as
* dense and sparse fields on location(chains)
* loop concept to fill sparse fields
* reduction over neighbor(chains)
Nested reductions etc. are not supported. It is also assumed that each stage runs over the all k levels (the full vertical dimension). 

## Fixes / Enhances
Fixes #945 

## Testing
There is currently no (automated) testing of the code gen since we expect the code gen to heavily change in the near future. It can be manually tested using a adapted driver code for the diamond found [here](https://github.com/mroethlin/cuda_stencil/tree/codegen_experiment). 