### PR TITLE
Unstructured Dimension Checker Fix

### DIFF
--- a/dawn/src/dawn/Unittest/IIRBuilder.cpp
+++ b/dawn/src/dawn/Unittest/IIRBuilder.cpp
@@ -14,6 +14,7 @@
 //
 // TODO there are death tests which rely on the following code to die, needs refactoring
 #include "dawn/AST/LocationType.h"
+#include "dawn/Validator/IntegrityChecker.h"
 #ifdef NDEBUG
 #undef NDEBUG
 #define HAD_NDEBUG
@@ -93,6 +94,8 @@ IIRBuilder::build(std::string const& name, std::unique_ptr<iir::Stencil> stencil
   restoreIIR(si_);
 
   if(si_->getIIR()->getGridType() == ast::GridType::Unstructured) {
+    IntegrityChecker integrityChecker(si_.get());
+    integrityChecker.run();
     auto [checkResultDimensions, errorLocDimension] =
         UnstructuredDimensionChecker::checkDimensionsConsistency(*si_->getIIR().get(),
                                                                  si_->getMetaData());

--- a/dawn/src/dawn/Unittest/IIRBuilder.cpp
+++ b/dawn/src/dawn/Unittest/IIRBuilder.cpp
@@ -14,7 +14,6 @@
 //
 // TODO there are death tests which rely on the following code to die, needs refactoring
 #include "dawn/AST/LocationType.h"
-#include "dawn/Validator/IntegrityChecker.h"
 #ifdef NDEBUG
 #undef NDEBUG
 #define HAD_NDEBUG
@@ -31,6 +30,7 @@
 #include "dawn/IIR/InstantiationHelper.h"
 #include "dawn/Optimizer/Lowering.h"
 #include "dawn/Validator/GridTypeChecker.h"
+#include "dawn/Validator/IntegrityChecker.h"
 #include "dawn/Validator/UnstructuredDimensionChecker.h"
 #include "dawn/Validator/WeightChecker.h"
 

--- a/dawn/src/dawn/Validator/IntegrityChecker.cpp
+++ b/dawn/src/dawn/Validator/IntegrityChecker.cpp
@@ -120,10 +120,11 @@ void IntegrityChecker::visit(const std::shared_ptr<iir::UnaryOperator>& expr) {
 }
 
 void IntegrityChecker::visit(const std::shared_ptr<iir::ReductionOverNeighborExpr>& expr) {
+  bool parentHadIterationContext = parentHasIterationContext_;
   parentHasIterationContext_ = true;
   for(auto& stmt : expr->getChildren())
     stmt->accept(*this);
-  parentHasIterationContext_ = false;
+  parentHasIterationContext_ = parentHadIterationContext;
 }
 
 void IntegrityChecker::visit(const std::shared_ptr<iir::LoopStmt>& expr) {

--- a/dawn/src/dawn/Validator/IntegrityChecker.cpp
+++ b/dawn/src/dawn/Validator/IntegrityChecker.cpp
@@ -12,6 +12,7 @@
 //
 //===------------------------------------------------------------------------------------------===//
 #include "dawn/Validator/IntegrityChecker.h"
+#include "dawn/AST/GridType.h"
 #include "dawn/IIR/ASTExpr.h"
 
 namespace dawn {
@@ -100,6 +101,16 @@ void IntegrityChecker::visit(const std::shared_ptr<iir::FieldAccessExpr>& expr) 
                    std::string(metadata_.getFieldNameFromAccessID(accessID)) + std::string(")."))
                       .c_str());
 
+  if(expr->getOffset().horizontalOffset().hasType() &&
+     expr->getOffset().horizontalOffset().getGridType() == ast::GridType::Unstructured) {
+    auto unstrOffset =
+        ast::offset_cast<const ast::UnstructuredOffset&>(expr->getOffset().horizontalOffset());
+    if(unstrOffset.hasOffset() && !parentHasIterationContext_) {
+      throw SemanticError("Attempting to offset read from/write to unstructured field outside of a "
+                          "reduction expression or loop statement!");
+    }
+  }
+
   ast::ASTVisitorForwarding::visit(expr);
 }
 
@@ -109,8 +120,17 @@ void IntegrityChecker::visit(const std::shared_ptr<iir::UnaryOperator>& expr) {
 }
 
 void IntegrityChecker::visit(const std::shared_ptr<iir::ReductionOverNeighborExpr>& expr) {
+  parentHasIterationContext_ = true;
   for(auto& stmt : expr->getChildren())
     stmt->accept(*this);
+  parentHasIterationContext_ = false;
+}
+
+void IntegrityChecker::visit(const std::shared_ptr<iir::LoopStmt>& expr) {
+  parentHasIterationContext_ = true;
+  for(auto& stmt : expr->getChildren())
+    stmt->accept(*this);
+  parentHasIterationContext_ = false;
 }
 
 void IntegrityChecker::visit(const std::shared_ptr<iir::BinaryOperator>& expr) {

--- a/dawn/src/dawn/Validator/IntegrityChecker.h
+++ b/dawn/src/dawn/Validator/IntegrityChecker.h
@@ -28,6 +28,8 @@ namespace dawn {
 class IntegrityChecker : public ast::ASTVisitorForwarding {
   iir::StencilInstantiation* instantiation_;
   iir::StencilMetaInformation& metadata_;
+  // are we in a loop or reduction expression?
+  bool parentHasIterationContext_ = false;
 
 public:
   IntegrityChecker(iir::StencilInstantiation* instantiation);
@@ -43,6 +45,7 @@ public:
   void visit(const std::shared_ptr<iir::FieldAccessExpr>& expr) override;
   void visit(const std::shared_ptr<iir::UnaryOperator>& expr) override;
   void visit(const std::shared_ptr<iir::ReductionOverNeighborExpr>& expr) override;
+  void visit(const std::shared_ptr<iir::LoopStmt>& expr) override;
   void visit(const std::shared_ptr<iir::BinaryOperator>& expr) override;
   void visit(const std::shared_ptr<iir::TernaryOperator>& expr) override;
   void visit(const std::shared_ptr<iir::FunCallExpr>& expr) override;

--- a/dawn/src/dawn/Validator/UnstructuredDimensionChecker.cpp
+++ b/dawn/src/dawn/Validator/UnstructuredDimensionChecker.cpp
@@ -169,6 +169,10 @@ void UnstructuredDimensionChecker::UnstructuredDimensionCheckerImpl::visit(
       dimensionsConsistent_ &= getUnstructuredDim(*curDimensions_).getDenseLocationType() ==
                                config_.currentChain_->back();
     }
+    if(hasOffset && !getUnstructuredDim(*curDimensions_).isDense()) {
+      dimensionsConsistent_ &=
+          getUnstructuredDim(*curDimensions_).getNeighborChain() == config_.currentChain_.value();
+    }
   }
 
   if(fieldAccessExpr->getOffset().hasVerticalIndirection()) {

--- a/dawn/src/dawn/Validator/UnstructuredDimensionChecker.cpp
+++ b/dawn/src/dawn/Validator/UnstructuredDimensionChecker.cpp
@@ -6,6 +6,7 @@
 #include "dawn/SIR/SIR.h"
 #include "dawn/Support/SourceLocation.h"
 #include "dawn/Validator/WeightChecker.h"
+#include <optional>
 
 namespace dawn {
 
@@ -443,11 +444,10 @@ void UnstructuredDimensionChecker::UnstructuredDimensionCheckerImpl::visit(
       nameToDimensions_, idToNameMap_, idToLocalVariableData_, config_);
 
   config_.parentIsReduction_ = true;
+  reductionExpr->getInit()->accept(init);
   config_.currentChain_ = reductionExpr->getNbhChain();
   UnstructuredDimensionChecker::UnstructuredDimensionCheckerImpl ops(
       nameToDimensions_, idToNameMap_, idToLocalVariableData_, config_);
-  config_.currentChain_ = std::nullopt;
-  reductionExpr->getInit()->accept(init);
   reductionExpr->getRhs()->accept(ops);
 
   if(!ops.isConsistent()) {

--- a/dawn/test/unit-test/dawn/Validator/TestUnstructuredDimensionChecker.cpp
+++ b/dawn/test/unit-test/dawn/Validator/TestUnstructuredDimensionChecker.cpp
@@ -111,6 +111,34 @@ TEST(UnstructuredDimensionCheckerTest, AssignmentCase4) {
                                  b.stmt(b.assignExpr(b.at(dense_field), b.at(sparse_field)))))))),
       ".*Dimensions consistency check failed.*");
 }
