### PR TITLE
Fix a Bug in the Unstructured Dimensions Checker

### DIFF
--- a/dawn/src/dawn/AST/ASTExpr.h
+++ b/dawn/src/dawn/AST/ASTExpr.h
@@ -441,6 +441,8 @@ public:
     return dynamic_cast<DataType&>(*data_.get());
   }
 
+  bool hasData() const { return data_ != nullptr; }
+
   const std::string& getName() const { return name_; }
 
   void setName(std::string name) { name_ = name; }

--- a/dawn/src/dawn/AST/ASTStmt.h
+++ b/dawn/src/dawn/AST/ASTStmt.h
@@ -111,6 +111,8 @@ public:
     return dynamic_cast<DataType&>(*data_.get());
   }
 
+  bool hasData() const { return data_ != nullptr; }
+
   /// @brief Iterate children (if any)
   virtual StmtRangeType getChildren() { return StmtRangeType(); }
 

--- a/dawn/src/dawn/AST/ASTStmt.h
+++ b/dawn/src/dawn/AST/ASTStmt.h
@@ -111,8 +111,6 @@ public:
     return dynamic_cast<DataType&>(*data_.get());
   }
 
-  bool hasData() const { return data_ != nullptr; }
-
   /// @brief Iterate children (if any)
   virtual StmtRangeType getChildren() { return StmtRangeType(); }
 

--- a/dawn/src/dawn/Validator/UnstructuredDimensionChecker.cpp
+++ b/dawn/src/dawn/Validator/UnstructuredDimensionChecker.cpp
@@ -113,7 +113,7 @@ UnstructuredDimensionChecker::UnstructuredDimensionCheckerImpl::UnstructuredDime
     UnstructuredDimensionCheckerConfig config)
     : nameToDimensions_(nameToDimensionsMap), idToNameMap_(idToNameMap),
       idToLocalVariableData_(idToLocalVariableData), config_(config) {
-  checkType_ = checkType::runOnSIR;
+  checkType_ = checkType::runOnIIR;
 }
 
 const sir::FieldDimensions&

