### PR TITLE
Fix: CUDA tests are disabled if CUDA should be enabled

### DIFF
--- a/gtclang/CMakeLists.txt
+++ b/gtclang/CMakeLists.txt
@@ -150,11 +150,11 @@ if(${PROJECT_NAME}_TESTING)
   )
   cmake_dependent_option(GTCLANG_BUILD_TESTING_GT_CUDA
     "Build integration tests with the GridTools CUDA backend"
-    ON "BUILD_TESTING;CMAKE_CUDA_COMPILER;NOT ENABLE_CUDA_IF_FOUND" OFF
+    ON "BUILD_TESTING;CMAKE_CUDA_COMPILER;ENABLE_CUDA_IF_FOUND" OFF
   )
   cmake_dependent_option(GTCLANG_BUILD_TESTING_PLAIN_CUDA
     "Build integration tests with the plain CUDA backend"
-    ON "BUILD_TESTING;CMAKE_CUDA_COMPILER;NOT ENABLE_CUDA_IF_FOUND" OFF
+    ON "BUILD_TESTING;CMAKE_CUDA_COMPILER;ENABLE_CUDA_IF_FOUND" OFF
   )
 
   add_subdirectory(test)


### PR DESCRIPTION
## Technical Description

There is a typo in setting `GTCLANG_BUILD_TESTING_GT_CUDA` and `GTCLANG_BUILD_TESTING_PLAIN_CUDA` which disables CUDA tests by default if `ENABLE_CUDA_IF_FOUND == ON`. Not sure if testing is affected (if the flags were set explicitly tests are ok).

