### PR TITLE
Fix global precision in codegen

### DIFF
--- a/dawn/src/dawn/SIR/SIR.cpp
+++ b/dawn/src/dawn/SIR/SIR.cpp
@@ -21,6 +21,7 @@
 #include "dawn/Support/Printing.h"
 #include "dawn/Support/StringUtil.h"
 #include "dawn/Support/Unreachable.h"
+#include <iomanip>
 #include <iostream>
 #include <sstream>
 
@@ -722,6 +723,7 @@ BuiltinTypeID sir::Value::typeToBuiltinTypeID(sir::Value::Kind type) {
 }
 
 std::string sir::Value::toString() const {
+  std::ostringstream out;
   DAWN_ASSERT(has_value());
   switch(type_) {
   case Kind::Boolean:
@@ -729,9 +731,12 @@ std::string sir::Value::toString() const {
   case Kind::Integer:
     return std::to_string(std::get<int>(*value_));
   case Kind::Double:
-    return std::to_string(std::get<double>(*value_));
+    out << std::setprecision(std::numeric_limits<double>::digits10 + 1)
+        << std::get<double>(*value_);
+    return out.str();
   case Kind::Float:
-    return std::to_string(std::get<float>(*value_));
+    out << std::setprecision(std::numeric_limits<float>::digits10 + 1) << std::get<float>(*value_);
+    return out.str();
   case Kind::String:
     return std::get<std::string>(*value_);
   default:

--- a/dawn/test/unit-test/dawn/CodeGen/reference/update_dz_c.cpp
+++ b/dawn/test/unit-test/dawn/CodeGen/reference/update_dz_c.cpp
@@ -42,7 +42,7 @@ namespace cxxnaive{
 struct globals {
   double dt;
 
-  globals() : dt(0.000000){
+  globals() : dt(0){
   }
 };
 } // namespace cxxnaive

--- a/dawn/test/unit-test/dawn/CodeGen/reference/update_dz_c.cu
+++ b/dawn/test/unit-test/dawn/CodeGen/reference/update_dz_c.cu
@@ -42,7 +42,7 @@ namespace cuda{
 struct globals {
   double dt;
 
-  globals() : dt(0.000000){
+  globals() : dt(0){
   }
 };
 } // namespace cuda


### PR DESCRIPTION
## Technical Description

(problem discovered by Joerg Behrens)
Fixes codegen to output float/double globals in full precision (instead of default precision).

### Example

Globals d17=1.1234567890123457 and d13=1.1234567890123. Both used to get cut to 1.123457
