### PR TITLE
Pragma headers

### DIFF
--- a/dawn/src/dawn/AST/AST.h
+++ b/dawn/src/dawn/AST/AST.h
@@ -12,8 +12,7 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
-#ifndef DAWN_AST_AST_H
-#define DAWN_AST_AST_H
+#pragma once
 
 #include "dawn/AST/ASTExpr.h"
 #include "dawn/AST/ASTStmt.h"
@@ -71,5 +70,3 @@ public:
 };
 } // namespace ast
 } // namespace dawn
-
-#endif

--- a/dawn/src/dawn/AST/ASTExpr.h
+++ b/dawn/src/dawn/AST/ASTExpr.h
@@ -12,8 +12,7 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
-#ifndef DAWN_AST_ASTEXPR_H
-#define DAWN_AST_ASTEXPR_H
+#pragma once
 
 #include "ASTVisitorHelpers.h"
 #include "LocationType.h"
@@ -682,5 +681,3 @@ public:
 
 } // namespace ast
 } // namespace dawn
-
-#endif

--- a/dawn/src/dawn/AST/ASTFwd.h
+++ b/dawn/src/dawn/AST/ASTFwd.h
@@ -12,8 +12,7 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
-#ifndef DAWN_AST_ASTFWD_H
-#define DAWN_AST_ASTFWD_H
+#pragma once
 
 namespace dawn {
 namespace ast {
@@ -50,5 +49,3 @@ class ASTHelper;
 class ASTVisitor; //   Compiler complains if declared as class
 } // namespace ast
 } // namespace dawn
-
-#endif

--- a/dawn/src/dawn/AST/ASTStmt.h
+++ b/dawn/src/dawn/AST/ASTStmt.h
@@ -12,8 +12,7 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
-#ifndef DAWN_AST_ASTSTMT_H
-#define DAWN_AST_ASTSTMT_H
+#pragma once
 
 #include "dawn/AST/ASTVisitorHelpers.h"
 #include "dawn/AST/LocationType.h"
@@ -594,5 +593,3 @@ public:
 
 } // namespace ast
 } // namespace dawn
-
-#endif

--- a/dawn/src/dawn/AST/ASTStringifier.h
+++ b/dawn/src/dawn/AST/ASTStringifier.h
@@ -12,8 +12,7 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
-#ifndef DAWN_AST_ASTSTRINGIFER_H
-#define DAWN_AST_ASTSTRINGIFER_H
+#pragma once
 
 #include "dawn/AST/ASTFwd.h"
 #include <iosfwd>
@@ -46,5 +45,3 @@ extern std::ostream& operator<<(std::ostream& os, const std::shared_ptr<Expr>& s
 /// @}
 } // namespace ast
 } // namespace dawn
-
-#endif

--- a/dawn/src/dawn/AST/ASTUtil.h
+++ b/dawn/src/dawn/AST/ASTUtil.h
@@ -12,8 +12,7 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
-#ifndef DAWN_AST_ASTUTIL_H
-#define DAWN_AST_ASTUTIL_H
+#pragma once
 
 #include "dawn/AST/ASTFwd.h"
 #include "dawn/SIR/SIR.h"
@@ -93,4 +92,3 @@ public:
 
 } // namespace ast
 } // namespace dawn
-#endif

--- a/dawn/src/dawn/AST/ASTVisitor.h
+++ b/dawn/src/dawn/AST/ASTVisitor.h
@@ -12,8 +12,7 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
-#ifndef DAWN_AST_ASTVISITOR_H
-#define DAWN_AST_ASTVISITOR_H
+#pragma once
 
 #include "dawn/AST/ASTFwd.h"
 #include <memory>
@@ -314,5 +313,3 @@ public:
 
 } // namespace ast
 } // namespace dawn
-
-#endif

--- a/dawn/src/dawn/AST/ASTVisitorHelpers.h
+++ b/dawn/src/dawn/AST/ASTVisitorHelpers.h
@@ -11,8 +11,7 @@
 //  See LICENSE.txt for details.
 //
 //===------------------------------------------------------------------------------------------===//
-#ifndef DAWN_AST_ASTVISITORHELPERS_H
-#define DAWN_AST_ASTVISITORHELPERS_H
+#pragma once
 #include "dawn/AST/ASTVisitor.h"
 
 #define ACCEPTVISITOR(subtype, type)                                                               \
@@ -26,5 +25,3 @@
       override {                                                                                   \
     return visitor.visitAndReplace(std::static_pointer_cast<type>(shared_from_this()));            \
   }
-
-#endif

--- a/dawn/src/dawn/AST/Offsets.cpp
+++ b/dawn/src/dawn/AST/Offsets.cpp
@@ -12,8 +12,7 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
-#ifndef DAWN_AST_OFFSETS_CPP
-#define DAWN_AST_OFFSETS_CPP
+#pragma once
 
 #include "Offsets.h"
 
@@ -189,4 +188,5 @@ std::string to_string(Offsets const& offset) {
 Offsets operator+(Offsets o1, Offsets const& o2) { return o1 += o2; }
 } // namespace dawn::ast
 
-#endif
+
+

--- a/dawn/src/dawn/AST/Offsets.h
+++ b/dawn/src/dawn/AST/Offsets.h
@@ -12,8 +12,7 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
-#ifndef DAWN_AST_OFFSET_H
-#define DAWN_AST_OFFSET_H
+#pragma once
 
 #include "dawn/AST/GridType.h"
 #include "dawn/AST/Tags.h"
@@ -219,4 +218,3 @@ std::string to_string(unstructured_, Offsets const& offset);
 std::string to_string(Offsets const& offset);
 
 } // namespace dawn::ast
-#endif

--- a/dawn/src/dawn/AST/Tags.h
+++ b/dawn/src/dawn/AST/Tags.h
@@ -13,8 +13,7 @@
 //===------------------------------------------------------------------------------------------===//
 //
 
-#ifndef DAWN_AST_TAGS
-#define DAWN_AST_TAGS
+#pragma once
 
 namespace dawn::ast {
 
@@ -22,5 +21,3 @@ struct unstructured_ {};
 struct cartesian_ {};
 
 } // namespace dawn::ast
-
-#endif

--- a/dawn/src/dawn/CodeGen/ASTCodeGenCXX.h
+++ b/dawn/src/dawn/CodeGen/ASTCodeGenCXX.h
@@ -12,8 +12,7 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
-#ifndef DAWN_CODEGEN_ASTCODEGENCXX_H
-#define DAWN_CODEGEN_ASTCODEGENCXX_H
+#pragma once
 
 #include "dawn/IIR/ASTFwd.h"
 #include "dawn/IIR/ASTVisitor.h"
@@ -78,5 +77,3 @@ public:
 
 } // namespace codegen
 } // namespace dawn
-
-#endif

--- a/dawn/src/dawn/CodeGen/CXXNaive-ico/ASTStencilBody.h
+++ b/dawn/src/dawn/CodeGen/CXXNaive-ico/ASTStencilBody.h
@@ -12,8 +12,7 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
-#ifndef DAWN_CODEGEN_CXXNAIVEICO_ASTSTENCILBODY_H
-#define DAWN_CODEGEN_CXXNAIVEICO_ASTSTENCILBODY_H
+#pragma once
 
 #include "dawn/CodeGen/ASTCodeGenCXX.h"
 #include "dawn/CodeGen/CodeGenProperties.h"
@@ -144,5 +143,3 @@ public:
 } // namespace cxxnaiveico
 } // namespace codegen
 } // namespace dawn
-
-#endif

--- a/dawn/src/dawn/CodeGen/CXXNaive-ico/ASTStencilDesc.h
+++ b/dawn/src/dawn/CodeGen/CXXNaive-ico/ASTStencilDesc.h
@@ -12,8 +12,7 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
-#ifndef DAWN_CODEGEN_CXXNAIVEICO_ASTSTENCILDESC_H
-#define DAWN_CODEGEN_CXXNAIVEICO_ASTSTENCILDESC_H
+#pragma once
 
 #include "dawn/CodeGen/ASTCodeGenCXX.h"
 #include "dawn/CodeGen/CodeGenProperties.h"
@@ -70,5 +69,3 @@ public:
 } // namespace cxxnaiveico
 } // namespace codegen
 } // namespace dawn
-
-#endif

--- a/dawn/src/dawn/CodeGen/CXXNaive-ico/ASTStencilFunctionParamVisitor.h
+++ b/dawn/src/dawn/CodeGen/CXXNaive-ico/ASTStencilFunctionParamVisitor.h
@@ -12,8 +12,7 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
-#ifndef DAWN_CODEGEN_CXXNAIVEICO_ASTSTENCILFUNCTIONPARAMVISITOR_H
-#define DAWN_CODEGEN_CXXNAIVEICO_ASTSTENCILFUNCTIONPARAMVISITOR_H
+#pragma once
 
 #include "dawn/CodeGen/ASTCodeGenCXX.h"
 #include "dawn/IIR/Interval.h"
@@ -64,5 +63,3 @@ public:
 } // namespace cxxnaiveico
 } // namespace codegen
 } // namespace dawn
-
-#endif

--- a/dawn/src/dawn/CodeGen/CXXNaive-ico/CXXNaiveCodeGen.h
+++ b/dawn/src/dawn/CodeGen/CXXNaive-ico/CXXNaiveCodeGen.h
@@ -12,8 +12,7 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
-#ifndef DAWN_CODEGEN_CXXNAIVEICO_CXXNAIVECODEGEN_H
-#define DAWN_CODEGEN_CXXNAIVEICO_CXXNAIVECODEGEN_H
+#pragma once
 
 #include "dawn/CodeGen/CodeGen.h"
 #include "dawn/CodeGen/CodeGenProperties.h"
@@ -79,5 +78,3 @@ private:
 } // namespace cxxnaiveico
 } // namespace codegen
 } // namespace dawn
-
-#endif

--- a/dawn/src/dawn/CodeGen/CXXNaive/ASTStencilBody.h
+++ b/dawn/src/dawn/CodeGen/CXXNaive/ASTStencilBody.h
@@ -12,8 +12,7 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
-#ifndef DAWN_CODEGEN_CXXNAIVE_ASTSTENCILBODY_H
-#define DAWN_CODEGEN_CXXNAIVE_ASTSTENCILBODY_H
+#pragma once
 
 #include "dawn/CodeGen/ASTCodeGenCXX.h"
 #include "dawn/CodeGen/CodeGenProperties.h"
@@ -101,5 +100,3 @@ public:
 } // namespace cxxnaive
 } // namespace codegen
 } // namespace dawn
-
-#endif

--- a/dawn/src/dawn/CodeGen/CXXNaive/ASTStencilDesc.h
+++ b/dawn/src/dawn/CodeGen/CXXNaive/ASTStencilDesc.h
@@ -12,8 +12,7 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
-#ifndef DAWN_CODEGEN_CXXNAIVE_ASTSTENCILDESC_H
-#define DAWN_CODEGEN_CXXNAIVE_ASTSTENCILDESC_H
+#pragma once
 
 #include "dawn/CodeGen/ASTCodeGenCXX.h"
 #include "dawn/CodeGen/CodeGenProperties.h"
@@ -71,5 +70,3 @@ public:
 } // namespace cxxnaive
 } // namespace codegen
 } // namespace dawn
-
-#endif

--- a/dawn/src/dawn/CodeGen/CXXNaive/ASTStencilFunctionParamVisitor.h
+++ b/dawn/src/dawn/CodeGen/CXXNaive/ASTStencilFunctionParamVisitor.h
@@ -12,8 +12,7 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
-#ifndef DAWN_CODEGEN_CXXNAIVE_ASTSTENCILFUNCTIONPARAMVISITOR_H
-#define DAWN_CODEGEN_CXXNAIVE_ASTSTENCILFUNCTIONPARAMVISITOR_H
+#pragma once
 
 #include "dawn/CodeGen/ASTCodeGenCXX.h"
 #include "dawn/IIR/Interval.h"
@@ -64,5 +63,3 @@ public:
 } // namespace cxxnaive
 } // namespace codegen
 } // namespace dawn
-
-#endif

--- a/dawn/src/dawn/CodeGen/CXXNaive/CXXNaiveCodeGen.h
+++ b/dawn/src/dawn/CodeGen/CXXNaive/CXXNaiveCodeGen.h
@@ -12,8 +12,7 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
-#ifndef DAWN_CODEGEN_CXXNAIVE_CXXNAIVECODEGEN_H
-#define DAWN_CODEGEN_CXXNAIVE_CXXNAIVECODEGEN_H
+#pragma once
 
 #include "dawn/CodeGen/CodeGen.h"
 #include "dawn/CodeGen/CodeGenProperties.h"
@@ -79,5 +78,3 @@ private:
 } // namespace cxxnaive
 } // namespace codegen
 } // namespace dawn
-
-#endif

