### PR TITLE
add include vector for the ico code gen

### DIFF
--- a/dawn/src/dawn/CodeGen/CXXNaive-ico/CXXNaiveCodeGen.cpp
+++ b/dawn/src/dawn/CodeGen/CXXNaive-ico/CXXNaiveCodeGen.cpp
@@ -624,6 +624,7 @@ std::unique_ptr<TranslationUnit> CXXNaiveIcoCodeGen::generateCode() {
   ppDefines.push_back("#define DAWN_GENERATED 1");
   ppDefines.push_back("#undef DAWN_BACKEND_T");
   ppDefines.push_back("#define DAWN_BACKEND_T CXXNAIVEICO");
+  ppDefines.push_back("#include <vector>");
   ppDefines.push_back("#include <driver-includes/unstructured_interface.hpp>");
   DAWN_LOG(INFO) << "Done generating code";
 

--- a/dawn/src/dawn/CodeGen/Cuda-ico/CudaIcoCodeGen.cpp
+++ b/dawn/src/dawn/CodeGen/Cuda-ico/CudaIcoCodeGen.cpp
@@ -556,6 +556,7 @@ std::unique_ptr<TranslationUnit> CudaIcoCodeGen::generateCode() {
   }
 
   std::vector<std::string> ppDefines{
+      "#include <vector>",
       "#include \"driver-includes/unstructured_interface.hpp\"",
       "#include \"driver-includes/cuda_utils.hpp\"",
       "#include \"driver-includes/defs.hpp\"",


### PR DESCRIPTION
## Technical Description

add #include <vector> to the code gen of icosahedral codes, 
since it is used in the generated code

