### PR TITLE
Standalone lowering

### DIFF
--- a/dawn/src/dawn/IIR/StencilMetaInformation.h
+++ b/dawn/src/dawn/IIR/StencilMetaInformation.h
@@ -88,7 +88,7 @@ struct GetAccessesOfTypeHelper<FieldAccessType::APIField> {
 
 } // namespace impl
 
-/// @brief Specific instantiation of a stencil
+/// @brief Metadata associated with a stencil instantiation (stored next to IIR)
 /// @ingroup optimizer
 class StencilMetaInformation : public NonCopyable {
   friend IIRSerializer;

--- a/dawn/src/dawn/Optimizer/OptimizerContext.cpp
+++ b/dawn/src/dawn/Optimizer/OptimizerContext.cpp
@@ -658,8 +658,6 @@ std::map<std::string, std::shared_ptr<iir::StencilInstantiation>>
 toStencilInstantiationMap(const SIR& stencilIR) {
   std::map<std::string, std::shared_ptr<iir::StencilInstantiation>> stencilInstantiationMap;
 
-  // FillIIR()
-  // {
   std::vector<std::shared_ptr<sir::StencilFunction>> iirStencilFunctions;
   // Convert the asts of sir::StencilFunctions to iir
   std::transform(stencilIR.StencilFunctions.begin(), stencilIR.StencilFunctions.end(),
@@ -683,7 +681,6 @@ toStencilInstantiationMap(const SIR& stencilIR) {
       DAWN_LOG(INFO) << "Skipping processing of `" << stencil->Name << "`";
     }
   }
-  // }
 
   return stencilInstantiationMap;
 }

--- a/dawn/src/dawn/Optimizer/OptimizerContext.h
+++ b/dawn/src/dawn/Optimizer/OptimizerContext.h
@@ -64,8 +64,6 @@ private:
   PassManager passManager_;
   HardwareConfig hardwareConfiguration_;
 
-  void fillIIR();
-
 public:
   /// @brief Initialize the context with a SIR
   OptimizerContext(OptimizerContextOptions options, const std::shared_ptr<SIR>& SIR);
@@ -103,14 +101,10 @@ public:
   }
 
   /// @brief fillIIRFromSIR
+  /// @param name
   /// @param stencilInstantation
-  /// @param SIRStencil
-  /// @param fullSIR
   /// @return
-  bool fillIIRFromSIR(std::shared_ptr<iir::StencilInstantiation> stencilInstantation,
-                      const std::shared_ptr<sir::Stencil> SIRStencil,
-                      const std::shared_ptr<SIR> fullSIR);
-  bool restoreIIR(std::string const& name,
+  bool restoreIIR(const std::string& name,
                   std::shared_ptr<iir::StencilInstantiation> stencilInstantiation);
 };
 

--- a/dawn/src/dawn/Optimizer/OptimizerContext.h
+++ b/dawn/src/dawn/Optimizer/OptimizerContext.h
@@ -28,6 +28,12 @@ struct Stencil;
 namespace iir {
 class StencilInstantiation;
 }
+/// @brief Naively lower an SIR to a stencil instantiation map
+///
+/// This only transforms the SIR to IIR and creates some metadata. It will still need to be run with
+/// the parallel pass group to create valid IIR.
+std::map<std::string, std::shared_ptr<iir::StencilInstantiation>>
+toStencilInstantiationMap(const SIR& stencilIR);
 
 struct HardwareConfig {
   /// Maximum number of fields concurrently in shared memory

--- a/dawn/src/dawn/Optimizer/Options.inc
+++ b/dawn/src/dawn/Optimizer/Options.inc
@@ -55,8 +55,6 @@ OPT(bool, DisableKCaches, false, "disable-kcaches", "",
     "Disable use of the k-caches", "", false, true)
 OPT(bool, UseNonTempCaches, false, "cache-non-temp-fields", "",
     "Allows for caching of non-temporary fields", "", false, true)
-OPT(bool, KeepVarnames, false, "keep-varnames", "",
-    "Keep the names of locally defined variables (this should merely be used for debugging as it may result in invalid code)", "", false, true)
 
 OPT(bool, PassVerbose, false, "pass-verbose", "",
     "Compile in verbose mode", "", false, true)

--- a/dawn/src/dawn/Optimizer/PassTemporaryToStencilFunction.cpp
+++ b/dawn/src/dawn/Optimizer/PassTemporaryToStencilFunction.cpp
@@ -471,7 +471,7 @@ public:
     }
 
     // recompute the list of <statement, accesses> pairs
