### PR TITLE
Update CPU build to Ubuntu 20.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # IMAGE needs be be set to one of the docker/dawn-env.dockerfile images
-ARG IMAGE=gtclang/dawn-env-ubuntu19.10
+ARG IMAGE=gtclang/dawn-env-ubuntu20.04
 FROM $IMAGE
 ARG BUILD_TYPE=Release
 COPY . /usr/src/dawn

--- a/docker/ubuntu19.10.dockerfile
+++ b/docker/ubuntu19.10.dockerfile
@@ -1,9 +1,0 @@
-FROM ubuntu:eoan
-RUN apt update && apt install -y --no-install-recommends \
-    build-essential ninja-build cmake git openssh-client curl \
-    llvm-9-dev libclang-9-dev libclang-cpp9 \
-    python3 python3-pip libpython3-dev \
-    python3-setuptools python3-wheel \
-    libboost-dev && apt clean
-RUN python3 -m pip install --upgrade pip
-RUN update-alternatives --install /usr/bin/python python /usr/bin/python3 10

--- a/docker/ubuntu20.04.dockerfile
+++ b/docker/ubuntu20.04.dockerfile
@@ -1,0 +1,17 @@
+FROM ubuntu:focal
+RUN apt update && apt install -y --no-install-recommends \
+    apt-transport-https ca-certificates \
+    gnupg software-properties-common curl && apt clean
+# Add CMake repo
+RUN curl -L https://apt.kitware.com/keys/kitware-archive-latest.asc | apt-key add -
+RUN apt-add-repository 'deb https://apt.kitware.com/ubuntu/ focal main'
+RUN apt-add-repository 'deb https://apt.kitware.com/ubuntu/ focal-rc main'
+RUN apt-get install kitware-archive-keyring && apt clean
+RUN apt update && apt install -y --no-install-recommends \
+    build-essential ninja-build cmake git openssh-client curl \
+    llvm-9-dev libclang-9-dev libclang-cpp9 \
+    python3 python3-pip libpython3-dev \
+    python3-setuptools python3-wheel \
+    libboost-dev && apt clean
+RUN python3 -m pip install --upgrade pip
+RUN update-alternatives --install /usr/bin/python python /usr/bin/python3 10

--- a/docker/update-images
+++ b/docker/update-images
@@ -11,34 +11,27 @@ if [ $# -eq 0 ]; then
     usage
 fi
 
-if [ "$1" = "-s" ]; then
-    cmd_prefix="sudo"
-    shift
-else
-    cmd_prefix=""
-fi
-
 while [ "$1" != "" ]; do
     case $1 in
     c | cpu)
-        image_name=gtclang/dawn-env-ubuntu19.10
-        $cmd_prefix docker build --rm \
+        image_name=gtclang/dawn-env-ubuntu20.04
+        docker build --rm \
             --tag $image_name-base \
-            --file docker/ubuntu19.10.dockerfile .
-        $cmd_prefix docker build --rm \
+            --file docker/ubuntu20.04.dockerfile .
+        docker build --rm \
             --tag $image_name --build-arg IMAGE=$image_name-base \
             --file docker/dawn-env.dockerfile .
-        echo "Now run:\n\t$cmd_prefix docker push $image_name"
+        echo "Now run:\n\tdocker push $image_name"
         ;;
     g | gpu)
         image_name=gtclang/dawn-env-cuda10.1-ubuntu18.04
-        $cmd_prefix docker build --rm \
+        docker build --rm \
             --tag $image_name-base \
             --file docker/cuda10.1-ubuntu18.04.dockerfile .
-        $cmd_prefix docker build --rm \
+        docker build --rm \
             --tag $image_name --build-arg IMAGE=$image_name-base \
             --file docker/dawn-env.dockerfile .
-        echo "Now run:\n\t$cmd_prefix docker push $image_name"
+        echo "Now run:\n\tdocker push $image_name"
         ;;
     *)
         usage


### PR DESCRIPTION
## Technical Description

CMake 3.14 is required with GridTools v1.1. The GPU build image using 18.04 has at least 3.14 installed through the Kitware PPA, but Ubuntu 19.10 is not supported in the PPA. Therefore, this updates to the next LTS release, Ubuntu 20.04, for the CPU build and uses that PPA.