### PR TITLE
Fix pragma once warning in AST/Offsets

### DIFF
--- a/dawn/src/dawn/AST/Offsets.cpp
+++ b/dawn/src/dawn/AST/Offsets.cpp
@@ -12,15 +12,13 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
-#pragma once
-
-#include "Offsets.h"
-
+#include "dawn/AST/Offsets.h"
 #include "dawn/Support/Assert.h"
-#include "dawn/Support/Unreachable.h"
+
 #include <iostream>
 
-namespace dawn::ast {
+namespace dawn {
+namespace ast {
 
 // HorizontalOffsetImpl
 std::unique_ptr<HorizontalOffsetImpl> HorizontalOffsetImpl::clone() const { return cloneImpl(); }
@@ -175,18 +173,17 @@ std::string to_string(cartesian_, Offsets const& offsets, std::string const& sep
 }
 
 std::string to_string(Offsets const& offset) {
-  return offset_dispatch(offset.horizontalOffset(),
-                         [&](CartesianOffset const&) { return to_string(cartesian, offset); },
-                         [&](UnstructuredOffset const&) { return to_string(unstructured, offset); },
-                         [&]() {
-                           using namespace std::string_literals;
-                           return "<no_horizontal_offset>,"s +
-                                  std::to_string(offset.verticalOffset());
-                         });
+  return offset_dispatch(
+      offset.horizontalOffset(),
+      [&](CartesianOffset const&) { return to_string(cartesian, offset); },
+      [&](UnstructuredOffset const&) { return to_string(unstructured, offset); },
+      [&]() {
+        using namespace std::string_literals;
+        return "<no_horizontal_offset>,"s + std::to_string(offset.verticalOffset());
+      });
 }
 
 Offsets operator+(Offsets o1, Offsets const& o2) { return o1 += o2; }
-} // namespace dawn::ast
 
-
-
+} // namespace ast
+} // namespace dawn

--- a/dawn/src/dawn/AST/Offsets.h
+++ b/dawn/src/dawn/AST/Offsets.h
@@ -22,7 +22,8 @@
 #include <memory>
 #include <string>
 
-namespace dawn::ast {
+namespace dawn {
+namespace ast {
 
 class Offsets;
 
@@ -217,4 +218,5 @@ std::string to_string(unstructured_, Offsets const& offset);
 
 std::string to_string(Offsets const& offset);
 
-} // namespace dawn::ast
+} // namespace ast
+} // namespace dawn


### PR DESCRIPTION
## Technical Description

Using #pragma once uncovered an issue in AST/Offsets.cpp. This PR fixes that and cleans up the file.