### PR TITLE
Cxxopt backend

### DIFF
--- a/dawn/src/dawn/CodeGen/CMakeLists.txt
+++ b/dawn/src/dawn/CodeGen/CMakeLists.txt
@@ -28,6 +28,8 @@ add_library(DawnCodeGen
   CXXNaive/ASTStencilFunctionParamVisitor.h
   CXXNaive/CXXNaiveCodeGen.cpp
   CXXNaive/CXXNaiveCodeGen.h
+  CXXOpt/CXXOptCodeGen.cpp
+  CXXOpt/CXXOptCodeGen.h
   CXXNaive-ico/ASTStencilBody.cpp
   CXXNaive-ico/ASTStencilBody.h
   CXXNaive-ico/ASTStencilDesc.cpp

--- a/dawn/src/dawn/CodeGen/CXXNaive/CXXNaiveCodeGen.h
+++ b/dawn/src/dawn/CodeGen/CXXNaive/CXXNaiveCodeGen.h
@@ -35,7 +35,7 @@ namespace cxxnaive {
 /// @brief Run the cxx-naive code generation
 std::unique_ptr<TranslationUnit>
 run(const std::map<std::string, std::shared_ptr<iir::StencilInstantiation>>&
-stencilInstantiationMap,
+        stencilInstantiationMap,
     const Options& options = {});
 
 /// @brief GridTools C++ code generation for the gtclang DSL

--- a/dawn/src/dawn/CodeGen/CXXOpt/CXXOptCodeGen.cpp
+++ b/dawn/src/dawn/CodeGen/CXXOpt/CXXOptCodeGen.cpp
@@ -1,0 +1,422 @@
+//===--------------------------------------------------------------------------------*- C++ -*-===//
+//                          _
+//                         | |
+//                       __| | __ ___      ___ ___
+//                      / _` |/ _` \ \ /\ / / '_  |
+//                     | (_| | (_| |\ V  V /| | | |
+//                      \__,_|\__,_| \_/\_/ |_| |_| - Compiler Toolchain
+//
+//
+//  This file is distributed under the MIT License (MIT).
+//  See LICENSE.txt for details.
+//
+//===------------------------------------------------------------------------------------------===//
+
+#include "CXXOptCodeGen.h"
+#include "dawn/AST/GridType.h"
+#include "dawn/AST/Offsets.h"
+#include "dawn/CodeGen/CXXNaive/ASTStencilBody.h"
+#include "dawn/CodeGen/CXXNaive/ASTStencilDesc.h"
+#include "dawn/CodeGen/CXXUtil.h"
+#include "dawn/CodeGen/CodeGenProperties.h"
+#include "dawn/IIR/Extents.h"
+#include "dawn/IIR/IIRNodeIterator.h"
+#include "dawn/IIR/Interval.h"
+#include "dawn/IIR/Stage.h"
+#include "dawn/IIR/StencilInstantiation.h"
+#include "dawn/SIR/SIR.h"
+#include "dawn/Support/Assert.h"
+#include "dawn/Support/Exception.h"
+#include "dawn/Support/Logger.h"
+#include "dawn/Support/StringUtil.h"
+#include <algorithm>
+#include <string>
+#include <vector>
+
+namespace dawn {
+namespace codegen {
+namespace cxxopt {
+
+namespace {
+std::string makeLoopImpl(int lowerExtent, int upperExtent, const std::string& dim,
+                         const std::string& lower, const std::string& upper,
+                         const std::string& comparison, const std::string& increment,
+                         bool isParallel = false, bool isVectorized = false) {
+  std::string loopCode = "";
+  std::string pragma = "#pragma omp ";
+  if(isParallel)
+    loopCode = "\n" + pragma + "parallel for\n";
+  else if(isVectorized)
+    loopCode = pragma + "simd\n";
+  loopCode += "for(int " + dim + " = " + lower + "+" + std::to_string(lowerExtent) + "; " + dim +
+              " " + comparison + " " + upper + "+" + std::to_string(upperExtent) + "; " +
+              increment + dim + ")";
+  return loopCode;
+}
+
+std::string makeIJLoop(int lowerExtent, int upperExtent, const std::string dom,
+                       const std::string& dim, bool parallelize = false) {
+  return makeLoopImpl(lowerExtent, upperExtent, dim, dim + "Min", dim + "Max", " <= ", "++", false,
+                      parallelize);
+}
+
+std::string makeIntervalBoundReadable(std::string dim, const iir::Interval& interval,
+                                      iir::Interval::Bound bound) {
+  if(interval.levelIsEnd(bound)) {
+    return dim + "Max + " + std::to_string(interval.offset(bound));
+  }
+  auto notEnd = interval.level(bound);
+  if(notEnd == 0) {
+    return dim + "Min + " + std::to_string(interval.offset(bound));
+  }
+  return dim + "Min + " + std::to_string(notEnd + interval.offset(bound));
+}
+std::string makeIntervalBoundExplicit(std::string dim, const iir::Interval& interval,
+                                      iir::Interval::Bound bound, std::string dom) {
+  if(interval.levelIsEnd(bound)) {
+    return dom + "." + dim + "size() - " + dom + "." + dim + "plus()  + " +
+           std::to_string(interval.offset(bound));
+  }
+  auto notEnd = interval.level(bound);
+  if(notEnd == 0) {
+    return dom + "." + dim + "minus() + " + std::to_string(interval.offset(bound));
+  }
+  return dom + "." + dim + "minus() + " + std::to_string(notEnd + interval.offset(bound));
+}
+
+std::string makeKLoop(bool isBackward, iir::Interval const& interval, bool isParallel = false) {
+
+  const std::string lower = makeIntervalBoundReadable("k", interval, iir::Interval::Bound::lower);
+  const std::string upper = makeIntervalBoundReadable("k", interval, iir::Interval::Bound::upper);
+
+  return isBackward ? makeLoopImpl(0, 0, "k", upper, lower, ">=", "--", isParallel)
+                    : makeLoopImpl(0, 0, "k", lower, upper, "<=", "++", isParallel);
+}
+} // namespace
+
+std::unique_ptr<TranslationUnit>
+run(const std::map<std::string, std::shared_ptr<iir::StencilInstantiation>>&
+        stencilInstantiationMap, const Options& options) {
+  CXXOptCodeGen CG(stencilInstantiationMap, options.MaxHaloSize);
+
+  return CG.generateCode();
+}
+
+CXXOptCodeGen::CXXOptCodeGen(const StencilInstantiationContext& ctx, int maxHaloPoint)
+    : CXXNaiveCodeGen(ctx, maxHaloPoint) {}
+
+CXXOptCodeGen::~CXXOptCodeGen() {}
+
+std::string CXXOptCodeGen::generateStencilInstantiation(
+    const std::shared_ptr<iir::StencilInstantiation> stencilInstantiation) {
+  using namespace codegen;
+
+  std::stringstream ssSW;
+
+  Namespace dawnNamespace("dawn_generated", ssSW);
+  Namespace cxxoptNamespace("cxxopt", ssSW);
+
+  const auto& globalsMap = stencilInstantiation->getIIR()->getGlobalVariableMap();
+
+  Class stencilWrapperClass(stencilInstantiation->getName(), ssSW);
+  stencilWrapperClass.changeAccessibility("private");
+
+  CodeGenProperties codeGenProperties = computeCodeGenProperties(stencilInstantiation.get());
+
+  generateStencilFunctions(stencilWrapperClass, stencilInstantiation, codeGenProperties);
+
+  generateStencilClasses(stencilInstantiation, stencilWrapperClass, codeGenProperties);
+
+  generateStencilWrapperMembers(stencilWrapperClass, stencilInstantiation, codeGenProperties);
+
+  generateStencilWrapperCtr(stencilWrapperClass, stencilInstantiation, codeGenProperties);
+
+  generateGlobalsAPI(*stencilInstantiation, stencilWrapperClass, globalsMap, codeGenProperties);
+
+  generateStencilWrapperRun(stencilWrapperClass, stencilInstantiation, codeGenProperties);
+
+  stencilWrapperClass.commit();
+
+  cxxoptNamespace.commit();
+  dawnNamespace.commit();
+
+  return ssSW.str();
+}
+
+void CXXOptCodeGen::generateStencilClasses(
+    const std::shared_ptr<iir::StencilInstantiation> stencilInstantiation,
+    Class& stencilWrapperClass, const CodeGenProperties& codeGenProperties) const {
+
+  const auto& stencils = stencilInstantiation->getStencils();
+  const auto& globalsMap = stencilInstantiation->getIIR()->getGlobalVariableMap();
+
+  // Stencil members:
+  // generate the code for each of the stencils
+  for(std::size_t stencilIdx = 0; stencilIdx < stencils.size(); ++stencilIdx) {
+    const auto& stencil = *stencils[stencilIdx];
+
+    std::string stencilName =
+        codeGenProperties.getStencilName(StencilContext::SC_Stencil, stencil.getStencilID());
+
+    auto stencilProperties =
+        codeGenProperties.getStencilProperties(StencilContext::SC_Stencil, stencilName);
+
+    if(stencil.isEmpty())
+      continue;
+
+    // fields used in the stencil
+    const auto stencilFields = stencil.getOrderedFields();
+
+    auto nonTempFields =
+        makeRange(stencilFields, [](std::pair<int, iir::Stencil::FieldInfo> const& p) {
+          return !p.second.IsTemporary;
+        });
+    auto tempFields =
+        makeRange(stencilFields, [](std::pair<int, iir::Stencil::FieldInfo> const& p) {
+          return p.second.IsTemporary;
+        });
+
+    Structure stencilClass = stencilWrapperClass.addStruct(stencilName);
+
+    ASTStencilBody stencilBodyCXXVisitor(stencilInstantiation->getMetaData(),
+                                         StencilContext::SC_Stencil);
+
+    stencilClass.addComment("Members");
+    bool iterationSpaceSet = hasGlobalIndices(stencil);
+    if(iterationSpaceSet) {
+      generateGlobalIndices(stencil, stencilClass);
+    }
+
+    stencilClass.addComment("Temporary storages");
+    addTempStorageTypedef(stencilClass, stencil);
+
+    stencilClass.addMember("const " + c_dgt() + "domain", "m_dom");
+
+    if(!globalsMap.empty()) {
+      stencilClass.addMember("const globals&", "m_globals");
+    }
+
+    stencilClass.addComment("Input/Output storages");
+
+    addTmpStorageDeclaration(stencilClass, tempFields);
+
+    stencilClass.changeAccessibility("public");
+
+    auto stencilClassCtr = stencilClass.addConstructor();
+
+    stencilClassCtr.addArg("const " + c_dgt() + "domain& dom_");
+    if(!globalsMap.empty()) {
+      stencilClassCtr.addArg("const globals& globals_");
+    }
+    stencilClassCtr.addArg("int rank");
+    stencilClassCtr.addArg("int xcols");
+    stencilClassCtr.addArg("int ycols");
+
+    stencilClassCtr.addInit("m_dom(dom_)");
+    if(!globalsMap.empty()) {
+      stencilClassCtr.addArg("m_globals(globals_)");
+    }
+    for(auto& stage : iterateIIROver<iir::Stage>(stencil)) {
+      if(stage->getIterationSpace()[0].has_value()) {
+        stencilClassCtr.addInit(
+            "stage" + std::to_string(stage->getStageID()) + "GlobalIIndices({" +
+            makeIntervalBoundExplicit("i", stage->getIterationSpace()[0].value(),
+                                      iir::Interval::Bound::lower, "dom_") +
+            " , " +
+            makeIntervalBoundExplicit("i", stage->getIterationSpace()[0].value(),
+                                      iir::Interval::Bound::upper, "dom_") +
+            "})");
+      }
+      if(stage->getIterationSpace()[1].has_value()) {
+        stencilClassCtr.addInit(
+            "stage" + std::to_string(stage->getStageID()) + "GlobalJIndices({" +
+            makeIntervalBoundExplicit("j", stage->getIterationSpace()[1].value(),
+                                      iir::Interval::Bound::lower, "dom_") +
+            " , " +
+            makeIntervalBoundExplicit("j", stage->getIterationSpace()[1].value(),
+                                      iir::Interval::Bound::upper, "dom_") +
+            "})");
+      }
+    }
+
+    if(iterationSpaceSet) {
+      stencilClassCtr.addInit("globalOffsets({computeGlobalOffsets(rank, m_dom, xcols, ycols)})");
+    }
+
+    addTmpStorageInit(stencilClassCtr, stencil, tempFields);
+    stencilClassCtr.commit();
+
+    // virtual dtor
+
+    // synchronize storages method
+
+    // accumulated extents of API fields
+    generateFieldExtentsInfo(stencilClass, nonTempFields, ast::GridType::Cartesian);
+
+    //
+    // Run-Method
+    //
+    MemberFunction stencilRunMethod = stencilClass.addMemberFunction("void", "run", "");
+    for(auto it = nonTempFields.begin(); it != nonTempFields.end(); ++it) {
+      std::string type = stencilProperties->paramNameToType_.at((*it).second.Name);
+      stencilRunMethod.addArg(type + "& " + (*it).second.Name + "_");
+    }
+
+    stencilRunMethod.startBody();
+    // Compute the loop bounds for readability
+    stencilRunMethod.addStatement("int iMin = m_dom.iminus()");
+    stencilRunMethod.addStatement("int iMax = m_dom.isize() - m_dom.iplus() - 1");
+    stencilRunMethod.addStatement("int jMin = m_dom.jminus()");
+    stencilRunMethod.addStatement("int jMax = m_dom.jsize() - m_dom.jplus() - 1");
+    stencilRunMethod.addStatement("int kMin = m_dom.kminus()");
+    stencilRunMethod.addStatement("int kMax = m_dom.ksize() - m_dom.kplus() - 1");
+
+    for(const auto& fieldPair : nonTempFields) {
+      stencilRunMethod.addStatement(fieldPair.second.Name + "_" + ".sync()");
+    }
+    for(const auto& multiStagePtr : stencil.getChildren()) {
+
+      stencilRunMethod.ss() << "{";
+
+      const iir::MultiStage& multiStage = *multiStagePtr;
+
+      // create all the data views
+      for(auto it = nonTempFields.begin(); it != nonTempFields.end(); ++it) {
+        const auto fieldName = (*it).second.Name;
+        std::string type = stencilProperties->paramNameToType_.at(fieldName);
+        stencilRunMethod.addStatement(c_gt() + "data_view<" + type + "> " + fieldName + "= " +
+                                      c_gt() + "make_host_view(" + fieldName + "_)");
+        stencilRunMethod.addStatement("std::array<int,3> " + fieldName + "_offsets{0,0,0}");
+      }
+      for(const auto& fieldPair : tempFields) {
+        const auto fieldName = fieldPair.second.Name;
+        stencilRunMethod.addStatement(c_gt() + "data_view<tmp_storage_t> " + fieldName + "= " +
+                                      c_gt() + "make_host_view(m_" + fieldName + ")");
+        stencilRunMethod.addStatement("std::array<int,3> " + fieldName + "_offsets{0,0,0}");
+      }
+
+      auto intervals_set = multiStage.getIntervals();
+      std::vector<iir::Interval> intervals_v;
+      std::copy(intervals_set.begin(), intervals_set.end(), std::back_inserter(intervals_v));
+
+      // compute the partition of the intervals
+      auto partitionIntervals = iir::Interval::computePartition(intervals_v);
+      if((multiStage.getLoopOrder() == iir::LoopOrderKind::Backward))
+        std::reverse(partitionIntervals.begin(), partitionIntervals.end());
+
+      for(auto interval : partitionIntervals) {
+
+        // for each interval, we generate naive nested loops
+        stencilRunMethod.addBlockStatement(
+            makeKLoop((multiStage.getLoopOrder() == iir::LoopOrderKind::Backward), interval,
+                      (multiStage.getLoopOrder() == iir::LoopOrderKind::Parallel)),
+            [&]() {
+              for(const auto& stagePtr : multiStage.getChildren()) {
+                iir::Stage& stage = *stagePtr;
+
+                auto const& extents = iir::extent_cast<iir::CartesianExtent const&>(
+                    stage.getExtents().horizontalExtent());
+
+                // Check if we need to execute this statement:
+                bool hasOverlappingInterval = false;
+                for(const auto& doMethodPtr : stage.getChildren()) {
+                  hasOverlappingInterval |= (doMethodPtr->getInterval().overlaps(interval));
+                }
+
+                if(hasOverlappingInterval) {
+                  auto doMethodGenerator = [&]() {
+                    // Generate Do-Method
+                    for(const auto& doMethodPtr : stage.getChildren()) {
+                      const iir::DoMethod& doMethod = *doMethodPtr;
+                      if(!doMethod.getInterval().overlaps(interval))
+                        continue;
+                      for(const auto& stmt : doMethod.getAST().getStatements()) {
+                        stmt->accept(stencilBodyCXXVisitor);
+                        stencilRunMethod << stencilBodyCXXVisitor.getCodeAndResetStream();
+                      }
+                    }
+                  };
+
+                  stencilRunMethod.addBlockStatement(
+                      makeIJLoop(extents.iMinus(), extents.iPlus(), "m_dom", "i"), [&]() {
+                        stencilRunMethod.addBlockStatement(
+                            makeIJLoop(extents.jMinus(), extents.jPlus(), "m_dom", "j", true),
+                            [&] {
+                              if(std::any_of(stage.getIterationSpace().cbegin(),
+                                             stage.getIterationSpace().cend(),
+                                             [](const auto& p) -> bool { return p.has_value(); })) {
+                                std::string conditional = "if(";
+                                if(stage.getIterationSpace()[0]) {
+                                  conditional += "checkOffset(stage" +
+                                                 std::to_string(stage.getStageID()) +
+                                                 "GlobalIIndices[0], stage" +
+                                                 std::to_string(stage.getStageID()) +
+                                                 "GlobalIIndices[1], globalOffsets[0] + i)";
+                                }
+                                if(stage.getIterationSpace()[1]) {
+                                  if(stage.getIterationSpace()[0]) {
+                                    conditional += " && ";
+                                  }
+                                  conditional += "checkOffset(stage" +
+                                                 std::to_string(stage.getStageID()) +
+                                                 "GlobalJIndices[0], stage" +
+                                                 std::to_string(stage.getStageID()) +
+                                                 "GlobalJIndices[1], globalOffsets[1] + j)";
+                                }
+                                conditional += ")";
+                                stencilRunMethod.addBlockStatement(conditional, doMethodGenerator);
+                              } else {
+                                doMethodGenerator();
+                              }
+                            });
+                      });
+                }
+              }
+            });
+      }
+      stencilRunMethod.ss() << "}";
+    }
+    for(const auto& fieldPair : nonTempFields) {
+      stencilRunMethod.addStatement(fieldPair.second.Name + "_" + ".sync()");
+    }
+    stencilRunMethod.commit();
+  }
+}
+
+std::unique_ptr<TranslationUnit> CXXOptCodeGen::generateCode() {
+  DAWN_LOG(INFO) << "Starting code generation for GTClang ...";
+
+  // Generate code for StencilInstantiations
+  std::map<std::string, std::string> stencils;
+  for(const auto& nameStencilCtxPair : context_) {
+    std::string code = generateStencilInstantiation(nameStencilCtxPair.second);
+    if(code.empty())
+      return nullptr;
+    stencils.emplace(nameStencilCtxPair.first, std::move(code));
+  }
+
+  std::string globals = generateGlobals(context_, "dawn_generated", "cxxopt");
+
+  std::vector<std::string> ppDefines;
+  auto makeDefine = [](std::string define, int value) {
+    return "#define " + define + " " + std::to_string(value);
+  };
+
+  ppDefines.push_back(makeDefine("DAWN_GENERATED", 1));
+  ppDefines.push_back("#undef DAWN_BACKEND_T");
+  ppDefines.push_back("#define DAWN_BACKEND_T CXXOPT");
+
+  CodeGen::addMplIfdefs(ppDefines, 30);
+  ppDefines.push_back("#include <driver-includes/gridtools_includes.hpp>");
+  ppDefines.push_back("using namespace gridtools::dawn;");
+  ppDefines.push_back("#include <omp.h>");
+  DAWN_LOG(INFO) << "Done generating code";
+
+  std::string filename = generateFileName(context_);
+  return std::make_unique<TranslationUnit>(filename, std::move(ppDefines), std::move(stencils),
+                                           std::move(globals));
+}
+
+} // namespace cxxopt
+} // namespace codegen
+} // namespace dawn

--- a/dawn/src/dawn/CodeGen/CXXOpt/CXXOptCodeGen.h
+++ b/dawn/src/dawn/CodeGen/CXXOpt/CXXOptCodeGen.h
@@ -17,6 +17,7 @@
 #include "dawn/CodeGen/CodeGen.h"
 #include "dawn/CodeGen/CodeGenProperties.h"
 #include "dawn/CodeGen/Options.h"
+#include "dawn/CodeGen/CXXNaive/CXXNaiveCodeGen.h"
 #include "dawn/IIR/Interval.h"
 #include "dawn/Support/IndexRange.h"
 #include <set>
@@ -30,50 +31,32 @@ class StencilInstantiation;
 }
 
 namespace codegen {
-namespace cxxnaive {
+namespace cxxopt {
 
-/// @brief Run the cxx-naive code generation
+using namespace cxxnaive;
+
+/// @brief Run the cxx-opt code generation
 std::unique_ptr<TranslationUnit>
 run(const std::map<std::string, std::shared_ptr<iir::StencilInstantiation>>&
-stencilInstantiationMap,
-    const Options& options = {});
+        stencilInstantiationMap, const Options& options = {});
 
 /// @brief GridTools C++ code generation for the gtclang DSL
-/// @ingroup cxxnaive
-class CXXNaiveCodeGen : public CodeGen {
+/// @ingroup cxxopt
+class CXXOptCodeGen : public CXXNaiveCodeGen {
 public:
   ///@brief constructor
-  CXXNaiveCodeGen(const StencilInstantiationContext& ctx, int maxHaloPoint);
-  virtual ~CXXNaiveCodeGen();
+  CXXOptCodeGen(const StencilInstantiationContext& ctx, int maxHaloPoint);
+  virtual ~CXXOptCodeGen();
   virtual std::unique_ptr<TranslationUnit> generateCode() override;
 
-protected:
+private:
   std::string generateStencilInstantiation(
       const std::shared_ptr<iir::StencilInstantiation> stencilInstantiation);
-
-  void
-  generateStencilFunctions(Class& stencilWrapperClass,
-                           const std::shared_ptr<iir::StencilInstantiation> stencilInstantiation,
-                           const CodeGenProperties& codeGenProperties) const;
 
   void generateStencilClasses(const std::shared_ptr<iir::StencilInstantiation> stencilInstantiation,
                               Class& stencilWrapperClass,
                               const CodeGenProperties& codeGenProperties) const;
-  void generateStencilWrapperMembers(
-      Class& stencilWrapperClass,
-      const std::shared_ptr<iir::StencilInstantiation> stencilInstantiation,
-      CodeGenProperties& codeGenProperties) const;
-
-  void
-  generateStencilWrapperCtr(Class& stencilWrapperClass,
-                            const std::shared_ptr<iir::StencilInstantiation> stencilInstantiation,
-                            const CodeGenProperties& codeGenProperties) const;
-
-  void
-  generateStencilWrapperRun(Class& stencilWrapperClass,
-                            const std::shared_ptr<iir::StencilInstantiation> stencilInstantiation,
-                            const CodeGenProperties& codeGenProperties) const;
 };
-} // namespace cxxnaive
+} // namespace cxxopt
 } // namespace codegen
 } // namespace dawn

