### PR TITLE
Update field access name

### DIFF
--- a/dawn/src/dawn/IIR/DoMethod.cpp
+++ b/dawn/src/dawn/IIR/DoMethod.cpp
@@ -55,8 +55,12 @@ public:
       expr->accept(*this);
   }
   void visit(const std::shared_ptr<VarAccessExpr>& expr) override {
-    auto data = expr->getData<iir::IIRAccessExprData>();
-    int accessID = *data.AccessID;
+    int accessID = iir::getAccessID(expr);
+    std::string realName = metadata_.getNameFromAccessID(accessID);
+    expr->setName(realName);
+  }
+  void visit(const std::shared_ptr<FieldAccessExpr>& expr) override {
+    int accessID = iir::getAccessID(expr);
     std::string realName = metadata_.getNameFromAccessID(accessID);
     expr->setName(realName);
   }

--- a/dawn/src/dawn/Validator/IntegrityChecker.cpp
+++ b/dawn/src/dawn/Validator/IntegrityChecker.cpp
@@ -12,6 +12,7 @@
 //
 //===------------------------------------------------------------------------------------------===//
 #include "dawn/Validator/IntegrityChecker.h"
+#include "dawn/IIR/ASTExpr.h"
 
 namespace dawn {
 IntegrityChecker::IntegrityChecker(iir::StencilInstantiation* instantiation)
@@ -88,6 +89,18 @@ void IntegrityChecker::visit(const std::shared_ptr<iir::AssignmentExpr>& expr) {
     throw SemanticError("Attempt to assign constant expression " + value, metadata_.getFileName(),
                         expr->getSourceLocation().Line);
   }
+  ast::ASTVisitorForwarding::visit(expr);
+}
+
+void IntegrityChecker::visit(const std::shared_ptr<iir::FieldAccessExpr>& expr) {
+  int accessID = iir::getAccessID(expr);
+  DAWN_ASSERT_MSG(metadata_.getFieldNameFromAccessID(accessID) == expr->getName(),
+                  (std::string("Field name (") + std::string(expr->getName()) +
+                   std::string(") doesn't match name registered in metadata(") +
+                   std::string(metadata_.getFieldNameFromAccessID(accessID)) + std::string(")."))
+                      .c_str());
+
+  ast::ASTVisitorForwarding::visit(expr);
 }
 
 void IntegrityChecker::visit(const std::shared_ptr<iir::UnaryOperator>& expr) {

--- a/dawn/src/dawn/Validator/IntegrityChecker.h
+++ b/dawn/src/dawn/Validator/IntegrityChecker.h
@@ -40,6 +40,7 @@ public:
   void visit(const std::shared_ptr<iir::IfStmt>& stmt) override;
   void visit(const std::shared_ptr<iir::VarDeclStmt>& stmt) override;
   void visit(const std::shared_ptr<iir::AssignmentExpr>& expr) override;
+  void visit(const std::shared_ptr<iir::FieldAccessExpr>& expr) override;
   void visit(const std::shared_ptr<iir::UnaryOperator>& expr) override;
   void visit(const std::shared_ptr<iir::ReductionOverNeighborExpr>& expr) override;
   void visit(const std::shared_ptr<iir::BinaryOperator>& expr) override;


### PR DESCRIPTION
## Technical Description

Update `FieldAccessExpr::getName()` to be the correct name (found in metadata).
Adds equality check in `IntegrityChecker`.

### Resolves / Enhances

resolves #591 

