### PR TITLE
Fixed arrayAddons.hpp for gcc 10.1

### DIFF
--- a/dawn/src/driver-includes/arrayAddons.hpp
+++ b/dawn/src/driver-includes/arrayAddons.hpp
@@ -14,15 +14,16 @@
 
 #pragma once
 
+#include <cstddef>
 #include <array>
 
 namespace gridtools {
 namespace dawn {
 
-template <size_t N>
+template <std::size_t N>
 std::array<int, N> operator+(std::array<int, N> const& lhs, std::array<int, N> const& rhs) {
   std::array<int, N> res;
-  for(size_t i = 0; i < N; ++i) {
+  for(std::size_t i = 0; i < N; ++i) {
     res[i] = lhs[i] + rhs[i];
   }
   return res;


### PR DESCRIPTION
## Technical Description

Fixes incorrect usage of `size_t` in `arrayAddons.hpp`

### Resolves / Enhances

None.

### Example

Compiliation with gcc 10.1.

### Testing

Was tested locally with gcc 10.1.

### Dependencies

None

### Commets

We could also include `stddef.h` instead and then `size_t` will be defined in the _global_ namespace.