--- a/dawn/src/dawn/CodeGen/CXXUtil.h
+++ b/dawn/src/dawn/CodeGen/CXXUtil.h
@@ -12,8 +12,7 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
-#ifndef DAWN_CODEGEN_CXXUTIL_H
-#define DAWN_CODEGEN_CXXUTIL_H
+#pragma once
 
 #include "dawn/Support/Printing.h"
 #include "dawn/Support/StringUtil.h"
@@ -677,5 +676,3 @@ auto c_gt_intent = []() { return Twine("gridtools::intent::"); };
 } // namespace codegen
 
 } // namespace dawn
-
-#endif

--- a/dawn/src/dawn/CodeGen/CodeGen.h
+++ b/dawn/src/dawn/CodeGen/CodeGen.h
@@ -12,8 +12,7 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
-#ifndef DAWN_CODEGEN_CODEGEN_H
-#define DAWN_CODEGEN_CODEGEN_H
+#pragma once
 
 #include "dawn/AST/GridType.h"
 #include "dawn/CodeGen/CXXUtil.h"
@@ -113,5 +112,3 @@ public:
 
 } // namespace codegen
 } // namespace dawn
-
-#endif

--- a/dawn/src/dawn/CodeGen/CodeGenProperties.h
+++ b/dawn/src/dawn/CodeGen/CodeGenProperties.h
@@ -12,8 +12,7 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
-#ifndef DAWN_CODEGEN_CODEGENPROPERTIES_H
-#define DAWN_CODEGEN_CODEGENPROPERTIES_H
+#pragma once
 
 #include "dawn/IIR/Stencil.h"
 #include "dawn/IIR/StencilInstantiation.h"
@@ -125,4 +124,3 @@ private:
 };
 } // namespace codegen
 } // namespace dawn
-#endif

--- a/dawn/src/dawn/CodeGen/Cuda/ASTStencilBody.h
+++ b/dawn/src/dawn/CodeGen/Cuda/ASTStencilBody.h
@@ -12,8 +12,7 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
-#ifndef DAWN_CODEGEN_CUDA_ASTSTENCILBODY_H
-#define DAWN_CODEGEN_CUDA_ASTSTENCILBODY_H
+#pragma once
 
 #include "dawn/CodeGen/ASTCodeGenCXX.h"
 #include "dawn/CodeGen/CodeGenProperties.h"
@@ -84,5 +83,3 @@ private:
 } // namespace cuda
 } // namespace codegen
 } // namespace dawn
-
-#endif

--- a/dawn/src/dawn/CodeGen/Cuda/ASTStencilDesc.h
+++ b/dawn/src/dawn/CodeGen/Cuda/ASTStencilDesc.h
@@ -12,8 +12,7 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
-#ifndef DAWN_CODEGEN_CUDA_ASTSTENCILDESC_H
-#define DAWN_CODEGEN_CUDA_ASTSTENCILDESC_H
+#pragma once
 
 #include "dawn/CodeGen/ASTCodeGenCXX.h"
 #include "dawn/CodeGen/CodeGenProperties.h"
@@ -67,5 +66,3 @@ public:
 } // namespace cuda
 } // namespace codegen
 } // namespace dawn
-
-#endif

--- a/dawn/src/dawn/CodeGen/Cuda/ASTStencilFunctionParamVisitor.h
+++ b/dawn/src/dawn/CodeGen/Cuda/ASTStencilFunctionParamVisitor.h
@@ -12,8 +12,7 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
-#ifndef DAWN_CODEGEN_CUDA_ASTSTENCILFUNCTIONPARAMVISITOR_H
-#define DAWN_CODEGEN_CUDA_ASTSTENCILFUNCTIONPARAMVISITOR_H
+#pragma once
 
 #include "dawn/CodeGen/ASTCodeGenCXX.h"
 #include "dawn/IIR/Interval.h"
@@ -64,5 +63,3 @@ public:
 } // namespace cuda
 } // namespace codegen
 } // namespace dawn
-
-#endif

--- a/dawn/src/dawn/CodeGen/Cuda/CacheProperties.h
+++ b/dawn/src/dawn/CodeGen/Cuda/CacheProperties.h
@@ -12,8 +12,7 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
-#ifndef DAWN_CODEGEN_CACHEPROPERTIES_H
-#define DAWN_CODEGEN_CACHEPROPERTIES_H
+#pragma once
 #include "dawn/IIR/Extents.h"
 #include "dawn/IIR/MultiStage.h"
 #include <memory>
@@ -104,5 +103,3 @@ makeCacheProperties(const std::unique_ptr<iir::MultiStage>& ms,
 } // namespace cuda
 } // namespace codegen
 } // namespace dawn
-
-#endif

--- a/dawn/src/dawn/CodeGen/Cuda/CodeGeneratorHelper.h
+++ b/dawn/src/dawn/CodeGen/Cuda/CodeGeneratorHelper.h
@@ -12,8 +12,7 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
-#ifndef DAWN_CODEGEN_CUDA_CODEGENERATORHELPER_H
-#define DAWN_CODEGEN_CUDA_CODEGENERATORHELPER_H
+#pragma once
 
 #include "dawn/IIR/Cache.h"
 #include "dawn/IIR/Stage.h"
@@ -96,5 +95,3 @@ public:
 } // namespace cuda
 } // namespace codegen
 } // namespace dawn
-
-#endif

--- a/dawn/src/dawn/CodeGen/Cuda/CudaCodeGen.h
+++ b/dawn/src/dawn/CodeGen/Cuda/CudaCodeGen.h
@@ -12,8 +12,7 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
-#ifndef DAWN_CODEGEN_CUDA_CUDACODEGEN_H
-#define DAWN_CODEGEN_CUDA_CUDACODEGEN_H
+#pragma once
 
 #include "dawn/CodeGen/CodeGen.h"
 #include "dawn/CodeGen/CodeGenProperties.h"
@@ -131,5 +130,3 @@ private:
 } // namespace cuda
 } // namespace codegen
 } // namespace dawn
-
-#endif

--- a/dawn/src/dawn/CodeGen/Cuda/MSCodeGen.h
+++ b/dawn/src/dawn/CodeGen/Cuda/MSCodeGen.h
@@ -12,8 +12,7 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
-#ifndef DAWN_CODEGEN_CUDA_MSCODEGEN_H
-#define DAWN_CODEGEN_CUDA_MSCODEGEN_H
+#pragma once
 
 #include <sstream>
 #include <unordered_set>
@@ -167,5 +166,3 @@ private:
 } // namespace cuda
 } // namespace codegen
 } // namespace dawn
-
-#endif

--- a/dawn/src/dawn/CodeGen/Driver.h
+++ b/dawn/src/dawn/CodeGen/Driver.h
@@ -12,8 +12,7 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
-#ifndef DAWN_CODEGEN_DRIVER_H
-#define DAWN_CODEGEN_DRIVER_H
+#pragma once
 
 #include "dawn/CodeGen/Options.h"
 #include "dawn/CodeGen/TranslationUnit.h"
@@ -50,5 +49,3 @@ std::string generate(const std::unique_ptr<TranslationUnit>& translationUnit);
 
 } // namespace codegen
 } // namespace dawn
-
-#endif

--- a/dawn/src/dawn/CodeGen/GridTools/ASTStencilBody.h
+++ b/dawn/src/dawn/CodeGen/GridTools/ASTStencilBody.h
@@ -12,8 +12,7 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
-#ifndef DAWN_CODEGEN_GRIDTOOLS_ASTSTENCILBODY_H
-#define DAWN_CODEGEN_GRIDTOOLS_ASTSTENCILBODY_H
+#pragma once
 
 #include "dawn/CodeGen/ASTCodeGenCXX.h"
 #include "dawn/IIR/Interval.h"
@@ -84,5 +83,3 @@ public:
 } // namespace gt
 } // namespace codegen
 } // namespace dawn
-
-#endif

--- a/dawn/src/dawn/CodeGen/GridTools/ASTStencilDesc.h
+++ b/dawn/src/dawn/CodeGen/GridTools/ASTStencilDesc.h
@@ -12,8 +12,7 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
-#ifndef DAWN_CODEGEN_GRIDTOOLS_ASTSTENCILDESC_H
-#define DAWN_CODEGEN_GRIDTOOLS_ASTSTENCILDESC_H
+#pragma once
 
 #include "dawn/CodeGen/ASTCodeGenCXX.h"
 #include "dawn/CodeGen/CodeGenProperties.h"
@@ -70,5 +69,3 @@ public:
 } // namespace gt
 } // namespace codegen
 } // namespace dawn
-
-#endif

--- a/dawn/src/dawn/CodeGen/GridTools/CodeGenUtils.h
+++ b/dawn/src/dawn/CodeGen/GridTools/CodeGenUtils.h
@@ -12,8 +12,7 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
-#ifndef DAWN_CODEGEN_GRIDTOOLS_CODEGENUTILS_H
-#define DAWN_CODEGEN_GRIDTOOLS_CODEGENUTILS_H
+#pragma once
 
 #include "dawn/IIR/Stencil.h"
 #include <map>
@@ -35,5 +34,3 @@ struct CodeGenUtils {
 } // namespace gt
 } // namespace codegen
 } // namespace dawn
-
-#endif

--- a/dawn/src/dawn/CodeGen/GridTools/GTCodeGen.h
+++ b/dawn/src/dawn/CodeGen/GridTools/GTCodeGen.h
@@ -12,8 +12,7 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
-#ifndef DAWN_CODEGEN_GRIDTOOLS_GTCODEGEN_H
-#define DAWN_CODEGEN_GRIDTOOLS_GTCODEGEN_H
+#pragma once
 
 #include "dawn/CodeGen/CodeGen.h"
 #include "dawn/CodeGen/CodeGenProperties.h"
@@ -141,5 +140,3 @@ private:
 } // namespace gt
 } // namespace codegen
 } // namespace dawn
-
-#endif

--- a/dawn/src/dawn/CodeGen/Options.h
+++ b/dawn/src/dawn/CodeGen/Options.h
@@ -12,8 +12,7 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
-#ifndef DAWN_CODEGEN_OPTIONS_H
-#define DAWN_CODEGEN_OPTIONS_H
+#pragma once
 
 namespace dawn {
 namespace codegen {
@@ -33,5 +32,3 @@ struct Options {
 
 } // namespace codegen
 } // namespace dawn
-
-#endif

--- a/dawn/src/dawn/CodeGen/StencilFunctionAsBCGenerator.h
+++ b/dawn/src/dawn/CodeGen/StencilFunctionAsBCGenerator.h
@@ -12,8 +12,7 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
-#ifndef DAWN_CODEGEN_STENCILFUNCTIONASBCGENERATOR_H
-#define DAWN_CODEGEN_STENCILFUNCTIONASBCGENERATOR_H
+#pragma once
 
 #include "dawn/CodeGen/ASTCodeGenCXX.h"
 #include "dawn/CodeGen/CXXUtil.h"
@@ -90,4 +89,3 @@ public:
 };
 } // namespace codegen
 } // namespace dawn
-#endif

--- a/dawn/src/dawn/CodeGen/TranslationUnit.h
+++ b/dawn/src/dawn/CodeGen/TranslationUnit.h
@@ -12,8 +12,7 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
-#ifndef DAWN_CODEGEN_TRANSLATIONUNIT_H
-#define DAWN_CODEGEN_TRANSLATIONUNIT_H
+#pragma once
 
 #include <map>
 #include <string>
@@ -55,5 +54,3 @@ public:
 
 } // namespace codegen
 } // namespace dawn
-
-#endif

--- a/dawn/src/dawn/Compiler/Driver.h
+++ b/dawn/src/dawn/Compiler/Driver.h
@@ -12,8 +12,7 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
-#ifndef DAWN_COMPILER_DRIVER_H
-#define DAWN_COMPILER_DRIVER_H
+#pragma once
 
 #include "dawn/CodeGen/Driver.h"
 #include "dawn/CodeGen/Options.h"
@@ -68,5 +67,3 @@ std::string compile(const std::string& sir, SIRSerializer::Format format,
                     codegen::Backend backend, const codegen::Options& codegenOptions);
 
 } // namespace dawn
-
-#endif

