### PR TITLE
Remove Twine usage from dawn

### DIFF
--- a/dawn/src/dawn/CodeGen/CXXNaive-ico/CXXNaiveCodeGen.cpp
+++ b/dawn/src/dawn/CodeGen/CXXNaive-ico/CXXNaiveCodeGen.cpp
@@ -256,7 +256,7 @@ void CXXNaiveIcoCodeGen::generateStencilWrapperMembers(
   const auto& globalsMap = stencilInstantiation->getIIR()->getGlobalVariableMap();
 
   stencilWrapperClass.addMember("static constexpr const char* s_name =",
-                                Twine("\"") + stencilWrapperClass.getName() + Twine("\""));
+                                "\"" + stencilWrapperClass.getName() + "\"");
 
   if(!globalsMap.empty()) {
     stencilWrapperClass.addMember("globals", "m_globals");

--- a/dawn/src/dawn/CodeGen/CXXNaive/CXXNaiveCodeGen.cpp
+++ b/dawn/src/dawn/CodeGen/CXXNaive/CXXNaiveCodeGen.cpp
@@ -230,7 +230,7 @@ void CXXNaiveCodeGen::generateStencilWrapperMembers(
   const auto& globalsMap = stencilInstantiation->getIIR()->getGlobalVariableMap();
 
   stencilWrapperClass.addMember("static constexpr const char* s_name =",
-                                Twine("\"") + stencilWrapperClass.getName() + Twine("\""));
+                                "\"" + stencilWrapperClass.getName() + "\"");
 
   if(!globalsMap.empty()) {
     stencilWrapperClass.addMember("globals", "m_globals");

--- a/dawn/src/dawn/CodeGen/CXXUtil.h
+++ b/dawn/src/dawn/CodeGen/CXXUtil.h
@@ -14,9 +14,9 @@
 
 #pragma once
 
+#include "dawn/Support/Assert.h"
 #include "dawn/Support/Printing.h"
 #include "dawn/Support/StringUtil.h"
-#include "dawn/Support/Twine.h"
 #include <functional>
 #include <sstream>
 
@@ -61,17 +61,7 @@ struct hasCommitImpl {
   static constexpr bool value = hasCommitImplDetail<T, void (T::*)()>::value;
 };
 
-inline std::string twineToStr(const Twine& twine) {
-  return twine.str() + (twine.isTriviallyEmpty() ? "" : " ");
-}
-
 } // namespace internal
-
-/// @brief Convert variadic pack to Twine
-template <typename T, typename... Args>
-inline Twine makeTwine(T&& arg, Args&&... args) {
-  return (Twine(arg) + ... + Twine(args));
-}
 
 /// @brief Clear the string stream and return it again
 inline std::stringstream& clear(std::stringstream& ss) {
@@ -190,12 +180,15 @@ struct Statement : public NewLine {
 struct Type : public Streamable {
   int hasTemplate = false;
 
-  Type(const Twine& name, std::stringstream& s, int il = 0) : Streamable(s, il) { ss() << name; }
+  Type(const std::string& name, std::stringstream& s, int il = 0) : Streamable(s, il) {
+    ss() << name;
+  }
   Type(Type&&) = default;
 
   /// @brief Add a template to the Type `type<name>`
   /// @{
-  Type& addTemplate(const Twine& name) {
+  template <typename T>
+  Type& addTemplate(const T& name) {
     if(!hasTemplate) {
       hasTemplate = true;
       ss() << "<" << name;
@@ -238,12 +231,12 @@ struct Using : public Statement {
   bool RHSDeclared = false;
 
   /// @brief Add typedef `using name = ...`
-  Using(const Twine& name, std::stringstream& s, int il = 0) : Statement(s, il) {
+  Using(const std::string& name, std::stringstream& s, int il = 0) : Statement(s, il) {
     ss() << "using " << name;
   }
 
   /// @brief Add a Type to the right-hand side of the using
-  Type addType(const Twine& name) {
+  Type addType(const std::string& name) {
     ss() << " = ";
     return Type(name, ss());
   }
@@ -258,12 +251,12 @@ struct Using : public Statement {
 /// @brief Definition of a `namespace`
 /// @ingroup codegen
 struct Namespace {
-  const Twine name_;
+  const std::string name_;
   std::stringstream& s_;
 
   ~Namespace() {}
   /// @brief Add `namespace`
-  Namespace(const Twine& name, std::stringstream& s) : name_(name), s_(s) {
+  Namespace(const std::string& name, std::stringstream& s) : name_(name), s_(s) {
     s_ << "namespace " << name_ << "{" << std::endl;
   }
 
@@ -287,22 +280,26 @@ struct MemberFunction : public NewLine {
   bool IsConst = false;
 
   /// @brief Declare function with return type (possibly empty) and the name of the function
-  MemberFunction(const Twine& returnType, const Twine& name, std::stringstream& s, int il = 0)
+  MemberFunction(const std::string& returnType, const std::string& name, std::stringstream& s,
+                 int il = 0)
       : NewLine(s, il), IndentLevel(il) {
-    ss() << internal::twineToStr(returnType) << name.str();
+    if(!returnType.empty()) {
+      ss() << returnType << " ";
+    }
+    ss() << name;
   }
 
   /// @brief Add an argument to the function
   ///
   /// This function can only be called *before* the body is added.
-  MemberFunction& addArg(const Twine& name) {
+  MemberFunction& addArg(const std::string& name) {
     DAWN_ASSERT(!IsBodyDeclared);
     ss() << (NumArgs++ == 0 ? "(" : ", ") << name;
     return *this;
   }
 
   /// @brief Add a an initializer (only used by constructors)
-  MemberFunction& addInit(const Twine& name) {
+  MemberFunction& addInit(const std::string& name) {
     DAWN_ASSERT(CanHaveInit && !IsBodyDeclared);
     finishArgs();
     ss() << (NumInits++ == 0 ? ": " : ", ") << name;
@@ -321,18 +318,17 @@ struct MemberFunction : public NewLine {
   /// @{
   template <class Sequence, class StrinfigyFunctor,
             class ValueType = typename std::decay<Sequence>::type::value_type>
-  MemberFunction& addArgs(const Twine& typeName, Sequence&& sequence,
+  MemberFunction& addArgs(const std::string& typeName, Sequence&& sequence,
                           StrinfigyFunctor&& stringifier) {
     DAWN_ASSERT(!IsBodyDeclared);
-    std::string typeNameStr = internal::twineToStr(typeName);
     ss() << RangeToString(", ", (NumArgs++ == 0 ? "(" : ", "), "")(
         sequence,
-        [&](const ValueType& value) -> std::string { return typeNameStr + stringifier(value); });
+        [&](const ValueType& value) -> std::string { return typeName + stringifier(value); });
     return *this;
   }
 
   template <class Sequence>
-  MemberFunction& addArgs(const Twine& typeName, Sequence&& sequence) {
+  MemberFunction& addArgs(const std::string& typeName, Sequence&& sequence) {
     return addArgs(typeName, std::forward<Sequence>(sequence),
                    RangeToString::DefaultStringifyFunctor());
   }
@@ -363,10 +359,10 @@ struct MemberFunction : public NewLine {
   /// @brief Add a statement to the function body
   ///
   /// This function can only be called *after* the body was added.
-  MemberFunction& addStatement(const Twine& arg) {
+  MemberFunction& addStatement(const std::string& arg) {
     startBody();
     Statement stmt(ss(), IndentLevel + 1);
-    stmt << arg.str();
+    stmt << arg;
     return *this;
   }
 
@@ -386,7 +382,7 @@ struct MemberFunction : public NewLine {
   ///
   /// This function can only be called *after* the body was added.
   template <class BlockBodyFunType>
-  MemberFunction& addBlockStatement(const Twine& init, BlockBodyFunType&& blockBodyFun) {
+  MemberFunction& addBlockStatement(const std::string& init, BlockBodyFunType&& blockBodyFun) {
     startBody();
     indentImpl(IndentLevel) << init << " {\n";
     IndentLevel++;
@@ -397,13 +393,13 @@ struct MemberFunction : public NewLine {
   }
 
   /// @brief Add a typedef
-  Using addTypeDef(const Twine& typeName) {
+  Using addTypeDef(const std::string& typeName) {
     indentImpl(IndentLevel + 1);
     return Using(typeName, ss());
   }
 
   /// @brief Add a comment
-  NewLine addComment(const Twine& comment) {
+  NewLine addComment(const std::string& comment) {
     indentImpl(IndentLevel + 1, true);
     NewLine nl(ss());
     nl << ("// " + comment);
@@ -443,16 +439,14 @@ struct Structure : public Statement {
   std::string StructureName;
   std::string SuffixMember;
 
-  Structure(const char* identifier, const Twine& name, std::stringstream& s,
-            const Twine& templateName = Twine::createNull(),
-            const Twine& derived = Twine::createNull(), int il = 0)
+  Structure(const char* identifier, const std::string& name, std::stringstream& s,
+            const std::string& templateName = "", const std::string& derived = "", int il = 0)
       : Statement(s), IndentLevel(il) {
-    StructureName = name.str();
-    if(!templateName.isTriviallyEmpty())
-      indentImpl(IndentLevel) << "template<" << templateName.str() << ">";
+    StructureName = name;
+    if(!templateName.empty())
+      indentImpl(IndentLevel) << "template<" << templateName << ">";
     indentImpl(IndentLevel, true) << identifier << " " << StructureName
-                                  << (derived.isTriviallyEmpty() ? std::string()
-                                                                 : " : public " + derived.str())
+                                  << (derived.empty() ? std::string() : " : public " + derived)
                                   << " {\n";
   }
 
@@ -464,10 +458,10 @@ struct Structure : public Statement {
   ///
   ///   } SuffixMember;
   /// @endcode
-  void addSuffixMember(const Twine& suffixMember) { SuffixMember = suffixMember.str(); }
+  void addSuffixMember(const std::string& suffixMember) { SuffixMember = suffixMember; }
 
   /// @brief Change the accessibility of the following members and methods
-  void changeAccessibility(const Twine& specifier) {
+  void changeAccessibility(const std::string& specifier) {
     NewLine nl(ss(), IndentLevel);
     nl << specifier << ":";
   }
@@ -483,7 +477,7 @@ struct Structure : public Statement {
   /// @endcode
   MemberFunction
   addCopyConstructor(ConstructorDefaultKind constructorKind = ConstructorDefaultKind::Custom) {
-    return addBuiltinConstructor(Twine("const ") + StructureName + "&", constructorKind);
+    return addBuiltinConstructor("const " + StructureName + "&", constructorKind);
   }
 
   /// @brief Add a move constructor
@@ -494,7 +488,7 @@ struct Structure : public Statement {
   /// @endcode
   MemberFunction
   addMoveConstructor(ConstructorDefaultKind constructorKind = ConstructorDefaultKind::Custom) {
-    return addBuiltinConstructor(Twine(StructureName) + "&&", constructorKind);
+    return addBuiltinConstructor(StructureName + "&&", constructorKind);
   }
 
   /// @brief Add a constructor
@@ -504,8 +498,8 @@ struct Structure : public Statement {
   ///   template< templateName >
   ///   Structure(...) {...}
   /// @endcode
-  MemberFunction addConstructor(const Twine& templateName = Twine::createNull()) {
-    MemberFunction memFun = addMemberFunction(Twine::createNull(), StructureName, templateName);
+  MemberFunction addConstructor(const std::string& templateName = "") {
+    MemberFunction memFun = addMemberFunction("", StructureName, templateName);
     memFun.CanHaveInit = true;
     return memFun;
   }
@@ -518,8 +512,7 @@ struct Structure : public Statement {
   ///   Structure(...) {...}
   /// @endcode
   MemberFunction addDestructor(bool isVirtual) {
-    return addMemberFunction(Twine::createNull(),
-                             (isVirtual ? Twine("virtual ~") : Twine("~")) + StructureName);
+    return addMemberFunction("", (isVirtual ? "virtual ~" : "~") + StructureName);
   }
 
   /// @brief Add a member function (method)
@@ -529,11 +522,11 @@ struct Structure : public Statement {
   ///   template< templateName >
   ///   returnType funcName(...) {...}
   /// @endcode
-  MemberFunction addMemberFunction(const Twine& returnType, const Twine& funcName,
-                                   const Twine& templateName = Twine::createNull()) {
+  MemberFunction addMemberFunction(const std::string& returnType, const std::string& funcName,
+                                   const std::string& templateName = "") {
     newlineImpl();
-    if(!templateName.isTriviallyEmpty())
-      indentImpl(IndentLevel + 1) << "template<" << templateName.str() << ">\n";
+    if(!templateName.empty())
+      indentImpl(IndentLevel + 1) << "template<" << templateName << ">\n";
     return MemberFunction(returnType, funcName, ss(), IndentLevel + 1);
   }
 
@@ -543,7 +536,7 @@ struct Structure : public Statement {
   /// @code
   ///   using typeName = ...
   /// @endcode
-  Using addTypeDef(const Twine& typeName) {
+  Using addTypeDef(const std::string& typeName) {
     indentImpl(IndentLevel + 1);
     return Using(typeName, ss());
   }
@@ -554,7 +547,7 @@ struct Structure : public Statement {
   /// @code
   ///   typeName memberName;
   /// @endcode
-  Statement addMember(const Twine& typeName, const Twine& memberName) {
+  Statement addMember(const std::string& typeName, const std::string& memberName) {
     Statement member(ss(), IndentLevel + 1);
     member << typeName << " " << memberName;
     return member;
@@ -566,7 +559,7 @@ struct Structure : public Statement {
   /// @code
   ///   // comment
   /// @endcode
-  NewLine addComment(const Twine& comment) {
+  NewLine addComment(const std::string& comment) {
     indentImpl(IndentLevel + 1, true);
     NewLine nl(ss());
     nl << "// " + comment;
@@ -579,7 +572,7 @@ struct Structure : public Statement {
   /// @code
   ///   statment;
   /// @endcode
-  Statement addStatement(const Twine& statment) {
+  Statement addStatement(const std::string& statment) {
     Statement stmt(ss(), IndentLevel + 1);
     stmt << statment;
     return stmt;
@@ -593,8 +586,8 @@ struct Structure : public Statement {
   ///    ...
   ///   };
   /// @endcode
-  Structure addStruct(const Twine& name, const Twine& templateName = Twine::createNull(),
-                      const Twine& derived = Twine::createNull()) {
+  Structure addStruct(const std::string& name, const std::string& templateName = "",
+                      const std::string& derived = "") {
     return Structure("struct", name, ss(), templateName, derived, IndentLevel + 1);
   }
 
@@ -606,9 +599,9 @@ struct Structure : public Statement {
   ///    ...
   ///   } member;
   /// @endcode
-  Structure addStructMember(const Twine& name, const Twine& member,
-                            const Twine& derived = Twine::createNull()) {
-    Structure s("struct", name, ss(), Twine::createNull(), derived, IndentLevel + 1);
+  Structure addStructMember(const std::string& name, const std::string& member,
+                            const std::string& derived = "") {
+    Structure s("struct", name, ss(), "", derived, IndentLevel + 1);
     s.addSuffixMember(member);
     return s;
   }
@@ -621,8 +614,8 @@ struct Structure : public Statement {
   ///    ...
   ///   };
   /// @endcode
-  Structure addClass(const Twine& name, const Twine& templateName = Twine::createNull()) {
-    return Structure("class", name, ss(), templateName, Twine::createNull(), IndentLevel + 1);
+  Structure addClass(const std::string& name, const std::string& templateName = "") {
+    return Structure("class", name, ss(), templateName, "", IndentLevel + 1);
   }
 
   void commitImpl() {
@@ -632,10 +625,10 @@ struct Structure : public Statement {
 
 protected:
   MemberFunction
-  addBuiltinConstructor(const Twine& arg,
+  addBuiltinConstructor(const std::string& arg,
                         ConstructorDefaultKind constructorKind = ConstructorDefaultKind::Custom) {
     newlineImpl();
-    MemberFunction ctor(Twine::createNull(), StructureName, ss(), IndentLevel + 1);
+    MemberFunction ctor("", StructureName, ss(), IndentLevel + 1);
     ctor.addArg(arg);
     switch(constructorKind) {
     case ConstructorDefaultKind::Default:
@@ -656,7 +649,7 @@ protected:
 /// @ingroup codegen
 struct Class : public Structure {
   using Structure::Structure;
-  Class(const Twine& name, std::stringstream& s, const Twine& templateName = Twine::createNull())
+  Class(const std::string& name, std::stringstream& s, const std::string& templateName = "")
       : Structure("class", name, s, templateName) {}
 };
 
@@ -664,14 +657,14 @@ struct Class : public Structure {
 /// @ingroup codegen
 struct Struct : public Structure {
   using Structure::Structure;
-  Struct(const Twine& name, std::stringstream& s, const Twine& templateName = Twine::createNull())
+  Struct(const std::string& name, std::stringstream& s, const std::string& templateName = "")
       : Structure("struct", name, s, templateName) {}
 };
 
-auto c_gt = []() { return Twine("gridtools::"); };
-auto c_dgt = []() { return Twine("gridtools::dawn::"); };
-auto c_gt_enum = []() { return Twine("gridtools::enumtype::"); };
-auto c_gt_intent = []() { return Twine("gridtools::intent::"); };
+auto c_gt = []() { return std::string("gridtools::"); };
+auto c_dgt = []() { return std::string("gridtools::dawn::"); };
+auto c_gt_enum = []() { return std::string("gridtools::enumtype::"); };
+auto c_gt_intent = []() { return std::string("gridtools::intent::"); };
 
 } // namespace codegen
 

--- a/dawn/src/dawn/CodeGen/CodeGen.cpp
+++ b/dawn/src/dawn/CodeGen/CodeGen.cpp
@@ -146,7 +146,7 @@ void CodeGen::generateBoundaryConditionFunctions(
     for(const auto& sf : stencilInstantiation->getIIR()->getStencilFunctions()) {
       if(sf->Name == usedBoundaryCondition.second->getFunctor()) {
 
-        Structure BoundaryCondition = stencilWrapperClass.addStruct(Twine(sf->Name));
+        Structure BoundaryCondition = stencilWrapperClass.addStruct(sf->Name);
         std::string templatefunctions = "typename Direction ";
         std::string functionargs = "Direction ";
 
@@ -156,8 +156,8 @@ void CodeGen::generateBoundaryConditionFunctions(
           functionargs += dawn::format(", DataField_%i &data_field_%i", i, i);
         }
         functionargs += ", int i , int j, int k";
-        auto BC = BoundaryCondition.addMemberFunction(
-            Twine("GT_FUNCTION void"), Twine("operator()"), Twine(templatefunctions));
+        auto BC = BoundaryCondition.addMemberFunction("GT_FUNCTION void", "operator()",
+                                                      templatefunctions);
         BC.isConst(true);
         BC.addArg(functionargs);
         BC.startBody();
@@ -249,7 +249,7 @@ CodeGen::computeCodeGenProperties(const iir::StencilInstantiation* stencilInstan
       }
 
       for(const auto& field : tempFields) {
-        paramNameToType.emplace(field.second.Name, c_dgt().str() + "storage_t");
+        paramNameToType.emplace(field.second.Name, c_dgt() + "storage_t");
       }
     }
   }

--- a/dawn/src/dawn/CodeGen/Cuda/CudaCodeGen.cpp
+++ b/dawn/src/dawn/CodeGen/Cuda/CudaCodeGen.cpp
@@ -216,7 +216,7 @@ void CudaCodeGen::generateStencilClasses(
     }
 
     for(const auto& fieldPair : tempFields) {
-      paramNameToType.emplace(fieldPair.second.Name, c_dgt().str() + "storage_t");
+      paramNameToType.emplace(fieldPair.second.Name, c_dgt() + "storage_t");
     }
 
     iterationSpaceSet_ = hasGlobalIndices(stencil);
@@ -377,7 +377,7 @@ void CudaCodeGen::generateStencilWrapperMembers(
   const auto& globalsMap = stencilInstantiation->getIIR()->getGlobalVariableMap();
 
   stencilWrapperClass.addMember("static constexpr const char* s_name =",
-                                Twine("\"") + stencilWrapperClass.getName() + Twine("\""));
+                                "\"" + stencilWrapperClass.getName() + "\"");
 
   for(auto stencilPropertiesPair :
       codeGenProperties.stencilProperties(StencilContext::SC_Stencil)) {

--- a/dawn/src/dawn/CodeGen/GridTools/GTCodeGen.cpp
+++ b/dawn/src/dawn/CodeGen/GridTools/GTCodeGen.cpp
@@ -169,7 +169,7 @@ void GTCodeGen::generatePlaceholderDefinitions(
     // Fields
     stencilClass.addTypeDef("p_" + fieldInfo.Name)
         .addType(c_gt() + (fieldInfo.IsTemporary ? "tmp_arg" : "arg"))
-        .addTemplate(Twine(accessorIdx))
+        .addTemplate(accessorIdx)
         .addTemplate(codeGenProperties.getParamType(stencilInstantiation, fieldInfo));
     ++accessorIdx;
   }
@@ -178,7 +178,7 @@ void GTCodeGen::generatePlaceholderDefinitions(
     stencilClass.addTypeDef("globals_gp_t").addType(c_gt() + "global_parameter<backend_t,globals>");
     stencilClass.addTypeDef("p_globals")
         .addType(c_gt() + "arg")
-        .addTemplate(Twine(accessorIdx))
+        .addTemplate(accessorIdx)
         .addTemplate("globals_gp_t");
   }
 }
@@ -437,7 +437,7 @@ void GTCodeGen::generateStencilWrapperMembers(
   stencilWrapperClass.addMember("const " + c_dgt() + "domain", "m_dom");
 
   stencilWrapperClass.addMember("static constexpr const char* s_name =",
-                                Twine("\"") + stencilWrapperClass.getName() + Twine("\""));
+                                "\"" + stencilWrapperClass.getName() + "\"");
 
   // globals member
   if(!globalsMap.empty()) {
@@ -607,13 +607,13 @@ void GTCodeGen::generateStencilClasses(
               iir::extent_cast<dawn::iir::CartesianExtent const&>(extents.horizontalExtent());
           auto const& vExtents = extents.verticalExtent();
 
-          extent.addTemplate(Twine(hExtents.iMinus()) + ", " + Twine(hExtents.iPlus()));
-          extent.addTemplate(Twine(hExtents.jMinus()) + ", " + Twine(hExtents.jPlus()));
-          extent.addTemplate(Twine(vExtents.minus()) + ", " + Twine(vExtents.plus()));
+          extent.addTemplate(hExtents.iMinus() + ", " + hExtents.iPlus());
+          extent.addTemplate(hExtents.jMinus() + ", " + hExtents.jPlus());
+          extent.addTemplate(vExtents.minus() + ", " + vExtents.plus());
 
           StencilFunStruct.addTypeDef(paramName)
               .addType(c_gt() + "accessor")
-              .addTemplate(Twine(accessorID))
+              .addTemplate(accessorID)
               .addTemplate(c_gt_intent() + ((fields[m].getIntend() == iir::Field::IntendKind::Input)
                                                 ? "in"
                                                 : "inout"))
@@ -626,7 +626,7 @@ void GTCodeGen::generateStencilClasses(
         if(stencilFun->hasGlobalVariables()) {
           StencilFunStruct.addTypeDef("globals")
               .addType(c_gt() + "global_accessor")
-              .addTemplate(Twine(accessorID));
+              .addTemplate(accessorID);
           accessorID++;
           arglist.push_back("globals");
         }
@@ -721,8 +721,7 @@ void GTCodeGen::generateStencilClasses(
                   c_gt() + "cache_io_policy::" + cache.getIOPolicyAsString() +
                   // Interval: if IOPolicy is not local, we need to provide the interval
                   ">(p_" + metadata.getFieldNameFromAccessID(cache.getCachedFieldAccessID()) +
-                  "())")
-              .str();
+                  "())");
         });
       }
 
@@ -732,8 +731,8 @@ void GTCodeGen::generateStencilClasses(
         const auto& stagePtr = *stageIt;
         const iir::Stage& stage = *stagePtr;
 
-        Structure StageStruct =
-            stencilClass.addStruct(Twine("stage_") + Twine(multiStageIdx) + "_" + Twine(stageIdx));
+        Structure StageStruct = stencilClass.addStruct("stage_" + std::to_string(multiStageIdx) +
+                                                       "_" + std::to_string(stageIdx));
 
         ssMS << c_gt() + "make_stage_with_extent<" << StageStruct.getName()
              << ", " + c_gt() + "extent< ";
@@ -770,13 +769,13 @@ void GTCodeGen::generateStencilClasses(
               iir::extent_cast<iir::CartesianExtent const&>(extents.horizontalExtent());
           auto const& fieldVExtents = extents.verticalExtent();
 
-          extent.addTemplate(Twine(fieldHExtents.iMinus()) + ", " + Twine(fieldHExtents.iPlus()));
-          extent.addTemplate(Twine(fieldHExtents.jMinus()) + ", " + Twine(fieldHExtents.jPlus()));
-          extent.addTemplate(Twine(fieldVExtents.minus()) + ", " + Twine(fieldVExtents.plus()));
+          extent.addTemplate(fieldHExtents.iMinus() + ", " + fieldHExtents.iPlus());
+          extent.addTemplate(fieldHExtents.jMinus() + ", " + fieldHExtents.jPlus());
+          extent.addTemplate(fieldVExtents.minus() + ", " + fieldVExtents.plus());
 
           StageStruct.addTypeDef(paramName)
               .addType(c_gt() + "accessor")
-              .addTemplate(Twine(accessorIdx))
+              .addTemplate(accessorIdx)
               .addTemplate(c_gt_intent() +
                            ((field.getIntend() == iir::Field::IntendKind::Input) ? "in" : "inout"))
               .addTemplate(extent);
@@ -792,7 +791,7 @@ void GTCodeGen::generateStencilClasses(
         if(stage.hasGlobalVariables()) {
           StageStruct.addTypeDef("globals")
               .addType(c_gt() + "global_accessor")
-              .addTemplate(Twine(accessorIdx));
+              .addTemplate(accessorIdx);
 
           ssMS << "p_"
                << "globals"
@@ -941,9 +940,9 @@ void GTCodeGen::generateStencilClasses(
         (!domainMapPlaceholders.empty() ? RangeToString(", ", "", ",")(domainMapPlaceholders) : "");
 
     // This is a memory leak.. but nothing we can do ;)
-    StencilConstructor.addStatement(Twine("m_stencil = " + c_gt() +
-                                          "make_computation<backend_t>(grid_, " + plchdrStr +
-                                          RangeToString(", ", "", ")")(makeComputation)));
+    StencilConstructor.addStatement("m_stencil = " + c_gt() +
+                                    "make_computation<backend_t>(grid_, " + plchdrStr +
+                                    RangeToString(", ", "", ")")(makeComputation));
     StencilConstructor.commit();
 
     stencilClass.addComment("Members");
@@ -951,7 +950,7 @@ void GTCodeGen::generateStencilClasses(
     auto plchdrs = CodeGenUtils::buildPlaceholderList(stencilInstantiation->getMetaData(),
                                                       stencilFields, globalsMap);
 
-    stencilType = c_gt().str() + "computation" + RangeToString(",", "<", ">")(plchdrs);
+    stencilType = c_gt() + "computation" + RangeToString(",", "<", ">")(plchdrs);
 
     stencilClass.addMember(stencilType, "m_stencil");
 

--- a/dawn/src/dawn/CodeGen/GridTools/GTCodeGen.cpp
+++ b/dawn/src/dawn/CodeGen/GridTools/GTCodeGen.cpp
@@ -607,9 +607,9 @@ void GTCodeGen::generateStencilClasses(
               iir::extent_cast<dawn::iir::CartesianExtent const&>(extents.horizontalExtent());
           auto const& vExtents = extents.verticalExtent();
 
-          extent.addTemplate(hExtents.iMinus() + ", " + hExtents.iPlus());
-          extent.addTemplate(hExtents.jMinus() + ", " + hExtents.jPlus());
-          extent.addTemplate(vExtents.minus() + ", " + vExtents.plus());
+          extent.addTemplate(std::to_string(hExtents.iMinus()) + ", " + std::to_string(hExtents.iPlus()));
+          extent.addTemplate(std::to_string(hExtents.jMinus()) + ", " + std::to_string(hExtents.jPlus()));
+          extent.addTemplate(std::to_string(vExtents.minus()) + ", " + std::to_string(vExtents.plus()));
 
           StencilFunStruct.addTypeDef(paramName)
               .addType(c_gt() + "accessor")
@@ -769,9 +769,9 @@ void GTCodeGen::generateStencilClasses(
               iir::extent_cast<iir::CartesianExtent const&>(extents.horizontalExtent());
           auto const& fieldVExtents = extents.verticalExtent();
 
-          extent.addTemplate(fieldHExtents.iMinus() + ", " + fieldHExtents.iPlus());
-          extent.addTemplate(fieldHExtents.jMinus() + ", " + fieldHExtents.jPlus());
-          extent.addTemplate(fieldVExtents.minus() + ", " + fieldVExtents.plus());
+          extent.addTemplate(std::to_string(fieldHExtents.iMinus()) + ", " + std::to_string(fieldHExtents.iPlus()));
+          extent.addTemplate(std::to_string(fieldHExtents.jMinus()) + ", " + std::to_string(fieldHExtents.jPlus()));
+          extent.addTemplate(std::to_string(fieldVExtents.minus()) + ", " + std::to_string(fieldVExtents.plus()));
 
           StageStruct.addTypeDef(paramName)
               .addType(c_gt() + "accessor")

--- a/dawn/src/dawn/IIR/Interval.cpp
+++ b/dawn/src/dawn/IIR/Interval.cpp
@@ -61,6 +61,8 @@ std::string Interval::toStringGen() const {
   return ss.str();
 }
 
+Interval::operator std::string() const { return toString(); }
+
 std::ostream& operator<<(std::ostream& os, const Interval& interval) {
   auto printLevel = [&](int level, int offset) -> void {
     if(level == sir::Interval::Start)

--- a/dawn/src/dawn/IIR/Interval.h
+++ b/dawn/src/dawn/IIR/Interval.h
@@ -181,8 +181,8 @@ public:
   bool upperLevelIsEnd() const { return upper_.isEnd(); }
 
   /// @brief Convert interval to string
+  explicit operator std::string() const;
   std::string toString() const;
-
   std::string toStringGen() const;
 
   friend std::ostream& operator<<(std::ostream& os, const Interval& interval);

--- a/dawn/src/dawn/IIR/StencilInstantiation.cpp
+++ b/dawn/src/dawn/IIR/StencilInstantiation.cpp
@@ -31,7 +31,6 @@
 #include "dawn/Support/Logger.h"
 #include "dawn/Support/Printing.h"
 #include "dawn/Support/RemoveIf.hpp"
-#include "dawn/Support/Twine.h"
 #include <cstdlib>
 #include <fstream>
 #include <functional>
@@ -226,8 +225,8 @@ void StencilInstantiation::jsonDump(std::string filename) const {
 
 template <int Level>
 struct PrintDescLine {
-  PrintDescLine(std::ostream& os, const Twine& name) : os_(os) {
-    os_ << MakeIndent<Level>::value << format("\033[1;3%im", Level) << name.str() << "\n"
+  PrintDescLine(std::ostream& os, const std::string& name) : os_(os) {
+    os_ << MakeIndent<Level>::value << format("\033[1;3%im", Level) << name << "\n"
         << MakeIndent<Level>::value << "{\n\033[0m";
   }
   ~PrintDescLine() { os_ << MakeIndent<Level>::value << format("\033[1;3%im}\n\033[0m", Level); }
@@ -240,12 +239,12 @@ void StencilInstantiation::dump(std::ostream& os) const {
 
   int i = 0;
   for(const auto& stencil : getStencils()) {
-    PrintDescLine<1> iline(os, "Stencil_" + Twine(i));
+    PrintDescLine<1> iline(os, "Stencil_" + std::to_string(i));
 
     int j = 0;
     const auto& multiStages = stencil->getChildren();
     for(const auto& multiStage : multiStages) {
-      PrintDescLine<2> jline(os, Twine("MultiStage_") + Twine(j) + " [" +
+      PrintDescLine<2> jline(os, "MultiStage_" + std::to_string(j) + " [" +
                                      loopOrderToString(multiStage->getLoopOrder()) + "]");
 
       int k = 0;
@@ -260,13 +259,13 @@ void StencilInstantiation::dump(std::ostream& os) const {
           globidx += "J: " + iterSpace[1]->toString() + " ";
         }
 
-        PrintDescLine<3> kline(os, Twine("Stage_") + Twine(k) + Twine(" ") + Twine(globidx));
+        PrintDescLine<3> kline(os, "Stage_" + std::to_string(k) + " " + globidx);
 
         int l = 0;
         const auto& doMethods = stage->getChildren();
         for(const auto& doMethod : doMethods) {
-          PrintDescLine<4> lline(os, Twine("Do_") + Twine(l) + " " +
-                                         doMethod->getInterval().toString());
+          PrintDescLine<4> lline(os, "Do_" + std::to_string(l) + " " +
+                                         std::string(doMethod->getInterval()));
 
           const auto& stmts = doMethod->getAST().getStatements();
           for(std::size_t m = 0; m < stmts.size(); ++m) {

--- a/gtclang/src/gtclang/Unittest/ParsingComparison.cpp
+++ b/gtclang/src/gtclang/Unittest/ParsingComparison.cpp
@@ -27,6 +27,7 @@
 #include "llvm/ProfileData/InstrProf.h"
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/Path.h"
+
 #include <fstream>
 
 namespace gtclang {
@@ -93,7 +94,7 @@ struct VerticalRegion : public NestableFunctions {
 
 struct StencilBase : public dawn::codegen::Structure {
   StencilBase(const std::string& type, const std::string& name, std::stringstream& s)
-      : Structure(type.str().c_str(), name, s) {}
+      : Structure(type.c_str(), name, s) {}
 
   Statement addStorage(const std::string& memberName) {
     Statement member(ss(), IndentLevel + 1);

--- a/gtclang/src/gtclang/Unittest/ParsingComparison.cpp
+++ b/gtclang/src/gtclang/Unittest/ParsingComparison.cpp
@@ -20,6 +20,7 @@
 #include "dawn/SIR/SIR.h"
 #include "dawn/Support/Array.h"
 #include "dawn/Support/Casting.h"
+#include "dawn/Support/Twine.h"
 #include "dawn/Support/Unreachable.h"
 #include "gtclang/Unittest/GTClang.h"
 #include "gtclang/Unittest/UnittestEnvironment.h"

--- a/gtclang/src/gtclang/Unittest/ParsingComparison.cpp
+++ b/gtclang/src/gtclang/Unittest/ParsingComparison.cpp
@@ -134,7 +134,7 @@ struct Stencil : public StencilBase {
 };
 
 struct Globals : public StencilBase {
-  Globals(std::stringstream& s) : StencilBase("globals", std::string::createNull(), s) {}
+  Globals(std::stringstream& s) : StencilBase("globals", "", s) {}
   virtual NestableFunctions addDoMethod(const std::string& type) = delete;
   virtual Statement addOffset(const std::string& offsetName) = delete;
   virtual ~Globals() {}

--- a/gtclang/src/gtclang/Unittest/ParsingComparison.cpp
+++ b/gtclang/src/gtclang/Unittest/ParsingComparison.cpp
@@ -62,24 +62,24 @@ using namespace gtclang::dsl;
 };
 
 struct NestableFunctions : public dawn::codegen::MemberFunction {
-  NestableFunctions(const dawn::Twine& type, const dawn::Twine& name, std::stringstream& s,
+  NestableFunctions(const std::string& type, const std::string& name, std::stringstream& s,
                     int il = 0)
       : MemberFunction(type, name, s, il) {}
 
-  NestableFunctions addFunction(const dawn::Twine& returntype, const dawn::Twine& name) {
+  NestableFunctions addFunction(const std::string& returntype, const std::string& name) {
     NestableFunctions nf(returntype, name, ss(), IndentLevel + 1);
     return nf;
   }
 
-  NestableFunctions addVerticalRegion(const dawn::Twine& min, const dawn::Twine& max) {
-    NestableFunctions nf(dawn::Twine::createNull(), "vertical_region", ss(), IndentLevel + 1);
+  NestableFunctions addVerticalRegion(const std::string& min, const std::string& max) {
+    NestableFunctions nf("", "vertical_region", ss(), IndentLevel + 1);
     nf.addArg(min).addArg(max);
     nf.startBody();
     return nf;
   }
 
-  NestableFunctions addIfStatement(const dawn::Twine& ifCondition) {
-    NestableFunctions ifStatement(dawn::Twine::createNull(), "if", ss(), IndentLevel + 1);
+  NestableFunctions addIfStatement(const std::string& ifCondition) {
+    NestableFunctions ifStatement("", "if", ss(), IndentLevel + 1);
     ifStatement.addArg(ifCondition);
     ifStatement.startBody();
     return ifStatement;
@@ -87,27 +87,27 @@ struct NestableFunctions : public dawn::codegen::MemberFunction {
 };
 
 struct VerticalRegion : public NestableFunctions {
-  VerticalRegion(const dawn::Twine& name, std::stringstream& s, int il = 0)
-      : NestableFunctions(dawn::Twine::createNull(), name, s, il) {}
+  VerticalRegion(const std::string& name, std::stringstream& s, int il = 0)
+      : NestableFunctions("", name, s, il) {}
 };
 
 struct StencilBase : public dawn::codegen::Structure {
-  StencilBase(const dawn::Twine& type, const dawn::Twine& name, std::stringstream& s)
+  StencilBase(const std::string& type, const std::string& name, std::stringstream& s)
       : Structure(type.str().c_str(), name, s) {}
 
-  Statement addStorage(const dawn::Twine& memberName) {
+  Statement addStorage(const std::string& memberName) {
     Statement member(ss(), IndentLevel + 1);
     member << "storage"
            << " " << memberName;
     return member;
   }
 
-  NestableFunctions addDoMethod(const dawn::Twine& type) {
+  NestableFunctions addDoMethod(const std::string& type) {
     NestableFunctions nf(type, "Do", ss(), IndentLevel + 1);
     return nf;
   }
 
-  Statement addOffset(const dawn::Twine& offsetName) {
+  Statement addOffset(const std::string& offsetName) {
     Statement member(ss(), IndentLevel + 1);
     member << "offset"
            << " " << offsetName;
@@ -116,10 +116,10 @@ struct StencilBase : public dawn::codegen::Structure {
 };
 
 struct StencilFunction : public StencilBase {
-  StencilFunction(const dawn::Twine& name, std::stringstream& s)
+  StencilFunction(const std::string& name, std::stringstream& s)
       : StencilBase("stencil_function", name, s) {}
 
-  virtual NestableFunctions addDoMethod(const dawn::Twine& type) {
+  virtual NestableFunctions addDoMethod(const std::string& type) {
     NestableFunctions nf(type, "Do", ss(), IndentLevel + 1);
     nf.startBody();
     return nf;
@@ -129,13 +129,13 @@ struct StencilFunction : public StencilBase {
 };
 
 struct Stencil : public StencilBase {
-  Stencil(const dawn::Twine& name, std::stringstream& s) : StencilBase("stencil", name, s) {}
+  Stencil(const std::string& name, std::stringstream& s) : StencilBase("stencil", name, s) {}
 };
 
 struct Globals : public StencilBase {
-  Globals(std::stringstream& s) : StencilBase("globals", dawn::Twine::createNull(), s) {}
-  virtual NestableFunctions addDoMethod(const dawn::Twine& type) = delete;
-  virtual Statement addOffset(const dawn::Twine& offsetName) = delete;
+  Globals(std::stringstream& s) : StencilBase("globals", std::string::createNull(), s) {}
+  virtual NestableFunctions addDoMethod(const std::string& type) = delete;
+  virtual Statement addOffset(const std::string& offsetName) = delete;
   virtual ~Globals() {}
 };
 


### PR DESCRIPTION
## Technical Description

Remove usage of Support/Twine (and all helper classes) from Dawn in preparation for moving this code to GTClang.