### PR TITLE
Fix Faulty Code Generation for Reductions in Cuda Backend

### DIFF
--- a/dawn/src/dawn/CodeGen/CMakeLists.txt
+++ b/dawn/src/dawn/CodeGen/CMakeLists.txt
@@ -75,4 +75,4 @@ add_library(DawnCodeGen
 )
 
 target_add_dawn_standard_props(DawnCodeGen)
-target_link_libraries(DawnCodeGen PUBLIC DawnSupport DawnIIR)
+target_link_libraries(DawnCodeGen PUBLIC DawnSerialization DawnSupport DawnIIR)

--- a/dawn/src/dawn/CodeGen/Cuda-ico/ASTStencilBody.cpp
+++ b/dawn/src/dawn/CodeGen/Cuda-ico/ASTStencilBody.cpp
@@ -78,19 +78,9 @@ void ASTStencilBody::visit(const std::shared_ptr<iir::VarAccessExpr>& expr) {
 }
 
 void ASTStencilBody::visit(const std::shared_ptr<iir::AssignmentExpr>& expr) {
-  // FindReduceOverNeighborExpr reductionFinder;
-  // expr->getRight()->accept(reductionFinder);
-  // if(reductionFinder.hasReduceOverNeighborExpr()) {
-  //   expr->getRight()->accept(*this);
-  //   expr->getLeft()->accept(*this);
-
-  //   ss_ << expr->getOp()
-  //       << "lhs_" + std::to_string(reductionFinder.reduceOverNeighborExpr()->getID()) << ";}\n";
-  // } else {
   expr->getLeft()->accept(*this);
   ss_ << " " << expr->getOp() << " ";
   expr->getRight()->accept(*this);
-  // }
 }
 
 void ASTStencilBody::visit(const std::shared_ptr<iir::FieldAccessExpr>& expr) {

--- a/dawn/src/dawn/CodeGen/Cuda-ico/ASTStencilBody.h
+++ b/dawn/src/dawn/CodeGen/Cuda-ico/ASTStencilBody.h
@@ -35,6 +35,21 @@ class StencilMetaInformation;
 namespace codegen {
 namespace cudaico {
 
+class FindReduceOverNeighborExpr : public dawn::ast::ASTVisitorForwarding {
+  std::vector<std::shared_ptr<dawn::iir::ReductionOverNeighborExpr>> foundReductions_;
+
+public:
+  void visit(const std::shared_ptr<dawn::iir::ReductionOverNeighborExpr>& expr) override {
+    foundReductions_.push_back(expr);
+    return;
+  }
+  bool hasReduceOverNeighborExpr() const { return !foundReductions_.empty(); }
+  const std::vector<std::shared_ptr<dawn::iir::ReductionOverNeighborExpr>>&
+  reduceOverNeighborExprs() const {
+    return foundReductions_;
+  }
+};
+
 /// @brief ASTVisitor to generate C++ naive code for the stencil and stencil function bodies
 /// @ingroup cxxnaiveico
 class ASTStencilBody : public ASTCodeGenCXX {
@@ -48,6 +63,8 @@ protected:
   bool parentIsReduction_ = false;
   bool parentIsForLoop_ = false;
 
+  bool firstPass_ = true;
+
   /// Nesting level of argument lists of stencil function *calls*
   int nestingOfStencilFunArgLists_;
 
@@ -59,6 +76,9 @@ public:
   ASTStencilBody(const iir::StencilMetaInformation& metadata);
 
   virtual ~ASTStencilBody();
+
+  void setFirstPass() { firstPass_ = true; };
+  void setSecondPass() { firstPass_ = false; };
 
   /// @name Statement implementation
   /// @{

--- a/dawn/src/dawn/CodeGen/Cuda-ico/CudaIcoCodeGen.cpp
+++ b/dawn/src/dawn/CodeGen/Cuda-ico/CudaIcoCodeGen.cpp
@@ -472,6 +472,13 @@ void CudaIcoCodeGen::generateAllCudaKernels(
         for(const auto& doMethodPtr : stage->getChildren()) {
           const iir::DoMethod& doMethod = *doMethodPtr;
           for(const auto& stmt : doMethod.getAST().getStatements()) {
+            FindReduceOverNeighborExpr findReduceOverNeighborExpr;
+            stmt->accept(findReduceOverNeighborExpr);
+            stencilBodyCXXVisitor.setFirstPass();
+            for(auto redExpr : findReduceOverNeighborExpr.reduceOverNeighborExprs()) {
+              redExpr->accept(stencilBodyCXXVisitor);
+            }
+            stencilBodyCXXVisitor.setSecondPass();
             stmt->accept(stencilBodyCXXVisitor);
             cudaKernel << stencilBodyCXXVisitor.getCodeAndResetStream();
           }

--- a/dawn/src/dawn/CodeGen/Cuda-ico/CudaIcoCodeGen.cpp
+++ b/dawn/src/dawn/CodeGen/Cuda-ico/CudaIcoCodeGen.cpp
@@ -515,7 +515,8 @@ std::string CudaIcoCodeGen::generateStencilInstantiation(
     ss << "int " + chainToSparseSizeString(chain) << " ";
     first = false;
   }
-  Class stencilWrapperClass(stencilInstantiation->getName(), ssSW, "typename LibTag, " + ss.str());
+  std::string templates = chains.empty() ? "typename LibTag" : "typename LibTag, " + ss.str();
+  Class stencilWrapperClass(stencilInstantiation->getName(), ssSW, templates);
 
   stencilWrapperClass.changeAccessibility("public");
 

--- a/dawn/test/integration-test/unstructured/GenerateUnstructuredStencils.cpp
+++ b/dawn/test/integration-test/unstructured/GenerateUnstructuredStencils.cpp
@@ -258,40 +258,6 @@ int main() {
     using LocType = dawn::ast::LocationType;
 
     UnstructuredIIRBuilder b;
-    auto cell_f = b.field("cell_field", LocType::Cells);
-    auto edge_f = b.field("edge_field", LocType::Edges);
-
-    auto stencilInstantiation = b.build(
-        "gradient",
-        b.stencil(b.multistage(
-            dawn::iir::LoopOrderKind::Parallel,
-            b.stage(
-                LocType::Edges,
-                b.doMethod(dawn::sir::Interval::Start, dawn::sir::Interval::End,
-                           b.stmt(b.assignExpr(
-                               b.at(edge_f), b.reduceOverNeighborExpr<float>(
-                                                 Op::plus, b.at(cell_f, HOffsetType::withOffset, 0),
-                                                 b.lit(0.), {LocType::Edges, LocType::Cells},
-                                                 std::vector<float>({1., -1.})))))),
-            b.stage(
-                LocType::Cells,
-                b.doMethod(dawn::sir::Interval::Start, dawn::sir::Interval::End,
-                           b.stmt(b.assignExpr(
-                               b.at(cell_f), b.reduceOverNeighborExpr<float>(
-                                                 Op::plus, b.at(edge_f, HOffsetType::withOffset, 0),
-                                                 b.lit(0.), {LocType::Cells, LocType::Edges},
-                                                 std::vector<float>({0.5, 0., 0., 0.5})))))))));
-
-    std::ofstream of("generated/generated_gradient.hpp");
-    auto tu = dawn::codegen::run(stencilInstantiation, dawn::codegen::Backend::CXXNaiveIco);
-    of << dawn::codegen::generate(tu) << std::endl;
-  }
-
-  {
-    using namespace dawn::iir;
-    using LocType = dawn::ast::LocationType;
-
-    UnstructuredIIRBuilder b;
     auto edge_f = b.field("edge_field", LocType::Edges);
     auto node_f = b.field("vertex_field", LocType::Vertices);
 

--- a/dawn/test/unit-test/dawn/CodeGen/CMakeLists.txt
+++ b/dawn/test/unit-test/dawn/CodeGen/CMakeLists.txt
@@ -27,3 +27,15 @@ foreach(backend IN ITEMS Cuda Naive)
     DISCOVERY_TIMEOUT 30
   )
 endforeach()
+
+foreach(backend IN ITEMS Cuda-Ico Naive-Ico)
+  set(executable ${PROJECT_NAME}UnittestCodeGen${backend})
+  add_executable(${executable} ${backend}/Test${backend}CodeGen.cpp UnstructuredStencils.cpp)
+  target_add_dawn_standard_props(${executable})
+  target_include_directories(${executable} PRIVATE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>)
+  target_link_libraries(${executable} DawnUnittest gtest gtest_main)
+  gtest_discover_tests(${executable} TEST_PREFIX "Dawn::Unit::UnstructuredCodeGen::"
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    DISCOVERY_TIMEOUT 30
+  )
+endforeach()

--- a/dawn/test/unit-test/dawn/CodeGen/Cuda-Ico/TestCuda-IcoCodeGen.cpp
+++ b/dawn/test/unit-test/dawn/CodeGen/Cuda-Ico/TestCuda-IcoCodeGen.cpp
@@ -22,6 +22,8 @@ namespace {
 
 constexpr auto backend = dawn::codegen::Backend::CUDAIco;
 
-TEST(CudaIco, Reductions) { runTest(dawn::getReductionsStencil(), backend); }
+TEST(CudaIco, Reductions) {
+  runTest(dawn::getReductionsStencil(), backend, "reference/reductions_cuda-ico.cu");
+}
 
 } // namespace

--- a/dawn/test/unit-test/dawn/CodeGen/Cuda-Ico/TestCuda-IcoCodeGen.cpp
+++ b/dawn/test/unit-test/dawn/CodeGen/Cuda-Ico/TestCuda-IcoCodeGen.cpp
@@ -1,0 +1,27 @@
+//===--------------------------------------------------------------------------------*- C++ -*-===//
+//                          _
+//                         | |
+//                       __| | __ ___      ___ ___
+//                      / _` |/ _` \ \ /\ / / '_  |
+//                     | (_| | (_| |\ V  V /| | | |
+//                      \__,_|\__,_| \_/\_/ |_| |_| - Compiler Toolchain
+//
+//
+//  This file is distributed under the MIT License (MIT).
+//  See LICENSE.txt for details.
+//
+//===------------------------------------------------------------------------------------------===//
+
+#include "UnstructuredStencils.h"
+#include "dawn/CodeGen/Options.h"
+#include "dawn/Serialization/IIRSerializer.h"
+
+#include <gtest/gtest.h>
+
+namespace {
+
+constexpr auto backend = dawn::codegen::Backend::CUDAIco;
+
+TEST(CudaIco, Reductions) { runTest(dawn::getReductionsStencil(), backend); }
+
+} // namespace

--- a/dawn/test/unit-test/dawn/CodeGen/Naive-Ico/TestNaive-IcoCodeGen.cpp
+++ b/dawn/test/unit-test/dawn/CodeGen/Naive-Ico/TestNaive-IcoCodeGen.cpp
@@ -1,0 +1,27 @@
+//===--------------------------------------------------------------------------------*- C++ -*-===//
+//                          _
+//                         | |
+//                       __| | __ ___      ___ ___
+//                      / _` |/ _` \ \ /\ / / '_  |
+//                     | (_| | (_| |\ V  V /| | | |
+//                      \__,_|\__,_| \_/\_/ |_| |_| - Compiler Toolchain
+//
+//
+//  This file is distributed under the MIT License (MIT).
+//  See LICENSE.txt for details.
+//
+//===------------------------------------------------------------------------------------------===//
+
+#include "UnstructuredStencils.h"
+#include "dawn/CodeGen/Options.h"
+#include "dawn/Serialization/IIRSerializer.h"
+
+#include <gtest/gtest.h>
+
+namespace {
+
+constexpr auto backend = dawn::codegen::Backend::CXXNaiveIco;
+
+TEST(NaiveIco, Reductions) { runTest(dawn::getReductionsStencil(), backend); }
+
+} // namespace

--- a/dawn/test/unit-test/dawn/CodeGen/Naive-Ico/TestNaive-IcoCodeGen.cpp
+++ b/dawn/test/unit-test/dawn/CodeGen/Naive-Ico/TestNaive-IcoCodeGen.cpp
@@ -22,6 +22,8 @@ namespace {
 
 constexpr auto backend = dawn::codegen::Backend::CXXNaiveIco;
 
-TEST(NaiveIco, Reductions) { runTest(dawn::getReductionsStencil(), backend); }
+TEST(NaiveIco, Reductions) {
+  runTest(dawn::getReductionsStencil(), backend, "reference/reductions_cpp-naive-ico.cpp");
+}
 
 } // namespace

--- a/dawn/test/unit-test/dawn/CodeGen/UnstructuredStencils.cpp
+++ b/dawn/test/unit-test/dawn/CodeGen/UnstructuredStencils.cpp
@@ -48,17 +48,6 @@ void runTest(const std::shared_ptr<iir::StencilInstantiation> stencilInstantiati
   auto tu = dawn::codegen::run(stencilInstantiation, backend, options);
   const std::string code = dawn::codegen::generate(tu);
 
-  // FILE* fp = 0;
-  // if(backend == codegen::Backend::CUDAIco) {
-  //   fp = fopen("reductions_cuda-ico.cu", "w+");
-  // }
-  // if(backend == codegen::Backend::CXXNaiveIco) {
-  //   fp = fopen("reductions_cpp-naive-ico.cpp", "w+");
-  // }
-
-  // fprintf(fp, "%s", code.c_str());
-  // fclose(fp);
-
   std::ifstream t(refFile);
   const std::string ref((std::istreambuf_iterator<char>(t)), std::istreambuf_iterator<char>());
   ASSERT_EQ(code, ref) << "Generated code does not match reference code";

--- a/dawn/test/unit-test/dawn/CodeGen/UnstructuredStencils.cpp
+++ b/dawn/test/unit-test/dawn/CodeGen/UnstructuredStencils.cpp
@@ -1,0 +1,50 @@
+#include "UnstructuredStencils.h"
+#include "dawn/AST/LocationType.h"
+#include "dawn/CodeGen/Driver.h"
+#include "dawn/Unittest/IIRBuilder.h"
+
+namespace dawn {
+
+std::shared_ptr<iir::StencilInstantiation> getReductionsStencil() {
+  UIDGenerator::getInstance()->reset();
+
+  using namespace dawn::iir;
+  using LocType = dawn::ast::LocationType;
+
+  iir::UnstructuredIIRBuilder b;
+  auto lhs_f = b.field("lhs_field", LocType::Edges);
+  auto rhs_f = b.field("rhs_field", LocType::Edges);
+  auto cell_f = b.field("cell_field", LocType::Cells);
+  auto node_f = b.field("node_field", LocType::Vertices);
+
+  auto stencilInstantiation = b.build(
+      "reductions",
+      b.stencil(b.multistage(
+          LoopOrderKind::Parallel,
+          b.stage(LocType::Cells,
+                  b.doMethod(
+                      dawn::sir::Interval::Start, dawn::sir::Interval::End,
+                      b.stmt(b.assignExpr(
+                          b.at(lhs_f),
+                          b.binaryExpr(b.binaryExpr(b.at(rhs_f),
+                                                    b.reduceOverNeighborExpr(
+                                                        iir::Op::plus, b.at(cell_f), b.lit(0.),
+                                                        {ast::LocationType::Edges,
+                                                         ast::LocationType::Cells}),
+                                                    iir::Op::plus),
+                                       b.reduceOverNeighborExpr(
+                                           iir::Op::plus, b.at(node_f), b.lit(0.),
+                                           {ast::LocationType::Edges, ast::LocationType::Vertices}),
+                                       iir::Op::plus))))))));
+  return stencilInstantiation;
+}
+
+void runTest(const std::shared_ptr<iir::StencilInstantiation> stencilInstantiation,
+             codegen::Backend backend) {
+  dawn::codegen::Options options;
+
+  auto tu = dawn::codegen::run(stencilInstantiation, backend, options);
+  const std::string code = dawn::codegen::generate(tu);
+}
+
+} // namespace dawn

--- a/dawn/test/unit-test/dawn/CodeGen/UnstructuredStencils.cpp
+++ b/dawn/test/unit-test/dawn/CodeGen/UnstructuredStencils.cpp
@@ -3,6 +3,8 @@
 #include "dawn/CodeGen/Driver.h"
 #include "dawn/Unittest/IIRBuilder.h"
 
+#include <gtest/gtest.h>
+
 namespace dawn {
 
 std::shared_ptr<iir::StencilInstantiation> getReductionsStencil() {
@@ -40,11 +42,26 @@ std::shared_ptr<iir::StencilInstantiation> getReductionsStencil() {
 }
 
 void runTest(const std::shared_ptr<iir::StencilInstantiation> stencilInstantiation,
-             codegen::Backend backend) {
+             codegen::Backend backend, const std::string& refFile) {
   dawn::codegen::Options options;
 
   auto tu = dawn::codegen::run(stencilInstantiation, backend, options);
   const std::string code = dawn::codegen::generate(tu);
+
+  // FILE* fp = 0;
+  // if(backend == codegen::Backend::CUDAIco) {
+  //   fp = fopen("reductions_cuda-ico.cu", "w+");
+  // }
+  // if(backend == codegen::Backend::CXXNaiveIco) {
+  //   fp = fopen("reductions_cpp-naive-ico.cpp", "w+");
+  // }
+
+  // fprintf(fp, "%s", code.c_str());
+  // fclose(fp);
+
+  std::ifstream t(refFile);
+  const std::string ref((std::istreambuf_iterator<char>(t)), std::istreambuf_iterator<char>());
+  ASSERT_EQ(code, ref) << "Generated code does not match reference code";
 }
 
 } // namespace dawn

--- a/dawn/test/unit-test/dawn/CodeGen/UnstructuredStencils.h
+++ b/dawn/test/unit-test/dawn/CodeGen/UnstructuredStencils.h
@@ -24,6 +24,6 @@ namespace dawn {
 std::shared_ptr<iir::StencilInstantiation> getReductionsStencil();
 
 void runTest(const std::shared_ptr<iir::StencilInstantiation> stencilInstantiation,
-             codegen::Backend backend);
+             codegen::Backend backend, const std::string& refFile);
 
 } // namespace dawn

--- a/dawn/test/unit-test/dawn/CodeGen/UnstructuredStencils.h
+++ b/dawn/test/unit-test/dawn/CodeGen/UnstructuredStencils.h
@@ -1,0 +1,29 @@
+//===--------------------------------------------------------------------------------*- C++ -*-===//
+//                          _
+//                         | |
+//                       __| | __ ___      ___ ___
+//                      / _` |/ _` \ \ /\ / / '_  |
+//                     | (_| | (_| |\ V  V /| | | |
+//                      \__,_|\__,_| \_/\_/ |_| |_| - Compiler Toolchain
+//
+//
+//  This file is distributed under the MIT License (MIT).
+//  See LICENSE.txt for details.
+//
+//===------------------------------------------------------------------------------------------===//
+
+#include "dawn/CodeGen/Options.h"
+#include "dawn/IIR/StencilInstantiation.h"
+#include "dawn/Unittest/IIRBuilder.h"
+
+#include <memory>
+#include <string>
+
+namespace dawn {
+
+std::shared_ptr<iir::StencilInstantiation> getReductionsStencil();
+
+void runTest(const std::shared_ptr<iir::StencilInstantiation> stencilInstantiation,
+             codegen::Backend backend);
+
+} // namespace dawn

--- a/dawn/test/unit-test/dawn/CodeGen/reference/reductions_cpp-naive-ico.cpp
+++ b/dawn/test/unit-test/dawn/CodeGen/reference/reductions_cpp-naive-ico.cpp
@@ -1,0 +1,68 @@
+#define DAWN_GENERATED 1
+#undef DAWN_BACKEND_T
+#define DAWN_BACKEND_T CXXNAIVEICO
+#include <driver-includes/unstructured_interface.hpp>
+
+
+namespace dawn_generated{
+namespace cxxnaiveico{
+template<typename LibTag>
+class reductions {
+private:
+
+  struct stencil_35 {
+    dawn::mesh_t<LibTag> const& m_mesh;
+    int m_k_size;
+    dawn::edge_field_t<LibTag, double>& m_lhs_field;
+    dawn::edge_field_t<LibTag, double>& m_rhs_field;
+    dawn::cell_field_t<LibTag, double>& m_cell_field;
+    dawn::vertex_field_t<LibTag, double>& m_node_field;
+  public:
+
+    stencil_35(dawn::mesh_t<LibTag> const &mesh, int k_size, dawn::edge_field_t<LibTag, double>&lhs_field, dawn::edge_field_t<LibTag, double>&rhs_field, dawn::cell_field_t<LibTag, double>&cell_field, dawn::vertex_field_t<LibTag, double>&node_field) : m_mesh(mesh), m_k_size(k_size), m_lhs_field(lhs_field), m_rhs_field(rhs_field), m_cell_field(cell_field), m_node_field(node_field){}
+
+    ~stencil_35() {
+    }
+
+    void sync_storages() {
+    }
+    static constexpr dawn::driver::unstructured_extent lhs_field_extent = {false, 0,0};
+    static constexpr dawn::driver::unstructured_extent rhs_field_extent = {false, 0,0};
+    static constexpr dawn::driver::unstructured_extent cell_field_extent = {false, 0,0};
+    static constexpr dawn::driver::unstructured_extent node_field_extent = {false, 0,0};
+
+    void run() {
+      using dawn::deref;
+{
+    for(int k = 0+0; k <= ( m_k_size == 0 ? 0 : (m_k_size - 1)) + 0+0; ++k) {
+      for(auto const& loc : getCells(LibTag{}, m_mesh)) {
+{
+int sparse_dimension_idx0 = 0;
+m_lhs_field(deref(LibTag{}, loc),k+0) = ((m_rhs_field(deref(LibTag{}, loc),k+0) + reduce(LibTag{}, m_mesh,loc, (::dawn::float_type) 0.000000, std::vector<dawn::LocationType>{dawn::LocationType::Edges, dawn::LocationType::Cells}, [&](auto& lhs, auto red_loc1) { lhs += m_cell_field(deref(LibTag{}, red_loc1),k+0);
+sparse_dimension_idx0++;
+return lhs;
+})) + reduce(LibTag{}, m_mesh,loc, (::dawn::float_type) 0.000000, std::vector<dawn::LocationType>{dawn::LocationType::Edges, dawn::LocationType::Vertices}, [&](auto& lhs, auto red_loc1) { lhs += m_node_field(deref(LibTag{}, red_loc1),k+0);
+sparse_dimension_idx0++;
+return lhs;
+}));
+}
+      }    }}      sync_storages();
+    }
+  };
+  static constexpr const char* s_name = "reductions";
+  stencil_35 m_stencil_35;
+public:
+
+  reductions(const reductions&) = delete;
+
+  // Members
+
+  reductions(const dawn::mesh_t<LibTag> &mesh, int k_size, dawn::edge_field_t<LibTag, double>& lhs_field, dawn::edge_field_t<LibTag, double>& rhs_field, dawn::cell_field_t<LibTag, double>& cell_field, dawn::vertex_field_t<LibTag, double>& node_field) : m_stencil_35(mesh, k_size,lhs_field,rhs_field,cell_field,node_field){}
+
+  void run() {
+    m_stencil_35.run();
+;
+  }
+};
+} // namespace cxxnaiveico
+} // namespace dawn_generated

--- a/dawn/test/unit-test/dawn/CodeGen/reference/reductions_cuda-ico.cu
+++ b/dawn/test/unit-test/dawn/CodeGen/reference/reductions_cuda-ico.cu
@@ -1,0 +1,102 @@
+#include "driver-includes/unstructured_interface.hpp"
+#include "driver-includes/cuda_utils.hpp"
+#include "driver-includes/defs.hpp"
+#include "driver-includes/math.hpp"
+#include "driver-includes/timer_cuda.hpp"
+#define BLOCK_SIZE 16
+#define LEVELS_PER_THREAD 1
+using namespace gridtools::dawn;
+
+
+namespace dawn_generated{
+namespace cuda_ico{
+template<int E_C_SIZE, int E_V_SIZE>__global__ void reductions_stencil35_ms34_s32_kernel(int NumCells, int NumEdges, int NumVertices, int kSize, const int *ecTable, const int *evTable, ::dawn::float_type * __restrict__ lhs_field, const ::dawn::float_type * __restrict__ rhs_field, const ::dawn::float_type * __restrict__ cell_field, const ::dawn::float_type * __restrict__ node_field) {
+  unsigned int pidx = blockIdx.x * blockDim.x + threadIdx.x;
+  unsigned int kidx = blockIdx.y * blockDim.y + threadIdx.y;
+  int klo = kidx * LEVELS_PER_THREAD;
+  int khi = (kidx + 1) * LEVELS_PER_THREAD;
+if (pidx >= NumCells) {
+    return;
+}for(int kIter = klo; kIter < khi; kIter++) {
+  if (kIter >= kSize) {
+      return;
+  }::dawn::float_type lhs_18 = (::dawn::float_type) 0.000000;
+for (int nbhIter = 0; nbhIter < E_C_SIZE; nbhIter++){
+int nbhIdx = ecTable[pidx * E_C_SIZE + nbhIter];
+if (nbhIdx == DEVICE_MISSING_VALUE) { continue; }lhs_18 +=cell_field[kIter * NumCells + pidx];}
+::dawn::float_type lhs_11 = (::dawn::float_type) 0.000000;
+for (int nbhIter = 0; nbhIter < E_V_SIZE; nbhIter++){
+int nbhIdx = evTable[pidx * E_V_SIZE + nbhIter];
+if (nbhIdx == DEVICE_MISSING_VALUE) { continue; }lhs_11 +=node_field[kIter * NumVertices + pidx];}
+lhs_field[kIter * NumEdges + pidx] = ((rhs_field[kIter * NumEdges + pidx] +  lhs_18 ) +  lhs_11 );
+}}
+template<typename LibTag, int E_C_SIZE , int E_V_SIZE >
+class reductions {
+public:
+
+  struct sbase : public timer_cuda {
+
+    sbase(std::string name) : timer_cuda(name){}
+
+    double get_time() {
+      return total_time();
+    }
+  };
+
+  struct GpuTriMesh {
+    int NumVertices;
+    int NumEdges;
+    int NumCells;
+    int* ecTable;
+    int* evTable;
+
+    GpuTriMesh(const dawn::mesh_t<LibTag>& mesh) {
+      NumVertices = mesh.nodes().size();
+      NumCells = mesh.cells().size();
+      NumEdges = mesh.edges().size();
+      gpuErrchk(cudaMalloc((void**)&ecTable, sizeof(int) * mesh.edges().size()* E_C_SIZE));
+      dawn::generateNbhTable<LibTag>(mesh, {dawn::LocationType::Edges, dawn::LocationType::Cells}, mesh.edges().size(), E_C_SIZE, ecTable);
+      gpuErrchk(cudaMalloc((void**)&evTable, sizeof(int) * mesh.edges().size()* E_V_SIZE));
+      dawn::generateNbhTable<LibTag>(mesh, {dawn::LocationType::Edges, dawn::LocationType::Vertices}, mesh.edges().size(), E_V_SIZE, evTable);
+    }
+  };
+
+  struct stencil_35 : public sbase {
+  private:
+    ::dawn::float_type* lhs_field_;
+    ::dawn::float_type* rhs_field_;
+    ::dawn::float_type* cell_field_;
+    ::dawn::float_type* node_field_;
+    int kSize_ = 0;
+    GpuTriMesh mesh_;
+  public:
+
+    stencil_35(const dawn::mesh_t<LibTag>& mesh, int kSize, dawn::edge_field_t<LibTag, ::dawn::float_type>& lhs_field, dawn::edge_field_t<LibTag, ::dawn::float_type>& rhs_field, dawn::cell_field_t<LibTag, ::dawn::float_type>& cell_field, dawn::vertex_field_t<LibTag, ::dawn::float_type>& node_field) : sbase("stencil_35"), mesh_(mesh), kSize_(kSize){
+      dawn::initField(lhs_field, &lhs_field_, mesh.edges().size(), kSize);
+      dawn::initField(rhs_field, &rhs_field_, mesh.edges().size(), kSize);
+      dawn::initField(cell_field, &cell_field_, mesh.cells().size(), kSize);
+      dawn::initField(node_field, &node_field_, mesh.nodes().size(), kSize);
+    }
+
+    void run() {
+      int dK = (kSize_ + LEVELS_PER_THREAD - 1) / LEVELS_PER_THREAD;
+      dim3 dGC((mesh_.NumCells + BLOCK_SIZE - 1) / BLOCK_SIZE, (dK + BLOCK_SIZE - 1) / BLOCK_SIZE, 1);
+      dim3 dB(BLOCK_SIZE, BLOCK_SIZE, 1);
+      sbase::start();
+      reductions_stencil35_ms34_s32_kernel<E_C_SIZE, E_V_SIZE><<<dGC,dB>>>(mesh_.NumCells, mesh_.NumEdges, mesh_.NumVertices, kSize_, mesh_.ecTable, mesh_.evTable, lhs_field_, rhs_field_, cell_field_, node_field_);
+      gpuErrchk(cudaPeekAtLastError());
+      gpuErrchk(cudaDeviceSynchronize());
+      sbase::pause();
+    }
+
+    void CopyResultToHost(dawn::edge_field_t<LibTag, ::dawn::float_type>& lhs_field) {
+     {
+        ::dawn::float_type* host_buf = new ::dawn::float_type[lhs_field.numElements()];
+        gpuErrchk(cudaMemcpy((::dawn::float_type*) host_buf, lhs_field_, lhs_field.numElements()*sizeof(::dawn::float_type), cudaMemcpyDeviceToHost));
+        dawn::reshape_back(host_buf, lhs_field.data(), kSize_, mesh_.NumEdges);
+        delete[] host_buf;
+    }    }
+  };
+};
+} // namespace cuda_ico
+} // namespace dawn_generated


### PR DESCRIPTION
## Technical Description

Reductions which are not used in this exact fashion:
```
a = reduce(...)
```
but are part of a binary expression, e.g.
```
a = reduce(...) + b
```
lead to nonsensical code in the cuda code generation. This PR fixes this issue. Now, the Cuda code generation performs two passes per statement, first generating all reductions, saving each result to a temporary. In the second pass, this temporary is used in place of the reduction. 

### Example

```
ddt_vn_adv = ddt_vn_adv + reduce(
            coeff_gradekin*z_ekinh,
            Edge > Cell,
            [-1.0, 1.0],
        )
```

### Testing

Two CodeGen tests have been added for this situation. Correct working of the fix was ensured using the icondusk-e2e repo. 

### Dependencies

This PR is independent


