### PR TITLE
add stdc++fs also for GNU CXX compiler

### DIFF
--- a/dawn/setup.py
+++ b/dawn/setup.py
@@ -57,13 +57,14 @@ with open(os.path.join(DAWN_DIR, "version.txt"), mode="r") as f:
 shutil.copyfile(os.path.join(DAWN_DIR, "version.txt"), os.path.join(DAWN4PY_DIR, "version.txt"))
 
 # Copy additional C++ headers for the generated code
-target_path = os.path.join(DAWN4PY_DIR, "_external_src", "driver-includes")
-if os.path.exists(target_path):
-    shutil.rmtree(target_path)
-shutil.copytree(
-    os.path.join(DAWN_DIR, "src", "driver-includes"), target_path,
-)
 
+for srcdir in ["driver-includes", "interface"]:
+  target_path = os.path.join(DAWN4PY_DIR, "_external_src", srcdir)
+  if os.path.exists(target_path):
+    shutil.rmtree(target_path)
+  shutil.copytree(
+      os.path.join(DAWN_DIR, "src", srcdir), target_path,
+  )
 
 # Based on:
 #   https://www.benjack.io/2018/02/02/python-cpp-revisited.html

--- a/dawn/src/dawn/CMakeLists.txt
+++ b/dawn/src/dawn/CMakeLists.txt
@@ -24,7 +24,8 @@ install(
 # GCC 8, still a common compiler, requires linking to a separate library for std::filesystem support.
 # Once that is no longer common we can remove this hack
 add_library(cpp_extra_libs INTERFACE)
-if (CMAKE_COMPILER_IS_GNUCC AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 9.0)
+if ((CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX) AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 9.0)
+
     target_link_libraries(cpp_extra_libs INTERFACE stdc++fs)
 endif()
 

--- a/dawn/src/dawn/CMakeLists.txt
+++ b/dawn/src/dawn/CMakeLists.txt
@@ -24,7 +24,7 @@ install(
 # GCC 8, still a common compiler, requires linking to a separate library for std::filesystem support.
 # Once that is no longer common we can remove this hack
 add_library(cpp_extra_libs INTERFACE)
-if ((CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX) AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 9.0)
+if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 9.0)
 
     target_link_libraries(cpp_extra_libs INTERFACE stdc++fs)
 endif()


### PR DESCRIPTION
## Technical Description

* Fix adding -lstdc++fs for gcc 8
On ubuntu 18.04, gcc8.4.0, cmake 3.16.2: CMAKE_COMPILER_IS_GNUCC is not set 

* install the interface with setup.py as external sources for dawn4py