### PR TITLE
Removed a Restriction which doesn't Allow FunCalls in Weights

### DIFF
--- a/dawn/src/dawn/Validator/WeightChecker.cpp
+++ b/dawn/src/dawn/Validator/WeightChecker.cpp
@@ -46,16 +46,6 @@ void WeightChecker::WeightCheckerImpl::visit(
                         .isDense();
   }
 }
-void WeightChecker::WeightCheckerImpl::visit(const std::shared_ptr<dawn::ast::FunCallExpr>& expr) {
-  if(parentIsWeight_) {
-    weightsValid_ = false;
-    return;
-  } else {
-    for(const auto& s : expr->getChildren()) {
-      s->accept(*this);
-    }
-  }
-}
 void WeightChecker::WeightCheckerImpl::visit(
     const std::shared_ptr<dawn::ast::StencilFunCallExpr>& expr) {
   if(parentIsWeight_) {

--- a/dawn/src/dawn/Validator/WeightChecker.h
+++ b/dawn/src/dawn/Validator/WeightChecker.h
@@ -56,7 +56,6 @@ private:
 
   public:
     void visit(const std::shared_ptr<dawn::ast::FieldAccessExpr>& expr) override;
-    void visit(const std::shared_ptr<dawn::ast::FunCallExpr>& expr) override;
     void visit(const std::shared_ptr<dawn::ast::StencilFunCallExpr>& expr) override;
     void visit(const std::shared_ptr<dawn::ast::ReductionOverNeighborExpr>& expr) override;
 


### PR DESCRIPTION
## Technical Description

The `WeightChecker` prevented weights from being constructed that contain function calls. Even though I introduced this check, I can currently not think of a good reason to disallow such weights. Maybe I put this into place because I misunderstood what a `FunCallExpr` in dawn does. I can see no harm being done by allowing math functions in weights, the generated code looks good and no tests are failing, so I'm re-enabling such weights.

### Example

Example in dusk
```
def power_operator(
    a: Field[Edge], b: Field[Edge], d: Field[Edge > Cell]
):
    with levels_downward:
        a = min_over(Edge > Cell, pow(d, 5), weights=[b ** 3, -1])
```