--- a/dawn/src/dawn/Dawn.h
+++ b/dawn/src/dawn/Dawn.h
@@ -12,8 +12,7 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
-#ifndef DAWN_DAWN_H
-#define DAWN_DAWN_H
+#pragma once
 
 #ifdef DAWN_DOXYGEN_INVOKED
 /**
@@ -44,5 +43,3 @@
 
 #include "dawn/Compiler/Compiler.h"
 #include "dawn/SIR/SIR.h"
-
-#endif

--- a/dawn/src/dawn/IIR/AST.h
+++ b/dawn/src/dawn/IIR/AST.h
@@ -12,8 +12,7 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
-#ifndef DAWN_IIR_AST_H
-#define DAWN_IIR_AST_H
+#pragma once
 
 #include "dawn/AST/AST.h"
 #include "dawn/IIR/ASTStmt.h"
@@ -29,5 +28,3 @@ inline std::shared_ptr<ast::AST> makeAST() {
 using AST = ast::AST;
 } // namespace iir
 } // namespace dawn
-
-#endif

--- a/dawn/src/dawn/IIR/ASTConverter.h
+++ b/dawn/src/dawn/IIR/ASTConverter.h
@@ -12,8 +12,7 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
-#ifndef DAWN_IIR_ASTCONVERTER_H
-#define DAWN_IIR_ASTCONVERTER_H
+#pragma once
 
 #include "dawn/IIR/ASTStmt.h"
 #include "dawn/SIR/ASTStmt.h"
@@ -53,5 +52,3 @@ private:
 };
 
 } // namespace dawn
-
-#endif

--- a/dawn/src/dawn/IIR/ASTExpr.h
+++ b/dawn/src/dawn/IIR/ASTExpr.h
@@ -12,8 +12,7 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
-#ifndef DAWN_IIR_ASTEXPR_H
-#define DAWN_IIR_ASTEXPR_H
+#pragma once
 
 #include "dawn/AST/ASTExpr.h"
 
@@ -62,5 +61,3 @@ int getAccessID(const std::shared_ptr<Expr>& expr);
 
 } // namespace iir
 } // namespace dawn
-
-#endif

--- a/dawn/src/dawn/IIR/ASTFwd.h
+++ b/dawn/src/dawn/IIR/ASTFwd.h
@@ -12,8 +12,7 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
-#ifndef DAWN_IIR_ASTFWD_H
-#define DAWN_IIR_ASTFWD_H
+#pragma once
 
 #include "dawn/AST/ASTFwd.h"
 
@@ -53,5 +52,3 @@ using ASTHelper = ast::ASTHelper;
 using ASTVisitor = ast::ASTVisitor;
 } // namespace iir
 } // namespace dawn
-
-#endif

--- a/dawn/src/dawn/IIR/ASTMatcher.h
+++ b/dawn/src/dawn/IIR/ASTMatcher.h
@@ -12,8 +12,7 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
-#ifndef DAWN_AST_ASTMATCHER_H
-#define DAWN_AST_ASTMATCHER_H
+#pragma once
 
 #include "dawn/AST/ASTVisitor.h"
 #include "dawn/IIR/StencilInstantiation.h"
@@ -69,5 +68,3 @@ private:
 
 } // namespace iir
 } // namespace dawn
-
-#endif // DAWN_AST_ASTMATCHER_H

--- a/dawn/src/dawn/IIR/ASTStmt.h
+++ b/dawn/src/dawn/IIR/ASTStmt.h
@@ -12,8 +12,7 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
-#ifndef DAWN_IIR_ASTSTMT_H
-#define DAWN_IIR_ASTSTMT_H
+#pragma once
 
 #include "dawn/AST/ASTStmt.h"
 #include "dawn/IIR/Accesses.h"
@@ -143,5 +142,3 @@ int getAccessID(const std::shared_ptr<VarDeclStmt>& stmt);
 
 } // namespace iir
 } // namespace dawn
-
-#endif

--- a/dawn/src/dawn/IIR/ASTStringifier.h
+++ b/dawn/src/dawn/IIR/ASTStringifier.h
@@ -12,8 +12,7 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
-#ifndef DAWN_IIR_ASTSTRINGIFER_H
-#define DAWN_IIR_ASTSTRINGIFER_H
+#pragma once
 
 #include "dawn/AST/ASTStringifier.h"
 #include "dawn/IIR/ASTFwd.h"
@@ -35,5 +34,3 @@ extern inline std::ostream& operator<<(std::ostream& os, const std::shared_ptr<E
 }
 } // namespace iir
 } // namespace dawn
-
-#endif

--- a/dawn/src/dawn/IIR/ASTUtil.h
+++ b/dawn/src/dawn/IIR/ASTUtil.h
@@ -12,8 +12,7 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
-#ifndef DAWN_IIR_ASTUTIL_H
-#define DAWN_IIR_ASTUTIL_H
+#pragma once
 
 #include "dawn/AST/ASTUtil.h"
 #include "dawn/IIR/ASTFwd.h"
@@ -84,5 +83,3 @@ extern bool evalExprAsBoolean(const std::shared_ptr<Expr>& expr, bool& result,
 using ASTHelper = ast::ASTHelper;
 } // namespace iir
 } // namespace dawn
-
-#endif

--- a/dawn/src/dawn/IIR/ASTVisitor.h
+++ b/dawn/src/dawn/IIR/ASTVisitor.h
@@ -12,8 +12,7 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
-#ifndef DAWN_IIR_ASTVISITOR_H
-#define DAWN_IIR_ASTVISITOR_H
+#pragma once
 
 #include "dawn/AST/ASTVisitor.h"
 
@@ -30,5 +29,3 @@ using ASTVisitorForwardingNonConst = ast::ASTVisitorForwardingNonConst;
 using ASTVisitorDisabled = ast::ASTVisitorDisabled;
 } // namespace iir
 } // namespace dawn
-
-#endif

--- a/dawn/src/dawn/IIR/AccessComputation.h
+++ b/dawn/src/dawn/IIR/AccessComputation.h
@@ -12,8 +12,7 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
-#ifndef DAWN_IIR_ACCESSCOMPUTATION_H
-#define DAWN_IIR_ACCESSCOMPUTATION_H
+#pragma once
 
 #include "dawn/IIR/ASTFwd.h"
 #include "dawn/Support/ArrayRef.h"
@@ -53,5 +52,3 @@ void computeAccesses(
 /// @}
 
 } // namespace dawn
-
-#endif

--- a/dawn/src/dawn/IIR/AccessToNameMapper.h
+++ b/dawn/src/dawn/IIR/AccessToNameMapper.h
@@ -12,8 +12,7 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
-#ifndef DAWN_IIR_ACCESSTONAMEMAPPER_H
-#define DAWN_IIR_ACCESSTONAMEMAPPER_H
+#pragma once
 
 #include "dawn/IIR/ASTFwd.h"
 #include "dawn/IIR/ASTVisitor.h"
@@ -55,5 +54,3 @@ private:
 
 } // namespace iir
 } // namespace dawn
-
-#endif

--- a/dawn/src/dawn/IIR/AccessUtils.h
+++ b/dawn/src/dawn/IIR/AccessUtils.h
@@ -12,8 +12,7 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
-#ifndef DAWN_IIR_ACCESSUTILS_H
-#define DAWN_IIR_ACCESSUTILS_H
+#pragma once
 
 #include "dawn/IIR/Accesses.h"
 #include "dawn/IIR/Field.h"
@@ -49,5 +48,3 @@ void recordReadAccess(std::unordered_map<int, iir::Field>& inputOutputFields,
 
 } // namespace AccessUtils
 } // namespace dawn
-
-#endif // DAWN_IIR_ACCESSUTILS_H

--- a/dawn/src/dawn/IIR/Accesses.h
+++ b/dawn/src/dawn/IIR/Accesses.h
@@ -12,8 +12,7 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
-#ifndef DAWN_IIR_ACCESSES_H
-#define DAWN_IIR_ACCESSES_H
+#pragma once
 
 #include "dawn/AST/Offsets.h"
 #include "dawn/IIR/Extents.h"
@@ -99,5 +98,3 @@ public:
 
 } // namespace iir
 } // namespace dawn
-
-#endif

--- a/dawn/src/dawn/IIR/Cache.h
+++ b/dawn/src/dawn/IIR/Cache.h
@@ -12,8 +12,7 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
-#ifndef DAWN_IIR_CACHE_H
-#define DAWN_IIR_CACHE_H
+#pragma once
 
 #include "dawn/IIR/Interval.h"
 #include "dawn/Support/HashCombine.h"
@@ -127,5 +126,3 @@ struct hash<dawn::iir::Cache> {
 };
 
 } // namespace std
-
-#endif

--- a/dawn/src/dawn/IIR/ControlFlowDescriptor.h
+++ b/dawn/src/dawn/IIR/ControlFlowDescriptor.h
@@ -11,8 +11,7 @@
 //  See LICENSE.txt for details.
 //
 //===------------------------------------------------------------------------------------------===//
-#ifndef DAWN_IIR_CONTROLFLOWDESCRIPTOR_H
-#define DAWN_IIR_CONTROLFLOWDESCRIPTOR_H
+#pragma once
 
 #include "dawn/IIR/ASTStmt.h"
 #include <set>
@@ -51,5 +50,3 @@ public:
 };
 } // namespace iir
 } // namespace dawn
-
-#endif

--- a/dawn/src/dawn/IIR/DependencyGraph.h
+++ b/dawn/src/dawn/IIR/DependencyGraph.h
@@ -12,8 +12,7 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
-#ifndef DAWN_IIR_DEPENDENCYGRAPH_H
-#define DAWN_IIR_DEPENDENCYGRAPH_H
+#pragma once
 
 #include "dawn/Support/Assert.h"
 #include "dawn/Support/Unreachable.h"
@@ -278,5 +277,3 @@ protected:
 
 } // namespace iir
 } // namespace dawn
-
-#endif

--- a/dawn/src/dawn/IIR/DependencyGraphAccesses.h
+++ b/dawn/src/dawn/IIR/DependencyGraphAccesses.h
@@ -12,8 +12,7 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
-#ifndef DAWN_IIR_DEPENDENCYGRAPHACCESSES_H
-#define DAWN_IIR_DEPENDENCYGRAPHACCESSES_H
+#pragma once
 
 #include "dawn/IIR/ASTFwd.h"
 #include "dawn/IIR/DependencyGraph.h"
@@ -182,5 +181,3 @@ public:
 };
 } // namespace iir
 } // namespace dawn
-
-#endif

--- a/dawn/src/dawn/IIR/DependencyGraphStage.h
+++ b/dawn/src/dawn/IIR/DependencyGraphStage.h
@@ -12,8 +12,7 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
-#ifndef DAWN_IIR_DEPENDENCYGRAPHSTAGE_H
-#define DAWN_IIR_DEPENDENCYGRAPHSTAGE_H
+#pragma once
 
 #include "dawn/IIR/DependencyGraph.h"
 
@@ -64,5 +63,3 @@ public:
 
 } // namespace iir
 } // namespace dawn
-
-#endif

--- a/dawn/src/dawn/IIR/DoMethod.h
+++ b/dawn/src/dawn/IIR/DoMethod.h
@@ -12,8 +12,7 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
-#ifndef DAWN_IIR_DOMETHOD_H
-#define DAWN_IIR_DOMETHOD_H
+#pragma once
 
 #include "dawn/IIR/ASTFwd.h"
 #include "dawn/IIR/DependencyGraphAccesses.h"
@@ -148,5 +147,3 @@ auto iterateIIROverStmt(const RootNode& root) {
   return allStmts;
 }
 } // namespace dawn
-
-#endif

--- a/dawn/src/dawn/IIR/Extents.h
+++ b/dawn/src/dawn/IIR/Extents.h
@@ -12,8 +12,7 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
-#ifndef DAWN_IIR_EXTENTS_H
-#define DAWN_IIR_EXTENTS_H
+#pragma once
 
 #include "LoopOrder.h"
 
@@ -343,5 +342,3 @@ struct hash<dawn::iir::Extents> {
 };
 
 } // namespace std
-
-#endif

--- a/dawn/src/dawn/IIR/Field.h
+++ b/dawn/src/dawn/IIR/Field.h
@@ -12,8 +12,7 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
-#ifndef DAWN_IIR_FIELD_H
-#define DAWN_IIR_FIELD_H
+#pragma once
 
 #include "dawn/AST/ASTExpr.h"
 #include "dawn/IIR/Extents.h"
@@ -161,5 +160,3 @@ struct hash<dawn::iir::Field> {
 };
 
 } // namespace std
-
-#endif

--- a/dawn/src/dawn/IIR/FieldAccessExtents.h
+++ b/dawn/src/dawn/IIR/FieldAccessExtents.h
@@ -12,8 +12,7 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
-#ifndef DAWN_IIR_FIELDACCESSEXTENTS_H
-#define DAWN_IIR_FIELDACCESSEXTENTS_H
+#pragma once
 
 #include "dawn/IIR/Extents.h"
 #include "dawn/Support/Json.h"
@@ -61,4 +60,3 @@ private:
 
 } // namespace iir
 } // namespace dawn
-#endif

--- a/dawn/src/dawn/IIR/FieldAccessMetadata.h
+++ b/dawn/src/dawn/IIR/FieldAccessMetadata.h
@@ -12,8 +12,7 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
-#ifndef DAWN_IIR_FIELDACCESSMETADATA_H
-#define DAWN_IIR_FIELDACCESSMETADATA_H
+#pragma once
 
 #include "dawn/Support/Assert.h"
 #include "dawn/Support/Json.h"
@@ -253,5 +252,3 @@ struct FieldAccessMetadata {
 };
 } // namespace iir
 } // namespace dawn
-
-#endif

--- a/dawn/src/dawn/IIR/IIR.h
+++ b/dawn/src/dawn/IIR/IIR.h
@@ -12,8 +12,7 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
-#ifndef DAWN_IIR_IIR_H
-#define DAWN_IIR_IIR_H
+#pragma once
 
 #include "dawn/AST/GridType.h"
 #include "dawn/IIR/ControlFlowDescriptor.h"
@@ -113,5 +112,3 @@ public:
 };
 } // namespace iir
 } // namespace dawn
-
-#endif

--- a/dawn/src/dawn/IIR/IIRNode.h
+++ b/dawn/src/dawn/IIR/IIRNode.h
@@ -12,8 +12,7 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
-#ifndef DAWN_IIR_IIRNODE_H
-#define DAWN_IIR_IIRNODE_H
+#pragma once
 
 #include "dawn/IIR/NodeUpdateType.h"
 #include "dawn/Support/Assert.h"
@@ -676,5 +675,3 @@ private:
 } // namespace dawn
 
 #undef PROTECT_TEMPLATE
-
-#endif

--- a/dawn/src/dawn/IIR/IIRNodeIterator.h
+++ b/dawn/src/dawn/IIR/IIRNodeIterator.h
@@ -12,8 +12,7 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
-#ifndef DAWN_IIR_IIRNODEITERATOR_H
-#define DAWN_IIR_IIRNODEITERATOR_H
+#pragma once
 
 #include "dawn/Support/Assert.h"
 #include "dawn/Support/Unreachable.h"
@@ -201,5 +200,3 @@ struct iterator_traits<dawn::iir::IIRNodeIterator<RootNode, LeafNode>> {
       typename iterator_traits<typename LeafNode::ChildIterator>::iterator_category;
 };
 } // namespace std
-
-#endif

--- a/dawn/src/dawn/IIR/InstantiationHelper.h
+++ b/dawn/src/dawn/IIR/InstantiationHelper.h
@@ -12,8 +12,7 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
-#ifndef DAWN_IIR_INSTANTIATIONHELPER_H
-#define DAWN_IIR_INSTANTIATIONHELPER_H
+#pragma once
 
 #include "dawn/Support/NonCopyable.h"
 #include <string>
@@ -51,5 +50,3 @@ public:
 };
 } // namespace iir
 } // namespace dawn
-
-#endif

--- a/dawn/src/dawn/IIR/Interval.h
+++ b/dawn/src/dawn/IIR/Interval.h
@@ -12,8 +12,7 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
-#ifndef DAWN_IIR_INTERVAL_H
-#define DAWN_IIR_INTERVAL_H
+#pragma once
 
 #include "dawn/IIR/Extents.h"
 #include "dawn/SIR/SIR.h"
@@ -331,5 +330,3 @@ struct hash<dawn::iir::IntervalProperties> {
 };
 
 } // namespace std
-
-#endif

--- a/dawn/src/dawn/IIR/IntervalAlgorithms.h
+++ b/dawn/src/dawn/IIR/IntervalAlgorithms.h
@@ -13,8 +13,7 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
-#ifndef DAWN_IIR_INTERVALALGORITHMS_H
-#define DAWN_IIR_INTERVALALGORITHMS_H
+#pragma once
 
 #include "dawn/IIR/Cache.h"
 #include "dawn/IIR/Interval.h"
@@ -43,5 +42,3 @@ Cache::window computeWindowOffset(LoopOrderKind loopOrder, iir::Interval const& 
 
 } // namespace iir
 } // namespace dawn
-
-#endif

--- a/dawn/src/dawn/IIR/LoopOrder.h
+++ b/dawn/src/dawn/IIR/LoopOrder.h
@@ -12,8 +12,7 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
-#ifndef DAWN_IIR_LOOPORDER_H
-#define DAWN_IIR_LOOPORDER_H
+#pragma once
 
 #include <iosfwd>
 
@@ -51,5 +50,3 @@ void increment(int& lev, LoopOrderKind order, int step);
 bool isLevelExecBeforeEqThan(int level, int limit, LoopOrderKind order);
 } // namespace iir
 } // namespace dawn
-
-#endif

--- a/dawn/src/dawn/IIR/MultiInterval.h
+++ b/dawn/src/dawn/IIR/MultiInterval.h
@@ -12,8 +12,7 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
-#ifndef DAWN_IIR_MULTIINTERVAL_H
-#define DAWN_IIR_MULTIINTERVAL_H
+#pragma once
 
 #include "dawn/IIR/Interval.h"
 #include <list>
@@ -53,5 +52,3 @@ public:
 
 } // namespace iir
 } // namespace dawn
-
-#endif

--- a/dawn/src/dawn/IIR/MultiStage.h
+++ b/dawn/src/dawn/IIR/MultiStage.h
@@ -12,8 +12,7 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
-#ifndef DAWN_IIR_MULTISTAGE_H
-#define DAWN_IIR_MULTISTAGE_H
+#pragma once
 
 #include "dawn/IIR/Cache.h"
 #include "dawn/IIR/IIRNode.h"
@@ -202,5 +201,3 @@ public:
 
 } // namespace iir
 } // namespace dawn
-
-#endif

--- a/dawn/src/dawn/IIR/NodeUpdateType.h
+++ b/dawn/src/dawn/IIR/NodeUpdateType.h
@@ -12,8 +12,7 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
-#ifndef DAWN_IIR_NODEUPDATETYPE_H
-#define DAWN_IIR_NODEUPDATETYPE_H
+#pragma once
 
 namespace dawn {
 namespace iir {
@@ -36,5 +35,3 @@ bool updateTreeBelow(NodeUpdateType updateType);
 } // namespace impl
 } // namespace iir
 } // namespace dawn
-
-#endif

--- a/dawn/src/dawn/IIR/Stage.h
+++ b/dawn/src/dawn/IIR/Stage.h
@@ -12,8 +12,7 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
-#ifndef DAWN_IIR_STAGE_H
-#define DAWN_IIR_STAGE_H
+#pragma once
 
 #include "dawn/IIR/DoMethod.h"
 #include "dawn/IIR/Extents.h"
@@ -255,5 +254,3 @@ public:
 
 } // namespace iir
 } // namespace dawn
-
-#endif

--- a/dawn/src/dawn/IIR/Stencil.h
+++ b/dawn/src/dawn/IIR/Stencil.h
@@ -12,8 +12,7 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
-#ifndef DAWN_IIR_STENCIL_H
-#define DAWN_IIR_STENCIL_H
+#pragma once
 
 #include "dawn/IIR/DependencyGraphStage.h"
 #include "dawn/IIR/IIRNodeIterator.h"
@@ -309,5 +308,3 @@ private:
 } // namespace iir
 
 } // namespace dawn
-
-#endif

--- a/dawn/src/dawn/IIR/StencilFunctionInstantiation.h
+++ b/dawn/src/dawn/IIR/StencilFunctionInstantiation.h
@@ -12,8 +12,7 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
-#ifndef DAWN_IIR_STENCILFUNCTIONINSTANTIATION_H
-#define DAWN_IIR_STENCILFUNCTIONINSTANTIATION_H
+#pragma once
 
 #include "dawn/IIR/DoMethod.h"
 #include "dawn/IIR/Extents.h"
@@ -427,5 +426,3 @@ public:
 
 } // namespace iir
 } // namespace dawn
-
-#endif

--- a/dawn/src/dawn/IIR/StencilInstantiation.h
+++ b/dawn/src/dawn/IIR/StencilInstantiation.h
@@ -12,8 +12,7 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
-#ifndef DAWN_IIR_STENCILINSTANTIATION_H
-#define DAWN_IIR_STENCILINSTANTIATION_H
+#pragma once
 
 #include "dawn/IIR/Accesses.h"
 #include "dawn/IIR/IIR.h"
@@ -127,5 +126,3 @@ public:
 };
 } // namespace iir
 } // namespace dawn
-
-#endif

--- a/dawn/src/dawn/IIR/StencilMetaInformation.h
+++ b/dawn/src/dawn/IIR/StencilMetaInformation.h
@@ -12,8 +12,7 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
-#ifndef DAWN_IIR_METAINFORMATION_H
-#define DAWN_IIR_METAINFORMATION_H
+#pragma once
 
 #include "dawn/IIR/ASTFwd.h"
 #include "dawn/IIR/Extents.h"
@@ -429,5 +428,3 @@ private:
 };
 } // namespace iir
 } // namespace dawn
-
-#endif

--- a/dawn/src/dawn/Optimizer/CreateVersionAndRename.h
+++ b/dawn/src/dawn/Optimizer/CreateVersionAndRename.h
@@ -12,8 +12,7 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
-#ifndef DAWN_OPTIMIZER_CREATEVERSIONANDRENAME_H
-#define DAWN_OPTIMIZER_CREATEVERSIONANDRENAME_H
+#pragma once
 
 #include "dawn/IIR/ASTFwd.h"
 #include <memory>
@@ -65,5 +64,3 @@ int createVersionAndRename(iir::StencilInstantiation* instantiation, int AccessI
                            std::shared_ptr<iir::Expr>& expr, RenameDirection dir);
 
 } // namespace dawn
-
-#endif // DAWN_OPTIMIZER_CREATEVERSIONANDRENAME_H

--- a/dawn/src/dawn/Optimizer/Driver.h
+++ b/dawn/src/dawn/Optimizer/Driver.h
@@ -12,8 +12,7 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
-#ifndef DAWN_OPTIMIZER_DRIVER_H
-#define DAWN_OPTIMIZER_DRIVER_H
+#pragma once
 
 #include "dawn/Optimizer/Options.h"
 
@@ -28,5 +27,3 @@ std::list<PassGroup> defaultPassGroups();
 /// TODO Driver methods will go here when OptimizerContext is removed.
 
 } // namespace dawn
-
-#endif

--- a/dawn/src/dawn/Optimizer/OptimizerContext.h
+++ b/dawn/src/dawn/Optimizer/OptimizerContext.h
@@ -12,8 +12,7 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
-#ifndef DAWN_OPTIMIZER_OPTIMIZERCONTEXT_H
-#define DAWN_OPTIMIZER_OPTIMIZERCONTEXT_H
+#pragma once
 
 #include "dawn/Optimizer/PassManager.h"
 #include "dawn/Support/DiagnosticsEngine.h"
@@ -120,5 +119,3 @@ public:
 };
 
 } // namespace dawn
-
-#endif

--- a/dawn/src/dawn/Optimizer/Options.h
+++ b/dawn/src/dawn/Optimizer/Options.h
@@ -12,8 +12,7 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
-#ifndef DAWN_OPTIMIZER_OPTIMIZEROPTIONS_H
-#define DAWN_OPTIMIZER_OPTIMIZEROPTIONS_H
+#pragma once
 
 #include <string>
 
@@ -45,5 +44,3 @@ struct Options {
 };
 
 } // namespace dawn
-
-#endif

--- a/dawn/src/dawn/Optimizer/Pass.h
+++ b/dawn/src/dawn/Optimizer/Pass.h
@@ -12,8 +12,7 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
-#ifndef DAWN_OPTIMIZER_PASS_H
-#define DAWN_OPTIMIZER_PASS_H
+#pragma once
 
 #include <memory>
 #include <string>
@@ -69,5 +68,3 @@ public:
 };
 
 } // namespace dawn
-
-#endif

--- a/dawn/src/dawn/Optimizer/PassDataLocalityMetric.h
+++ b/dawn/src/dawn/Optimizer/PassDataLocalityMetric.h
@@ -12,8 +12,7 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
-#ifndef DAWN_OPTIMIZER_PASSDATALOCALITYMETRIC_H
-#define DAWN_OPTIMIZER_PASSDATALOCALITYMETRIC_H
+#pragma once
 
 #include "dawn/IIR/MultiStage.h"
 #include "dawn/Optimizer/Pass.h"
@@ -52,5 +51,3 @@ std::unordered_map<int, ReadWriteAccumulator> computeReadWriteAccessesMetricPerA
     const iir::MultiStage& multiStage);
 
 } // namespace dawn
-
-#endif

--- a/dawn/src/dawn/Optimizer/PassFieldVersioning.h
+++ b/dawn/src/dawn/Optimizer/PassFieldVersioning.h
@@ -12,8 +12,7 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
-#ifndef DAWN_OPTIMIZER_PASSFIELDVERSIONING_H
-#define DAWN_OPTIMIZER_PASSFIELDVERSIONING_H
+#pragma once
 
 #include "dawn/IIR/LoopOrder.h"
 #include "dawn/Optimizer/Pass.h"
@@ -85,5 +84,3 @@ public:
 };
 
 } // namespace dawn
-
-#endif

--- a/dawn/src/dawn/Optimizer/PassFixVersionedInputFields.h
+++ b/dawn/src/dawn/Optimizer/PassFixVersionedInputFields.h
@@ -12,8 +12,7 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
-#ifndef DAWN_OPTIMIZER_PASSFIXVERSIONEDINPUTFIELDS_H
-#define DAWN_OPTIMIZER_PASSFIXVERSIONEDINPUTFIELDS_H
+#pragma once
 
 #include "dawn/Optimizer/Pass.h"
 
@@ -32,5 +31,3 @@ public:
 };
 
 } // namespace dawn
-
-#endif

--- a/dawn/src/dawn/Optimizer/PassInlining.h
+++ b/dawn/src/dawn/Optimizer/PassInlining.h
@@ -12,8 +12,7 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
-#ifndef DAWN_OPTIMIZER_PASSINLINING_H
-#define DAWN_OPTIMIZER_PASSINLINING_H
+#pragma once
 
 #include "dawn/Optimizer/Pass.h"
 
@@ -49,5 +48,3 @@ private:
 };
 
 } // namespace dawn
-
-#endif

--- a/dawn/src/dawn/Optimizer/PassIntervalPartitioning.h
+++ b/dawn/src/dawn/Optimizer/PassIntervalPartitioning.h
@@ -12,8 +12,7 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
-#ifndef DAWN_OPTIMIZER_PASSINTERVALPARTITIONER_H
-#define DAWN_OPTIMIZER_PASSINTERVALPARTITIONER_H
+#pragma once
 
 #include "dawn/Optimizer/Pass.h"
 #include "dawn/Support/Assert.h"
@@ -47,5 +46,3 @@ public:
 };
 
 } // namespace dawn
-
-#endif

--- a/dawn/src/dawn/Optimizer/PassManager.h
+++ b/dawn/src/dawn/Optimizer/PassManager.h
@@ -12,8 +12,7 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
-#ifndef DAWN_OPTIMIZER_PASSMANAGER_H
-#define DAWN_OPTIMIZER_PASSMANAGER_H
+#pragma once
 
 #include "dawn/Optimizer/Pass.h"
 #include "dawn/Optimizer/PassValidation.h"
@@ -53,5 +52,3 @@ public:
 };
 
 } // namespace dawn
-
-#endif

--- a/dawn/src/dawn/Optimizer/PassMultiStageSplitter.h
+++ b/dawn/src/dawn/Optimizer/PassMultiStageSplitter.h
@@ -12,8 +12,7 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
-#ifndef DAWN_OPTIMIZER_PASSMULTISTAGESPLITTER_H
-#define DAWN_OPTIMIZER_PASSMULTISTAGESPLITTER_H
+#pragma once
 
 #include "dawn/Optimizer/Pass.h"
 
@@ -41,5 +40,3 @@ private:
 };
 
 } // namespace dawn
-
-#endif

--- a/dawn/src/dawn/Optimizer/PassPrintStencilGraph.h
+++ b/dawn/src/dawn/Optimizer/PassPrintStencilGraph.h
@@ -12,8 +12,7 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
-#ifndef DAWN_OPTIMIZER_PASSPRINTSTENCILGRAPH_H
-#define DAWN_OPTIMIZER_PASSPRINTSTENCILGRAPH_H
+#pragma once
 
 #include "dawn/Optimizer/Pass.h"
 
@@ -35,5 +34,3 @@ public:
 };
 
 } // namespace dawn
-
-#endif

--- a/dawn/src/dawn/Optimizer/PassSSA.h
+++ b/dawn/src/dawn/Optimizer/PassSSA.h
@@ -12,8 +12,7 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
-#ifndef DAWN_OPTIMIZER_PASSSSA_H
-#define DAWN_OPTIMIZER_PASSSSA_H
+#pragma once
 
 #include "dawn/Optimizer/Pass.h"
 
@@ -34,5 +33,3 @@ public:
 };
 
 } // namespace dawn
-
-#endif

--- a/dawn/src/dawn/Optimizer/PassSetBlockSize.h
+++ b/dawn/src/dawn/Optimizer/PassSetBlockSize.h
@@ -12,8 +12,7 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
-#ifndef DAWN_OPTIMIZER_PASSSETBLOCKSIZE_H
-#define DAWN_OPTIMIZER_PASSSETBLOCKSIZE_H
+#pragma once
 
 #include "dawn/Optimizer/Pass.h"
 
@@ -35,5 +34,3 @@ public:
 };
 
 } // namespace dawn
-
-#endif

--- a/dawn/src/dawn/Optimizer/PassSetBoundaryCondition.h
+++ b/dawn/src/dawn/Optimizer/PassSetBoundaryCondition.h
@@ -12,8 +12,7 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
-#ifndef DAWN_OPTIMIZER_PASSSETBOUNDARYCONDITIONS_H
-#define DAWN_OPTIMIZER_PASSSETBOUNDARYCONDITIONS_H
+#pragma once
 
 #include "dawn/Optimizer/Pass.h"
 #include <unordered_map>
@@ -56,5 +55,3 @@ private:
 };
 
 } // namespace dawn
-
-#endif

--- a/dawn/src/dawn/Optimizer/PassSetCaches.h
+++ b/dawn/src/dawn/Optimizer/PassSetCaches.h
@@ -12,8 +12,7 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
-#ifndef DAWN_OPTIMIZER_PASSSETMULTISTAGECACHES_H
-#define DAWN_OPTIMIZER_PASSSETMULTISTAGECACHES_H
+#pragma once
 
 #include "dawn/IIR/Cache.h"
 #include "dawn/IIR/Interval.h"
@@ -37,5 +36,3 @@ public:
 };
 
 } // namespace dawn
-
-#endif

--- a/dawn/src/dawn/Optimizer/PassSetDependencyGraph.h
+++ b/dawn/src/dawn/Optimizer/PassSetDependencyGraph.h
@@ -12,8 +12,7 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
-#ifndef DAWN_OPTIMIZER_PASSSETDEPENDENCYGRAPH_H
-#define DAWN_OPTIMIZER_PASSSETDEPENDENCYGRAPH_H
+#pragma once
 
 #include "dawn/Optimizer/Pass.h"
 
@@ -29,5 +28,3 @@ public:
 };
 
 } // namespace dawn
-
-#endif // DAWN_OPTIMIZER_PASSSETDEPENDENCYGRAPH_H

--- a/dawn/src/dawn/Optimizer/PassSetNonTempCaches.h
+++ b/dawn/src/dawn/Optimizer/PassSetNonTempCaches.h
@@ -12,8 +12,7 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
-#ifndef DAWN_OPTIMIZER_PASSNONTEMPCACHES_H
-#define DAWN_OPTIMIZER_PASSNONTEMPCACHES_H
+#pragma once
 
 #include "dawn/Optimizer/Pass.h"
 
@@ -50,5 +49,3 @@ public:
 };
 
 } // namespace dawn
-
-#endif

--- a/dawn/src/dawn/Optimizer/PassSetStageGraph.h
+++ b/dawn/src/dawn/Optimizer/PassSetStageGraph.h
@@ -12,8 +12,7 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
-#ifndef DAWN_OPTIMIZER_PASSSETSTAGEGRAPH_H
-#define DAWN_OPTIMIZER_PASSSETSTAGEGRAPH_H
+#pragma once
 
 #include "dawn/Optimizer/Pass.h"
 
@@ -35,5 +34,3 @@ public:
 };
 
 } // namespace dawn
-
-#endif

--- a/dawn/src/dawn/Optimizer/PassSetStageName.h
+++ b/dawn/src/dawn/Optimizer/PassSetStageName.h
@@ -12,8 +12,7 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
-#ifndef DAWN_OPTIMIZER_PASSSETSTAGENAME_H
-#define DAWN_OPTIMIZER_PASSSETSTAGENAME_H
+#pragma once
 
 #include "dawn/Optimizer/Pass.h"
 
@@ -32,5 +31,3 @@ public:
 };
 
 } // namespace dawn
-
-#endif

--- a/dawn/src/dawn/Optimizer/PassSetSyncStage.h
+++ b/dawn/src/dawn/Optimizer/PassSetSyncStage.h
@@ -12,8 +12,7 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
-#ifndef DAWN_OPTIMIZER_PASSSETSYNCSTAGE_H
-#define DAWN_OPTIMIZER_PASSSETSYNCSTAGE_H
+#pragma once
 
 #include "dawn/IIR/Cache.h"
 #include "dawn/IIR/Interval.h"
@@ -40,5 +39,3 @@ private:
 };
 
 } // namespace dawn
-
-#endif

--- a/dawn/src/dawn/Optimizer/PassStageMerger.h
+++ b/dawn/src/dawn/Optimizer/PassStageMerger.h
@@ -12,8 +12,7 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
-#ifndef DAWN_OPTIMIZER_PASSSTAGEMERGER_H
-#define DAWN_OPTIMIZER_PASSSTAGEMERGER_H
+#pragma once
 
 #include "dawn/Optimizer/Pass.h"
 
@@ -41,5 +40,3 @@ public:
 };
 
 } // namespace dawn
-
-#endif

--- a/dawn/src/dawn/Optimizer/PassStageReordering.h
+++ b/dawn/src/dawn/Optimizer/PassStageReordering.h
@@ -12,8 +12,7 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
-#ifndef DAWN_OPTIMIZER_PASSSTAGEREORDERING_H
-#define DAWN_OPTIMIZER_PASSSTAGEREORDERING_H
+#pragma once
 
 #include "dawn/Optimizer/Pass.h"
 #include "dawn/Optimizer/ReorderStrategy.h"
@@ -39,5 +38,3 @@ private:
 };
 
 } // namespace dawn
-
-#endif

--- a/dawn/src/dawn/Optimizer/PassStageSplitter.h
+++ b/dawn/src/dawn/Optimizer/PassStageSplitter.h
@@ -12,8 +12,7 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
-#ifndef DAWN_OPTIMIZER_PASSSTAGESPLITTER_H
-#define DAWN_OPTIMIZER_PASSSTAGESPLITTER_H
+#pragma once
 
 #include "dawn/Optimizer/Pass.h"
 
@@ -35,5 +34,3 @@ public:
 };
 
 } // namespace dawn
-
-#endif

--- a/dawn/src/dawn/Optimizer/PassStencilSplitter.h
+++ b/dawn/src/dawn/Optimizer/PassStencilSplitter.h
@@ -12,8 +12,7 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
-#ifndef DAWN_OPTIMIZER_PASSSTENCILSPLITTER_H
-#define DAWN_OPTIMIZER_PASSSTENCILSPLITTER_H
+#pragma once
 
 #include "dawn/Optimizer/Pass.h"
 
@@ -40,5 +39,3 @@ public:
 };
 
 } // namespace dawn
-
-#endif

--- a/dawn/src/dawn/Optimizer/PassTemporaryFirstAccess.h
+++ b/dawn/src/dawn/Optimizer/PassTemporaryFirstAccess.h
@@ -12,8 +12,7 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
-#ifndef DAWN_OPTIMIZER_PASSTEMPORARYFIRSTACCESS_H
-#define DAWN_OPTIMIZER_PASSTEMPORARYFIRSTACCESS_H
+#pragma once
 
 #include "dawn/Optimizer/Pass.h"
 
@@ -31,5 +30,3 @@ public:
 };
 
 } // namespace dawn
-
-#endif

--- a/dawn/src/dawn/Optimizer/PassTemporaryMerger.h
+++ b/dawn/src/dawn/Optimizer/PassTemporaryMerger.h
@@ -12,8 +12,7 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
-#ifndef DAWN_OPTIMIZER_PASSTEMPORARYMERGER_H
-#define DAWN_OPTIMIZER_PASSTEMPORARYMERGER_H
+#pragma once
 
 #include "dawn/Optimizer/Pass.h"
 
@@ -32,5 +31,3 @@ public:
 };
 
 } // namespace dawn
-
-#endif

--- a/dawn/src/dawn/Optimizer/PassTemporaryToStencilFunction.h
+++ b/dawn/src/dawn/Optimizer/PassTemporaryToStencilFunction.h
@@ -12,8 +12,7 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
-#ifndef DAWN_OPTIMIZER_PASSTEMPORARYTOSTENCILFUNCTION_H
-#define DAWN_OPTIMIZER_PASSTEMPORARYTOSTENCILFUNCTION_H
+#pragma once
 
 #include "dawn/Optimizer/Pass.h"
 #include "dawn/Support/Assert.h"
@@ -63,5 +62,3 @@ private:
 };
 
 } // namespace dawn
-
-#endif

--- a/dawn/src/dawn/Optimizer/PassTemporaryType.h
+++ b/dawn/src/dawn/Optimizer/PassTemporaryType.h
@@ -12,8 +12,7 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
-#ifndef DAWN_OPTIMIZER_PASSTEMPORARYTYPE_H
-#define DAWN_OPTIMIZER_PASSTEMPORARYTYPE_H
+#pragma once
 
 #include "dawn/Optimizer/Pass.h"
 #include <memory>
@@ -91,5 +90,3 @@ public:
 };
 
 } // namespace dawn
-
-#endif

--- a/dawn/src/dawn/Optimizer/PassValidation.h
+++ b/dawn/src/dawn/Optimizer/PassValidation.h
@@ -12,8 +12,7 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
-#ifndef DAWN_OPTIMIZER_PASSINTEGRITYCHECK_H
-#define DAWN_OPTIMIZER_PASSINTEGRITYCHECK_H
+#pragma once
 
 #include "dawn/Optimizer/Pass.h"
 #include "dawn/SIR/SIR.h"
@@ -41,5 +40,3 @@ public:
 };
 
 } // namespace dawn
-
-#endif // DAWN_OPTIMIZER_PASSINTEGRITYCHECK_H

--- a/dawn/src/dawn/Optimizer/ReadBeforeWriteConflict.h
+++ b/dawn/src/dawn/Optimizer/ReadBeforeWriteConflict.h
@@ -12,8 +12,7 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
-#ifndef DAWN_OPTIMITZER_READBEFOREWRITECONFLICT_H
-#define DAWN_OPTIMITZER_READBEFOREWRITECONFLICT_H
+#pragma once
 
 #include "dawn/IIR/LoopOrder.h"
 
@@ -106,5 +105,3 @@ hasVerticalReadBeforeWriteConflict(const iir::DependencyGraphAccesses& graph,
 bool hasHorizontalReadBeforeWriteConflict(const iir::DependencyGraphAccesses& graph);
 
 } // namespace dawn
-
-#endif

--- a/dawn/src/dawn/Optimizer/Renaming.h
+++ b/dawn/src/dawn/Optimizer/Renaming.h
@@ -12,8 +12,7 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
-#ifndef DAWN_OPTIMIZER_RENAMING_H
-#define DAWN_OPTIMIZER_RENAMING_H
+#pragma once
 
 #include "dawn/IIR/ASTFwd.h"
 #include "dawn/IIR/DoMethod.h"
@@ -76,5 +75,3 @@ void renameAccessIDInStencil(iir::Stencil* stencil, int oldAccessID, int newAcce
 void renameCallerAccessIDInStencilFunction(iir::StencilFunctionInstantiation* function,
                                            int oldAccessID, int newAccessID);
 } // namespace dawn
-
-#endif

--- a/dawn/src/dawn/Optimizer/ReorderStrategy.h
+++ b/dawn/src/dawn/Optimizer/ReorderStrategy.h
@@ -12,8 +12,7 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
-#ifndef DAWN_OPTIMIZER_REORDERSTRATEGY_H
-#define DAWN_OPTIMIZER_REORDERSTRATEGY_H
+#pragma once
 
 #include <memory>
 
@@ -48,5 +47,3 @@ public:
 };
 
 } // namespace dawn
-
-#endif

--- a/dawn/src/dawn/Optimizer/ReorderStrategyGreedy.h
+++ b/dawn/src/dawn/Optimizer/ReorderStrategyGreedy.h
@@ -12,8 +12,7 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
-#ifndef DAWN_OPTIMIZER_REORDERSTRATEGYGREEDY_H
-#define DAWN_OPTIMIZER_REORDERSTRATEGYGREEDY_H
+#pragma once
 
 #include "dawn/Optimizer/ReorderStrategy.h"
 
@@ -34,5 +33,3 @@ public:
 };
 
 } // namespace dawn
-
-#endif

--- a/dawn/src/dawn/Optimizer/ReorderStrategyPartitioning.h
+++ b/dawn/src/dawn/Optimizer/ReorderStrategyPartitioning.h
@@ -12,8 +12,7 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
-#ifndef DAWN_OPTIMIZER_REORDERSTRATEGYPARTITIONING_H
-#define DAWN_OPTIMIZER_REORDERSTRATEGYPARTITIONING_H
+#pragma once
 
 #include "dawn/Optimizer/ReorderStrategy.h"
 
@@ -31,5 +30,3 @@ public:
 };
 
 } // namespace dawn
-
-#endif

--- a/dawn/src/dawn/Optimizer/Replacing.h
+++ b/dawn/src/dawn/Optimizer/Replacing.h
@@ -12,8 +12,7 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
-#ifndef DAWN_OPTIMIZER_REPLACING_H
-#define DAWN_OPTIMIZER_REPLACING_H
+#pragma once
 
 #include "dawn/IIR/ASTFwd.h"
 #include "dawn/IIR/ASTVisitor.h"
@@ -56,5 +55,3 @@ void replaceStencilCalls(const std::shared_ptr<iir::StencilInstantiation>& insta
 /// @}
 
 } // namespace dawn
-
-#endif

--- a/dawn/src/dawn/Optimizer/TemporaryHandling.h
+++ b/dawn/src/dawn/Optimizer/TemporaryHandling.h
@@ -11,8 +11,7 @@
 //  See LICENSE.txt for details.
 //
 //===------------------------------------------------------------------------------------------===/
-#ifndef DAWN_OPTIMIZER_TEMPORARYHANDLING_H
-#define DAWN_OPTIMIZER_TEMPORARYHANDLING_H
+#pragma once
 #include "dawn/IIR/StencilInstantiation.h"
 
 namespace dawn {
@@ -41,5 +40,3 @@ void demoteTemporaryFieldToLocalVariable(iir::StencilInstantiation* instantiatio
                                          iir::Stencil* stencil, int AccessID,
                                          const iir::Stencil::Lifetime& lifetime);
 } // namespace dawn
-
-#endif // DAWN_OPTIMIZER_TEMPORARYHANDLING_H

--- a/dawn/src/dawn/SIR/AST.h
+++ b/dawn/src/dawn/SIR/AST.h
@@ -12,8 +12,7 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
-#ifndef DAWN_SIR_AST_H
-#define DAWN_SIR_AST_H
+#pragma once
 
 #include "dawn/AST/AST.h"
 #include "dawn/SIR/ASTStmt.h"
@@ -29,5 +28,3 @@ inline std::shared_ptr<ast::AST> makeAST() {
 using AST = ast::AST;
 } // namespace sir
 } // namespace dawn
-
-#endif

--- a/dawn/src/dawn/SIR/ASTExpr.h
+++ b/dawn/src/dawn/SIR/ASTExpr.h
@@ -12,8 +12,7 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
-#ifndef DAWN_SIR_ASTEXPR_H
-#define DAWN_SIR_ASTEXPR_H
+#pragma once
 
 #include "dawn/AST/ASTExpr.h"
 
@@ -37,5 +36,3 @@ using LiteralAccessExpr = ast::LiteralAccessExpr;
 using ReductionOverNeighborExpr = ast::ReductionOverNeighborExpr;
 } // namespace sir
 } // namespace dawn
-
-#endif

--- a/dawn/src/dawn/SIR/ASTFwd.h
+++ b/dawn/src/dawn/SIR/ASTFwd.h
@@ -12,8 +12,7 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
-#ifndef DAWN_SIR_ASTFWD_H
-#define DAWN_SIR_ASTFWD_H
+#pragma once
 
 #include "dawn/AST/ASTFwd.h"
 
@@ -52,5 +51,3 @@ using ASTHelper = ast::ASTHelper;
 using ASTVisitor = ast::ASTVisitor;
 } // namespace sir
 } // namespace dawn
-
-#endif

--- a/dawn/src/dawn/SIR/ASTStmt.h
+++ b/dawn/src/dawn/SIR/ASTStmt.h
@@ -12,8 +12,7 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
-#ifndef DAWN_SIR_ASTSTMT_H
-#define DAWN_SIR_ASTSTMT_H
+#pragma once
 
 #include "dawn/AST/ASTStmt.h"
 
@@ -88,5 +87,3 @@ using LoopStmt = ast::LoopStmt;
 
 } // namespace sir
 } // namespace dawn
-
-#endif

--- a/dawn/src/dawn/SIR/ASTStringifier.h
+++ b/dawn/src/dawn/SIR/ASTStringifier.h
@@ -12,8 +12,7 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
-#ifndef DAWN_SIR_ASTSTRINGIFER_H
-#define DAWN_SIR_ASTSTRINGIFER_H
+#pragma once
 
 #include "dawn/AST/ASTStringifier.h"
 #include "dawn/SIR/ASTFwd.h"
@@ -35,5 +34,3 @@ extern inline std::ostream& operator<<(std::ostream& os, const std::shared_ptr<s
 }
 } // namespace sir
 } // namespace dawn
-
-#endif

--- a/dawn/src/dawn/SIR/ASTUtil.h
+++ b/dawn/src/dawn/SIR/ASTUtil.h
@@ -12,8 +12,7 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
-#ifndef DAWN_SIR_ASTUTIL_H
-#define DAWN_SIR_ASTUTIL_H
+#pragma once
 
 #include "dawn/AST/ASTUtil.h"
 #include "dawn/SIR/ASTFwd.h"
@@ -79,5 +78,3 @@ extern bool evalExprAsBoolean(const std::shared_ptr<Expr>& expr, bool& result,
 using ASTHelper = ast::ASTHelper;
 } // namespace sir
 } // namespace dawn
-
-#endif

--- a/dawn/src/dawn/SIR/ASTVisitor.h
+++ b/dawn/src/dawn/SIR/ASTVisitor.h
@@ -12,8 +12,7 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
-#ifndef DAWN_SIR_ASTVISITOR_H
-#define DAWN_SIR_ASTVISITOR_H
+#pragma once
 
 #include "dawn/AST/ASTVisitor.h"
 #include "dawn/SIR/ASTFwd.h"
@@ -31,5 +30,3 @@ using ASTVisitorForwardingNonConst = ast::ASTVisitorForwardingNonConst;
 using ASTVisitorDisabled = ast::ASTVisitorDisabled;
 } // namespace sir
 } // namespace dawn
-
-#endif

--- a/dawn/src/dawn/SIR/SIR.h
+++ b/dawn/src/dawn/SIR/SIR.h
@@ -12,8 +12,7 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
-#ifndef DAWN_SIR_SIR_H
-#define DAWN_SIR_SIR_H
+#pragma once
 
 #include "dawn/AST/GridType.h"
 #include "dawn/AST/Tags.h"
@@ -602,5 +601,3 @@ struct SIR : public dawn::NonCopyable {
 };
 
 } // namespace dawn
-
-#endif

--- a/dawn/src/dawn/Serialization/ASTSerializer.h
+++ b/dawn/src/dawn/Serialization/ASTSerializer.h
@@ -12,8 +12,7 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
-#ifndef DAWN_SUPPORT_ASTSERIALIZER_H
-#define DAWN_SUPPORT_ASTSERIALIZER_H
+#pragma once
 
 #include "dawn/AST/ASTFwd.h"
 #include "dawn/AST/ASTStmt.h"
@@ -145,5 +144,3 @@ std::shared_ptr<ast::Stmt> makeStmt(const proto::statements::Stmt& statementProt
 
 std::shared_ptr<ast::AST> makeAST(const dawn::proto::statements::AST& astProto,
                                   ast::StmtData::DataType dataType, int& maxID);
-
-#endif // DAWN_SUPPORT_ASTSERIALIZER_H

--- a/dawn/src/dawn/Serialization/IIRSerializer.h
+++ b/dawn/src/dawn/Serialization/IIRSerializer.h
@@ -12,8 +12,7 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
-#ifndef DAWN_IIR_IIRSERIALIZER_H
-#define DAWN_IIR_IIRSERIALIZER_H
+#pragma once
 
 #include "dawn/IIR/IIR.h"
 #include "dawn/IIR/IIR/IIR.pb.h"
@@ -127,5 +126,3 @@ private:
 };
 
 } // namespace dawn
-
-#endif // DAWN_IIR_IIRSERIALIZER_H

--- a/dawn/src/dawn/Serialization/SIRSerializer.h
+++ b/dawn/src/dawn/Serialization/SIRSerializer.h
@@ -12,8 +12,7 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
-#ifndef DAWN_SIR_SIRSERIALIZER_H
-#define DAWN_SIR_SIRSERIALIZER_H
+#pragma once
 
 #include <memory>
 #include <string>
@@ -71,5 +70,3 @@ public:
 };
 
 } // namespace dawn
-
-#endif

--- a/dawn/src/dawn/Support/AlignOf.h
+++ b/dawn/src/dawn/Support/AlignOf.h
@@ -12,8 +12,7 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
-#ifndef DAWN_SUPPORT_ALIGNOF_H
-#define DAWN_SUPPORT_ALIGNOF_H
+#pragma once
 
 #include "dawn/Support/Compiler.h"
 #include <cstddef>
@@ -75,5 +74,3 @@ struct AlignedCharArrayUnion
                        sizeof(internal::SizerImpl<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>)> {};
 
 } // namespace dawn
-
-#endif

--- a/dawn/src/dawn/Support/Array.h
+++ b/dawn/src/dawn/Support/Array.h
@@ -12,8 +12,7 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
-#ifndef DAWN_SUPPORT_ARRAY_H
-#define DAWN_SUPPORT_ARRAY_H
+#pragma once
 
 #include "dawn/Support/HashCombine.h"
 #include <array>
@@ -55,5 +54,3 @@ struct hash<dawn::Array3i> {
 };
 
 } // namespace std
-
-#endif

--- a/dawn/src/dawn/Support/ArrayRef.h
+++ b/dawn/src/dawn/Support/ArrayRef.h
@@ -12,8 +12,7 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
-#ifndef DAWN_SUPPORT_ARRAYREF_H
-#define DAWN_SUPPORT_ARRAYREF_H
+#pragma once
 
 #include "dawn/Support/Assert.h"
 #include "dawn/Support/Compiler.h"
@@ -497,5 +496,3 @@ inline bool operator!=(ArrayRef<T> LHS, ArrayRef<T> RHS) {
 } // namespace dawn
 
 /// @}
-
-#endif

--- a/dawn/src/dawn/Support/Assert.h
+++ b/dawn/src/dawn/Support/Assert.h
@@ -12,8 +12,7 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
-#ifndef DAWN_SUPPORT_ASSERT_H
-#define DAWN_SUPPORT_ASSERT_H
+#pragma once
 
 #include "dawn/Support/Compiler.h"
 
@@ -49,7 +48,5 @@ extern void assertionFailedMsg(char const* expr, char const* msg, char const* fu
   (DAWN_BUILTIN_LIKELY(!!(expr))                                                                   \
        ? ((void)0)                                                                                 \
        : dawn::assertionFailedMsg(#expr, msg, DAWN_CURRENT_FUNCTION, __FILE__, __LINE__))
-
-#endif
 
 #endif

--- a/dawn/src/dawn/Support/Casting.h
+++ b/dawn/src/dawn/Support/Casting.h
@@ -17,8 +17,7 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
-#ifndef DAWN_SUPPORT_CASTING_H
-#define DAWN_SUPPORT_CASTING_H
+#pragma once
 
 #include "dawn/Support/Assert.h"
 #include "dawn/Support/Compiler.h"
@@ -324,5 +323,3 @@ inline std::shared_ptr<T> dyn_pointer_cast(const std::shared_ptr<U>& ptr) noexce
 }
 
 } // namespace dawn
-
-#endif

--- a/dawn/src/dawn/Support/ComparisonHelpers.h
+++ b/dawn/src/dawn/Support/ComparisonHelpers.h
@@ -12,8 +12,7 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
-#ifndef DAWN_SUPPORT_COMPARISONHELPERS_H
-#define DAWN_SUPPORT_COMPARISONHELPERS_H
+#pragma once
 
 #include <string>
 
@@ -30,5 +29,3 @@ struct CompareResult {
 };
 
 } // namespace dawn
-
-#endif

--- a/dawn/src/dawn/Support/Compiler.h
+++ b/dawn/src/dawn/Support/Compiler.h
@@ -12,8 +12,7 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
-#ifndef DAWN_SUPPORT_COMPILER_H
-#define DAWN_SUPPORT_COMPILER_H
+#pragma once
 
 #include "dawn/Support/Config.h"
 
@@ -198,6 +197,4 @@
 #define DAWN_CURRENT_FUNCTION __func__
 #else
 #define DAWN_CURRENT_FUNCTION "(unknown)"
-#endif
-
 #endif

--- a/dawn/src/dawn/Support/Config.h.cmake
+++ b/dawn/src/dawn/Support/Config.h.cmake
@@ -12,8 +12,7 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
-#ifndef DAWN_SUPPORT_CONFIG_H
-#define DAWN_SUPPORT_CONFIG_H
+#pragma once
 
 // Major version of DAWN
 #define DAWN_VERSION_MAJOR ${VERSION_MAJOR}
@@ -30,4 +29,5 @@
 // DAWN full version string
 #define DAWN_FULL_VERSION_STR "${DAWN_FULL_VERSION}"
 
-#endif
+
+

--- a/dawn/src/dawn/Support/ContainerUtils.h
+++ b/dawn/src/dawn/Support/ContainerUtils.h
@@ -12,8 +12,7 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
-#ifndef DAWN_SUPPORT_CONTAINERUTILS_H
-#define DAWN_SUPPORT_CONTAINERUTILS_H
+#pragma once
 #include <map>
 #include <unordered_map>
 
@@ -31,5 +30,3 @@ std::map<Key, Value> orderMap(const std::unordered_map<Key, Value>& umap) {
 
 } // namespace support
 } // namespace dawn
-
-#endif

--- a/dawn/src/dawn/Support/DiagnosticsEngine.h
+++ b/dawn/src/dawn/Support/DiagnosticsEngine.h
@@ -12,8 +12,7 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
-#ifndef DAWN_SUPPORT_DIAGNOSTICSENGINE_H
-#define DAWN_SUPPORT_DIAGNOSTICSENGINE_H
+#pragma once
 
 #include "dawn/Support/DiagnosticsMessage.h"
 #include "dawn/Support/DiagnosticsQueue.h"
@@ -53,5 +52,3 @@ public:
 };
 
 } // namespace dawn
-
-#endif

--- a/dawn/src/dawn/Support/DiagnosticsMessage.h
+++ b/dawn/src/dawn/Support/DiagnosticsMessage.h
@@ -12,8 +12,7 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
-#ifndef DAWN_SUPPORT_DIAGNOSTICMESSAGE_H
-#define DAWN_SUPPORT_DIAGNOSTICMESSAGE_H
+#pragma once
 
 #include "dawn/Support/SourceLocation.h"
 #include <sstream>
@@ -99,5 +98,3 @@ public:
 };
 
 } // namespace dawn
-
-#endif

--- a/dawn/src/dawn/Support/DiagnosticsQueue.h
+++ b/dawn/src/dawn/Support/DiagnosticsQueue.h
@@ -12,8 +12,7 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
-#ifndef DAWN_SUPPORT_DIAGNOSTICQUEUE_H
-#define DAWN_SUPPORT_DIAGNOSTICQUEUE_H
+#pragma once
 
 #include "dawn/Support/DiagnosticsMessage.h"
 #include "dawn/Support/NonCopyable.h"
@@ -64,5 +63,3 @@ public:
 };
 
 } // namespace dawn
-
-#endif

--- a/dawn/src/dawn/Support/DoubleSidedMap.h
+++ b/dawn/src/dawn/Support/DoubleSidedMap.h
@@ -12,8 +12,7 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
-#ifndef DAWN_SUPPORT_DOUBLESIDEDMAP_H
-#define DAWN_SUPPORT_DOUBLESIDEDMAP_H
+#pragma once
 
 #include "dawn/Support/Assert.h"
 #include <unordered_map>
@@ -58,4 +57,3 @@ public:
   const std::unordered_map<Key2, Key1>& getReverseMap() const { return reverseMap_; }
 };
 } // namespace dawn
-#endif

--- a/dawn/src/dawn/Support/EditDistance.h
+++ b/dawn/src/dawn/Support/EditDistance.h
@@ -12,8 +12,7 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
-#ifndef DAWN_SUPPORT_EDITDISTANCE_H
-#define DAWN_SUPPORT_EDITDISTANCE_H
+#pragma once
 
 #include "dawn/Support/ArrayRef.h"
 #include <algorithm>
@@ -108,5 +107,3 @@ inline unsigned computeEditDistance(const std::string& fromStr, const std::strin
 /// @}
 
 } // namespace dawn
-
-#endif

--- a/dawn/src/dawn/Support/Exception.h
+++ b/dawn/src/dawn/Support/Exception.h
@@ -12,8 +12,7 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
-#ifndef DAWN_SUPPORT_EXCEPTION_H
-#define DAWN_SUPPORT_EXCEPTION_H
+#pragma once
 
 #include "dawn/Support/SourceLocation.h"
 #include <exception>
@@ -68,5 +67,3 @@ struct LogicError : public CompileError {
 };
 
 } // namespace dawn
-
-#endif // DAWN_SUPPORT_EXCEPTION_H

--- a/dawn/src/dawn/Support/FileSystem.h
+++ b/dawn/src/dawn/Support/FileSystem.h
@@ -12,8 +12,7 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
-#ifndef DAWN_SUPPORT_FILESYSTEM_H
-#define DAWN_SUPPORT_FILESYSTEM_H
+#pragma once
 
 #if __has_include(<filesystem>)
 #include <filesystem>
@@ -21,6 +20,4 @@ namespace fs = std::filesystem;
 #elif __has_include(<experimental/filesystem>)
 #include <experimental/filesystem>
 namespace fs = std::experimental::filesystem;
-#endif
-
 #endif

--- a/dawn/src/dawn/Support/Format.h
+++ b/dawn/src/dawn/Support/Format.h
@@ -17,8 +17,7 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
-#ifndef DAWN_SUPPORT_FORMAT_H
-#define DAWN_SUPPORT_FORMAT_H
+#pragma once
 
 #include "dawn/Support/Assert.h"
 
@@ -43,5 +42,3 @@ namespace dawn {
 using tfm::format;
 
 } // namespace dawn
-
-#endif

--- a/dawn/src/dawn/Support/HashCombine.h
+++ b/dawn/src/dawn/Support/HashCombine.h
@@ -12,8 +12,7 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
-#ifndef DAWN_SUPPORT_HASHCOMBINE_H
-#define DAWN_SUPPORT_HASHCOMBINE_H
+#pragma once
 
 #include <functional>
 
@@ -48,5 +47,3 @@ inline void hash_combine(std::size_t& seed, const T& v, Rest... rest) {
 /// @}
 
 } // namespace dawn
-
-#endif

--- a/dawn/src/dawn/Support/IndexGenerator.h
+++ b/dawn/src/dawn/Support/IndexGenerator.h
@@ -12,8 +12,7 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
-#ifndef DAWN_SUPPORT_INDEXGENERATOR_H
-#define DAWN_SUPPORT_INDEXGENERATOR_H
+#pragma once
 
 #include "dawn/Support/Assert.h"
 #include <limits>
@@ -48,4 +47,3 @@ public:
 };
 
 } // namespace dawn
-#endif

--- a/dawn/src/dawn/Support/IndexRange.h
+++ b/dawn/src/dawn/Support/IndexRange.h
@@ -11,8 +11,7 @@
 //  See LICENSE.txt for details.
 //
 //===------------------------------------------------------------------------------------------===//
-#ifndef DAWN_SUPPORT_INDEXRANGE_H
-#define DAWN_SUPPORT_INDEXRANGE_H
+#pragma once
 
 #include <functional>
 #include <iterator>
@@ -220,5 +219,3 @@ struct iterator_traits<dawn::IndexRangeIterator<Cont>> {
 };
 
 } // namespace std
-
-#endif

--- a/dawn/src/dawn/Support/Iterator.h
+++ b/dawn/src/dawn/Support/Iterator.h
@@ -17,8 +17,7 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
-#ifndef DAWN_SUPPORT_ITERATOR_H
-#define DAWN_SUPPORT_ITERATOR_H
+#pragma once
 
 #include <easy_iterator.hpp>
 
@@ -27,5 +26,3 @@ namespace dawn {
 using namespace easy_iterator;
 
 } // namespace dawn
-
-#endif // DAWN_SUPPORT_ITERATOR_H

--- a/dawn/src/dawn/Support/Json.h
+++ b/dawn/src/dawn/Support/Json.h
@@ -17,8 +17,7 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
-#ifndef DAWN_SUPPORT_JSON_H
-#define DAWN_SUPPORT_JSON_H
+#pragma once
 
 #include <nlohmann_json.hpp>
 
@@ -36,5 +35,3 @@ using nlohmann::json;
 } // namespace json
 
 } // namespace dawn
-
-#endif

--- a/dawn/src/dawn/Support/Logger.h
+++ b/dawn/src/dawn/Support/Logger.h
@@ -12,8 +12,7 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
-#ifndef DAWN_SUPPORT_LOGGER_H
-#define DAWN_SUPPORT_LOGGER_H
+#pragma once
 
 #include "dawn/Support/SourceLocation.h"
 #include <functional>
@@ -180,5 +179,3 @@ void setVerbosity(Level level);
 #define DAWN_DIAG_INFO_IMPL(file, loc) dawn::log::info(__FILE__, __LINE__, file, loc)
 #define DAWN_DIAG_WARNING_IMPL(file, loc) dawn::log::warn(__FILE__, __LINE__, file, loc)
 #define DAWN_DIAG_ERROR_IMPL(file, loc) dawn::log::error(__FILE__, __LINE__, file, loc)
-
-#endif

--- a/dawn/src/dawn/Support/MathExtras.h
+++ b/dawn/src/dawn/Support/MathExtras.h
@@ -12,8 +12,7 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
-#ifndef DAWN_SUPPORT_MATHEXTRAS_H
-#define DAWN_SUPPORT_MATHEXTRAS_H
+#pragma once
 
 #include <cstdint>
 
@@ -34,5 +33,3 @@ inline std::uint64_t nextPowerOf2(std::uint64_t A) {
 }
 
 } // namespace dawn
-
-#endif

--- a/dawn/src/dawn/Support/NonCopyable.h
+++ b/dawn/src/dawn/Support/NonCopyable.h
@@ -12,8 +12,7 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
-#ifndef DAWN_SUPPORT_NONCOPYABLE_H
-#define DAWN_SUPPORT_NONCOPYABLE_H
+#pragma once
 
 namespace dawn {
 
@@ -31,5 +30,3 @@ protected:
 };
 
 } // namespace dawn
-
-#endif

--- a/dawn/src/dawn/Support/Printing.h
+++ b/dawn/src/dawn/Support/Printing.h
@@ -12,8 +12,7 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
-#ifndef DAWN_SUPPORT_PRINTING_H
-#define DAWN_SUPPORT_PRINTING_H
+#pragma once
 
 namespace dawn {
 
@@ -58,5 +57,3 @@ struct MakeIndent<4> {
 };
 
 } // namespace dawn
-
-#endif

--- a/dawn/src/dawn/Support/RemoveIf.hpp
+++ b/dawn/src/dawn/Support/RemoveIf.hpp
@@ -12,8 +12,7 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
-#ifndef DAWN_REMOVEIF_H
-#define DAWN_REMOVEIF_H
+#pragma once
 #include <list>
 
 namespace dawn {
@@ -44,4 +43,5 @@ bool RemoveIf(Container& cont, UnaryPredicate p) {
 
 } // namespace dawn
 
-#endif
+
+

--- a/dawn/src/dawn/Support/STLExtras.h
+++ b/dawn/src/dawn/Support/STLExtras.h
@@ -12,8 +12,7 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
-#ifndef DAWN_SUPPORT_STLEXTRAS_H
-#define DAWN_SUPPORT_STLEXTRAS_H
+#pragma once
 
 #include "dawn/Support/Compiler.h"
 #include <algorithm>
@@ -183,5 +182,3 @@ struct is_callable<
 /// @}
 
 } // namespace dawn
-
-#endif

--- a/dawn/src/dawn/Support/SmallString.h
+++ b/dawn/src/dawn/Support/SmallString.h
@@ -16,8 +16,7 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
-#ifndef DAWN_SUPPORT_SMALLSTRING_H
-#define DAWN_SUPPORT_SMALLSTRING_H
+#pragma once
 
 #include "dawn/Support/SmallVector.h"
 #include "dawn/Support/StringRef.h"
@@ -262,5 +261,3 @@ public:
 };
 
 } // namespace dawn
-
-#endif

--- a/dawn/src/dawn/Support/SmallVector.h
+++ b/dawn/src/dawn/Support/SmallVector.h
@@ -16,8 +16,7 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
-#ifndef DAWN_SUPPORT_SMALLVECTOR_H
-#define DAWN_SUPPORT_SMALLVECTOR_H
+#pragma once
 
 #include "dawn/Support/AlignOf.h"
 #include "dawn/Support/Assert.h"
@@ -901,5 +900,3 @@ inline void swap(dawn::SmallVector<T, N>& LHS, dawn::SmallVector<T, N>& RHS) {
 }
 
 } // namespace std
-
-#endif

--- a/dawn/src/dawn/Support/SourceLocation.h
+++ b/dawn/src/dawn/Support/SourceLocation.h
@@ -12,8 +12,7 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
-#ifndef DAWN_SUPPORT_SOURCELOCATION_H
-#define DAWN_SUPPORT_SOURCELOCATION_H
+#pragma once
 
 #include <iosfwd>
 
@@ -49,5 +48,3 @@ extern bool operator!=(const SourceLocation& a, const SourceLocation& b);
 extern std::ostream& operator<<(std::ostream& os, const SourceLocation& sourceLocation);
 
 } // namespace dawn
-
-#endif

--- a/dawn/src/dawn/Support/StringRef.h
+++ b/dawn/src/dawn/Support/StringRef.h
@@ -16,8 +16,7 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
-#ifndef DAWN_SUPPORT_STRINGREF_H
-#define DAWN_SUPPORT_STRINGREF_H
+#pragma once
 
 #include "dawn/Support/Assert.h"
 #include "dawn/Support/Compiler.h"
@@ -672,5 +671,3 @@ struct isPodLike<StringRef> {
 /// @}
 
 } // namespace dawn
-
-#endif

--- a/dawn/src/dawn/Support/StringSwitch.h
+++ b/dawn/src/dawn/Support/StringSwitch.h
@@ -12,8 +12,7 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
-#ifndef DAWN_SUPPORT_STRINGSWITCH_H
-#define DAWN_SUPPORT_STRINGSWITCH_H
+#pragma once
 
 #include "dawn/Support/StringRef.h"
 #include <cstring>
@@ -216,5 +215,3 @@ public:
 };
 
 } // namespace dawn
-
-#endif

--- a/dawn/src/dawn/Support/StringUtil.h
+++ b/dawn/src/dawn/Support/StringUtil.h
@@ -12,8 +12,7 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
-#ifndef DAWN_SUPPORT_STRINGUTIL_H
-#define DAWN_SUPPORT_STRINGUTIL_H
+#pragma once
 
 #include "dawn/Support/Printing.h"
 #include "dawn/Support/STLExtras.h"
@@ -131,5 +130,3 @@ extern std::string decimalToOrdinal(int dec);
 /// @}
 
 } // namespace dawn
-
-#endif

--- a/dawn/src/dawn/Support/Twine.h
+++ b/dawn/src/dawn/Support/Twine.h
@@ -16,8 +16,7 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
-#ifndef DAWN_SUPPORT_TWINE_H
-#define DAWN_SUPPORT_TWINE_H
+#pragma once
 
 #include "dawn/Support/SmallVector.h"
 #include "dawn/Support/StringRef.h"
@@ -515,5 +514,3 @@ inline std::ostream& operator<<(std::ostream& OS, const Twine& RHS) {
 /// @}
 
 } // namespace dawn
-
-#endif

--- a/dawn/src/dawn/Support/Type.h
+++ b/dawn/src/dawn/Support/Type.h
@@ -12,8 +12,7 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
-#ifndef DAWN_SUPPORT_TYPE_H
-#define DAWN_SUPPORT_TYPE_H
+#pragma once
 
 #include <iosfwd>
 #include <string>
@@ -114,5 +113,3 @@ struct Type::TypeInfo<double> {
 extern std::ostream& operator<<(std::ostream& os, Type type);
 
 } // namespace dawn
-
-#endif

--- a/dawn/src/dawn/Support/TypeTraits.h
+++ b/dawn/src/dawn/Support/TypeTraits.h
@@ -12,8 +12,7 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
-#ifndef DAWN_SUPPORT_TYPETRAITS_H
-#define DAWN_SUPPORT_TYPETRAITS_H
+#pragma once
 
 #include <type_traits>
 #include <utility>
@@ -94,5 +93,3 @@ struct and_<Cond, Conds...> : std::conditional<Cond::value, and_<Conds...>, std:
 /// @}
 
 } // namespace dawn
-
-#endif

--- a/dawn/src/dawn/Support/UIDGenerator.h
+++ b/dawn/src/dawn/Support/UIDGenerator.h
@@ -12,8 +12,7 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
-#ifndef DAWN_SUPPORT_UIDGENERATOR
-#define DAWN_SUPPORT_UIDGENERATOR
+#pragma once
 
 #include "dawn/Support/NonCopyable.h"
 
@@ -40,5 +39,3 @@ public:
 };
 
 } // namespace dawn
-
-#endif

--- a/dawn/src/dawn/Support/Unreachable.h
+++ b/dawn/src/dawn/Support/Unreachable.h
@@ -12,8 +12,7 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
-#ifndef DAWN_SUPPORT_UNREACHABLE_H
-#define DAWN_SUPPORT_UNREACHABLE_H
+#pragma once
 
 #include "dawn/Support/Compiler.h"
 
@@ -47,5 +46,3 @@ dawn_unreachable_internal(const char* msg = nullptr, const char* file = nullptr,
 /// @}
 
 } // namespace dawn
-
-#endif

--- a/dawn/src/dawn/Unittest/IIRBuilder.h
+++ b/dawn/src/dawn/Unittest/IIRBuilder.h
@@ -12,8 +12,7 @@
 //
 //===------------------------------------------------------------------------------------------===//
 //
-#ifndef DAWN_IIR_IIRBUILDER_H
-#define DAWN_IIR_IIRBUILDER_H
+#pragma once
 
 #include "dawn/AST/ASTExpr.h"
 #include "dawn/AST/LocationType.h"
@@ -351,5 +350,3 @@ public:
 };
 } // namespace iir
 } // namespace dawn
-
-#endif

--- a/dawn/src/dawn/Validator/IntegrityChecker.h
+++ b/dawn/src/dawn/Validator/IntegrityChecker.h
@@ -12,8 +12,7 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
-#ifndef DAWN_OPTIMIZER_INTEGRITYCHECKER_H
-#define DAWN_OPTIMIZER_INTEGRITYCHECKER_H
+#pragma once
 
 #include "dawn/IIR/ASTExpr.h"
 #include "dawn/IIR/ASTUtil.h"
@@ -56,5 +55,3 @@ private:
 };
 
 } // namespace dawn
-
-#endif // DAWN_OPTIMIZER_INTEGRITYCHECKER_H

--- a/dawn/src/driver-includes/defs.hpp
+++ b/dawn/src/driver-includes/defs.hpp
@@ -81,6 +81,5 @@ using float_type = float;
 using float_type = double;
 #else
 #error DAWN_PRECISION is invalid
-
-
+#endif
 } // namespace dawn

--- a/dawn/src/driver-includes/defs.hpp
+++ b/dawn/src/driver-includes/defs.hpp
@@ -81,5 +81,6 @@ using float_type = float;
 using float_type = double;
 #else
 #error DAWN_PRECISION is invalid
-#endif
+
+
 } // namespace dawn

--- a/dawn/src/driver-includes/storage.hpp
+++ b/dawn/src/driver-includes/storage.hpp
@@ -30,7 +30,8 @@
 #endif
 
 // Default storage type is HOST
-#pragma once
+#ifndef DAWN_STORAGE_TYPE
+#define DAWN_STORAGE_TYPE DAWN_STORAGE_HOST
 #endif
 
 // Default grid type is structured
@@ -83,5 +84,4 @@
 #include "timer_cuda.hpp"
 #endif
 
-
-
+#endif

--- a/dawn/src/driver-includes/storage.hpp
+++ b/dawn/src/driver-includes/storage.hpp
@@ -30,8 +30,7 @@
 #endif
 
 // Default storage type is HOST
-#ifndef DAWN_STORAGE_TYPE
-#define DAWN_STORAGE_TYPE DAWN_STORAGE_HOST
+#pragma once
 #endif
 
 // Default grid type is structured
@@ -84,4 +83,5 @@
 #include "timer_cuda.hpp"
 #endif
 
-#endif
+
+

--- a/dawn/src/driver-includes/storage_runtime.hpp
+++ b/dawn/src/driver-includes/storage_runtime.hpp
@@ -105,7 +105,6 @@ using storage_t = storage_ijk_t;
 #elif DAWN_STORAGE_TYPE == DAWN_STORAGE_CUDA
 #define GT_BACKEND_DECISION_viewmaker(x) make_device_view(x)
 #define GT_BACKEND_DECISION_bcapply gridtools::boundary_apply_gpu
-
-
+#endif
 } // namespace dawn
 } // namespace gridtools

--- a/dawn/src/driver-includes/storage_runtime.hpp
+++ b/dawn/src/driver-includes/storage_runtime.hpp
@@ -105,6 +105,7 @@ using storage_t = storage_ijk_t;
 #elif DAWN_STORAGE_TYPE == DAWN_STORAGE_CUDA
 #define GT_BACKEND_DECISION_viewmaker(x) make_device_view(x)
 #define GT_BACKEND_DECISION_bcapply gridtools::boundary_apply_gpu
-#endif
+
+
 } // namespace dawn
 } // namespace gridtools

--- a/dawn/src/interface/atlas_interface.hpp
+++ b/dawn/src/interface/atlas_interface.hpp
@@ -12,8 +12,7 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
-#ifndef DAWN_INTERFACE_ATLAS_INTERFACE_H_
-#define DAWN_INTERFACE_ATLAS_INTERFACE_H_
+#pragma once
 
 #include "atlas/mesh.h"
 #include <algorithm>
@@ -297,4 +296,5 @@ auto reduce(atlasTag, atlas::Mesh const& m, int idx, Init init,
 }
 
 } // namespace atlasInterface
-#endif
+
+


### PR DESCRIPTION
## Technical Description

If we use pragma once in some places, why not everywhere in dawn?

```
for f in $(grep -rl "#ifndef DAWN" dawn/src); do
    gsed -z -i \
         -e 's/\#ifndef DAWN[^\n]*\n\#define DAWN[^\n]*/#pragma once/' \
         -e 's/\(.*\)\#endif[^\n]*/\1\n/' $f;
done
find dawn/src -type f -name '*.h' -exec gsed --in-place -e :a -e '/^\n*$/{$d;N;};/\n$/ba' {} \;
```