### PR TITLE
Use max_digits10 for serialization

### DIFF
--- a/dawn/src/dawn/SIR/SIR.cpp
+++ b/dawn/src/dawn/SIR/SIR.cpp
@@ -730,11 +730,11 @@ std::string sir::Value::toString() const {
   case Kind::Integer:
     return std::to_string(std::get<int>(*value_));
   case Kind::Double:
-    out << std::setprecision(std::numeric_limits<double>::digits10 + 1)
+    out << std::setprecision(std::numeric_limits<double>::max_digits10)
         << std::get<double>(*value_);
     return out.str();
   case Kind::Float:
-    out << std::setprecision(std::numeric_limits<float>::digits10 + 1) << std::get<float>(*value_);
+    out << std::setprecision(std::numeric_limits<float>::max_digits10) << std::get<float>(*value_);
     return out.str();
   case Kind::String:
     return std::get<std::string>(*value_);


### PR DESCRIPTION
## Technical Description

`max_digits10` guarantees no loss when serializing -> deserializing

> Unlike most mathematical operations, the conversion of a floating-point value to text and back is exact as long as at least max_digits10 were used (9 for float, 17 for double)

from https://en.cppreference.com/w/cpp/types/numeric_limits/max_digits10