+TEST(UnstructuredDimensionCheckerTest, AssignmentCase5) {
+  using namespace dawn::iir;
+  using LocType = dawn::ast::LocationType;
+
+  UnstructuredIIRBuilder b;
+  auto dense_field_v = b.field("dense_v_field", LocType::Vertices);
+  auto dense_field_e = b.field("dense_e_field", LocType::Edges);
+  auto sparse_field = b.field("sparse_field", {LocType::Edges, LocType::Cells});
+
+  auto stencil = b.build(
+      "passing",
+      b.stencil(b.multistage(
+          LoopOrderKind::Parallel,
+          b.stage(b.doMethod(
+              dawn::sir::Interval::Start, dawn::sir::Interval::End,
+              b.loopStmtChain(
+                  b.stmt(b.assignExpr(
+                      b.at(sparse_field),
+                      b.binaryExpr(b.reduceOverNeighborExpr(Op::plus, b.at(dense_field_e),
+                                                            b.lit(0.),
+                                                            {LocType::Cells, LocType::Edges}),
+                                   b.at(sparse_field, HOffsetType::withOffset, 0), Op::plus))),
+                  {LocType::Edges, LocType::Cells}))))));
+
+  auto result = UnstructuredDimensionChecker::checkDimensionsConsistency(*stencil->getIIR(),
+                                                                         stencil->getMetaData());
+  EXPECT_EQ(result, UnstructuredDimensionChecker::ConsistencyResult(true, dawn::SourceLocation()));
+}
 TEST(UnstructuredDimensionCheckerTest, BinaryOpCase0) {
   using namespace dawn::iir;
   using LocType = dawn::ast::LocationType;


### PR DESCRIPTION
## Technical Description

There was an oversight in the unstructured Dimensions checker never looking at the sparse dimension of a `FieldAccessExpr` in a reduction or loop (fill) concept. Hence, this dusk code was accidentally allowed:

```
 @stencil 
 def ambiguous_sparse_fill_bug( 
     sparse_field: Field[Edge > Vertex > Edge, K], edge: Field[Edge, K], 
 ): 
     with levels_downward: 
         # different location chain in sparse fill than `sparse_field` 
         with sparse[Edge > Cell > Edge]: 
             # invalid sparse write 
             sparse_field = edge[Edge > Cell > Edge] 
```


