### PR TITLE
Fix HAS_UNSTRUCTURED_DEPS

### DIFF
--- a/dawn/CMakeLists.txt
+++ b/dawn/CMakeLists.txt
@@ -60,6 +60,7 @@ endif()
 # Path for external CMake files
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 
+include(HasUnstructuredDeps)
 include(CTest)
 include(GNUInstallDirs)
 include(EnableCCache)

--- a/dawn/cmake/HasUnstructuredDeps.cmake
+++ b/dawn/cmake/HasUnstructuredDeps.cmake
@@ -30,9 +30,11 @@ if (NOT DEFINED HAS_UNSTRUCTURED_DEPS)
   if(atlas_FOUND AND eckit_FOUND)
     message(STATUS "Found atlas and eckit. Setting HAS_UNSTRUCTURED_DEPS=ON.")
     set(HAS_UNSTRUCTURED_DEPS ON CACHE BOOL "True if Dawn has detected necessary dependencies for supporting unstructured grids.")
-    mark_as_advanced(HAS_UNSTRUCTURED_DEPS)
   else()
     set(STATUS "Cound not find dependencies for unstructured support.")
+    set(HAS_UNSTRUCTURED_DEPS OFF CACHE BOOL "True if Dawn has detected necessary dependencies for supporting unstructured grids.")
   endif()
+  
+  mark_as_advanced(HAS_UNSTRUCTURED_DEPS)
 
 endif()

--- a/dawn/cmake/HasUnstructuredDeps.cmake
+++ b/dawn/cmake/HasUnstructuredDeps.cmake
@@ -11,11 +11,7 @@
 ##  See LICENSE.txt for details.
 ##
 ##===------------------------------------------------------------------------------------------===##
-
 if (NOT DEFINED HAS_UNSTRUCTURED_DEPS)
-
-  set(HAS_UNSTRUCTURED_DEPS OFF CACHE BOOL "True if Dawn has detected necessary dependencies for supporting unstructured grids.")
-  mark_as_advanced(HAS_UNSTRUCTURED_DEPS)
 
   if(DAWN_REQUIRE_UNSTRUCTURED_TESTING)
     find_package(eckit REQUIRED)
@@ -33,7 +29,8 @@ if (NOT DEFINED HAS_UNSTRUCTURED_DEPS)
 
   if(atlas_FOUND AND eckit_FOUND)
     message(STATUS "Found atlas and eckit. Setting HAS_UNSTRUCTURED_DEPS=ON.")
-    set(HAS_UNSTRUCTURED_DEPS ON)
+    set(HAS_UNSTRUCTURED_DEPS ON CACHE BOOL "True if Dawn has detected necessary dependencies for supporting unstructured grids.")
+    mark_as_advanced(HAS_UNSTRUCTURED_DEPS)
   else()
     set(STATUS "Cound not find dependencies for unstructured support.")
   endif()

--- a/dawn/test/integration-test/CMakeLists.txt
+++ b/dawn/test/integration-test/CMakeLists.txt
@@ -15,7 +15,6 @@
 add_subdirectory(from-sir)
 add_subdirectory(serializer)
 
-include(HasUnstructuredDeps)
 if (HAS_UNSTRUCTURED_DEPS)
   add_subdirectory(unstructured)
 endif()

--- a/dawn/test/unit-test/CMakeLists.txt
+++ b/dawn/test/unit-test/CMakeLists.txt
@@ -17,7 +17,6 @@ add_subdirectory(dawn)
 add_subdirectory(dawn4py-tests)
 add_subdirectory(driver-includes)
 
-include(HasUnstructuredDeps)
 if(HAS_UNSTRUCTURED_DEPS)
     add_subdirectory(interface)
 endif()


### PR DESCRIPTION
## Technical Description
Fixes recurrent problem with `HAS_UNSTRUCTURED_DEPS` cached variable (unstructured integration tests or interface unit tests not being built).
