### PR TITLE
Replace logger

### DIFF
--- a/dawn/src/dawn/CodeGen/CXXNaive-ico/CXXNaiveCodeGen.cpp
+++ b/dawn/src/dawn/CodeGen/CXXNaive-ico/CXXNaiveCodeGen.cpp
@@ -20,7 +20,7 @@
 #include "dawn/IIR/StencilInstantiation.h"
 #include "dawn/SIR/SIR.h"
 #include "dawn/Support/Assert.h"
-#include "dawn/Support/Logging.h"
+#include "dawn/Support/Logger.h"
 #include "dawn/Support/StringUtil.h"
 #include <algorithm>
 #include <vector>

--- a/dawn/src/dawn/CodeGen/CXXNaive/CXXNaiveCodeGen.cpp
+++ b/dawn/src/dawn/CodeGen/CXXNaive/CXXNaiveCodeGen.cpp
@@ -26,7 +26,7 @@
 #include "dawn/IIR/StencilInstantiation.h"
 #include "dawn/SIR/SIR.h"
 #include "dawn/Support/Assert.h"
-#include "dawn/Support/Logging.h"
+#include "dawn/Support/Logger.h"
 #include "dawn/Support/StringUtil.h"
 #include <algorithm>
 #include <string>

--- a/dawn/src/dawn/CodeGen/Cuda/CudaCodeGen.cpp
+++ b/dawn/src/dawn/CodeGen/Cuda/CudaCodeGen.cpp
@@ -26,7 +26,7 @@
 #include "dawn/Support/Array.h"
 #include "dawn/Support/Assert.h"
 #include "dawn/Support/Iterator.h"
-#include "dawn/Support/Logging.h"
+#include "dawn/Support/Logger.h"
 #include "dawn/Support/StringUtil.h"
 #include <algorithm>
 #include <numeric>

--- a/dawn/src/dawn/CodeGen/GridTools/GTCodeGen.cpp
+++ b/dawn/src/dawn/CodeGen/GridTools/GTCodeGen.cpp
@@ -23,7 +23,7 @@
 #include "dawn/SIR/SIR.h"
 #include "dawn/Support/Assert.h"
 #include "dawn/Support/DiagnosticsEngine.h"
-#include "dawn/Support/Logging.h"
+#include "dawn/Support/Logger.h"
 #include "dawn/Support/StringUtil.h"
 #include <map>
 #include <optional>

--- a/dawn/src/dawn/Compiler/Driver.cpp
+++ b/dawn/src/dawn/Compiler/Driver.cpp
@@ -17,7 +17,7 @@
 #include "dawn/CodeGen/TranslationUnit.h"
 #include "dawn/SIR/SIR.h"
 #include "dawn/Support/Iterator.h"
-#include "dawn/Support/Logging.h"
+#include "dawn/Support/Logger.h"
 #include "dawn/Support/StringSwitch.h"
 
 #include "dawn/Optimizer/OptimizerContext.h"

--- a/dawn/src/dawn/IIR/DoMethod.cpp
+++ b/dawn/src/dawn/IIR/DoMethod.cpp
@@ -29,7 +29,7 @@
 #include "dawn/IIR/Stencil.h"
 #include "dawn/IIR/StencilMetaInformation.h"
 #include "dawn/Support/IndexGenerator.h"
-#include "dawn/Support/Logging.h"
+#include "dawn/Support/Logger.h"
 #include <limits>
 #include <memory>
 

--- a/dawn/src/dawn/IIR/Stage.cpp
+++ b/dawn/src/dawn/IIR/Stage.cpp
@@ -25,7 +25,7 @@
 #include "dawn/IIR/StencilFunctionInstantiation.h"
 #include "dawn/IIR/StencilMetaInformation.h"
 #include "dawn/SIR/ASTVisitor.h"
-#include "dawn/Support/Logging.h"
+#include "dawn/Support/Logger.h"
 #include <algorithm>
 #include <iterator>
 #include <set>

--- a/dawn/src/dawn/IIR/StencilFunctionInstantiation.cpp
+++ b/dawn/src/dawn/IIR/StencilFunctionInstantiation.cpp
@@ -20,7 +20,7 @@
 #include "dawn/IIR/StencilInstantiation.h"
 #include "dawn/SIR/SIR.h"
 #include "dawn/Support/Casting.h"
-#include "dawn/Support/Logging.h"
+#include "dawn/Support/Logger.h"
 #include "dawn/Support/Printing.h"
 #include "dawn/Support/Unreachable.h"
 #include <iostream>

--- a/dawn/src/dawn/IIR/StencilInstantiation.cpp
+++ b/dawn/src/dawn/IIR/StencilInstantiation.cpp
@@ -29,7 +29,7 @@
 #include "dawn/Support/DiagnosticsEngine.h"
 #include "dawn/Support/Format.h"
 #include "dawn/Support/Json.h"
-#include "dawn/Support/Logging.h"
+#include "dawn/Support/Logger.h"
 #include "dawn/Support/Printing.h"
 #include "dawn/Support/RemoveIf.hpp"
 #include "dawn/Support/Twine.h"

--- a/dawn/src/dawn/Optimizer/OptimizerContext.cpp
+++ b/dawn/src/dawn/Optimizer/OptimizerContext.cpp
@@ -26,7 +26,7 @@
 #include "dawn/Optimizer/PassTemporaryType.h"
 #include "dawn/Optimizer/StatementMapper.h"
 #include "dawn/SIR/SIR.h"
-#include "dawn/Support/Logging.h"
+#include "dawn/Support/Logger.h"
 #include "dawn/Support/STLExtras.h"
 #include <stack>
 

--- a/dawn/src/dawn/Optimizer/PassFixVersionedInputFields.cpp
+++ b/dawn/src/dawn/Optimizer/PassFixVersionedInputFields.cpp
@@ -22,7 +22,7 @@
 #include "dawn/IIR/NodeUpdateType.h"
 #include "dawn/IIR/StencilInstantiation.h"
 #include "dawn/Optimizer/OptimizerContext.h"
-#include "dawn/Support/Logging.h"
+#include "dawn/Support/Logger.h"
 
 #include <memory>
 

--- a/dawn/src/dawn/Optimizer/PassInlining.cpp
+++ b/dawn/src/dawn/Optimizer/PassInlining.cpp
@@ -21,7 +21,7 @@
 #include "dawn/IIR/InstantiationHelper.h"
 #include "dawn/IIR/StencilInstantiation.h"
 #include "dawn/Optimizer/OptimizerContext.h"
-#include "dawn/Support/Logging.h"
+#include "dawn/Support/Logger.h"
 #include "dawn/Support/STLExtras.h"
 #include <iostream>
 #include <stack>

--- a/dawn/src/dawn/Optimizer/PassManager.cpp
+++ b/dawn/src/dawn/Optimizer/PassManager.cpp
@@ -17,7 +17,7 @@
 #include "dawn/IIR/StencilInstantiation.h"
 #include "dawn/Optimizer/OptimizerContext.h"
 #include "dawn/Support/Exception.h"
-#include "dawn/Support/Logging.h"
+#include "dawn/Support/Logger.h"
 #include <vector>
 
 namespace dawn {

--- a/dawn/src/dawn/Optimizer/PassRemoveScalars.cpp
+++ b/dawn/src/dawn/Optimizer/PassRemoveScalars.cpp
@@ -234,8 +234,8 @@ bool PassRemoveScalars::run(
   // Check if we have unsupported statements. If we do, warn the user and skip the pass execution.
   for(const auto& stmt : iterateIIROverStmt(*stencilInstantiation->getIIR())) {
     if(isStatementUnsupported(stmt, stencilInstantiation->getMetaData())) {
-      DAWN_LOG(INFO) << "Unsupported statement at line " << stmt->getSourceLocation()
-                     << ". Skipping removal of scalar variables.";
+      DAWN_DIAG(INFO, stencilInstantiation->getMetaData().getFileName(), stmt->getSourceLocation())
+          << "Unsupported statement. Skipping removal of scalar variables...";
       return true;
     }
   }
@@ -245,11 +245,9 @@ bool PassRemoveScalars::run(
     auto removedScalars = removeScalarsFromDoMethod(*doMethod, stencilInstantiation->getMetaData());
     if(context_.getOptions().ReportPassRemoveScalars) {
       for(const auto& varName : removedScalars) {
-        std::cout << "PASS: " << getName() << ": " << stencilInstantiation->getName()
-                  << ": DoMethod: " << doMethod->getID() << " removed variable: " << varName
-                  << std::endl;
+        DAWN_LOG(INFO) << stencilInstantiation->getName() << ": DoMethod: " << doMethod->getID()
+                       << " removed variable: " << varName;
       }
-      std::cout.flush();
     }
     // Recompute extents of fields
     doMethod->update(iir::NodeUpdateType::level);

--- a/dawn/src/dawn/Optimizer/PassRemoveScalars.cpp
+++ b/dawn/src/dawn/Optimizer/PassRemoveScalars.cpp
@@ -20,7 +20,7 @@
 #include "dawn/IIR/StencilInstantiation.h"
 #include "dawn/IIR/StencilMetaInformation.h"
 #include "dawn/Optimizer/OptimizerContext.h"
-#include "dawn/Support/Logging.h"
+#include "dawn/Support/Logger.h"
 
 #include <tuple>
 #include <unordered_map>

--- a/dawn/src/dawn/Optimizer/PassSetBoundaryCondition.cpp
+++ b/dawn/src/dawn/Optimizer/PassSetBoundaryCondition.cpp
@@ -23,7 +23,7 @@
 #include "dawn/IIR/StencilInstantiation.h"
 #include "dawn/Optimizer/OptimizerContext.h"
 #include "dawn/Support/Assert.h"
-#include "dawn/Support/Logging.h"
+#include "dawn/Support/Logger.h"
 #include <iostream>
 #include <set>
 #include <unordered_map>

--- a/dawn/src/dawn/Optimizer/PassSetStageLocationType.cpp
+++ b/dawn/src/dawn/Optimizer/PassSetStageLocationType.cpp
@@ -24,12 +24,13 @@
 #include "dawn/IIR/Stage.h"
 #include "dawn/IIR/StencilInstantiation.h"
 #include "dawn/IIR/StencilMetaInformation.h"
+#include "dawn/Support/Exception.h"
 #include "dawn/Support/Logging.h"
-#include "dawn/Support/Unreachable.h"
 #include <deque>
 #include <iterator>
 #include <memory>
 #include <stdexcept>
+#include <string>
 
 namespace dawn {
 namespace {
@@ -83,9 +84,8 @@ ast::LocationType deduceLocationType(const std::shared_ptr<iir::Stmt>& stmt,
       dawn_unreachable("unsupported loop descriptor!\n");
     }
   }
-  DAWN_LOG(ERROR) << "Couldn't deduce location type for statement at line "
-                  << stmt->getSourceLocation() << ".";
-  dawn_unreachable("Couldn't deduce location type.");
+  throw SemanticError(std::string("Couldn't deduce location type for statement at line ") +
+                      static_cast<std::string>(stmt->getSourceLocation()) + ".");
 }
 
 } // namespace

--- a/dawn/src/dawn/Optimizer/PassSetStageLocationType.cpp
+++ b/dawn/src/dawn/Optimizer/PassSetStageLocationType.cpp
@@ -25,7 +25,7 @@
 #include "dawn/IIR/StencilInstantiation.h"
 #include "dawn/IIR/StencilMetaInformation.h"
 #include "dawn/Support/Exception.h"
-#include "dawn/Support/Logging.h"
+#include "dawn/Support/Logger.h"
 #include <deque>
 #include <iterator>
 #include <memory>

--- a/dawn/src/dawn/Optimizer/PassStageSplitter.cpp
+++ b/dawn/src/dawn/Optimizer/PassStageSplitter.cpp
@@ -19,7 +19,7 @@
 #include "dawn/Optimizer/OptimizerContext.h"
 #include "dawn/Optimizer/ReadBeforeWriteConflict.h"
 #include "dawn/Support/Format.h"
-#include "dawn/Support/Logging.h"
+#include "dawn/Support/Logger.h"
 #include <deque>
 #include <iostream>
 #include <iterator>

--- a/dawn/src/dawn/Serialization/SIRSerializer.cpp
+++ b/dawn/src/dawn/Serialization/SIRSerializer.cpp
@@ -53,10 +53,10 @@ public:
       DAWN_LOG(WARNING) << "Protobuf: " << message;
       break;
     case google::protobuf::LOGLEVEL_ERROR:
-      throw SyntacticError(std::string("[FATAL] Protobuf error: ") + message);
+      throw SyntacticError(std::string("[ERROR] Protobuf error: ") + message);
       break;
     case google::protobuf::LOGLEVEL_FATAL:
-      throw std::runtime_error(std::string("[FATAL] Protobuf error occurred: ") + message);
+      throw SyntacticError(std::string("[FATAL] Protobuf error occurred: ") + message);
       break;
     }
 

--- a/dawn/src/dawn/Serialization/SIRSerializer.cpp
+++ b/dawn/src/dawn/Serialization/SIRSerializer.cpp
@@ -20,6 +20,7 @@
 #include "dawn/SIR/SIR/statements.pb.h"
 #include "dawn/Serialization/ASTSerializer.h"
 #include "dawn/Serialization/SIRSerializer.h"
+#include "dawn/Support/Exception.h"
 #include "dawn/Support/Format.h"
 #include "dawn/Support/Logging.h"
 #include "dawn/Support/Unreachable.h"
@@ -52,7 +53,7 @@ public:
       DAWN_LOG(WARNING) << "Protobuf: " << message;
       break;
     case google::protobuf::LOGLEVEL_ERROR:
-      DAWN_LOG(ERROR) << "Protobuf: " << message;
+      throw SyntacticError(std::string("[FATAL] Protobuf error: ") + message);
       break;
     case google::protobuf::LOGLEVEL_FATAL:
       throw std::runtime_error(std::string("[FATAL] Protobuf error occurred: ") + message);

--- a/dawn/src/dawn/Serialization/SIRSerializer.cpp
+++ b/dawn/src/dawn/Serialization/SIRSerializer.cpp
@@ -55,7 +55,7 @@ public:
       DAWN_LOG(ERROR) << "Protobuf: " << message;
       break;
     case google::protobuf::LOGLEVEL_FATAL:
-      DAWN_LOG(FATAL) << "Protobuf: " << message;
+      throw std::runtime_error(std::string("[FATAL] Protobuf error occurred: ") + message);
       break;
     }
 