-    StatementMapper statementMapper(stencilInstantiation_.get(), context_, stackTrace_,
+    StatementMapper statementMapper(stencilInstantiation_.get(), stackTrace_,
                                     *(cloneStencilFun->getDoMethod()), interval_, fieldsMap,
                                     cloneStencilFun);
 
@@ -661,8 +661,8 @@ bool PassTemporaryToStencilFunction::run(
                   iir::DoMethod tmpStmtDoMethod(doMethodInterval, metadata);
 
                   StatementMapper statementMapper(
-                      stencilInstantiation.get(), context_,
-                      *stmt->getData<iir::IIRStmtData>().StackTrace, tmpStmtDoMethod, sirInterval,
+                      stencilInstantiation.get(), *stmt->getData<iir::IIRStmtData>().StackTrace,
+                      tmpStmtDoMethod, sirInterval,
                       stencilInstantiation->getMetaData().getNameToAccessIDMap(), nullptr);
 
                   std::shared_ptr<iir::BlockStmt> blockStmt =

--- a/dawn/src/dawn/Optimizer/StatementMapper.cpp
+++ b/dawn/src/dawn/Optimizer/StatementMapper.cpp
@@ -20,13 +20,13 @@
 
 namespace dawn {
 StatementMapper::StatementMapper(
-    iir::StencilInstantiation* instantiation, OptimizerContext& context,
-    const std::vector<ast::StencilCall*>& stackTrace, iir::DoMethod& doMethod,
-    const iir::Interval& interval,
+    iir::StencilInstantiation* instantiation, const std::vector<ast::StencilCall*>& stackTrace,
+    iir::DoMethod& doMethod, const iir::Interval& interval,
     const std::unordered_map<std::string, int>& localFieldnameToAccessIDMap,
-    const std::shared_ptr<iir::StencilFunctionInstantiation> stencilFunctionInstantiation)
-    : instantiation_(instantiation), metadata_(instantiation->getMetaData()), context_(context),
-      stackTrace_(stackTrace) {
+    const std::shared_ptr<iir::StencilFunctionInstantiation> stencilFunctionInstantiation,
+    bool keepVarnames)
+    : instantiation_(instantiation), metadata_(instantiation->getMetaData()),
+      stackTrace_(stackTrace), initializedWithBlockStmt_(false), keepVarnames_(keepVarnames) {
 
   // Create the initial scope
   scope_.push(std::make_shared<Scope>(doMethod, interval, stencilFunctionInstantiation));
@@ -110,7 +110,7 @@ void StatementMapper::visit(const std::shared_ptr<iir::VarDeclStmt>& stmt) {
     int accessID = instantiation_->nextUID();
 
     std::string globalName;
-    if(context_.getOptions().KeepVarnames)
+    if(keepVarnames_)
       globalName = stmt->getName();
     else
       globalName = iir::InstantiationHelper::makeLocalVariablename(stmt->getName(), accessID);

--- a/dawn/src/dawn/Optimizer/StatementMapper.h
+++ b/dawn/src/dawn/Optimizer/StatementMapper.h
@@ -61,18 +61,18 @@ class StatementMapper : public iir::ASTVisitor {
 
   iir::StencilInstantiation* instantiation_;
   iir::StencilMetaInformation& metadata_;
-  OptimizerContext& context_;
   const std::vector<ast::StencilCall*>& stackTrace_;
   std::stack<std::shared_ptr<Scope>> scope_;
-  bool initializedWithBlockStmt_ = false;
+  bool initializedWithBlockStmt_;
+  bool keepVarnames_;
 
 public:
   StatementMapper(
-      iir::StencilInstantiation* instantiation, OptimizerContext& context,
-      const std::vector<ast::StencilCall*>& stackTrace, iir::DoMethod& doMethod,
-      const iir::Interval& interval,
+      iir::StencilInstantiation* instantiation, const std::vector<ast::StencilCall*>& stackTrace,
+      iir::DoMethod& doMethod, const iir::Interval& interval,
       const std::unordered_map<std::string, int>& localFieldnameToAccessIDMap,
-      const std::shared_ptr<iir::StencilFunctionInstantiation> stencilFunctionInstantiation);
+      const std::shared_ptr<iir::StencilFunctionInstantiation> stencilFunctionInstantiation,
+      bool keepVarnames = false);
 
   Scope* getCurrentCandidateScope();
 

--- a/dawn/src/dawn4py/_dawn4py.cpp
+++ b/dawn/src/dawn4py/_dawn4py.cpp
@@ -61,11 +61,11 @@ PYBIND11_MODULE(_dawn4py, m) {
       .def(py::init([](int MaxHaloPoints, const std::string& ReorderStrategy,
                        int MaxFieldsPerStencil, bool MaxCutMSS, int BlockSizeI, int BlockSizeJ,
                        int BlockSizeK, bool SplitStencils, bool MergeStages, bool MergeDoMethods,
-                       bool DisableKCaches, bool UseNonTempCaches, bool KeepVarnames,
-                       bool PassVerbose, bool ReportAccesses, bool SerializeIIR,
-                       const std::string& IIRFormat, bool DumpSplitGraphs, bool DumpStageGraph,
-                       bool DumpTemporaryGraphs, bool DumpRaceConditionGraph,
-                       bool DumpStencilInstantiation, bool DumpStencilGraph) {
+                       bool DisableKCaches, bool UseNonTempCaches, bool PassVerbose,
+                       bool ReportAccesses, bool SerializeIIR, const std::string& IIRFormat,
+                       bool DumpSplitGraphs, bool DumpStageGraph, bool DumpTemporaryGraphs,
+                       bool DumpRaceConditionGraph, bool DumpStencilInstantiation,
+                       bool DumpStencilGraph) {
              return dawn::Options{MaxHaloPoints,
                                   ReorderStrategy,
                                   MaxFieldsPerStencil,
@@ -78,7 +78,6 @@ PYBIND11_MODULE(_dawn4py, m) {
                                   MergeDoMethods,
                                   DisableKCaches,
                                   UseNonTempCaches,
-                                  KeepVarnames,
                                   PassVerbose,
                                   ReportAccesses,
                                   SerializeIIR,
@@ -95,11 +94,11 @@ PYBIND11_MODULE(_dawn4py, m) {
            py::arg("block_size_i") = 0, py::arg("block_size_j") = 0, py::arg("block_size_k") = 0,
            py::arg("split_stencils") = false, py::arg("merge_stages") = false,
            py::arg("merge_do_methods") = true, py::arg("disable_k_caches") = false,
-           py::arg("use_non_temp_caches") = false, py::arg("keep_varnames") = false,
-           py::arg("pass_verbose") = false, py::arg("report_accesses") = false,
-           py::arg("serialize_iir") = false, py::arg("iir_format") = "json",
-           py::arg("dump_split_graphs") = false, py::arg("dump_stage_graph") = false,
-           py::arg("dump_temporary_graphs") = false, py::arg("dump_race_condition_graph") = false,
+           py::arg("use_non_temp_caches") = false, py::arg("pass_verbose") = false,
+           py::arg("report_accesses") = false, py::arg("serialize_iir") = false,
+           py::arg("iir_format") = "json", py::arg("dump_split_graphs") = false,
+           py::arg("dump_stage_graph") = false, py::arg("dump_temporary_graphs") = false,
+           py::arg("dump_race_condition_graph") = false,
            py::arg("dump_stencil_instantiation") = false, py::arg("dump_stencil_graph") = false)
       .def_readwrite("max_halo_points", &dawn::Options::MaxHaloPoints)
       .def_readwrite("reorder_strategy", &dawn::Options::ReorderStrategy)
@@ -113,7 +112,6 @@ PYBIND11_MODULE(_dawn4py, m) {
       .def_readwrite("merge_do_methods", &dawn::Options::MergeDoMethods)
       .def_readwrite("disable_k_caches", &dawn::Options::DisableKCaches)
       .def_readwrite("use_non_temp_caches", &dawn::Options::UseNonTempCaches)
-      .def_readwrite("keep_varnames", &dawn::Options::KeepVarnames)
       .def_readwrite("pass_verbose", &dawn::Options::PassVerbose)
       .def_readwrite("report_accesses", &dawn::Options::ReportAccesses)
       .def_readwrite("serialize_iir", &dawn::Options::SerializeIIR)
@@ -140,7 +138,6 @@ PYBIND11_MODULE(_dawn4py, m) {
            << "merge_do_methods=" << self.MergeDoMethods << ",\n    "
            << "disable_k_caches=" << self.DisableKCaches << ",\n    "
            << "use_non_temp_caches=" << self.UseNonTempCaches << ",\n    "
-           << "keep_varnames=" << self.KeepVarnames << ",\n    "
            << "pass_verbose=" << self.PassVerbose << ",\n    "
            << "report_accesses=" << self.ReportAccesses << ",\n    "
            << "serialize_iir=" << self.SerializeIIR << ",\n    "


### PR DESCRIPTION
## Technical Description

Move IIR lowering out of the OptimizerContext class. Removed `KeepVarnames` option in the process. The removed option becomes a constructor argument to `StatementMapper` so most of the behavior remains the same.