--- a/dawn/src/dawn/CodeGen/Driver.cpp
+++ b/dawn/src/dawn/CodeGen/Driver.cpp
@@ -15,6 +15,7 @@
 #include "dawn/CodeGen/Driver.h"
 #include "dawn/CodeGen/CXXNaive-ico/CXXNaiveCodeGen.h"
 #include "dawn/CodeGen/CXXNaive/CXXNaiveCodeGen.h"
+#include "dawn/CodeGen/CXXOpt/CXXOptCodeGen.h"
 #include "dawn/CodeGen/Cuda-ico/CudaIcoCodeGen.h"
 #include "dawn/CodeGen/Cuda/CudaCodeGen.h"
 #include "dawn/CodeGen/GridTools/GTCodeGen.h"
@@ -30,6 +31,8 @@ codegen::Backend parseBackendString(const std::string& backendStr) {
     return codegen::Backend::GridTools;
   } else if(backendStr == "naive" || backendStr == "cxxnaive" || backendStr == "c++-naive") {
     return codegen::Backend::CXXNaive;
+  } else if(backendStr == "opt" || backendStr == "cxxopt" || backendStr == "c++-opt") {
+    return codegen::Backend::CXXOpt;
   } else if(backendStr == "ico" || backendStr == "naive-ico" || backendStr == "c++-naive-ico") {
     return codegen::Backend::CXXNaiveIco;
   } else if(backendStr == "cuda" || backendStr == "CUDA") {
@@ -57,7 +60,7 @@ run(const std::map<std::string, std::shared_ptr<iir::StencilInstantiation>>& con
   case Backend::CUDAIco:
     return cudaico::run(context, options);
   case Backend::CXXOpt:
-    throw std::invalid_argument("Backend not supported");
+    return cxxopt::run(context, options);
   }
   // This line should not be needed but the compiler seems to complain if it is not present.
   return nullptr;

--- a/dawn/test/unit-test/dawn/CodeGen/CMakeLists.txt
+++ b/dawn/test/unit-test/dawn/CodeGen/CMakeLists.txt
@@ -16,7 +16,7 @@ include(GoogleTest)
 file(COPY input DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
 file(COPY reference DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
 
-foreach(backend IN ITEMS Cuda Naive)
+foreach(backend IN ITEMS Cuda Naive Opt)
   set(executable ${PROJECT_NAME}UnittestCodeGen${backend})
   add_executable(${executable} ${backend}/Test${backend}CodeGen.cpp Stencils.cpp)
   target_add_dawn_standard_props(${executable})

--- a/dawn/test/unit-test/dawn/CodeGen/Opt/TestOptCodeGen.cpp
+++ b/dawn/test/unit-test/dawn/CodeGen/Opt/TestOptCodeGen.cpp
@@ -1,0 +1,29 @@
+//===--------------------------------------------------------------------------------*- C++ -*-===//
+//                          _
+//                         | |
+//                       __| | __ ___      ___ ___
+//                      / _` |/ _` \ \ /\ / / '_  |
+//                     | (_| | (_| |\ V  V /| | | |
+//                      \__,_|\__,_| \_/\_/ |_| |_| - Compiler Toolchain
+//
+//
+//  This file is distributed under the MIT License (MIT).
+//  See LICENSE.txt for details.
+//
+//===------------------------------------------------------------------------------------------===//
+
+#include "Stencils.h"
+#include "dawn/CodeGen/Options.h"
+#include "dawn/Serialization/IIRSerializer.h"
+
+#include <gtest/gtest.h>
+
+namespace {
+
+constexpr auto backend = dawn::codegen::Backend::CXXOpt;
+
+TEST(Opt, LaplacianStencil) {
+  runTest(dawn::getLaplacianStencil(), backend, "reference/laplacian_stencil_opt.cpp");
+}
+
+} // namespace

--- a/dawn/test/unit-test/dawn/CodeGen/reference/laplacian_stencil_opt.cpp
+++ b/dawn/test/unit-test/dawn/CodeGen/reference/laplacian_stencil_opt.cpp
@@ -1,0 +1,110 @@
+#define DAWN_GENERATED 1
+#undef DAWN_BACKEND_T
+#define DAWN_BACKEND_T CXXOPT
+#ifndef BOOST_RESULT_OF_USE_TR1
+ #define BOOST_RESULT_OF_USE_TR1 1
+#endif
+#ifndef BOOST_NO_CXX11_DECLTYPE
+ #define BOOST_NO_CXX11_DECLTYPE 1
+#endif
+#ifndef GRIDTOOLS_DAWN_HALO_EXTENT
+ #define GRIDTOOLS_DAWN_HALO_EXTENT 3
+#endif
+#ifndef BOOST_PP_VARIADICS
+ #define BOOST_PP_VARIADICS 1
+#endif
+#ifndef BOOST_FUSION_DONT_USE_PREPROCESSED_FILES
+ #define BOOST_FUSION_DONT_USE_PREPROCESSED_FILES 1
+#endif
+#ifndef BOOST_MPL_CFG_NO_PREPROCESSED_HEADERS
+ #define BOOST_MPL_CFG_NO_PREPROCESSED_HEADERS 1
+#endif
+#ifndef GT_VECTOR_LIMIT_SIZE
+ #define GT_VECTOR_LIMIT_SIZE 30
+#endif
+#ifndef BOOST_FUSION_INVOKE_MAX_ARITY
+ #define BOOST_FUSION_INVOKE_MAX_ARITY GT_VECTOR_LIMIT_SIZE
+#endif
+#ifndef FUSION_MAX_VECTOR_SIZE
+ #define FUSION_MAX_VECTOR_SIZE GT_VECTOR_LIMIT_SIZE
+#endif
+#ifndef FUSION_MAX_MAP_SIZE
+ #define FUSION_MAX_MAP_SIZE GT_VECTOR_LIMIT_SIZE
+#endif
+#ifndef BOOST_MPL_LIMIT_VECTOR_SIZE
+ #define BOOST_MPL_LIMIT_VECTOR_SIZE GT_VECTOR_LIMIT_SIZE
+#endif
+#include <driver-includes/gridtools_includes.hpp>
+using namespace gridtools::dawn;
+#include <omp.h>
+
+
+namespace dawn_generated{
+namespace cxxopt{
+
+class generated {
+private:
+
+  struct stencil_47 {
+
+    // Members
+
+    // Temporary storages
+    using tmp_halo_t = gridtools::halo< GRIDTOOLS_DAWN_HALO_EXTENT, GRIDTOOLS_DAWN_HALO_EXTENT, 0>;
+    using tmp_meta_data_t = storage_traits_t::storage_info_t< 0, 3, tmp_halo_t >;
+    using tmp_storage_t = storage_traits_t::data_store_t< ::dawn::float_type, tmp_meta_data_t>;
+    const gridtools::dawn::domain m_dom;
+
+    // Input/Output storages
+  public:
+
+    stencil_47(const gridtools::dawn::domain& dom_, int rank, int xcols, int ycols) : m_dom(dom_){}
+    static constexpr dawn::driver::cartesian_extent in_extent = {-1,1, -1,1, 0,0};
+    static constexpr dawn::driver::cartesian_extent out_extent = {0,0, 0,0, 0,0};
+
+    void run(storage_ijk_t& in_, storage_ijk_t& out_) {
+      int iMin = m_dom.iminus();
+      int iMax = m_dom.isize() - m_dom.iplus() - 1;
+      int jMin = m_dom.jminus();
+      int jMax = m_dom.jsize() - m_dom.jplus() - 1;
+      int kMin = m_dom.kminus();
+      int kMax = m_dom.ksize() - m_dom.kplus() - 1;
+      in_.sync();
+      out_.sync();
+{      gridtools::data_view<storage_ijk_t> in= gridtools::make_host_view(in_);
+      std::array<int,3> in_offsets{0,0,0};
+      gridtools::data_view<storage_ijk_t> out= gridtools::make_host_view(out_);
+      std::array<int,3> out_offsets{0,0,0};
+    
+#pragma omp parallel for
+for(int k = kMin + 0+0; k <= kMax + 0+0; ++k) {
+      for(int i = iMin+0; i  <=  iMax+0; ++i) {
+        #pragma omp simd
+for(int j = jMin+0; j  <=  jMax+0; ++j) {
+::dawn::float_type dx;
+{
+  out(i+0, j+0, k+0) = (((int) -4 * (in(i+0, j+0, k+0) + (in(i+1, j+0, k+0) + (in(i+-1, j+0, k+0) + (in(i+0, j+-1, k+0) + in(i+0, j+1, k+0)))))) / (dx * dx));
+}
+        }      }    }}      in_.sync();
+      out_.sync();
+    }
+  };
+  static constexpr const char* s_name = "generated";
+  stencil_47 m_stencil_47;
+public:
+
+  generated(const generated&) = delete;
+
+  generated(const gridtools::dawn::domain& dom, int rank = 1, int xcols = 1, int ycols = 1) : m_stencil_47(dom, rank, xcols, ycols){
+    assert(dom.isize() >= dom.iminus() + dom.iplus());
+    assert(dom.jsize() >= dom.jminus() + dom.jplus());
+    assert(dom.ksize() >= dom.kminus() + dom.kplus());
+    assert(dom.ksize() >= 1);
+  }
+
+  void run(storage_ijk_t in, storage_ijk_t out) {
+    m_stencil_47.run(in,out);
+  }
+};
+} // namespace cxxopt
+} // namespace dawn_generated


### PR DESCRIPTION
## Technical Description

This PR introduces the `CXXOptCodeGen` class that implements the `dawn:cxxopt` backend. It is implemented as a subclass of `CXXNaiveCodeGen`, but adds OpenMP parallel pragmas above parallel k-loops (i.e,. MultiStage.LoopOrder == Parallel), and SIMD pragmas over the innermost j-loops.

### Resolves / Enhances

Resolves #1003