--- a/dawn/src/dawn/Serialization/SIRSerializer.cpp
+++ b/dawn/src/dawn/Serialization/SIRSerializer.cpp
@@ -22,7 +22,7 @@
 #include "dawn/Serialization/SIRSerializer.h"
 #include "dawn/Support/Exception.h"
 #include "dawn/Support/Format.h"
-#include "dawn/Support/Logging.h"
+#include "dawn/Support/Logger.h"
 #include "dawn/Support/Unreachable.h"
 #include <fstream>
 #include <google/protobuf/util/json_util.h>

--- a/dawn/src/dawn/Support/CMakeLists.txt
+++ b/dawn/src/dawn/Support/CMakeLists.txt
@@ -47,8 +47,8 @@ add_library(DawnSupport
   IndexRange.h
   Iterator.h
   Json.h
-  Logging.cpp
-  Logging.h
+  Logger.cpp
+  Logger.h
   MathExtras.h
   NonCopyable.h
   Printing.h

--- a/dawn/src/dawn/Support/Exception.cpp
+++ b/dawn/src/dawn/Support/Exception.cpp
@@ -40,7 +40,4 @@ int CompileError::getLine() const { return line_; }
 
 const char* CompileError::what() const throw() { return getMessage().c_str(); }
 
-SyntacticError::SyntacticError(const std::string& message, const std::string& file, unsigned line)
-    : CompileError(message, file, line) {}
-
 } // namespace dawn

--- a/dawn/src/dawn/Support/Exception.cpp
+++ b/dawn/src/dawn/Support/Exception.cpp
@@ -13,7 +13,6 @@
 //===------------------------------------------------------------------------------------------===//
 
 #include "dawn/Support/Exception.h"
-#include <cstring>
 
 namespace dawn {
 
@@ -35,11 +34,12 @@ std::string CompileError::getFile() const { return file_; }
 
 unsigned CompileError::getLine() const { return line_; }
 
-const char* CompileError::what() const throw() {
-  return getMessage().c_str();
-}
+const char* CompileError::what() const throw() { return getMessage().c_str(); }
 
 SemanticError::SemanticError(const std::string& message, const std::string& file, unsigned line)
+    : CompileError(message, file, line) {}
+
+SyntacticError::SyntacticError(const std::string& message, const std::string& file, unsigned line)
     : CompileError(message, file, line) {}
 
 } // namespace dawn

--- a/dawn/src/dawn/Support/Exception.h
+++ b/dawn/src/dawn/Support/Exception.h
@@ -67,11 +67,6 @@ struct LogicError : public CompileError {
       : CompileError(message, file, loc.Line, loc.Column) {}
 };
 
-struct SyntacticError : public CompileError {
-  SyntacticError(const std::string& message = "Syntactic Error", const std::string& file = "",
-                 unsigned line = 0);
-};
-
 } // namespace dawn
 
 #endif // DAWN_SUPPORT_EXCEPTION_H

--- a/dawn/src/dawn/Support/Exception.h
+++ b/dawn/src/dawn/Support/Exception.h
@@ -45,6 +45,11 @@ struct SemanticError : public CompileError {
                 unsigned line = 0);
 };
 
+struct SyntacticError : public CompileError {
+  SyntacticError(const std::string& message = "Syntactic Error", const std::string& file = "",
+                 unsigned line = 0);
+};
+
 } // namespace dawn
 
 #endif // DAWN_SUPPORT_EXCEPTION_H

--- a/dawn/src/dawn/Support/Logger.cpp
+++ b/dawn/src/dawn/Support/Logger.cpp
@@ -23,23 +23,32 @@ namespace dawn {
 
 Logger::MessageFormatter makeMessageFormatter(const std::string type) {
   return [type](const std::string& msg, const std::string& file, int line) {
-    return "[" + file + ":" + std::to_string(line) + "] " + type + ": " + msg;
+    std::stringstream ss;
+    ss << "[" << file << ":" << line << "] ";
+    if(type != "")
+      ss << type << ": ";
+    ss << msg;
+    return ss.str();
   };
 }
 
 Logger::DiagnosticFormatter makeDiagnosticFormatter(const std::string type) {
   return [type](const std::string& msg, const std::string& file, int line,
                 const std::string& source, SourceLocation loc) {
-    std::string diagnostic = "[" + file + ":" + std::to_string(line) + "]" + type + " at " + source;
     std::stringstream ss;
+    ss << "[" << file << ":" << line << "]";
+    if(source != "")
+      ss << " " << source;
     if(loc.Line >= 0) {
       ss << ":" << loc.Line;
     }
     if(loc.Column >= 0) {
       ss << ":" << loc.Column;
     }
-    diagnostic += ss.str() + ": " + msg;
-    return diagnostic;
+    if(type != "")
+      ss << " " << type;
+    ss << ": " << msg;
+    return ss.str();
   };
 }
 

--- a/dawn/src/dawn/Support/Logger.cpp
+++ b/dawn/src/dawn/Support/Logger.cpp
@@ -12,7 +12,7 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
-#include "dawn/Support/Logging.h"
+#include "dawn/Support/Logger.h"
 #include "dawn/Support/Assert.h"
 #include "dawn/Support/FileSystem.h"
 #include "dawn/Support/Format.h"
@@ -65,7 +65,6 @@ Logger::const_iterator Logger::end() const { return std::end(data_); }
 Logger::MessageContainer::size_type Logger::size() const { return std::size(data_); }
 
 Logger info(makeDefaultFormatter("[INFO]"), std::cout);
-Logger warn(makeDefaultFormatter("[WARN]"), std::cout);
-Logger error(makeDefaultFormatter("[ERROR"), std::cerr);
+Logger warn(makeDefaultFormatter("[WARN]"), std::cerr);
 
 } // namespace dawn

