### PR TITLE
Fix bug in unstructured Cuda Codegen

### DIFF
--- a/dawn/src/dawn/CodeGen/Cuda-ico/CudaIcoCodeGen.cpp
+++ b/dawn/src/dawn/CodeGen/Cuda-ico/CudaIcoCodeGen.cpp
@@ -450,15 +450,15 @@ void CudaIcoCodeGen::generateAllCudaKernels(
       cudaKernel.addStatement("int khi = (kidx + 1) * LEVELS_PER_THREAD");
       switch(loc) {
       case ast::LocationType::Cells:
-        cudaKernel.addBlockStatement("if (pidx >= NumCells)",
+        cudaKernel.addBlockStatement("if (pidx >= NumCells || kidx >= k_size)",
                                      [&]() { cudaKernel.addStatement("return"); });
         break;
       case ast::LocationType::Edges:
-        cudaKernel.addBlockStatement("if (pidx >= NumEdges)",
+        cudaKernel.addBlockStatement("if (pidx >= NumEdges || kidx >= k_size)",
                                      [&]() { cudaKernel.addStatement("return"); });
         break;
       case ast::LocationType::Vertices:
-        cudaKernel.addBlockStatement("if (pidx >= NumVertices)",
+        cudaKernel.addBlockStatement("if (pidx >= NumVertices || kidx >= k_size)",
                                      [&]() { cudaKernel.addStatement("return"); });
         break;
       }

--- a/dawn/src/dawn/CodeGen/Cuda-ico/CudaIcoCodeGen.cpp
+++ b/dawn/src/dawn/CodeGen/Cuda-ico/CudaIcoCodeGen.cpp
@@ -450,21 +450,24 @@ void CudaIcoCodeGen::generateAllCudaKernels(
       cudaKernel.addStatement("int khi = (kidx + 1) * LEVELS_PER_THREAD");
       switch(loc) {
       case ast::LocationType::Cells:
-        cudaKernel.addBlockStatement("if (pidx >= NumCells || kidx >= k_size)",
+        cudaKernel.addBlockStatement("if (pidx >= NumCells)",
                                      [&]() { cudaKernel.addStatement("return"); });
         break;
       case ast::LocationType::Edges:
-        cudaKernel.addBlockStatement("if (pidx >= NumEdges || kidx >= k_size)",
+        cudaKernel.addBlockStatement("if (pidx >= NumEdges)",
                                      [&]() { cudaKernel.addStatement("return"); });
         break;
       case ast::LocationType::Vertices:
-        cudaKernel.addBlockStatement("if (pidx >= NumVertices || kidx >= k_size)",
+        cudaKernel.addBlockStatement("if (pidx >= NumVertices)",
                                      [&]() { cudaKernel.addStatement("return"); });
         break;
       }
 
       // k loop
       cudaKernel.addBlockStatement("for(int kIter = klo; kIter < khi; kIter++)", [&]() {
+        cudaKernel.addBlockStatement("if (kIter >= k_size)",
+                                     [&]() { cudaKernel.addStatement("return"); });
+
         // Generate Do-Method
         for(const auto& doMethodPtr : stage->getChildren()) {
           const iir::DoMethod& doMethod = *doMethodPtr;

--- a/dawn/src/dawn/CodeGen/Cuda-ico/CudaIcoCodeGen.cpp
+++ b/dawn/src/dawn/CodeGen/Cuda-ico/CudaIcoCodeGen.cpp
@@ -465,7 +465,7 @@ void CudaIcoCodeGen::generateAllCudaKernels(
 
       // k loop
       cudaKernel.addBlockStatement("for(int kIter = klo; kIter < khi; kIter++)", [&]() {
-        cudaKernel.addBlockStatement("if (kIter >= k_size)",
+        cudaKernel.addBlockStatement("if (kIter >= kSize)",
                                      [&]() { cudaKernel.addStatement("return"); });
 
         // Generate Do-Method


### PR DESCRIPTION
## Technical Description

The unstructured cuda code emitted was guarding that the number of threads is smaller then the number of entities worked on in the horizontal, but not in the vertical. This bug was masked by the fact that tests often spool up thread numbers in powers of 2, which happen to be divisible the BLOCK_SIZE. This PR fixes that issue. 

### Dependencies

This PR is independent


