### PR TITLE
Add header to GTClangIncludeChecker

### DIFF
--- a/gtclang/src/gtclang/Frontend/GTClangIncludeChecker.h
+++ b/gtclang/src/gtclang/Frontend/GTClangIncludeChecker.h
@@ -17,6 +17,7 @@
 #ifndef GTCLANG_FRONTEND_INCLUDEPROCESSOR_H
 #define GTCLANG_FRONTEND_INCLUDEPROCESSOR_H
 
+#include <llvm/ADT/SmallVector.h>
 #include <llvm/ADT/StringRef.h>
 #include <string>
 #include <vector>


### PR DESCRIPTION
## Technical Description

Add header to GTClangIncludeChecker, required for LLVM 10.