--- a/dawn/src/dawn/Support/Logger.cpp
+++ b/dawn/src/dawn/Support/Logger.cpp
@@ -21,53 +21,123 @@
 
 namespace dawn {
 
-Logger::Formatter makeDefaultFormatter(const std::string prefix) {
-  return [prefix](const std::string& msg, const std::string& file, int line) {
-    return prefix + " " + "[" + file + ":" + std::to_string(line) + "] " + msg;
+Logger::MessageFormatter makeMessageFormatter(const std::string type) {
+  return [type](const std::string& msg, const std::string& file, int line) {
+    return "[" + file + ":" + std::to_string(line) + "] " + type + ": " + msg;
   };
 }
 
-LoggerProxy::LoggerProxy(const LoggerProxy& other)
-    : logger_(other.logger_), ss_(other.ss_.str()), source_(other.source_), line_(other.line_) {}
+Logger::DiagnosticFormatter makeDiagnosticFormatter(const std::string type) {
+  return [type](const std::string& msg, const std::string& file, int line,
+                const std::string& source, SourceLocation loc) {
+    std::string diagnostic = "[" + file + ":" + std::to_string(line) + "]" + type + " at " + source;
+    std::stringstream ss;
+    if(loc.Line >= 0) {
+      ss << ":" << loc.Line;
+    }
+    if(loc.Column >= 0) {
+      ss << ":" << loc.Column;
+    }
+    diagnostic += ss.str() + ": " + msg;
+    return diagnostic;
+  };
+}
 
-LoggerProxy::LoggerProxy(Logger& logger, const std::string& source, int line)
-    : logger_(logger), source_(source), line_(line) {}
+MessageProxy::MessageProxy(const MessageProxy& other)
+    : logger_(other.logger_), ss_(other.ss_.str()), file_(other.file_), line_(other.line_) {}
 
-LoggerProxy::~LoggerProxy() { logger_.enqueue(ss_.str(), source_, line_); }
+MessageProxy::MessageProxy(Logger& logger, const std::string& file, int line)
+    : logger_(logger), file_(file), line_(line) {}
 
-Logger::Logger(Formatter fmt, std::ostream& os) : fmt_(fmt), os_(&os), data_() {}
+MessageProxy::~MessageProxy() { logger_.enqueue(ss_.str(), file_, line_); }
+
+DiagnosticProxy::DiagnosticProxy(const DiagnosticProxy& other)
+    : logger_(other.logger_), ss_(other.ss_.str()), file_(other.file_), line_(other.line_),
+      source_(other.source_), loc_(other.loc_) {}
+
+DiagnosticProxy::DiagnosticProxy(Logger& logger, const std::string& file, int line,
+                                 const std::string& source, SourceLocation loc)
+    : logger_(logger), file_(file), line_(line), source_(source), loc_(loc) {}
+
+DiagnosticProxy::~DiagnosticProxy() { logger_.enqueue(ss_.str(), file_, line_, source_, loc_); }
+
+Logger::Logger(MessageFormatter msgFmt, DiagnosticFormatter diagFmt, std::ostream& os, bool show)
+    : msgFmt_(msgFmt), diagFmt_(diagFmt), os_(&os), data_(), show_(show) {}
+
+MessageProxy Logger::operator()(const std::string& file, int line) {
+  return MessageProxy(*this, file, line);
+}
+
+DiagnosticProxy Logger::operator()(const std::string& file, int line, const std::string& source,
+                                   SourceLocation loc) {
+  return DiagnosticProxy(*this, file, line, source, loc);
+}
 
 void Logger::enqueue(const std::string& msg, const std::string& file, int line) {
-  data_.push_back(fmt_(msg, file, line));
-  *os_ << data_.back();
+  data_.push_back(msgFmt_(msg, file, line));
+  if(show_)
+    *os << data_.back();
 }
 
-LoggerProxy Logger::operator()(const std::string& source, int line) {
-  return LoggerProxy(*this, source, line);
+void Logger::enqueue(const std::string& msg, const std::string& file, int line,
+                     const std::string& source, SourceLocation loc) {
+  data_.push_back(diagFmt_(msg, file, line, source, loc));
+  if(show_)
+    *os << data_.back();
 }
 
-// Get and set ostream
 std::ostream& Logger::stream() const { return *os_; }
 void Logger::stream(std::ostream& os) { os_ = &os; }
 
-// Get and set Formatter
-Logger::Formatter Logger::formatter() const { return fmt_; }
-void Logger::formatter(const Formatter& fmt) { fmt_ = fmt; }
+Logger::MessageFormatter Logger::messageFormatter() const { return msgFmt_; }
+void Logger::messageFormatter(const MessageFormatter& msgFmt) { msgFmt_ = msgFmt; }
 
-// Reset storage
+Logger::DiagnosticFormatter Logger::diagnosticFormatter() const { return diagFmt_; }
+void Logger::diagnosticFormatter(const DiagnosticFormatter& diagFmt) { diagFmt_ = diagFmt; }
+
 void Logger::clear() { data_.clear(); }
+
+void Logger::show() { show_ = true; }
+void Logger::hide() { show_ = false; }
 
 // Expose container of messages
 Logger::iterator Logger::begin() { return std::begin(data_); }
 Logger::iterator Logger::end() { return std::end(data_); }
 Logger::const_iterator Logger::begin() const { return std::begin(data_); }
 Logger::const_iterator Logger::end() const { return std::end(data_); }
-Logger::MessageContainer::size_type Logger::size() const { return std::size(data_); }
+Logger::Container::size_type Logger::size() const { return std::size(data_); }
 
 namespace log {
-Logger info(makeDefaultFormatter("[INFO]"), std::cout);
-Logger warn(makeDefaultFormatter("[WARN]"), std::cerr);
-Logger error(makeDefaultFormatter("[ERROR]"), std::cerr);
+
+Logger info(makeMessageFormatter("INFO"), makeDiagnosticFormatter("INFO"), std::cout, false);
+Logger warn(makeMessageFormatter("WARNING"), makeDiagnosticFormatter("WARNING"), std::cout, true);
+Logger error(makeMessageFormatter("ERROR"), makeDiagnosticFormatter("ERROR"), std::cerr, true);
+
+void setVerbosity(Level level) {
+  switch(level) {
+  case Level::All:
+    info.show();
+    warn.show();
+    error.show();
+    break;
+  case Level::Warnings:
+    info.hide();
+    warn.show();
+    error.show();
+    break;
+  case Level::Errors:
+    info.hide();
+    warn.hide();
+    error.show();
+    break;
+  case Level::None:
+    info.hide();
+    warn.hide();
+    error.hide();
+    break;
+  }
+}
+
 } // namespace log
 
 } // namespace dawn

--- a/dawn/src/dawn/Support/Logger.cpp
+++ b/dawn/src/dawn/Support/Logger.cpp
@@ -76,14 +76,14 @@ DiagnosticProxy Logger::operator()(const std::string& file, int line, const std:
 void Logger::enqueue(const std::string& msg, const std::string& file, int line) {
   data_.push_back(msgFmt_(msg, file, line));
   if(show_)
-    *os << data_.back();
+    *os_ << data_.back();
 }
 
 void Logger::enqueue(const std::string& msg, const std::string& file, int line,
                      const std::string& source, SourceLocation loc) {
   data_.push_back(diagFmt_(msg, file, line, source, loc));
   if(show_)
-    *os << data_.back();
+    *os_ << data_.back();
 }
 
 std::ostream& Logger::stream() const { return *os_; }

--- a/dawn/src/dawn/Support/Logger.cpp
+++ b/dawn/src/dawn/Support/Logger.cpp
@@ -82,21 +82,22 @@ DiagnosticProxy Logger::operator()(const std::string& file, int line, const std:
   return DiagnosticProxy(*this, file, line, source, loc);
 }
 
-void Logger::enqueue(std::string msg, const std::string& file, int line) {
-  if(msg.back() != '\n')
-    msg += '\n';
-  data_.push_back(msgFmt_(msg, file, line));
-  if(show_)
+void Logger::doEnqueue(const std::string& message) {
+  data_.push_back(message);
+  if(show_) {
     *os_ << data_.back();
+    if(data_.back().back() != '\n')
+      *os_ << '\n';
+  }
+}
+
+void Logger::enqueue(std::string msg, const std::string& file, int line) {
+  doEnqueue(msgFmt_(msg, file, line));
 }
 
 void Logger::enqueue(std::string msg, const std::string& file, int line, const std::string& source,
                      SourceLocation loc) {
-  if(msg.back() != '\n')
-    msg += '\n';
-  data_.push_back(diagFmt_(msg, file, line, source, loc));
-  if(show_)
-    *os_ << data_.back();
+  doEnqueue(diagFmt_(msg, file, line, source, loc));
 }
 
 std::ostream& Logger::stream() const { return *os_; }

--- a/dawn/src/dawn/Support/Logger.cpp
+++ b/dawn/src/dawn/Support/Logger.cpp
@@ -27,20 +27,13 @@ Logger::Formatter makeDefaultFormatter(const std::string prefix) {
   };
 }
 
-SourceLineLoggerProxy::SourceLineLoggerProxy(const SourceLineLoggerProxy& other)
+LoggerProxy::LoggerProxy(const LoggerProxy& other)
     : logger_(other.logger_), ss_(other.ss_.str()), source_(other.source_), line_(other.line_) {}
 
-SourceLineLoggerProxy::SourceLineLoggerProxy(Logger& logger, const std::string& source, int line)
+LoggerProxy::LoggerProxy(Logger& logger, const std::string& source, int line)
     : logger_(logger), source_(source), line_(line) {}
 
-SourceLineLoggerProxy::~SourceLineLoggerProxy() { logger_.enqueue(ss_.str(), source_, line_); }
-
-BasicLoggerProxy::BasicLoggerProxy(const BasicLoggerProxy& other)
-    : logger_(other.logger_), ss_(other.ss_.str()) {}
-
-BasicLoggerProxy::BasicLoggerProxy(Logger& logger) : logger_(logger) {}
-
-BasicLoggerProxy::~BasicLoggerProxy() { logger_.enqueue(ss_.str()); }
+LoggerProxy::~LoggerProxy() { logger_.enqueue(ss_.str(), source_, line_); }
 
 Logger::Logger(Formatter fmt, std::ostream& os) : fmt_(fmt), os_(&os), data_() {}
 
@@ -49,16 +42,9 @@ void Logger::enqueue(const std::string& msg, const std::string& file, int line) 
   *os_ << data_.back();
 }
 
-void Logger::enqueue(const std::string& msg) {
-  data_.push_back(msg);
-  *os_ << data_.back();
+LoggerProxy Logger::operator()(const std::string& source, int line) {
+  return LoggerProxy(*this, source, line);
 }
-
-SourceLineLoggerProxy Logger::operator()(const std::string& source, int line) {
-  return SourceLineLoggerProxy(*this, source, line);
-}
-
-BasicLoggerProxy Logger::operator()() { return BasicLoggerProxy(*this); }
 
 // Get and set ostream
 std::ostream& Logger::stream() const { return *os_; }

--- a/dawn/src/dawn/Support/Logger.cpp
+++ b/dawn/src/dawn/Support/Logger.cpp
@@ -64,7 +64,10 @@ Logger::const_iterator Logger::begin() const { return std::begin(data_); }
 Logger::const_iterator Logger::end() const { return std::end(data_); }
 Logger::MessageContainer::size_type Logger::size() const { return std::size(data_); }
 
+namespace log {
 Logger info(makeDefaultFormatter("[INFO]"), std::cout);
 Logger warn(makeDefaultFormatter("[WARN]"), std::cerr);
+Logger error(makeDefaultFormatter("[ERROR]"), std::cerr);
+} // namespace log
 
 } // namespace dawn

--- a/dawn/src/dawn/Support/Logger.cpp
+++ b/dawn/src/dawn/Support/Logger.cpp
@@ -46,7 +46,7 @@ Logger::DiagnosticFormatter makeDiagnosticFormatter(const std::string type) {
       ss << ":" << loc.Column;
     }
     if(type != "")
-      ss << " " << type;
+      ss << ": " << type;
     ss << ": " << msg;
     return ss.str();
   };
@@ -82,14 +82,18 @@ DiagnosticProxy Logger::operator()(const std::string& file, int line, const std:
   return DiagnosticProxy(*this, file, line, source, loc);
 }
 
-void Logger::enqueue(const std::string& msg, const std::string& file, int line) {
+void Logger::enqueue(std::string msg, const std::string& file, int line) {
+  if(msg.back() != '\n')
+    msg += '\n';
   data_.push_back(msgFmt_(msg, file, line));
   if(show_)
     *os_ << data_.back();
 }
 
-void Logger::enqueue(const std::string& msg, const std::string& file, int line,
-                     const std::string& source, SourceLocation loc) {
+void Logger::enqueue(std::string msg, const std::string& file, int line, const std::string& source,
+                     SourceLocation loc) {
+  if(msg.back() != '\n')
+    msg += '\n';
   data_.push_back(diagFmt_(msg, file, line, source, loc));
   if(show_)
     *os_ << data_.back();

--- a/dawn/src/dawn/Support/Logger.h
+++ b/dawn/src/dawn/Support/Logger.h
@@ -90,8 +90,8 @@ public:
 
   /// @brief Add a new message -- called from Proxy objects
   /// {
-  void enqueue(const std::string& msg, const std::string& file, int line);
-  void enqueue(const std::string& msg, const std::string& file, int line, const std::string& source,
+  void enqueue(std::string msg, const std::string& file, int line);
+  void enqueue(std::string msg, const std::string& file, int line, const std::string& source,
                SourceLocation loc);
   /// }
 

--- a/dawn/src/dawn/Support/Logger.h
+++ b/dawn/src/dawn/Support/Logger.h
@@ -44,6 +44,8 @@ private:
   const int line_;
 };
 
+/// @brief Logging interface
+/// @ingroup support
 class Logger {
 public:
   using MessageContainer = std::list<std::string>;
@@ -85,6 +87,7 @@ private:
 
 Logger::Formatter makeDefaultFormatter(const std::string prefix);
 
+// Loggers used for information and warnings
 extern Logger info;
 extern Logger warn;
 

--- a/dawn/src/dawn/Support/Logger.h
+++ b/dawn/src/dawn/Support/Logger.h
@@ -87,9 +87,13 @@ private:
 
 Logger::Formatter makeDefaultFormatter(const std::string prefix);
 
+namespace log {
 // Loggers used for information and warnings
 extern Logger info;
 extern Logger warn;
+extern Logger error;
+
+} // namespace log
 
 } // namespace dawn
 
@@ -98,7 +102,8 @@ extern Logger warn;
 /// @ingroup support
 #define DAWN_LOG(Level) DAWN_LOG_##Level##_IMPL()
 
-#define DAWN_LOG_INFO_IMPL() dawn::info(__FILE__, __LINE__)
-#define DAWN_LOG_WARNING_IMPL() dawn::warn(__FILE__, __LINE__)
+#define DAWN_LOG_INFO_IMPL() dawn::log::info(__FILE__, __LINE__)
+#define DAWN_LOG_WARNING_IMPL() dawn::log::warn(__FILE__, __LINE__)
+#define DAWN_LOG_ERROR_IMPL() dawn::log::warn(__FILE__, __LINE__)
 
 #endif

--- a/dawn/src/dawn/Support/Logger.h
+++ b/dawn/src/dawn/Support/Logger.h
@@ -25,14 +25,14 @@ namespace dawn {
 
 class Logger;
 
-class SourceLineLoggerProxy {
+class LoggerProxy {
 public:
-  SourceLineLoggerProxy(Logger& logger, const std::string& source, int line);
-  SourceLineLoggerProxy(const SourceLineLoggerProxy& other);
-  ~SourceLineLoggerProxy();
+  LoggerProxy(Logger& logger, const std::string& source, int line);
+  LoggerProxy(const LoggerProxy& other);
+  ~LoggerProxy();
 
   template <typename Streamable>
-  SourceLineLoggerProxy& operator<<(Streamable&& obj) {
+  LoggerProxy& operator<<(Streamable&& obj) {
     ss_ << obj;
     return *this;
   }
@@ -44,23 +44,6 @@ private:
   const int line_;
 };
 
-class BasicLoggerProxy {
-public:
-  BasicLoggerProxy(Logger& logger);
-  BasicLoggerProxy(const BasicLoggerProxy& other);
-  ~BasicLoggerProxy();
-
-  template <typename Streamable>
-  BasicLoggerProxy& operator<<(Streamable&& obj) {
-    ss_ << obj;
-    return *this;
-  }
-
-private:
-  Logger& logger_;
-  std::stringstream ss_;
-};
-
 /// @brief Logging interface
 /// @ingroup support
 class Logger {
@@ -70,11 +53,9 @@ public:
 
   Logger(Formatter fmt, std::ostream& os = std::cout);
 
-  SourceLineLoggerProxy operator()(const std::string& source, int line);
-  BasicLoggerProxy operator()();
+  LoggerProxy operator()(const std::string& source, int line);
 
   void enqueue(const std::string& msg, const std::string& file, int line);
-  void enqueue(const std::string& msg);
 
   // Get and set ostream
   std::ostream& stream() const;

--- a/dawn/src/dawn/Support/Logger.h
+++ b/dawn/src/dawn/Support/Logger.h
@@ -134,6 +134,8 @@ public:
   Container::size_type size() const;
 
 private:
+  void doEnqueue(const std::string& message);
+
   MessageFormatter msgFmt_;
   DiagnosticFormatter diagFmt_;
   std::ostream* os_;

--- a/dawn/src/dawn/Support/Logger.h
+++ b/dawn/src/dawn/Support/Logger.h
@@ -15,6 +15,7 @@
 #ifndef DAWN_SUPPORT_LOGGER_H
 #define DAWN_SUPPORT_LOGGER_H
 
+#include "dawn/Support/SourceLocation.h"
 #include <functional>
 #include <iostream>
 #include <list>
@@ -25,14 +26,15 @@ namespace dawn {
 
 class Logger;
 
-class LoggerProxy {
+/// @brief Proxy for logging messages.
+class MessageProxy {
 public:
-  LoggerProxy(Logger& logger, const std::string& source, int line);
-  LoggerProxy(const LoggerProxy& other);
-  ~LoggerProxy();
+  MessageProxy(Logger& logger, const std::string& file, int line);
+  MessageProxy(const MessageProxy& other);
+  ~MessageProxy();
 
   template <typename Streamable>
-  LoggerProxy& operator<<(Streamable&& obj) {
+  MessageProxy& operator<<(Streamable&& obj) {
     ss_ << obj;
     return *this;
   }
@@ -40,58 +42,120 @@ public:
 private:
   Logger& logger_;
   std::stringstream ss_;
-  const std::string source_;
+  const std::string file_;
   const int line_;
+};
+
+/// @brief Proxy for logging diagnostics.
+class DiagnosticProxy {
+public:
+  DiagnosticProxy(Logger& logger, const std::string& file, int line, const std::string& source,
+                  SourceLocation loc);
+  DiagnosticProxy(const DiagnosticProxy& other);
+  ~DiagnosticProxy();
+
+  template <typename Streamable>
+  DiagnosticProxy& operator<<(Streamable&& obj) {
+    ss_ << obj;
+    return *this;
+  }
+
+private:
+  Logger& logger_;
+  std::stringstream ss_;
+  const std::string file_;
+  const int line_;
+  const std::string source_;
+  const SourceLocation loc_;
 };
 
 /// @brief Logging interface
 /// @ingroup support
 class Logger {
 public:
-  using MessageContainer = std::list<std::string>;
-  using Formatter = std::function<std::string(const std::string&, const std::string&, int)>;
+  using Container = std::list<std::string>;
+  using MessageFormatter = std::function<std::string(const std::string&, const std::string&, int)>;
+  using DiagnosticFormatter = std::function<std::string(const std::string&, const std::string&, int,
+                                                        const std::string&, SourceLocation)>;
 
-  Logger(Formatter fmt, std::ostream& os = std::cout);
+  Logger(MessageFormatter msgFmt, DiagnosticFormatter diagFmt, std::ostream& os = std::cout,
+         bool show = true);
 
-  LoggerProxy operator()(const std::string& source, int line);
+  /// @brief Report message with file, line in dawn source
+  MessageProxy operator()(const std::string& filename, int line);
 
+  /// @brief Report message with file, line in dawn source and source,loc in input DSL code.
+  DiagnosticProxy operator()(const std::string& file, int line, const std::string& source,
+                             SourceLocation loc);
+
+  /// @brief Add a new message -- called from Proxy objects
+  /// {
   void enqueue(const std::string& msg, const std::string& file, int line);
+  void enqueue(const std::string& msg, const std::string& file, int line, const std::string& source,
+               SourceLocation loc);
+  /// }
 
-  // Get and set ostream
+  /// @brief Get and set ostream
+  /// {
   std::ostream& stream() const;
   void stream(std::ostream& os);
+  /// }
 
-  // Get and set Formatter
-  Formatter formatter() const;
-  void formatter(const Formatter& fmt);
+  /// @brief Get and set MessageFormatter
+  /// {
+  MessageFormatter messageFormatter() const;
+  void messageFormatter(const MessageFormatter& fmt);
+  /// }
 
-  // Reset storage
+  /// @brief Get and set DiagnosticFormatter
+  /// {
+  DiagnosticFormatter diagnosticFormatter() const;
+  void diagnosticFormatter(const DiagnosticFormatter& fmt);
+  /// }
+
+  /// @brief Reset storage
   void clear();
 
+  /// @brief Show or hide output from ostream -- still accessible in the container
+  /// {
+  void show();
+  void hide();
+  /// }
+
   // Expose container of messages
-  using iterator = MessageContainer::iterator;
+  using iterator = Container::iterator;
   iterator begin();
   iterator end();
 
-  using const_iterator = MessageContainer::const_iterator;
+  using const_iterator = Container::const_iterator;
   const_iterator begin() const;
   const_iterator end() const;
 
-  MessageContainer::size_type size() const;
+  Container::size_type size() const;
 
 private:
-  Formatter fmt_;
+  MessageFormatter msgFmt_;
+  DiagnosticFormatter diagFmt_;
   std::ostream* os_;
-  MessageContainer data_;
+  Container data_;
+  bool show_;
 };
 
-Logger::Formatter makeDefaultFormatter(const std::string prefix);
+/// @brief create a basic (default) message formatter
+Logger::MessageFormatter makeMessageFormatter(const std::string prefix);
+
+/// @brief create a basic (default) diagnostic formatter
+Logger::DiagnosticFormatter makeDiagnosticFormatter(const std::string prefix);
 
 namespace log {
 // Loggers used for information and warnings
 extern Logger info;
 extern Logger warn;
 extern Logger error;
+
+enum class Level { All, Warnings, Errors, None };
+
+void setVerbosity(Level level);
 
 } // namespace log
 
@@ -104,6 +168,15 @@ extern Logger error;
 
 #define DAWN_LOG_INFO_IMPL() dawn::log::info(__FILE__, __LINE__)
 #define DAWN_LOG_WARNING_IMPL() dawn::log::warn(__FILE__, __LINE__)
-#define DAWN_LOG_ERROR_IMPL() dawn::log::warn(__FILE__, __LINE__)
+#define DAWN_LOG_ERROR_IMPL() dawn::log::error(__FILE__, __LINE__)
+
+/// @macro DAWN_DIAG
+/// @brief Loggging macros
+/// @ingroup support
+#define DAWN_DIAG(Level, file, loc) DAWN_DIAG_##Level##_IMPL(file, loc)
+
+#define DAWN_DIAG_INFO_IMPL(file, loc) dawn::log::info(__FILE__, __LINE__, file, loc)
+#define DAWN_DIAG_WARNING_IMPL(file, loc) dawn::log::warn(__FILE__, __LINE__, file, loc)
+#define DAWN_DIAG_ERROR_IMPL(file, loc) dawn::log::error(__FILE__, __LINE__, file, loc)
 
 #endif

--- a/dawn/src/dawn/Support/Logger.h
+++ b/dawn/src/dawn/Support/Logger.h
@@ -25,14 +25,14 @@ namespace dawn {
 
 class Logger;
 
-class LoggerProxy {
+class SourceLineLoggerProxy {
 public:
-  LoggerProxy(Logger& logger, const std::string& source, int line);
-  LoggerProxy(const LoggerProxy& other);
-  ~LoggerProxy();
+  SourceLineLoggerProxy(Logger& logger, const std::string& source, int line);
+  SourceLineLoggerProxy(const SourceLineLoggerProxy& other);
+  ~SourceLineLoggerProxy();
 
   template <typename Streamable>
-  LoggerProxy& operator<<(Streamable&& obj) {
+  SourceLineLoggerProxy& operator<<(Streamable&& obj) {
     ss_ << obj;
     return *this;
   }
@@ -44,6 +44,23 @@ private:
   const int line_;
 };
 
+class BasicLoggerProxy {
+public:
+  BasicLoggerProxy(Logger& logger);
+  BasicLoggerProxy(const BasicLoggerProxy& other);
+  ~BasicLoggerProxy();
+
+  template <typename Streamable>
+  BasicLoggerProxy& operator<<(Streamable&& obj) {
+    ss_ << obj;
+    return *this;
+  }
+
+private:
+  Logger& logger_;
+  std::stringstream ss_;
+};
+
 /// @brief Logging interface
 /// @ingroup support
 class Logger {
@@ -53,9 +70,11 @@ public:
 
   Logger(Formatter fmt, std::ostream& os = std::cout);
 
-  LoggerProxy operator()(const std::string& source, int line);
+  SourceLineLoggerProxy operator()(const std::string& source, int line);
+  BasicLoggerProxy operator()();
 
   void enqueue(const std::string& msg, const std::string& file, int line);
+  void enqueue(const std::string& msg);
 
   // Get and set ostream
   std::ostream& stream() const;

--- a/dawn/src/dawn/Support/Logger.h
+++ b/dawn/src/dawn/Support/Logger.h
@@ -12,8 +12,8 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
-#ifndef DAWN_SUPPORT_LOGGING_H
-#define DAWN_SUPPORT_LOGGING_H
+#ifndef DAWN_SUPPORT_LOGGER_H
+#define DAWN_SUPPORT_LOGGER_H
 
 #include <functional>
 #include <iostream>

--- a/dawn/src/dawn/Support/Logger.h
+++ b/dawn/src/dawn/Support/Logger.h
@@ -142,10 +142,10 @@ private:
 };
 
 /// @brief create a basic (default) message formatter
-Logger::MessageFormatter makeMessageFormatter(const std::string prefix);
+Logger::MessageFormatter makeMessageFormatter(const std::string type = "");
 
 /// @brief create a basic (default) diagnostic formatter
-Logger::DiagnosticFormatter makeDiagnosticFormatter(const std::string prefix);
+Logger::DiagnosticFormatter makeDiagnosticFormatter(const std::string type = "");
 
 namespace log {
 // Loggers used for information and warnings

--- a/dawn/src/dawn/Support/Logging.h
+++ b/dawn/src/dawn/Support/Logging.h
@@ -23,8 +23,6 @@
 
 namespace dawn {
 
-enum class LoggingLevel { Info, Warning, Error, Fatal };
-
 class Logger;
 
 class LoggerProxy {
@@ -89,7 +87,6 @@ Logger::Formatter makeDefaultFormatter(const std::string prefix);
 
 extern Logger info;
 extern Logger warn;
-extern Logger error;
 
 } // namespace dawn
 
@@ -100,6 +97,5 @@ extern Logger error;
 
 #define DAWN_LOG_INFO_IMPL() dawn::info(__FILE__, __LINE__)
 #define DAWN_LOG_WARNING_IMPL() dawn::warn(__FILE__, __LINE__)
-#define DAWN_LOG_ERROR_IMPL() dawn::error(__FILE__, __LINE__)
 
 #endif

--- a/dawn/src/dawn/Support/SourceLocation.cpp
+++ b/dawn/src/dawn/Support/SourceLocation.cpp
@@ -14,16 +14,21 @@
 
 #include "dawn/Support/SourceLocation.h"
 #include <iostream>
+#include <string>
 
 namespace dawn {
 
-std::ostream& operator<<(std::ostream& os, const SourceLocation& sourceLocation) {
-  return (os << sourceLocation.Line << ":" << sourceLocation.Column);
+SourceLocation::operator std::string() const {
+  return std::to_string(Line) + ":" + std::to_string(Column);
 }
 
-extern bool operator==(const SourceLocation& a, const SourceLocation& b) {
+std::ostream& operator<<(std::ostream& os, const SourceLocation& sourceLocation) {
+  return os << static_cast<std::string>(sourceLocation);
+}
+
+bool operator==(const SourceLocation& a, const SourceLocation& b) {
   return a.Line == b.Line && a.Column == b.Column;
 }
-extern bool operator!=(const SourceLocation& a, const SourceLocation& b) { return !(a == b); }
+bool operator!=(const SourceLocation& a, const SourceLocation& b) { return !(a == b); }
 
 } // namespace dawn

--- a/dawn/src/dawn/Support/SourceLocation.h
+++ b/dawn/src/dawn/Support/SourceLocation.h
@@ -36,7 +36,7 @@ struct SourceLocation {
   SourceLocation& operator=(SourceLocation&&) = default;
   /// @}
 
-  bool isValid() const { return (Line != -1 && Column != -1); }
+  bool isValid() const { return (Line >= 0 && Column >= 0); }
 
   explicit operator std::string() const;
 

--- a/dawn/src/dawn/Support/SourceLocation.h
+++ b/dawn/src/dawn/Support/SourceLocation.h
@@ -38,6 +38,8 @@ struct SourceLocation {
 
   bool isValid() const { return (Line != -1 && Column != -1); }
 
+  explicit operator std::string() const;
+
   int Line;
   int Column;
 };

--- a/dawn/src/dawn/dawn-opt.cpp
+++ b/dawn/src/dawn/dawn-opt.cpp
@@ -20,7 +20,7 @@
 #include "dawn/Serialization/SIRSerializer.h"
 #include "dawn/Support/FileSystem.h"
 #include "dawn/Support/Json.h"
-#include "dawn/Support/Logging.h"
+#include "dawn/Support/Logger.h"
 
 #include <cxxopts.hpp>
 #include <fstream>

--- a/dawn/test/integration-test/serializer/GenerateInMemoryStencils.cpp
+++ b/dawn/test/integration-test/serializer/GenerateInMemoryStencils.cpp
@@ -31,7 +31,7 @@
 #include "dawn/SIR/ASTFwd.h"
 #include "dawn/SIR/SIR.h"
 #include "dawn/Serialization/IIRSerializer.h"
-#include "dawn/Support/Logging.h"
+#include "dawn/Support/Logger.h"
 #include "dawn/Support/STLExtras.h"
 #include "dawn/Unittest/IIRBuilder.h"
 

--- a/dawn/test/integration-test/serializer/TestIIRDeserializer.cpp
+++ b/dawn/test/integration-test/serializer/TestIIRDeserializer.cpp
@@ -29,7 +29,7 @@
 #include "dawn/SIR/ASTFwd.h"
 #include "dawn/SIR/SIR.h"
 #include "dawn/Serialization/IIRSerializer.h"
-#include "dawn/Support/Logging.h"
+#include "dawn/Support/Logger.h"
 #include "dawn/Support/STLExtras.h"
 
 #include <gtest/gtest.h>
@@ -284,4 +284,4 @@ TEST(TestIIRDeserializer, UnstructuredMixedCopies) {
   EXPECT_EQ(writes2it->second, iir::Extents(dawn::ast::cartesian, 0, 0, 0, 0, 0, 0));
 }
 
-} // anonymous namespace
+} // namespace dawn

--- a/dawn/test/integration-test/unstructured/ToylibIntegrationTestCompareOutput.cpp
+++ b/dawn/test/integration-test/unstructured/ToylibIntegrationTestCompareOutput.cpp
@@ -22,7 +22,7 @@
 //===------------------------------------------------------------------------------------------===//
 
 #include "UnstructuredVerifier.h"
-#include "dawn/Support/Logging.h"
+#include "dawn/Support/Logger.h"
 #include "interface/toylib_interface.hpp"
 #include "toylib/toylib.hpp"
 

--- a/dawn/test/unit-test/dawn/Optimizer/TestPassRemoveScalars.cpp
+++ b/dawn/test/unit-test/dawn/Optimizer/TestPassRemoveScalars.cpp
@@ -19,6 +19,7 @@
 #include "dawn/Unittest/UnittestUtils.h"
 
 #include <gtest/gtest.h>
+#include <sstream>
 
 using namespace dawn;
 using namespace astgen;
@@ -464,9 +465,6 @@ TEST(TestRemoveScalars, test_else_01) {
 TEST(TestRemoveScalars, warn_compound_assignments) {
   using namespace dawn::iir;
 
-  delete dawn::Logger::getSingleton().getLogger();
-  dawn::Logger::getSingleton().registerLogger(new dawn::DawnLogger(dawn::LoggingLevel::Info));
-
   UnstructuredIIRBuilder b;
   auto f_e = b.field("f_e", ast::LocationType::Edges);
   auto varA =
@@ -491,22 +489,19 @@ TEST(TestRemoveScalars, warn_compound_assignments) {
   OptimizerContext optimizer(diag, optimizerOptions,
                              std::make_shared<dawn::SIR>(ast::GridType::Unstructured));
 
+  std::ostringstream output;
+  dawn::info.stream(output);
+
   // run single pass (PassRemoveScalars) and expect info in output
   PassRemoveScalars passRemoveScalars(optimizer);
-  testing::internal::CaptureStderr();
   passRemoveScalars.run(stencil);
-  std::cout.flush();
-  std::string output = testing::internal::GetCapturedStderr();
-  ASSERT_NE(
-      output.find("Unsupported statement at line -1:-1. Skipping removal of scalar variables."),
-      std::string::npos);
+  ASSERT_NE(output.str().find(
+                "Unsupported statement at line -1:-1. Skipping removal of scalar variables."),
+            std::string::npos);
 }
 
 TEST(TestRemoveScalars, warn_increment) {
   using namespace dawn::iir;
-
-  delete dawn::Logger::getSingleton().getLogger();
-  dawn::Logger::getSingleton().registerLogger(new dawn::DawnLogger(dawn::LoggingLevel::Info));
 
   UnstructuredIIRBuilder b;
   auto f_e = b.field("f_e", ast::LocationType::Edges);
@@ -531,22 +526,19 @@ TEST(TestRemoveScalars, warn_increment) {
   OptimizerContext optimizer(diag, optimizerOptions,
                              std::make_shared<dawn::SIR>(ast::GridType::Unstructured));
 
+  std::ostringstream output;
+  dawn::info.stream(output);
+
   // run single pass (PassRemoveScalars) and expect info in output
   PassRemoveScalars passRemoveScalars(optimizer);
-  testing::internal::CaptureStderr();
   passRemoveScalars.run(stencil);
-  std::cout.flush();
-  std::string output = testing::internal::GetCapturedStderr();
-  ASSERT_NE(
-      output.find("Unsupported statement at line -1:-1. Skipping removal of scalar variables."),
-      std::string::npos);
+  ASSERT_NE(output.str().find(
+                "Unsupported statement at line -1:-1. Skipping removal of scalar variables."),
+            std::string::npos);
 }
 
 TEST(TestRemoveScalars, warn_condition_adimensional_01) {
   using namespace dawn::iir;
-
-  delete dawn::Logger::getSingleton().getLogger();
-  dawn::Logger::getSingleton().registerLogger(new dawn::DawnLogger(dawn::LoggingLevel::Info));
 
   UnstructuredIIRBuilder b;
   auto f_e = b.field("f_e", ast::LocationType::Edges);
@@ -574,22 +566,19 @@ TEST(TestRemoveScalars, warn_condition_adimensional_01) {
   OptimizerContext optimizer(diag, optimizerOptions,
                              std::make_shared<dawn::SIR>(ast::GridType::Unstructured));
 
+  std::ostringstream output;
+  dawn::info.stream(output);
+
   // run single pass (PassRemoveScalars) and expect info in output
   PassRemoveScalars passRemoveScalars(optimizer);
-  testing::internal::CaptureStderr();
   passRemoveScalars.run(stencil);
-  std::cout.flush();
-  std::string output = testing::internal::GetCapturedStderr();
-  ASSERT_NE(
-      output.find("Unsupported statement at line -1:-1. Skipping removal of scalar variables."),
-      std::string::npos);
+  ASSERT_NE(output.str().find(
+                "Unsupported statement at line -1:-1. Skipping removal of scalar variables."),
+            std::string::npos);
 }
 
 TEST(TestRemoveScalars, warn_condition_adimensional_02) {
   using namespace dawn::iir;
-
-  delete dawn::Logger::getSingleton().getLogger();
-  dawn::Logger::getSingleton().registerLogger(new dawn::DawnLogger(dawn::LoggingLevel::Info));
 
   UnstructuredIIRBuilder b;
   auto f_e = b.field("f_e", ast::LocationType::Edges);
@@ -617,22 +606,19 @@ TEST(TestRemoveScalars, warn_condition_adimensional_02) {
   OptimizerContext optimizer(diag, optimizerOptions,
                              std::make_shared<dawn::SIR>(ast::GridType::Unstructured));
 
+  std::ostringstream output;
+  dawn::info.stream(output);
+
   // run single pass (PassRemoveScalars) and expect info in output
   PassRemoveScalars passRemoveScalars(optimizer);
-  testing::internal::CaptureStderr();
   passRemoveScalars.run(stencil);
-  std::cout.flush();
-  std::string output = testing::internal::GetCapturedStderr();
-  ASSERT_NE(
-      output.find("Unsupported statement at line -1:-1. Skipping removal of scalar variables."),
-      std::string::npos);
+  ASSERT_NE(output.str().find(
+                "Unsupported statement at line -1:-1. Skipping removal of scalar variables."),
+            std::string::npos);
 }
 
 TEST(TestRemoveScalars, warn_condition_adimensional_03) {
   using namespace dawn::iir;
-
-  delete dawn::Logger::getSingleton().getLogger();
-  dawn::Logger::getSingleton().registerLogger(new dawn::DawnLogger(dawn::LoggingLevel::Info));
 
   UnstructuredIIRBuilder b;
   auto f_e = b.field("f_e", ast::LocationType::Edges);
@@ -657,6 +643,9 @@ TEST(TestRemoveScalars, warn_condition_adimensional_03) {
                       b.ifStmt(b.at(myBool), b.block(b.stmt(b.assignExpr(b.at(varA), b.lit(4.0))))),
                       b.stmt(b.assignExpr(b.at(f_e), b.at(varA))))))));
 
+  std::ostringstream output;
+  dawn::info.stream(output);
+
   OptimizerContext::OptimizerContextOptions optimizerOptions;
   DiagnosticsEngine diag;
   OptimizerContext optimizer(diag, optimizerOptions,
@@ -664,13 +653,10 @@ TEST(TestRemoveScalars, warn_condition_adimensional_03) {
 
   // run single pass (PassRemoveScalars) and expect info in output
   PassRemoveScalars passRemoveScalars(optimizer);
-  testing::internal::CaptureStderr();
   passRemoveScalars.run(stencil);
-  std::cout.flush();
-  std::string output = testing::internal::GetCapturedStderr();
-  ASSERT_NE(
-      output.find("Unsupported statement at line -1:-1. Skipping removal of scalar variables."),
-      std::string::npos);
+  ASSERT_NE(output.str().find(
+                "Unsupported statement at line -1:-1. Skipping removal of scalar variables."),
+            std::string::npos);
 }
 
 } // namespace

--- a/dawn/test/unit-test/dawn/Optimizer/TestPassRemoveScalars.cpp
+++ b/dawn/test/unit-test/dawn/Optimizer/TestPassRemoveScalars.cpp
@@ -490,7 +490,7 @@ TEST(TestRemoveScalars, warn_compound_assignments) {
                              std::make_shared<dawn::SIR>(ast::GridType::Unstructured));
 
   std::ostringstream output;
-  dawn::info.stream(output);
+  dawn::log::info.stream(output);
 
   // run single pass (PassRemoveScalars) and expect info in output
   PassRemoveScalars passRemoveScalars(optimizer);
@@ -527,7 +527,7 @@ TEST(TestRemoveScalars, warn_increment) {
                              std::make_shared<dawn::SIR>(ast::GridType::Unstructured));
 
   std::ostringstream output;
-  dawn::info.stream(output);
+  dawn::log::info.stream(output);
 
   // run single pass (PassRemoveScalars) and expect info in output
   PassRemoveScalars passRemoveScalars(optimizer);
@@ -567,7 +567,7 @@ TEST(TestRemoveScalars, warn_condition_adimensional_01) {
                              std::make_shared<dawn::SIR>(ast::GridType::Unstructured));
 
   std::ostringstream output;
-  dawn::info.stream(output);
+  dawn::log::info.stream(output);
 
   // run single pass (PassRemoveScalars) and expect info in output
   PassRemoveScalars passRemoveScalars(optimizer);
@@ -607,7 +607,7 @@ TEST(TestRemoveScalars, warn_condition_adimensional_02) {
                              std::make_shared<dawn::SIR>(ast::GridType::Unstructured));
 
   std::ostringstream output;
-  dawn::info.stream(output);
+  dawn::log::info.stream(output);
 
   // run single pass (PassRemoveScalars) and expect info in output
   PassRemoveScalars passRemoveScalars(optimizer);
@@ -644,7 +644,7 @@ TEST(TestRemoveScalars, warn_condition_adimensional_03) {
                       b.stmt(b.assignExpr(b.at(f_e), b.at(varA))))))));
 
   std::ostringstream output;
-  dawn::info.stream(output);
+  dawn::log::info.stream(output);
 
   OptimizerContext::OptimizerContextOptions optimizerOptions;
   DiagnosticsEngine diag;

--- a/dawn/test/unit-test/dawn/Optimizer/TestPassRemoveScalars.cpp
+++ b/dawn/test/unit-test/dawn/Optimizer/TestPassRemoveScalars.cpp
@@ -491,13 +491,12 @@ TEST(TestRemoveScalars, warn_compound_assignments) {
 
   std::ostringstream output;
   dawn::log::info.stream(output);
+  dawn::log::setVerbosity(dawn::log::Level::All);
 
   // run single pass (PassRemoveScalars) and expect info in output
   PassRemoveScalars passRemoveScalars(optimizer);
   passRemoveScalars.run(stencil);
-  ASSERT_NE(output.str().find(
-                "Unsupported statement at line -1:-1. Skipping removal of scalar variables."),
-            std::string::npos);
+  ASSERT_NE(output.str().find("Skipping removal of scalar variables."), std::string::npos);
 }
 
 TEST(TestRemoveScalars, warn_increment) {
@@ -528,13 +527,12 @@ TEST(TestRemoveScalars, warn_increment) {
 
   std::ostringstream output;
   dawn::log::info.stream(output);
+  dawn::log::setVerbosity(dawn::log::Level::All);
 
   // run single pass (PassRemoveScalars) and expect info in output
   PassRemoveScalars passRemoveScalars(optimizer);
   passRemoveScalars.run(stencil);
-  ASSERT_NE(output.str().find(
-                "Unsupported statement at line -1:-1. Skipping removal of scalar variables."),
-            std::string::npos);
+  ASSERT_NE(output.str().find("Skipping removal of scalar variables."), std::string::npos);
 }
 
 TEST(TestRemoveScalars, warn_condition_adimensional_01) {
@@ -568,13 +566,12 @@ TEST(TestRemoveScalars, warn_condition_adimensional_01) {
 
   std::ostringstream output;
   dawn::log::info.stream(output);
+  dawn::log::setVerbosity(dawn::log::Level::All);
 
   // run single pass (PassRemoveScalars) and expect info in output
   PassRemoveScalars passRemoveScalars(optimizer);
   passRemoveScalars.run(stencil);
-  ASSERT_NE(output.str().find(
-                "Unsupported statement at line -1:-1. Skipping removal of scalar variables."),
-            std::string::npos);
+  ASSERT_NE(output.str().find("Skipping removal of scalar variables."), std::string::npos);
 }
 
 TEST(TestRemoveScalars, warn_condition_adimensional_02) {
@@ -608,13 +605,12 @@ TEST(TestRemoveScalars, warn_condition_adimensional_02) {
 
   std::ostringstream output;
   dawn::log::info.stream(output);
+  dawn::log::setVerbosity(dawn::log::Level::All);
 
   // run single pass (PassRemoveScalars) and expect info in output
   PassRemoveScalars passRemoveScalars(optimizer);
   passRemoveScalars.run(stencil);
-  ASSERT_NE(output.str().find(
-                "Unsupported statement at line -1:-1. Skipping removal of scalar variables."),
-            std::string::npos);
+  ASSERT_NE(output.str().find("Skipping removal of scalar variables."), std::string::npos);
 }
 
 TEST(TestRemoveScalars, warn_condition_adimensional_03) {
@@ -645,6 +641,7 @@ TEST(TestRemoveScalars, warn_condition_adimensional_03) {
 
   std::ostringstream output;
   dawn::log::info.stream(output);
+  dawn::log::setVerbosity(dawn::log::Level::All);
 
   OptimizerContext::OptimizerContextOptions optimizerOptions;
   DiagnosticsEngine diag;
@@ -654,9 +651,7 @@ TEST(TestRemoveScalars, warn_condition_adimensional_03) {
   // run single pass (PassRemoveScalars) and expect info in output
   PassRemoveScalars passRemoveScalars(optimizer);
   passRemoveScalars.run(stencil);
-  ASSERT_NE(output.str().find(
-                "Unsupported statement at line -1:-1. Skipping removal of scalar variables."),
-            std::string::npos);
+  ASSERT_NE(output.str().find("Skipping removal of scalar variables."), std::string::npos);
 }
 
 } // namespace

--- a/dawn/test/unit-test/dawn/Optimizer/TestPassRemoveScalars.cpp
+++ b/dawn/test/unit-test/dawn/Optimizer/TestPassRemoveScalars.cpp
@@ -13,7 +13,7 @@
 //===------------------------------------------------------------------------------------------===//
 #include "dawn/Optimizer/OptimizerContext.h"
 #include "dawn/Optimizer/PassRemoveScalars.h"
-#include "dawn/Support/Logging.h"
+#include "dawn/Support/Logger.h"
 #include "dawn/Unittest/ASTConstructionAliases.h"
 #include "dawn/Unittest/IIRBuilder.h"
 #include "dawn/Unittest/UnittestUtils.h"

--- a/dawn/test/unit-test/dawn/Support/CMakeLists.txt
+++ b/dawn/test/unit-test/dawn/Support/CMakeLists.txt
@@ -15,6 +15,7 @@ include(GoogleTest)
 
 set(executable ${PROJECT_NAME}UnittestSupport)
 add_executable(${executable}
+  TestLogger.cpp
   TestSmallVector.cpp
   TestStringRef.cpp
   TestArrayRef.cpp

--- a/dawn/test/unit-test/dawn/Support/TestLogger.cpp
+++ b/dawn/test/unit-test/dawn/Support/TestLogger.cpp
@@ -21,30 +21,46 @@ using namespace dawn;
 
 namespace {
 
-TEST(Logger, Construction) {
+TEST(Logger, construction) {
   std::ostringstream buffer;
-  Logger log(makeDefaultFormatter("[LOG]"), buffer);
+  Logger log(makeMessageFormatter(), makeDiagnosticFormatter(), buffer);
   EXPECT_EQ(log.size(), 0);
 }
 
-TEST(Logger, size) {
+TEST(Logger, message_formatting) {
   std::ostringstream buffer;
-  Logger log(makeDefaultFormatter("[LOG]"), buffer);
-  log(__FILE__, __LINE__) << "A message\n";
-  log(__FILE__, __LINE__) << "Another message\n";
-  EXPECT_EQ(log.size(), 2);
+  Logger log(makeMessageFormatter("LOG"), makeDiagnosticFormatter(), buffer);
+  log("TestLogger.cpp", 42) << "Message";
+  EXPECT_EQ(buffer, "[TestLogger.cpp:42] LOG: Message");
 }
 
-TEST(Logger, CustomFormatter) {
+TEST(Logger, diagnostic_formatting) {
+  std::ostringstream buffer;
+  Logger log(makeMessageFormatter(), makeDiagnosticFormatter("LOG"), buffer);
+  log("TestLogger.cpp", 42, "test.input", SourceLocation(42, 4)) << "Message";
+  EXPECT_EQ(buffer, "[TestLogger.cpp:42] test.input:42:4: LOG: Message");
+}
+
+TEST(Logger, stream) {
+  std::ostringstream buffer;
+  Logger log(makeMessageFormatter(), makeDiagnosticFormatter(), buffer);
+  std::ostringstream anotherBuffer;
+  log.stream(anotherBuffer);
+  log("TestLogger.cpp", 42) << "Message";
+  EXPECT_EQ(buffer.str(), "");
+  EXPECT_NE(anotherBuffer.str(), "");
+}
+
+TEST(Logger, custom_MessageFormatter) {
   {
     std::ostringstream buffer;
     // Initialize with standard formatter
-    Logger log(makeDefaultFormatter(""), buffer);
+    Logger log(makeMessageFormatter(), makeDiagnosticFormatter(), buffer);
     // Replace formatter
-    log.formatter([](const std::string& msg, const std::string& file, int line) {
+    log.messageFormatter([](const std::string& msg, const std::string& file, int line) {
       return std::string(std::rbegin(msg), std::rend(msg));
     });
-    log(__FILE__, __LINE__) << "message";
+    log("TestLogger.cpp", 42) << "message";
     const std::string firstMessage = *log.begin();
     EXPECT_EQ(firstMessage[0], 'e');
     EXPECT_EQ(firstMessage[6], 'm');
@@ -53,19 +69,70 @@ TEST(Logger, CustomFormatter) {
     std::ostringstream buffer;
     Logger log([](const std::string& msg, const std::string& file,
                   int line) { return std::string(std::rbegin(msg), std::rend(msg)); },
-               buffer);
-    log(__FILE__, __LINE__) << "message";
+               makeDiagnosticFormatter(), buffer);
+    log("TestLogger.cpp", 42) << "message";
     const std::string firstMessage = *log.begin();
     EXPECT_EQ(firstMessage[0], 'e');
     EXPECT_EQ(firstMessage[6], 'm');
   }
 }
 
+TEST(Logger, custom_DiagnosticFormatter) {
+  {
+    std::ostringstream buffer;
+    // Initialize with standard formatter
+    Logger log(makeMessageFormatter(), makeDiagnosticFormatter(), buffer);
+    // Replace formatter
+    log.diagnosticFormatter(
+        [](const std::string& msg, const std::string& file, int line, const std::string& source,
+           SourceLocation loc) { return std::string(std::rbegin(msg), std::rend(msg)); });
+    log("TestLogger.cpp", 42, "", SourceLocation()) << "message";
+    const std::string firstMessage = *log.begin();
+    EXPECT_EQ(firstMessage[0], 'e');
+    EXPECT_EQ(firstMessage[6], 'm');
+  }
+  {
+    std::ostringstream buffer;
+    Logger log(makeMessageFormatter(),
+               [](const std::string& msg, const std::string& file, int line,
+                  const std::string& source,
+                  SourceLocation loc) { return std::string(std::rbegin(msg), std::rend(msg)); },
+               buffer);
+    log("TestLogger.cpp", 42) << "message";
+    const std::string firstMessage = *log.begin();
+    EXPECT_EQ(firstMessage[0], 'e');
+    EXPECT_EQ(firstMessage[6], 'm');
+  }
+}
+
+TEST(Logger, size_and_clear) {
+  std::ostringstream buffer;
+  Logger log(makeMessageFormatter(), makeDiagnosticFormatter(), buffer);
+  log("TestLogger.cpp", 42) << "A message\n";
+  log("TestLogger.cpp", 42) << "Another message\n";
+  EXPECT_EQ(log.size(), 2);
+  log.clear();
+  EXPECT_EQ(log.size(), 0);
+}
+
+TEST(Logger, show_and_hide) {
+  std::ostringstream buffer;
+  Logger log(makeMessageFormatter(), makeDiagnosticFormatter(), buffer, false);
+  log("TestLogger.cpp", 42) << "A message\n";
+  EXPECT_EQ(buffer, "");
+  EXPECT_EQ(log.size(), 1);
+  log.show();
+  log("TestLogger.cpp", 42) << "A message\n";
+  EXPECT_NE(buffer, "");
+  EXPECT_EQ(log.size(), 2);
+}
+
 TEST(Logger, iterate) {
   std::ostringstream buffer;
-  Logger log([](const std::string& msg, const std::string& file, int line) { return msg; }, buffer);
-  log(__FILE__, __LINE__) << "A message";
-  log(__FILE__, __LINE__) << "Another message";
+  Logger log([](const std::string& msg, const std::string& file, int line) { return msg; },
+             makeDiagnosticFormatter(), buffer);
+  log("TestLogger.cpp", 42) << "A message";
+  log("TestLogger.cpp", 42) << "Another message";
   auto iter = log.begin();
   EXPECT_EQ(iter->size(), 9);
   ++iter;

--- a/dawn/test/unit-test/dawn/Support/TestLogger.cpp
+++ b/dawn/test/unit-test/dawn/Support/TestLogger.cpp
@@ -64,7 +64,7 @@ TEST(Logger, CustomFormatter) {
 
 TEST(Logger, iterate) {
   std::ostringstream buffer;
-  Logger log(makeDefaultFormatter("[LOG]"), buffer);
+  Logger log([](const std::string& msg, const std::string& file, int line) { return msg; }, buffer);
   log(__FILE__, __LINE__) << "A message";
   log(__FILE__, __LINE__) << "Another message";
   auto iter = log.begin();

--- a/dawn/test/unit-test/dawn/Support/TestLogger.cpp
+++ b/dawn/test/unit-test/dawn/Support/TestLogger.cpp
@@ -12,7 +12,6 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
-// TODO Name this "Logger"
 #include "dawn/Support/Logger.h"
 #include <algorithm>
 #include <gtest/gtest.h>

--- a/dawn/test/unit-test/dawn/Support/TestLogger.cpp
+++ b/dawn/test/unit-test/dawn/Support/TestLogger.cpp
@@ -1,0 +1,76 @@
+//===--------------------------------------------------------------------------------*- C++ -*-===//
+//                          _
+//                         | |
+//                       __| | __ ___      ___ ___
+//                      / _` |/ _` \ \ /\ / / '_  |
+//                     | (_| | (_| |\ V  V /| | | |
+//                      \__,_|\__,_| \_/\_/ |_| |_| - Compiler Toolchain
+//
+//
+//  This file is distributed under the MIT License (MIT).
+//  See LICENSE.txt for details.
+//
+//===------------------------------------------------------------------------------------------===//
+
+// TODO Name this "Logger"
+#include "dawn/Support/Logging.h"
+#include <algorithm>
+#include <gtest/gtest.h>
+#include <sstream>
+
+using namespace dawn;
+
+namespace {
+
+TEST(Logger, Construction) {
+  std::ostringstream buffer;
+  Logger log(makeDefaultFormatter("[LOG]"), buffer);
+  EXPECT_EQ(log.size(), 0);
+}
+
+TEST(Logger, size) {
+  std::ostringstream buffer;
+  Logger log(makeDefaultFormatter("[LOG]"), buffer);
+  log(__FILE__, __LINE__) << "A message\n";
+  log(__FILE__, __LINE__) << "Another message\n";
+  EXPECT_EQ(log.size(), 2);
+}
+
+TEST(Logger, CustomFormatter) {
+  {
+    std::ostringstream buffer;
+    // Initialize with standard formatter
+    Logger log(makeDefaultFormatter(""), buffer);
+    // Replace formatter
+    log.formatter([](const std::string& msg, const std::string& file, int line) {
+      return std::string(std::rbegin(msg), std::rend(msg));
+    });
+    log(__FILE__, __LINE__) << "message";
+    const std::string firstMessage = *log.begin();
+    EXPECT_EQ(firstMessage[0], 'e');
+    EXPECT_EQ(firstMessage[6], 'm');
+  }
+  {
+    std::ostringstream buffer;
+    Logger log([](const std::string& msg, const std::string& file,
+                  int line) { return std::string(std::rbegin(msg), std::rend(msg)); },
+               buffer);
+    log(__FILE__, __LINE__) << "message";
+    const std::string firstMessage = *log.begin();
+    EXPECT_EQ(firstMessage[0], 'e');
+    EXPECT_EQ(firstMessage[6], 'm');
+  }
+}
+
+TEST(Logger, iterate) {
+  std::ostringstream buffer;
+  Logger log(makeDefaultFormatter("[LOG]"), buffer);
+  log(__FILE__, __LINE__) << "A message";
+  log(__FILE__, __LINE__) << "Another message";
+  auto iter = log.begin();
+  EXPECT_EQ(iter->size(), 9);
+  ++iter;
+  EXPECT_EQ(iter->size(), 15);
+}
+
+} // namespace

--- a/dawn/test/unit-test/dawn/Support/TestLogger.cpp
+++ b/dawn/test/unit-test/dawn/Support/TestLogger.cpp
@@ -31,14 +31,14 @@ TEST(Logger, message_formatting) {
   std::ostringstream buffer;
   Logger log(makeMessageFormatter("LOG"), makeDiagnosticFormatter(), buffer);
   log("TestLogger.cpp", 42) << "Message";
-  EXPECT_EQ(buffer, "[TestLogger.cpp:42] LOG: Message");
+  EXPECT_EQ(buffer.str(), "[TestLogger.cpp:42] LOG: Message");
 }
 
 TEST(Logger, diagnostic_formatting) {
   std::ostringstream buffer;
   Logger log(makeMessageFormatter(), makeDiagnosticFormatter("LOG"), buffer);
   log("TestLogger.cpp", 42, "test.input", SourceLocation(42, 4)) << "Message";
-  EXPECT_EQ(buffer, "[TestLogger.cpp:42] test.input:42:4: LOG: Message");
+  EXPECT_EQ(buffer.str(), "[TestLogger.cpp:42] test.input:42:4: LOG: Message");
 }
 
 TEST(Logger, stream) {
@@ -98,7 +98,7 @@ TEST(Logger, custom_DiagnosticFormatter) {
                   const std::string& source,
                   SourceLocation loc) { return std::string(std::rbegin(msg), std::rend(msg)); },
                buffer);
-    log("TestLogger.cpp", 42) << "message";
+    log("TestLogger.cpp", 42, "", SourceLocation()) << "message";
     const std::string firstMessage = *log.begin();
     EXPECT_EQ(firstMessage[0], 'e');
     EXPECT_EQ(firstMessage[6], 'm');
@@ -119,11 +119,11 @@ TEST(Logger, show_and_hide) {
   std::ostringstream buffer;
   Logger log(makeMessageFormatter(), makeDiagnosticFormatter(), buffer, false);
   log("TestLogger.cpp", 42) << "A message\n";
-  EXPECT_EQ(buffer, "");
+  EXPECT_EQ(buffer.str(), "");
   EXPECT_EQ(log.size(), 1);
   log.show();
   log("TestLogger.cpp", 42) << "A message\n";
-  EXPECT_NE(buffer, "");
+  EXPECT_NE(buffer.str(), "");
   EXPECT_EQ(log.size(), 2);
 }
 

--- a/dawn/test/unit-test/dawn/Support/TestLogger.cpp
+++ b/dawn/test/unit-test/dawn/Support/TestLogger.cpp
@@ -31,14 +31,14 @@ TEST(Logger, message_formatting) {
   std::ostringstream buffer;
   Logger log(makeMessageFormatter("LOG"), makeDiagnosticFormatter(), buffer);
   log("TestLogger.cpp", 42) << "Message";
-  EXPECT_EQ(buffer.str(), "[TestLogger.cpp:42] LOG: Message");
+  EXPECT_EQ(buffer.str(), "[TestLogger.cpp:42] LOG: Message\n");
 }
 
 TEST(Logger, diagnostic_formatting) {
   std::ostringstream buffer;
   Logger log(makeMessageFormatter(), makeDiagnosticFormatter("LOG"), buffer);
   log("TestLogger.cpp", 42, "test.input", SourceLocation(42, 4)) << "Message";
-  EXPECT_EQ(buffer.str(), "[TestLogger.cpp:42] test.input:42:4: LOG: Message");
+  EXPECT_EQ(buffer.str(), "[TestLogger.cpp:42] test.input:42:4: LOG: Message\n");
 }
 
 TEST(Logger, stream) {

--- a/dawn/test/unit-test/dawn/Support/TestLogger.cpp
+++ b/dawn/test/unit-test/dawn/Support/TestLogger.cpp
@@ -13,7 +13,7 @@
 //===------------------------------------------------------------------------------------------===//
 
 // TODO Name this "Logger"
-#include "dawn/Support/Logging.h"
+#include "dawn/Support/Logger.h"
 #include <algorithm>
 #include <gtest/gtest.h>
 #include <sstream>

--- a/gtclang/src/gtclang/Driver/Driver.cpp
+++ b/gtclang/src/gtclang/Driver/Driver.cpp
@@ -56,10 +56,13 @@ ReturnValue Driver::run(const llvm::SmallVectorImpl<const char*>& args) {
   if(!optionsParser.parse(args, clangArgs))
     return ReturnValue{1, returnSIR};
 
-  // Initialize the Logger
-  auto logger = std::make_unique<Logger>();
-  if(context->getOptions().Verbose)
-    dawn::Logger::getSingleton().registerLogger(logger.get());
+  // Save existing formatter and set to gtclang
+  auto infoFormatter = dawn::info.formatter();
+  auto warnFormatter = dawn::warn.formatter();
+  auto errorFormatter = dawn::error.formatter();
+  dawn::info.formatter(makeGTClangFormatter(dawn::LoggingLevel::Info));
+  dawn::warn.formatter(makeGTClangFormatter(dawn::LoggingLevel::Warning));
+  dawn::error.formatter(makeGTClangFormatter(dawn::LoggingLevel::Error));
 
   GTClangIncludeChecker includeChecker;
   if(clangArgs.size() > 1)
@@ -83,6 +86,11 @@ ReturnValue Driver::run(const llvm::SmallVectorImpl<const char*>& args) {
 
   includeChecker.Restore();
 
+  // Reset formatters
+  dawn::info.formatter(infoFormatter);
+  dawn::warn.formatter(warnFormatter);
+  dawn::error.formatter(errorFormatter);
+
   return ReturnValue{ret, returnSIR};
 }
 
@@ -104,10 +112,13 @@ std::shared_ptr<dawn::SIR> run(const std::string& fileName, const ParseOptions& 
   clangArgs.push_back("gtc-parse");
   clangArgs.push_back(fileName.c_str());
 
-  // Initialize the Logger
-  auto logger = std::make_unique<gtclang::Logger>();
-  if(options.Verbose)
-    dawn::Logger::getSingleton().registerLogger(logger.get());
+  // Save existing formatter and set to gtclang
+  auto infoFormatter = dawn::info.formatter();
+  auto warnFormatter = dawn::warn.formatter();
+  auto errorFormatter = dawn::error.formatter();
+  dawn::info.formatter(makeGTClangFormatter(dawn::LoggingLevel::Info));
+  dawn::warn.formatter(makeGTClangFormatter(dawn::LoggingLevel::Warning));
+  dawn::error.formatter(makeGTClangFormatter(dawn::LoggingLevel::Error));
 
   gtclang::GTClangIncludeChecker includeChecker;
   if(clangArgs.size() > 1)
@@ -135,6 +146,11 @@ std::shared_ptr<dawn::SIR> run(const std::string& fileName, const ParseOptions& 
   }
 
   includeChecker.Restore();
+
+  // Reset formatters
+  dawn::info.formatter(infoFormatter);
+  dawn::warn.formatter(warnFormatter);
+  dawn::error.formatter(errorFormatter);
 
   return stencilIR;
 }

--- a/gtclang/src/gtclang/Driver/Driver.cpp
+++ b/gtclang/src/gtclang/Driver/Driver.cpp
@@ -57,12 +57,19 @@ ReturnValue Driver::run(const llvm::SmallVectorImpl<const char*>& args) {
     return ReturnValue{1, returnSIR};
 
   // Save existing formatter and set to gtclang
-  auto infoFormatter = dawn::log::info.formatter();
-  auto warnFormatter = dawn::log::warn.formatter();
-  auto errorFormatter = dawn::log::error.formatter();
-  dawn::log::info.formatter(makeGTClangFormatter("[INFO]"));
-  dawn::log::warn.formatter(makeGTClangFormatter("[WARNING]"));
-  dawn::log::error.formatter(makeGTClangFormatter("[ERROR]"));
+  auto infoMessageFormatter = dawn::log::info.messageFormatter();
+  auto warnMessageFormatter = dawn::log::warn.messageFormatter();
+  auto errorMessageFormatter = dawn::log::error.messageFormatter();
+  dawn::log::info.messageFormatter(makeGTClangMessageFormatter("[INFO]"));
+  dawn::log::warn.messageFormatter(makeGTClangMessageFormatter("[WARNING]"));
+  dawn::log::error.messageFormatter(makeGTClangMessageFormatter("[ERROR]"));
+
+  auto infoDiagnosticFormatter = dawn::log::info.diagnosticFormatter();
+  auto warnDiagnosticFormatter = dawn::log::warn.diagnosticFormatter();
+  auto errorDiagnosticFormatter = dawn::log::error.diagnosticFormatter();
+  dawn::log::info.diagnosticFormatter(makeGTClangDiagnosticFormatter("[INFO]"));
+  dawn::log::warn.diagnosticFormatter(makeGTClangDiagnosticFormatter("[WARNING]"));
+  dawn::log::error.diagnosticFormatter(makeGTClangDiagnosticFormatter("[ERROR]"));
 
   GTClangIncludeChecker includeChecker;
   if(clangArgs.size() > 1)
@@ -87,9 +94,13 @@ ReturnValue Driver::run(const llvm::SmallVectorImpl<const char*>& args) {
   includeChecker.Restore();
 
   // Reset formatters
-  dawn::log::info.formatter(infoFormatter);
-  dawn::log::warn.formatter(warnFormatter);
-  dawn::log::error.formatter(errorFormatter);
+  dawn::log::info.messageFormatter(infoMessageFormatter);
+  dawn::log::warn.messageFormatter(warnMessageFormatter);
+  dawn::log::error.messageFormatter(errorMessageFormatter);
+
+  dawn::log::info.diagnosticFormatter(infoDiagnosticFormatter);
+  dawn::log::warn.diagnosticFormatter(warnDiagnosticFormatter);
+  dawn::log::error.diagnosticFormatter(errorDiagnosticFormatter);
 
   return ReturnValue{ret, returnSIR};
 }
@@ -113,12 +124,19 @@ std::shared_ptr<dawn::SIR> run(const std::string& fileName, const ParseOptions& 
   clangArgs.push_back(fileName.c_str());
 
   // Save existing formatter and set to gtclang
-  auto infoFormatter = dawn::log::info.formatter();
-  auto warnFormatter = dawn::log::warn.formatter();
-  auto errorFormatter = dawn::log::error.formatter();
-  dawn::log::info.formatter(makeGTClangFormatter("[INFO]"));
-  dawn::log::warn.formatter(makeGTClangFormatter("[WARNING]"));
-  dawn::log::error.formatter(makeGTClangFormatter("[ERROR]"));
+  auto infoMessageFormatter = dawn::log::info.messageFormatter();
+  auto warnMessageFormatter = dawn::log::warn.messageFormatter();
+  auto errorMessageFormatter = dawn::log::error.messageFormatter();
+  dawn::log::info.messageFormatter(makeGTClangMessageFormatter("[INFO]"));
+  dawn::log::warn.messageFormatter(makeGTClangMessageFormatter("[WARNING]"));
+  dawn::log::error.messageFormatter(makeGTClangMessageFormatter("[ERROR]"));
+
+  auto infoDiagnosticFormatter = dawn::log::info.diagnosticFormatter();
+  auto warnDiagnosticFormatter = dawn::log::warn.diagnosticFormatter();
+  auto errorDiagnosticFormatter = dawn::log::error.diagnosticFormatter();
+  dawn::log::info.diagnosticFormatter(makeGTClangDiagnosticFormatter("[INFO]"));
+  dawn::log::warn.diagnosticFormatter(makeGTClangDiagnosticFormatter("[WARNING]"));
+  dawn::log::error.diagnosticFormatter(makeGTClangDiagnosticFormatter("[ERROR]"));
 
   gtclang::GTClangIncludeChecker includeChecker;
   if(clangArgs.size() > 1)
@@ -148,9 +166,13 @@ std::shared_ptr<dawn::SIR> run(const std::string& fileName, const ParseOptions& 
   includeChecker.Restore();
 
   // Reset formatters
-  dawn::log::info.formatter(infoFormatter);
-  dawn::log::warn.formatter(warnFormatter);
-  dawn::log::error.formatter(errorFormatter);
+  dawn::log::info.messageFormatter(infoMessageFormatter);
+  dawn::log::warn.messageFormatter(warnMessageFormatter);
+  dawn::log::error.messageFormatter(errorMessageFormatter);
+
+  dawn::log::info.diagnosticFormatter(infoDiagnosticFormatter);
+  dawn::log::warn.diagnosticFormatter(warnDiagnosticFormatter);
+  dawn::log::error.diagnosticFormatter(errorDiagnosticFormatter);
 
   return stencilIR;
 }

--- a/gtclang/src/gtclang/Driver/Driver.cpp
+++ b/gtclang/src/gtclang/Driver/Driver.cpp
@@ -59,10 +59,8 @@ ReturnValue Driver::run(const llvm::SmallVectorImpl<const char*>& args) {
   // Save existing formatter and set to gtclang
   auto infoFormatter = dawn::info.formatter();
   auto warnFormatter = dawn::warn.formatter();
-  auto errorFormatter = dawn::error.formatter();
-  dawn::info.formatter(makeGTClangFormatter(dawn::LoggingLevel::Info));
-  dawn::warn.formatter(makeGTClangFormatter(dawn::LoggingLevel::Warning));
-  dawn::error.formatter(makeGTClangFormatter(dawn::LoggingLevel::Error));
+  dawn::info.formatter(makeGTClangFormatter("[INFO]"));
+  dawn::warn.formatter(makeGTClangFormatter("[WARNING]"));
 
   GTClangIncludeChecker includeChecker;
   if(clangArgs.size() > 1)
@@ -89,7 +87,6 @@ ReturnValue Driver::run(const llvm::SmallVectorImpl<const char*>& args) {
   // Reset formatters
   dawn::info.formatter(infoFormatter);
   dawn::warn.formatter(warnFormatter);
-  dawn::error.formatter(errorFormatter);
 
   return ReturnValue{ret, returnSIR};
 }
@@ -115,10 +112,8 @@ std::shared_ptr<dawn::SIR> run(const std::string& fileName, const ParseOptions& 
   // Save existing formatter and set to gtclang
   auto infoFormatter = dawn::info.formatter();
   auto warnFormatter = dawn::warn.formatter();
-  auto errorFormatter = dawn::error.formatter();
-  dawn::info.formatter(makeGTClangFormatter(dawn::LoggingLevel::Info));
-  dawn::warn.formatter(makeGTClangFormatter(dawn::LoggingLevel::Warning));
-  dawn::error.formatter(makeGTClangFormatter(dawn::LoggingLevel::Error));
+  dawn::info.formatter(makeGTClangFormatter("[INFO]"));
+  dawn::warn.formatter(makeGTClangFormatter("[WARNING]"));
 
   gtclang::GTClangIncludeChecker includeChecker;
   if(clangArgs.size() > 1)
@@ -150,7 +145,6 @@ std::shared_ptr<dawn::SIR> run(const std::string& fileName, const ParseOptions& 
   // Reset formatters
   dawn::info.formatter(infoFormatter);
   dawn::warn.formatter(warnFormatter);
-  dawn::error.formatter(errorFormatter);
 
   return stencilIR;
 }

--- a/gtclang/src/gtclang/Driver/Driver.cpp
+++ b/gtclang/src/gtclang/Driver/Driver.cpp
@@ -57,10 +57,12 @@ ReturnValue Driver::run(const llvm::SmallVectorImpl<const char*>& args) {
     return ReturnValue{1, returnSIR};
 
   // Save existing formatter and set to gtclang
-  auto infoFormatter = dawn::info.formatter();
-  auto warnFormatter = dawn::warn.formatter();
-  dawn::info.formatter(makeGTClangFormatter("[INFO]"));
-  dawn::warn.formatter(makeGTClangFormatter("[WARNING]"));
+  auto infoFormatter = dawn::log::info.formatter();
+  auto warnFormatter = dawn::log::warn.formatter();
+  auto errorFormatter = dawn::log::error.formatter();
+  dawn::log::info.formatter(makeGTClangFormatter("[INFO]"));
+  dawn::log::warn.formatter(makeGTClangFormatter("[WARNING]"));
+  dawn::log::error.formatter(makeGTClangFormatter("[ERROR]"));
 
   GTClangIncludeChecker includeChecker;
   if(clangArgs.size() > 1)
@@ -85,8 +87,9 @@ ReturnValue Driver::run(const llvm::SmallVectorImpl<const char*>& args) {
   includeChecker.Restore();
 
   // Reset formatters
-  dawn::info.formatter(infoFormatter);
-  dawn::warn.formatter(warnFormatter);
+  dawn::log::info.formatter(infoFormatter);
+  dawn::log::warn.formatter(warnFormatter);
+  dawn::log::error.formatter(errorFormatter);
 
   return ReturnValue{ret, returnSIR};
 }
@@ -110,10 +113,12 @@ std::shared_ptr<dawn::SIR> run(const std::string& fileName, const ParseOptions& 
   clangArgs.push_back(fileName.c_str());
 
   // Save existing formatter and set to gtclang
-  auto infoFormatter = dawn::info.formatter();
-  auto warnFormatter = dawn::warn.formatter();
-  dawn::info.formatter(makeGTClangFormatter("[INFO]"));
-  dawn::warn.formatter(makeGTClangFormatter("[WARNING]"));
+  auto infoFormatter = dawn::log::info.formatter();
+  auto warnFormatter = dawn::log::warn.formatter();
+  auto errorFormatter = dawn::log::error.formatter();
+  dawn::log::info.formatter(makeGTClangFormatter("[INFO]"));
+  dawn::log::warn.formatter(makeGTClangFormatter("[WARNING]"));
+  dawn::log::error.formatter(makeGTClangFormatter("[ERROR]"));
 
   gtclang::GTClangIncludeChecker includeChecker;
   if(clangArgs.size() > 1)
@@ -143,8 +148,9 @@ std::shared_ptr<dawn::SIR> run(const std::string& fileName, const ParseOptions& 
   includeChecker.Restore();
 
   // Reset formatters
-  dawn::info.formatter(infoFormatter);
-  dawn::warn.formatter(warnFormatter);
+  dawn::log::info.formatter(infoFormatter);
+  dawn::log::warn.formatter(warnFormatter);
+  dawn::log::error.formatter(errorFormatter);
 
   return stencilIR;
 }

--- a/gtclang/src/gtclang/Frontend/GTClangASTConsumer.cpp
+++ b/gtclang/src/gtclang/Frontend/GTClangASTConsumer.cpp
@@ -23,7 +23,7 @@
 #include "dawn/Serialization/SIRSerializer.h"
 #include "dawn/Support/FileSystem.h"
 #include "dawn/Support/Format.h"
-#include "dawn/Support/Logging.h"
+#include "dawn/Support/Logger.h"
 #include "gtclang/Frontend/ClangFormat.h"
 #include "gtclang/Frontend/Diagnostics.h"
 #include "gtclang/Frontend/GTClangASTAction.h"

--- a/gtclang/src/gtclang/Frontend/GTClangASTVisitor.cpp
+++ b/gtclang/src/gtclang/Frontend/GTClangASTVisitor.cpp
@@ -17,7 +17,7 @@
 #include "gtclang/Frontend/GTClangASTVisitor.h"
 #include "dawn/SIR/SIR.h"
 #include "dawn/Support/FileSystem.h"
-#include "dawn/Support/Logging.h"
+#include "dawn/Support/Logger.h"
 #include "gtclang/Frontend/GTClangContext.h"
 #include "gtclang/Support/ClangCompat/SourceLocation.h"
 #include "clang/AST/ASTContext.h"

--- a/gtclang/src/gtclang/Frontend/GTClangIncludeChecker.h
+++ b/gtclang/src/gtclang/Frontend/GTClangIncludeChecker.h
@@ -17,6 +17,7 @@
 #ifndef GTCLANG_FRONTEND_INCLUDEPROCESSOR_H
 #define GTCLANG_FRONTEND_INCLUDEPROCESSOR_H
 
+#include <llvm/ADT/SmallVector.h>
 #include <llvm/ADT/StringRef.h>
 #include <string>
 #include <vector>

--- a/gtclang/src/gtclang/Frontend/StencilParser.cpp
+++ b/gtclang/src/gtclang/Frontend/StencilParser.cpp
@@ -19,7 +19,7 @@
 #include "dawn/Support/Array.h"
 #include "dawn/Support/Assert.h"
 #include "dawn/Support/Casting.h"
-#include "dawn/Support/Logging.h"
+#include "dawn/Support/Logger.h"
 #include "dawn/Support/StringSwitch.h"
 #include "gtclang/Frontend/ClangASTStmtResolver.h"
 #include "gtclang/Frontend/GTClangContext.h"

--- a/gtclang/src/gtclang/Support/Logger.cpp
+++ b/gtclang/src/gtclang/Support/Logger.cpp
@@ -21,7 +21,7 @@
 
 namespace gtclang {
 
-dawn::Logger::Formatter makeGTClangFormatter(const std::string& prefix) {
+dawn::Logger::MessageFormatter makeGTClangMessageFormatter(const std::string& prefix) {
   return [prefix](const std::string& message, const std::string& file, int line) -> std::string {
     // Get current date-time (up to ms accuracy)
     std::chrono::system_clock::time_point now = std::chrono::system_clock::now();
@@ -40,6 +40,39 @@ dawn::Logger::Formatter makeGTClangFormatter(const std::string& prefix) {
 
     ss << prefix;
     ss << prefix << " [" << file << ":" << line << "] " << message << "\n";
+
+    return ss.str();
+  };
+}
+
+dawn::Logger::DiagnosticFormatter makeGTClangDiagnosticFormatter(const std::string& prefix) {
+  return [prefix](const std::string& message, const std::string& file, int line,
+                  const std::string& source, dawn::SourceLocation loc) -> std::string {
+    // Get current date-time (up to ms accuracy)
+    std::chrono::system_clock::time_point now = std::chrono::system_clock::now();
+    auto now_ms = now.time_since_epoch();
+    auto now_sec = std::chrono::duration_cast<std::chrono::seconds>(now_ms);
+    auto tm_ms = std::chrono::duration_cast<std::chrono::milliseconds>(now_ms - now_sec);
+
+    std::time_t currentTime = std::chrono::system_clock::to_time_t(now);
+    struct tm* localTime = std::localtime(&currentTime);
+
+    auto timeStr = dawn::format("%02i:%02i:%02i.%03i", localTime->tm_hour, localTime->tm_min,
+                                localTime->tm_sec, tm_ms.count());
+
+    std::stringstream ss;
+    ss << "[" << timeStr << "] ";
+
+    ss << prefix;
+    ss << prefix << " [" << file << ":" << line << "] " << source;
+
+    if(loc.Line) {
+      ss << ":" << loc.Line;
+    }
+    if(loc.Column) {
+      ss << ":" << loc.Column;
+    }
+    ss << " : " << message << "\n";
 
     return ss.str();
   };

--- a/gtclang/src/gtclang/Support/Logger.cpp
+++ b/gtclang/src/gtclang/Support/Logger.cpp
@@ -19,40 +19,10 @@
 #include <chrono>
 #include <sstream>
 
-namespace {
-enum Code {
-  FG_RED = 31,
-  FG_GREEN = 32,
-  FG_BLUE = 34,
-  FG_DEFAULT = 39,
-
-  BG_RED = 41,
-  BG_GREEN = 42,
-  BG_BLUE = 44,
-  BG_DEFAULT = 49
-};
-
-class Change {
-  Code code;
-
-public:
-  Change(Code _code) : code(_code) {}
-
-  friend std::ostream& operator<<(std::ostream& os, const Change& chng) {
-    return os << "\033[" << chng.code << "m";
-  }
-};
-
-Change red(FG_RED);
-Change green(FG_GREEN);
-Change blue(FG_BLUE);
-Change reset(FG_DEFAULT);
-} // namespace
-
 namespace gtclang {
 
-dawn::Logger::Formatter makeGTClangFormatter(dawn::LoggingLevel level) {
-  return [level](const std::string& message, const std::string& file, int line) -> std::string {
+dawn::Logger::Formatter makeGTClangFormatter(const std::string& prefix) {
+  return [prefix](const std::string& message, const std::string& file, int line) -> std::string {
     // Get current date-time (up to ms accuracy)
     std::chrono::system_clock::time_point now = std::chrono::system_clock::now();
     auto now_ms = now.time_since_epoch();
@@ -68,22 +38,8 @@ dawn::Logger::Formatter makeGTClangFormatter(dawn::LoggingLevel level) {
     std::stringstream ss;
     ss << "[" << timeStr << "] ";
 
-    switch(level) {
-    case dawn::LoggingLevel::Info:
-      ss << "[INFO]";
-      break;
-    case dawn::LoggingLevel::Warning:
-      ss << red << "[WARN]" << reset;
-      break;
-    case dawn::LoggingLevel::Error:
-      ss << red << "[ERROR]" << reset;
-      break;
-    case dawn::LoggingLevel::Fatal:
-      ss << red << "[FATAL]" << reset;
-      break;
-    }
-
-    ss << " [" << file << ":" << line << "] " << message << "\n";
+    ss << prefix;
+    ss << prefix << " [" << file << ":" << line << "] " << message << "\n";
 
     return ss.str();
   };

--- a/gtclang/src/gtclang/Support/Logger.h
+++ b/gtclang/src/gtclang/Support/Logger.h
@@ -21,14 +21,7 @@
 
 namespace gtclang {
 
-/// @brief Logger implementation
-/// @ingroup support
-class Logger : public dawn::LoggerInterface {
-public:
-  /// @brief Log `message` of severity `level` at position `file:line`
-  virtual void log(dawn::LoggingLevel level, const std::string& message, const char* file,
-                   int line) override;
-};
+dawn::Logger::Formatter makeGTClangFormatter(dawn::LoggingLevel level);
 
 } // namespace gtclang
 

--- a/gtclang/src/gtclang/Support/Logger.h
+++ b/gtclang/src/gtclang/Support/Logger.h
@@ -21,8 +21,11 @@
 
 namespace gtclang {
 
-/// @brief Make a Logger::Formatter for GTClang
-dawn::Logger::Formatter makeGTClangFormatter(const std::string& prefix);
+/// @brief Make a Logger::MessageFormatter for GTClang
+dawn::Logger::MessageFormatter makeGTClangMessageFormatter(const std::string& prefix);
+
+/// @brief Make a Logger::DiagnosticFormatter for GTClang
+dawn::Logger::DiagnosticFormatter makeGTClangDiagnosticFormatter(const std::string& prefix);
 
 } // namespace gtclang
 

--- a/gtclang/src/gtclang/Support/Logger.h
+++ b/gtclang/src/gtclang/Support/Logger.h
@@ -14,13 +14,14 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
-#include "dawn/Support/Logging.h"
+#include "dawn/Support/Logger.h"
 
 #ifndef GTCLANG_SUPPORT_LOGGER_H
 #define GTCLANG_SUPPORT_LOGGER_H
 
 namespace gtclang {
 
+/// @brief Make a Logger::Formatter for GTClang
 dawn::Logger::Formatter makeGTClangFormatter(const std::string& prefix);
 
 } // namespace gtclang

--- a/gtclang/src/gtclang/Support/Logger.h
+++ b/gtclang/src/gtclang/Support/Logger.h
@@ -21,7 +21,7 @@
 
 namespace gtclang {
 
-dawn::Logger::Formatter makeGTClangFormatter(dawn::LoggingLevel level);
+dawn::Logger::Formatter makeGTClangFormatter(const std::string& prefix);
 
 } // namespace gtclang
 


### PR DESCRIPTION
## Technical Description

Replace Logger by a similar but improved infrastructure.

A follow-up PR will replace the diagnostics with this.

The Logger design is similar to before, however there are separate loggers `dawn::log::info`, `dawn::log::warning`, and `dawn::log::error` which are globals similar to `std::cout` and `std::cerr`.

Each logger has an `LoggerProxy operator()(string, int)` as before that returns the stream operator

Each logger also acts as a container that stores the messages (a la `DiagnosticsEngine`).

Instead of a virtual LoggerInterface that potentially leaks memory when registering other class instance pointers, this is replaced with a lightweight std::function object `Logger::Formatter`, so GTClang and other frameworks can register their own message formatting.

Loggers also take underlying `std::ostream`s, which can be customized to write to strings, files, etc.

### Resolves / Enhances

Part of #950.

### Testing

Integrates into ctest.