--- a/dawn/src/dawn/Validator/UnstructuredDimensionChecker.cpp
+++ b/dawn/src/dawn/Validator/UnstructuredDimensionChecker.cpp
@@ -102,7 +102,9 @@ UnstructuredDimensionChecker::checkStageLocTypeConsistency(
 UnstructuredDimensionChecker::UnstructuredDimensionCheckerImpl::UnstructuredDimensionCheckerImpl(
     const std::unordered_map<std::string, sir::FieldDimensions> nameToDimensionsMap,
     UnstructuredDimensionCheckerConfig config)
-    : nameToDimensions_(nameToDimensionsMap), config_(config) {}
+    : nameToDimensions_(nameToDimensionsMap), config_(config) {
+  checkType_ = checkType::runOnSIR;
+}
 
 UnstructuredDimensionChecker::UnstructuredDimensionCheckerImpl::UnstructuredDimensionCheckerImpl(
     const std::unordered_map<std::string, sir::FieldDimensions> nameToDimensionsMap,
@@ -110,7 +112,9 @@ UnstructuredDimensionChecker::UnstructuredDimensionCheckerImpl::UnstructuredDime
     const std::unordered_map<int, iir::LocalVariableData> idToLocalVariableData,
     UnstructuredDimensionCheckerConfig config)
     : nameToDimensions_(nameToDimensionsMap), idToNameMap_(idToNameMap),
-      idToLocalVariableData_(idToLocalVariableData), config_(config) {}
+      idToLocalVariableData_(idToLocalVariableData), config_(config) {
+  checkType_ = checkType::runOnSIR;
+}
 
 const sir::FieldDimensions&
 UnstructuredDimensionChecker::UnstructuredDimensionCheckerImpl::getDimensions() const {
@@ -123,11 +127,10 @@ void UnstructuredDimensionChecker::UnstructuredDimensionCheckerImpl::visit(
   if(!dimensionsConsistent_) {
     return;
   }
-  auto accessID = stmt->getData<iir::VarDeclStmtData>().AccessID;
-  // access id is only set on SIR
-  if(!accessID.has_value()) {
+  if(checkType_ == checkType::runOnSIR) {
     return;
   }
+  auto accessID = stmt->getData<iir::VarDeclStmtData>().AccessID;
   const auto varDeclInfo = idToLocalVariableData_.at(*accessID);
   // type is not set if PassLocalVarType didn't run
   if(!varDeclInfo.isTypeSet()) {
@@ -149,7 +152,8 @@ void UnstructuredDimensionChecker::UnstructuredDimensionCheckerImpl::visit(
   auto fieldName = fieldAccessExpr->getName();
   // the name in the FieldAccessExpr may be stale if the there are nested stencils
   // in this case we need to look up the new AccessID in the data of the fieldAccessExpr
-  if(fieldAccessExpr->hasData()) {
+  if(checkType_ == checkType::runOnIIR) {
+    DAWN_ASSERT(fieldAccessExpr->hasData());
     auto newAccessID = fieldAccessExpr->getData<iir::IIRAccessExprData>().AccessID;
     if(newAccessID.has_value()) {
       DAWN_ASSERT(idToNameMap_.count(newAccessID.value()));
@@ -195,10 +199,10 @@ void UnstructuredDimensionChecker::UnstructuredDimensionCheckerImpl::visit(
   if(!dimensionsConsistent_) {
     return;
   }
-  // data is not set if coming from SIR
-  if(!varAccessExpr->hasData()) {
+  if(checkType_ == checkType::runOnSIR) {
     return;
   }
+  DAWN_ASSERT(varAccessExpr->hasData());
   auto accessID = *varAccessExpr->getData<iir::IIRAccessExprData>().AccessID;
   // access may be global
   if(!idToLocalVariableData_.count(accessID)) {

--- a/dawn/src/dawn/Validator/UnstructuredDimensionChecker.h
+++ b/dawn/src/dawn/Validator/UnstructuredDimensionChecker.h
@@ -58,6 +58,7 @@ private:
     void visit(const std::shared_ptr<iir::VarDeclStmt>& stmt) override;
     void visit(const std::shared_ptr<iir::VarAccessExpr>& stmt) override;
 
+    void setCurDimensionFromLocType(iir::LocalVariableType&& type);
     bool isConsistent() const { return dimensionsConsistent_; }
     bool hasDimensions() const { return curDimensions_.has_value(); };
     const sir::FieldDimensions& getDimensions() const;

--- a/dawn/src/dawn/Validator/UnstructuredDimensionChecker.h
+++ b/dawn/src/dawn/Validator/UnstructuredDimensionChecker.h
@@ -41,6 +41,7 @@ private:
     std::optional<sir::FieldDimensions> curDimensions_;
     const std::unordered_map<std::string, sir::FieldDimensions> nameToDimensions_;
     const std::unordered_map<int, std::string> idToNameMap_;
+    const std::unordered_map<int, iir::LocalVariableData> idToLocalVariableData_;
     bool dimensionsConsistent_ = true;
 
     UnstructuredDimensionCheckerConfig config_;
@@ -54,6 +55,7 @@ private:
     void visit(const std::shared_ptr<iir::AssignmentExpr>& stmt) override;
     void visit(const std::shared_ptr<iir::ReductionOverNeighborExpr>& stmt) override;
     void visit(const std::shared_ptr<iir::LoopStmt>& stmt) override;
+    void visit(const std::shared_ptr<iir::VarDeclStmt>& stmt) override;
 
     bool isConsistent() const { return dimensionsConsistent_; }
     bool hasDimensions() const { return curDimensions_.has_value(); };
@@ -70,6 +72,7 @@ private:
     UnstructuredDimensionCheckerImpl(
         const std::unordered_map<std::string, sir::FieldDimensions> nameToDimensionsMap,
         const std::unordered_map<int, std::string> idToNameMap,
+        const std::unordered_map<int, iir::LocalVariableData> idToLocalVariableData,
         UnstructuredDimensionCheckerConfig = UnstructuredDimensionCheckerConfig());
   };
 

--- a/dawn/src/dawn/Validator/UnstructuredDimensionChecker.h
+++ b/dawn/src/dawn/Validator/UnstructuredDimensionChecker.h
@@ -30,6 +30,7 @@ class UnstructuredDimensionChecker {
 private:
   class UnstructuredDimensionCheckerImpl : public ast::ASTVisitorForwarding {
   public:
+    enum class checkType { runOnIIR, runOnSIR };
     struct UnstructuredDimensionCheckerConfig {
       bool parentIsChainForLoop_ = false;
       bool parentIsReduction_ = false;
@@ -45,6 +46,7 @@ private:
     bool dimensionsConsistent_ = true;
 
     UnstructuredDimensionCheckerConfig config_;
+    checkType checkType_ = checkType::runOnIIR;
 
     void checkBinaryOpUnstructured(const sir::FieldDimensions& left,
                                    const sir::FieldDimensions& right);

--- a/dawn/src/dawn/Validator/UnstructuredDimensionChecker.h
+++ b/dawn/src/dawn/Validator/UnstructuredDimensionChecker.h
@@ -56,6 +56,7 @@ private:
     void visit(const std::shared_ptr<iir::ReductionOverNeighborExpr>& stmt) override;
     void visit(const std::shared_ptr<iir::LoopStmt>& stmt) override;
     void visit(const std::shared_ptr<iir::VarDeclStmt>& stmt) override;
+    void visit(const std::shared_ptr<iir::VarAccessExpr>& stmt) override;
 
     bool isConsistent() const { return dimensionsConsistent_; }
     bool hasDimensions() const { return curDimensions_.has_value(); };

--- a/dawn/test/unit-test/dawn/Validator/TestUnstructuredDimensionChecker.cpp
+++ b/dawn/test/unit-test/dawn/Validator/TestUnstructuredDimensionChecker.cpp
@@ -487,4 +487,25 @@ TEST(UnstructuredDimensionCheckerTest, StageLocType_3) {
                                                                            stencil->getMetaData());
   EXPECT_EQ(result, UnstructuredDimensionChecker::ConsistencyResult(true, dawn::SourceLocation()));
 }
+TEST(UnstructuredDimensionCheckerTest, VarAccessType) {
+  using namespace dawn::iir;
+  using LocType = dawn::ast::LocationType;
+
+  UnstructuredIIRBuilder b;
+
+  auto varB = b.localvar("varX", dawn::BuiltinTypeID::Double, {b.lit(1.0)},
+                         iir::LocalVariableType::OnEdges);
+
+  auto stencil = b.build(
+      "pass",
+      b.stencil(b.multistage(
+          LoopOrderKind::Parallel,
+          b.stage(LocType::Edges,
+                  b.doMethod(dawn::sir::Interval::Start, dawn::sir::Interval::End,
+                             b.declareVar(varB), b.stmt(b.assignExpr(b.at(varB), b.lit(2.0))))))));
+  auto result = UnstructuredDimensionChecker::checkStageLocTypeConsistency(*stencil->getIIR(),
+                                                                           stencil->getMetaData());
+  EXPECT_EQ(result, UnstructuredDimensionChecker::ConsistencyResult(true, dawn::SourceLocation()));
+}
+
 } // namespace


### PR DESCRIPTION
## Technical Description

There is a problem with the unstructured dimensions checker: VarDeclStmts as well as VarAccessExprs were never considered in the visitor, leaving some statements without a location type. This marked actually valid IIR as invalid.

### Resolves / Enhances

Addresses first bullet point of [#720](https://github.com/MeteoSwiss-APN/dawn/issues/720)

### Testing

New test in `TestUnstructuredDimensionsChecker`



