### PR TITLE
Add Horizontal Subdomains for Unstructured Domains

### DIFF
--- a/dawn/src/dawn/CodeGen/CXXNaive-ico/ASTStencilBody.cpp
+++ b/dawn/src/dawn/CodeGen/CXXNaive-ico/ASTStencilBody.cpp
@@ -27,11 +27,11 @@ static std::string nbhChainToVectorString(const std::vector<dawn::ast::LocationT
   auto getLocationTypeString = [](dawn::ast::LocationType type) {
     switch(type) {
     case dawn::ast::LocationType::Cells:
-      return "dawn::LocationType::Cells";
+      return "::dawn::LocationType::Cells";
     case dawn::ast::LocationType::Edges:
-      return "dawn::LocationType::Edges";
+      return "::dawn::LocationType::Edges";
     case dawn::ast::LocationType::Vertices:
-      return "dawn::LocationType::Vertices";
+      return "::dawn::LocationType::Vertices";
     default:
       dawn_unreachable("unknown location type");
       return "";
@@ -39,7 +39,7 @@ static std::string nbhChainToVectorString(const std::vector<dawn::ast::LocationT
   };
 
   std::stringstream ss;
-  ss << "std::vector<dawn::LocationType>{";
+  ss << "std::vector<::dawn::LocationType>{";
   bool first = true;
   for(const auto& loc : chain) {
     if(!first) {

--- a/dawn/src/dawn/CodeGen/CXXNaive-ico/CXXNaiveCodeGen.cpp
+++ b/dawn/src/dawn/CodeGen/CXXNaive-ico/CXXNaiveCodeGen.cpp
@@ -529,7 +529,7 @@ void CXXNaiveIcoCodeGen::generateStencilClasses(
                 DAWN_ASSERT_MSG(stage.getLocationType().has_value(),
                                 "Stage must have a location type");
                 std::string loopCode =
-                    getLoop(*stage.getLocationType(), stage.getIterationSpace()[0]);
+                    getLoop(*stage.getLocationType(), stage.getUnstructuredIterationSpace());
                 StencilRunMethod.addBlockStatement(loopCode, [&] {
                   // Generate Do-Method
                   for(const auto& doMethodPtr : stage.getChildren()) {

--- a/dawn/src/dawn/CodeGen/CXXNaive-ico/CXXNaiveCodeGen.cpp
+++ b/dawn/src/dawn/CodeGen/CXXNaive-ico/CXXNaiveCodeGen.cpp
@@ -295,7 +295,7 @@ void CXXNaiveIcoCodeGen::generateStencilWrapperMembers(
 
   auto splitterIdxFun = stencilWrapperClass.addMemberFunction("void", "set_splitter_index");
   splitterIdxFun.addArg("::dawn::LocationType loc");
-  splitterIdxFun.addArg("dawn::UnstructuredIterationSpace space");
+  splitterIdxFun.addArg("::dawn::UnstructuredIterationSpace space");
   splitterIdxFun.addArg("int offset");
   splitterIdxFun.addArg("int index");
   for(auto stencilPropertiesPair :
@@ -381,7 +381,7 @@ void CXXNaiveIcoCodeGen::generateStencilClasses(
       stencilClass.addMember(fieldInfoToDeclString(fieldIt.second) + "&",
                              "m_" + fieldIt.second.Name);
     }
-    stencilClass.addMember("dawn::unstructured_domain ", " m_unstructured_domain ");
+    stencilClass.addMember("::dawn::unstructured_domain ", " m_unstructured_domain ");
 
     // addTmpStorageDeclaration(StencilClass, tempFields);
 
@@ -466,15 +466,15 @@ void CXXNaiveIcoCodeGen::generateStencilClasses(
       auto spaceMagicNumToEnum = [](int magicNum) {
         switch(magicNum) {
         case 0:
-          return "dawn::UnstructuredIterationSpace::LateralBoundary";
+          return "::dawn::UnstructuredIterationSpace::LateralBoundary";
         case 1:
-          return "dawn::UnstructuredIterationSpace::Nudging";
+          return "::dawn::UnstructuredIterationSpace::Nudging";
         case 2:
-          return "dawn::UnstructuredIterationSpace::Interior";
+          return "::dawn::UnstructuredIterationSpace::Interior";
         case 3:
-          return "dawn::UnstructuredIterationSpace::Halo";
+          return "::dawn::UnstructuredIterationSpace::Halo";
         case 4:
-          return "dawn::UnstructuredIterationSpace::End";
+          return "::dawn::UnstructuredIterationSpace::End";
         default:
           assert(false);
         }

--- a/dawn/src/dawn/CodeGen/CXXNaive-ico/CXXNaiveCodeGen.cpp
+++ b/dawn/src/dawn/CodeGen/CXXNaive-ico/CXXNaiveCodeGen.cpp
@@ -23,7 +23,9 @@
 #include "dawn/Support/Exception.h"
 #include "dawn/Support/Logger.h"
 #include "dawn/Support/StringUtil.h"
+
 #include <algorithm>
+#include <optional>
 #include <vector>
 
 namespace dawn {
@@ -175,7 +177,7 @@ void CXXNaiveIcoCodeGen::generateStencilWrapperCtr(
   const auto& APIFields = metadata.getAccessesOfType<iir::FieldAccessType::APIField>();
   auto StencilWrapperConstructor = stencilWrapperClass.addConstructor();
 
-  StencilWrapperConstructor.addArg("const dawn::mesh_t<LibTag> &mesh");
+  StencilWrapperConstructor.addArg("const ::dawn::mesh_t<LibTag> &mesh");
   StencilWrapperConstructor.addArg("int k_size");
 
   auto getLocationTypeString = [](ast::LocationType type) {
@@ -193,7 +195,7 @@ void CXXNaiveIcoCodeGen::generateStencilWrapperCtr(
   };
   for(auto APIfieldID : APIFields) {
     if(metadata.getFieldDimensions(APIfieldID).isVertical()) {
-      StencilWrapperConstructor.addArg("dawn::vertical_field_t<LibTag, ::dawn::float_type>& " +
+      StencilWrapperConstructor.addArg("::dawn::vertical_field_t<LibTag, ::dawn::float_type>& " +
                                        metadata.getNameFromAccessID(APIfieldID));
       continue;
     }
@@ -202,13 +204,13 @@ void CXXNaiveIcoCodeGen::generateStencilWrapperCtr(
            .isDense()) {
       std::string typeString =
           getLocationTypeString(metadata.getDenseLocationTypeFromAccessID(APIfieldID));
-      StencilWrapperConstructor.addArg("dawn::" + typeString +
+      StencilWrapperConstructor.addArg("::dawn::" + typeString +
                                        "field_t<LibTag, ::dawn::float_type>& " +
                                        metadata.getNameFromAccessID(APIfieldID));
     } else {
       std::string typeString =
           getLocationTypeString(metadata.getDenseLocationTypeFromAccessID(APIfieldID));
-      StencilWrapperConstructor.addArg("dawn::sparse_" + typeString +
+      StencilWrapperConstructor.addArg("::dawn::sparse_" + typeString +
                                        "field_t<LibTag, ::dawn::float_type>& " +
                                        metadata.getNameFromAccessID(APIfieldID));
     }
@@ -290,6 +292,19 @@ void CXXNaiveIcoCodeGen::generateStencilWrapperMembers(
       stencilWrapperClass.addMember(c_dgt + "storage_t",
                                     "m_" + metadata.getFieldNameFromAccessID(AccessID));
   }
+
+  auto splitterIdxFun = stencilWrapperClass.addMemberFunction("void", "set_splitter_index");
+  splitterIdxFun.addArg("::dawn::LocationType loc");
+  splitterIdxFun.addArg("dawn::UnstructuredIterationSpace space");
+  splitterIdxFun.addArg("int offset");
+  splitterIdxFun.addArg("int index");
+  for(auto stencilPropertiesPair :
+      codeGenProperties.stencilProperties(StencilContext::SC_Stencil)) {
+    splitterIdxFun.addStatement(
+        "m_" + stencilPropertiesPair.second->name_ +
+        ".m_unstructured_domain.set_splitter_index({loc, space, offset}, index)");
+  }
+  splitterIdxFun.commit();
 }
 
 void CXXNaiveIcoCodeGen::generateStencilClasses(
@@ -328,7 +343,7 @@ void CXXNaiveIcoCodeGen::generateStencilClasses(
 
     auto fieldInfoToDeclString = [](iir::Stencil::FieldInfo info) {
       if(info.field.getFieldDimensions().isVertical()) {
-        return std::string("dawn::vertical_field_t<LibTag, ::dawn::float_type>");
+        return std::string("::dawn::vertical_field_t<LibTag, ::dawn::float_type>");
       }
 
       const auto& unstructuredDims = sir::dimension_cast<sir::UnstructuredFieldDimension const&>(
@@ -336,11 +351,11 @@ void CXXNaiveIcoCodeGen::generateStencilClasses(
       if(unstructuredDims.isDense()) {
         switch(unstructuredDims.getDenseLocationType()) {
         case ast::LocationType::Cells:
-          return std::string("dawn::cell_field_t<LibTag, ::dawn::float_type>");
+          return std::string("::dawn::cell_field_t<LibTag, ::dawn::float_type>");
         case ast::LocationType::Vertices:
-          return std::string("dawn::vertex_field_t<LibTag, ::dawn::float_type>");
+          return std::string("::dawn::vertex_field_t<LibTag, ::dawn::float_type>");
         case ast::LocationType::Edges:
-          return std::string("dawn::edge_field_t<LibTag, ::dawn::float_type>");
+          return std::string("::dawn::edge_field_t<LibTag, ::dawn::float_type>");
         default:
           dawn_unreachable("invalid location");
           return std::string("");
@@ -348,11 +363,11 @@ void CXXNaiveIcoCodeGen::generateStencilClasses(
       } else {
         switch(unstructuredDims.getDenseLocationType()) {
         case ast::LocationType::Cells:
-          return std::string("dawn::sparse_cell_field_t<LibTag, ::dawn::float_type>");
+          return std::string("::dawn::sparse_cell_field_t<LibTag, ::dawn::float_type>");
         case ast::LocationType::Vertices:
-          return std::string("dawn::sparse_vertex_field_t<LibTag, ::dawn::float_type>");
+          return std::string("::dawn::sparse_vertex_field_t<LibTag, ::dawn::float_type>");
         case ast::LocationType::Edges:
-          return std::string("dawn::sparse_edge_field_t<LibTag, ::dawn::float_type>");
+          return std::string("::dawn::sparse_edge_field_t<LibTag, ::dawn::float_type>");
         default:
           dawn_unreachable("invalid location");
           return std::string("");
@@ -360,12 +375,13 @@ void CXXNaiveIcoCodeGen::generateStencilClasses(
       }
     };
 
-    stencilClass.addMember("dawn::mesh_t<LibTag> const&", "m_mesh");
+    stencilClass.addMember("::dawn::mesh_t<LibTag> const&", "m_mesh");
     stencilClass.addMember("int", "m_k_size");
     for(auto fieldIt : nonTempFields) {
       stencilClass.addMember(fieldInfoToDeclString(fieldIt.second) + "&",
                              "m_" + fieldIt.second.Name);
     }
+    stencilClass.addMember("dawn::unstructured_domain ", " m_unstructured_domain ");
 
     // addTmpStorageDeclaration(StencilClass, tempFields);
 
@@ -373,7 +389,7 @@ void CXXNaiveIcoCodeGen::generateStencilClasses(
 
     auto stencilClassCtr = stencilClass.addConstructor();
 
-    stencilClassCtr.addArg("dawn::mesh_t<LibTag> const &mesh");
+    stencilClassCtr.addArg("::dawn::mesh_t<LibTag> const &mesh");
     stencilClassCtr.addArg("int k_size");
     for(auto fieldIt : nonTempFields) {
       stencilClassCtr.addArg(fieldInfoToDeclString(fieldIt.second) + "&" + fieldIt.second.Name);
@@ -418,11 +434,10 @@ void CXXNaiveIcoCodeGen::generateStencilClasses(
     StencilRunMethod.startBody();
 
     // TODO the generic deref should be moved to a different namespace
-    StencilRunMethod.addStatement("using dawn::deref");
+    StencilRunMethod.addStatement("using ::dawn::deref");
 
     // StencilRunMethod.addStatement("sync_storages()");
     for(const auto& multiStagePtr : stencil->getChildren()) {
-
       StencilRunMethod.ss() << "{\n";
 
       const iir::MultiStage& multiStage = *multiStagePtr;
@@ -448,14 +463,56 @@ void CXXNaiveIcoCodeGen::generateStencilClasses(
       if((multiStage.getLoopOrder() == iir::LoopOrderKind::Backward))
         std::reverse(partitionIntervals.begin(), partitionIntervals.end());
 
-      auto getLoop = [](ast::LocationType type) {
+      auto spaceMagicNumToEnum = [](int magicNum) {
+        switch(magicNum) {
+        case 0:
+          return "dawn::UnstructuredIterationSpace::LateralBoundary";
+        case 1:
+          return "dawn::UnstructuredIterationSpace::Nudging";
+        case 2:
+          return "dawn::UnstructuredIterationSpace::Interior";
+        case 3:
+          return "dawn::UnstructuredIterationSpace::Halo";
+        case 4:
+          return "dawn::UnstructuredIterationSpace::End";
+        default:
+          assert(false);
+        }
+      };
+
+      auto getLoop = [&](ast::LocationType type,
+                         std::optional<iir::Interval> iterSpace) -> std::string {
         switch(type) {
         case ast::LocationType::Cells:
-          return "for(auto const& loc : getCells(LibTag{}, m_mesh))";
+          return (iterSpace.has_value()
+                      ? std::string("for(auto const& loc : getCells(LibTag{}, m_mesh, ") +
+                            "m_unstructured_domain({::dawn::LocationType::Cells," +
+                            spaceMagicNumToEnum(iterSpace->lowerBound()) + "," +
+                            std::to_string(iterSpace->lowerOffset()) + "})," +
+                            "m_unstructured_domain({::dawn::LocationType::Cells," +
+                            spaceMagicNumToEnum(iterSpace->upperBound()) + "," +
+                            std::to_string(iterSpace->upperOffset()) + "})))"
+                      : "for(auto const& loc : getCells(LibTag{}, m_mesh))");
         case ast::LocationType::Vertices:
-          return "for(auto const& loc : getVertices(LibTag{}, m_mesh))";
+          return (iterSpace.has_value())
+                     ? std::string("for(auto const& loc : getVertices(LibTag{}, m_mesh, ") +
+                           "m_unstructured_domain({::dawn::LocationType::Vertices," +
+                           spaceMagicNumToEnum(iterSpace->lowerBound()) + "," +
+                           std::to_string(iterSpace->lowerOffset()) + "})," +
+                           "m_unstructured_domain({::dawn::LocationType::Vertices," +
+                           spaceMagicNumToEnum(iterSpace->upperBound()) + "," +
+                           std::to_string(iterSpace->upperOffset()) + "})))"
+                     : "for(auto const& loc : getVertices(LibTag{}, m_mesh))";
         case ast::LocationType::Edges:
-          return "for(auto const& loc : getEdges(LibTag{}, m_mesh))";
+          return (iterSpace.has_value())
+                     ? std::string("for(auto const& loc : getEdges(LibTag{}, m_mesh, ") +
+                           "m_unstructured_domain({::dawn::LocationType::Edges," +
+                           spaceMagicNumToEnum(iterSpace->lowerBound()) + "," +
+                           std::to_string(iterSpace->lowerOffset()) + "})," +
+                           "m_unstructured_domain({::dawn::LocationType::Edges," +
+                           spaceMagicNumToEnum(iterSpace->upperBound()) + "," +
+                           std::to_string(iterSpace->upperOffset()) + "})))"
+                     : "for(auto const& loc : getEdges(LibTag{}, m_mesh))";
         default:
           dawn_unreachable("invalid type");
           return "";
@@ -471,7 +528,8 @@ void CXXNaiveIcoCodeGen::generateStencilClasses(
 
                 DAWN_ASSERT_MSG(stage.getLocationType().has_value(),
                                 "Stage must have a location type");
-                std::string loopCode = getLoop(*stage.getLocationType());
+                std::string loopCode =
+                    getLoop(*stage.getLocationType(), stage.getIterationSpace()[0]);
                 StencilRunMethod.addBlockStatement(loopCode, [&] {
                   // Generate Do-Method
                   for(const auto& doMethodPtr : stage.getChildren()) {
@@ -622,13 +680,14 @@ std::unique_ptr<TranslationUnit> CXXNaiveIcoCodeGen::generateCode() {
     stencils.emplace(nameStencilCtxPair.first, std::move(code));
   }
 
-  std::string globals = generateGlobals(context_, "dawn_generated", "cxxnaiveico");
+  std::string globals = generateGlobals(context_, "::dawn_generated", "cxxnaiveico");
 
   std::vector<std::string> ppDefines;
   ppDefines.push_back("#define DAWN_GENERATED 1");
   ppDefines.push_back("#undef DAWN_BACKEND_T");
   ppDefines.push_back("#define DAWN_BACKEND_T CXXNAIVEICO");
   ppDefines.push_back("#include <driver-includes/unstructured_interface.hpp>");
+  ppDefines.push_back("#include <driver-includes/unstructured_domain.hpp>");
   DAWN_LOG(INFO) << "Done generating code";
 
   std::string filename = generateFileName(context_);

--- a/dawn/src/dawn/CodeGen/CodeGen.cpp
+++ b/dawn/src/dawn/CodeGen/CodeGen.cpp
@@ -512,8 +512,8 @@ void CodeGen::generateFieldExtentsInfo(
     IndexRange<const std::map<int, iir::Stencil::FieldInfo>>& nonTempFields,
     ast::GridType const& gridType) const {
   std::string extents_type = gridType == ast::GridType::Cartesian
-                                 ? "dawn::driver::cartesian_extent"
-                                 : "dawn::driver::unstructured_extent";
+                                 ? "::dawn::driver::cartesian_extent"
+                                 : "::dawn::driver::unstructured_extent";
 
   for([[maybe_unused]] auto const& [ignored, fieldInfo] : nonTempFields) {
     stencilClass.addStatement("static constexpr " + extents_type + " " + fieldInfo.Name +

--- a/dawn/src/dawn/CodeGen/Cuda-ico/CudaIcoCodeGen.cpp
+++ b/dawn/src/dawn/CodeGen/Cuda-ico/CudaIcoCodeGen.cpp
@@ -109,6 +109,7 @@ void CudaIcoCodeGen::generateGpuMesh(
   gpuMeshClass.addMember("int", "NumVertices");
   gpuMeshClass.addMember("int", "NumEdges");
   gpuMeshClass.addMember("int", "NumCells");
+  gpuMeshClass.addMember("dawn::unstructured_domain", "Domain");
 
   CollectChainStrings chainCollector;
   std::set<std::vector<ast::LocationType>> chains;
@@ -142,6 +143,7 @@ void CudaIcoCodeGen::generateGpuMesh(
     gpuMeshFromGlobalCtor.addStatement("NumVertices = mesh->NumVertices");
     gpuMeshFromGlobalCtor.addStatement("NumCells = mesh->NumCells");
     gpuMeshFromGlobalCtor.addStatement("NumEdges = mesh->NumEdges");
+    gpuMeshFromGlobalCtor.addStatement("Domain = mesh->Domain");
     for(auto chain : chains) {
       gpuMeshFromGlobalCtor.addStatement(chainToTableString(chain) + " = mesh->NeighborTables.at(" +
                                          chainToVectorString(chain) + ")");
@@ -192,20 +194,88 @@ void CudaIcoCodeGen::generateRunFun(
 
       // lets build correct block size
       std::string numElements;
-      switch(*stage->getLocationType()) {
-      case ast::LocationType::Cells:
-        numElements = "mesh_.NumCells";
-        break;
-      case ast::LocationType::Edges:
-        numElements = "mesh_.NumEdges";
-        break;
-      case ast::LocationType::Vertices:
-        numElements = "mesh_.NumVertices";
-        break;
-      }
 
+      auto spaceMagicNumToEnum = [](int magicNum) -> std::string {
+        switch(magicNum) {
+        case 0:
+          return "dawn::UnstructuredIterationSpace::LateralBoundary";
+        case 1:
+          return "dawn::UnstructuredIterationSpace::Nudging";
+        case 2:
+          return "dawn::UnstructuredIterationSpace::Interior";
+        case 3:
+          return "dawn::UnstructuredIterationSpace::Halo";
+        case 4:
+          return "dawn::UnstructuredIterationSpace::End";
+        default:
+          assert(false);
+        }
+      };
+
+      auto numElementsString = [&](ast::LocationType loc,
+                                   std::optional<iir::Interval> iterSpace) -> std::string {
+        switch(loc) {
+        case ast::LocationType::Cells:
+          return (iterSpace.has_value() ? "mesh_.Domain({::dawn::LocationType::Cells," +
+                                              spaceMagicNumToEnum(iterSpace->upperBound()) + "," +
+                                              std::to_string(iterSpace->upperOffset()) + "})" +
+                                              "- mesh_.Domain({::dawn::LocationType::Cells," +
+                                              spaceMagicNumToEnum(iterSpace->lowerBound()) + "," +
+                                              std::to_string(iterSpace->lowerOffset()) + "})"
+                                        : "mesh_.NumCells");
+          break;
+        case ast::LocationType::Edges:
+          return (iterSpace.has_value() ? "mesh_.Domain({::dawn::LocationType::Edges," +
+                                              spaceMagicNumToEnum(iterSpace->upperBound()) + "," +
+                                              std::to_string(iterSpace->upperOffset()) + "})" +
+                                              "- mesh_.Domain({::dawn::LocationType::Edges," +
+                                              spaceMagicNumToEnum(iterSpace->lowerBound()) + "," +
+                                              std::to_string(iterSpace->lowerOffset()) + "})"
+                                        : "mesh_.NumEdges");
+        case ast::LocationType::Vertices:
+          return (iterSpace.has_value() ? "mesh_.Domain({::dawn::LocationType::Vertices," +
+                                              spaceMagicNumToEnum(iterSpace->upperBound()) + "," +
+                                              std::to_string(iterSpace->upperOffset()) + "})" +
+                                              "- mesh_.Domain({::dawn::LocationType::Vertices," +
+                                              spaceMagicNumToEnum(iterSpace->lowerBound()) + "," +
+                                              std::to_string(iterSpace->lowerOffset()) + "})"
+                                        : "mesh_.NumVertices");
+        default:
+          assert(false);
+        }
+      };
+
+      auto hOffsetSizeString = [&](ast::LocationType loc, iir::Interval iterSpace) -> std::string {
+        switch(loc) {
+        case ast::LocationType::Cells:
+          return "mesh_.Domain({::dawn::LocationType::Cells," +
+                 spaceMagicNumToEnum(iterSpace.lowerBound()) + "," +
+                 std::to_string(iterSpace.lowerOffset()) + "})";
+          break;
+        case ast::LocationType::Edges:
+          return "mesh_.Domain({::dawn::LocationType::Edges," +
+                 spaceMagicNumToEnum(iterSpace.lowerBound()) + "," +
+                 std::to_string(iterSpace.lowerOffset()) + "})";
+        case ast::LocationType::Vertices:
+          return "mesh_.Domain({::dawn::LocationType::Vertices," +
+                 spaceMagicNumToEnum(iterSpace.lowerBound()) + "," +
+                 std::to_string(iterSpace.lowerOffset()) + "})";
+        default:
+          assert(false);
+        }
+      };
+
+      auto domain = stage->getIterationSpace()[0];
+      std::string numElString = "hsize" + std::to_string(stage->getStageID());
+      std::string hOffsetString = "hoffset" + std::to_string(stage->getStageID());
+      runFun.addStatement("int " + numElString + " = " +
+                          numElementsString(*stage->getLocationType(), domain));
+      if(domain.has_value()) {
+        runFun.addStatement("int " + hOffsetString + " = " +
+                            hOffsetSizeString(*stage->getLocationType(), *domain));
+      }
       runFun.addStatement("dim3 dG" + std::to_string(stage->getStageID()) + " = grid(" +
-                          k_size.str() + ", " + numElements + ")");
+                          k_size.str() + ", " + numElString + ")");
 
       //--------------------------------------
       // signature of kernel
@@ -239,7 +309,9 @@ void CudaIcoCodeGen::generateRunFun(
                  << "dG" + std::to_string(stage->getStageID()) + ",dB"
                  << ">>>(";
 
-      // which loc args (int CellIdx, int EdgeIdx, int CellIdx) need to be passed?
+      kernelCall << numElString << ", ";
+
+      // which loc size args (int CellIdx, int EdgeIdx, int CellIdx) need to be passed additionally?
       std::set<std::string> locArgs;
       for(auto field : fields) {
         if(field.second.getFieldDimensions().isVertical()) {
@@ -247,16 +319,23 @@ void CudaIcoCodeGen::generateRunFun(
         }
         auto dims = sir::dimension_cast<sir::UnstructuredFieldDimension const&>(
             field.second.getFieldDimensions().getHorizontalFieldDimension());
+        // dont add sizes twice
+        if(dims.getDenseLocationType() == *stage->getLocationType()) {
+          continue;
+        }
         locArgs.insert(locToDenseSizeStringGpuMesh(dims.getDenseLocationType()));
       }
-      auto loc = *stage->getLocationType();
-      locArgs.insert(locToDenseSizeStringGpuMesh(loc));
       for(auto arg : locArgs) {
         kernelCall << "mesh_." + arg + ", ";
       }
 
       // we always need the k size
       kernelCall << "kSize_, ";
+
+      // in case of horizontal iteration space we need the offset
+      if(domain.has_value()) {
+        kernelCall << hOffsetString << ", ";
+      }
 
       for(auto chain : chains) {
         kernelCall << "mesh_." + chainToTableString(chain) + ", ";
@@ -750,7 +829,11 @@ void CudaIcoCodeGen::generateAllCudaKernels(
           retString,
           cuda::CodeGeneratorHelper::buildCudaKernelName(stencilInstantiation, ms, stage), ssSW);
 
-      // which loc args (int CellIdx, int EdgeIdx, int CellIdx) need to be passed?
+      auto loc = *stage->getLocationType();
+      cudaKernel.addArg("int " + locToDenseSizeStringGpuMesh(loc));
+
+      // which additional loc size args ( int NumCells, int NumEdges, int NumVertices) need to be
+      // passed?
       std::set<std::string> locArgs;
       for(auto field : fields) {
         if(field.second.getFieldDimensions().isVertical()) {
@@ -758,16 +841,22 @@ void CudaIcoCodeGen::generateAllCudaKernels(
         }
         auto dims = sir::dimension_cast<sir::UnstructuredFieldDimension const&>(
             field.second.getFieldDimensions().getHorizontalFieldDimension());
+        if(dims.getDenseLocationType() == loc) {
+          continue;
+        }
         locArgs.insert(locToDenseSizeStringGpuMesh(dims.getDenseLocationType()));
       }
-      auto loc = *stage->getLocationType();
-      locArgs.insert(locToDenseSizeStringGpuMesh(loc));
       for(auto arg : locArgs) {
         cudaKernel.addArg("int " + arg);
       }
 
       // we always need the k size
       cudaKernel.addArg("int kSize");
+
+      // for horizontal iteration spaces we also need the offset
+      if(stage->getIterationSpace()[0].has_value()) {
+        cudaKernel.addArg("int hOffset");
+      }
 
       for(auto chain : chains) {
         cudaKernel.addArg("const int *" + chainToTableString(chain));
@@ -797,6 +886,7 @@ void CudaIcoCodeGen::generateAllCudaKernels(
       cudaKernel.addStatement("int klo = kidx * LEVELS_PER_THREAD + " + std::to_string(kStart));
       cudaKernel.addStatement("int khi = (kidx + 1) * LEVELS_PER_THREAD + " +
                               std::to_string(kStart));
+
       switch(loc) {
       case ast::LocationType::Cells:
         cudaKernel.addBlockStatement("if (pidx >= NumCells)",
@@ -810,6 +900,10 @@ void CudaIcoCodeGen::generateAllCudaKernels(
         cudaKernel.addBlockStatement("if (pidx >= NumVertices)",
                                      [&]() { cudaKernel.addStatement("return"); });
         break;
+      }
+
+      if(stage->getIterationSpace()[0].has_value()) {
+        cudaKernel.addStatement("pidx += hOffset");
       }
 
       std::stringstream k_size;
@@ -925,6 +1019,7 @@ std::unique_ptr<TranslationUnit> CudaIcoCodeGen::generateCode() {
       "#include <cpp_bindgen/export.hpp>",
       "#endif /* DAWN_ENABLE_BINDGEN */",
       "#include \"driver-includes/unstructured_interface.hpp\"",
+      "#include \"driver-includes/unstructured_domain.hpp\"",
       "#include \"driver-includes/defs.hpp\"",
       "#include \"driver-includes/cuda_utils.hpp\"",
       "#include \"driver-includes/math.hpp\"",

--- a/dawn/src/dawn/CodeGen/Cuda-ico/CudaIcoCodeGen.cpp
+++ b/dawn/src/dawn/CodeGen/Cuda-ico/CudaIcoCodeGen.cpp
@@ -265,7 +265,7 @@ void CudaIcoCodeGen::generateRunFun(
         }
       };
 
-      auto domain = stage->getIterationSpace()[0];
+      auto domain = stage->getUnstructuredIterationSpace();
       std::string numElString = "hsize" + std::to_string(stage->getStageID());
       std::string hOffsetString = "hoffset" + std::to_string(stage->getStageID());
       runFun.addStatement("int " + numElString + " = " +
@@ -854,7 +854,7 @@ void CudaIcoCodeGen::generateAllCudaKernels(
       cudaKernel.addArg("int kSize");
 
       // for horizontal iteration spaces we also need the offset
-      if(stage->getIterationSpace()[0].has_value()) {
+      if(stage->getUnstructuredIterationSpace().has_value()) {
         cudaKernel.addArg("int hOffset");
       }
 
@@ -902,7 +902,7 @@ void CudaIcoCodeGen::generateAllCudaKernels(
         break;
       }
 
-      if(stage->getIterationSpace()[0].has_value()) {
+      if(stage->getUnstructuredIterationSpace().has_value()) {
         cudaKernel.addStatement("pidx += hOffset");
       }
 

--- a/dawn/src/dawn/IIR/Stage.cpp
+++ b/dawn/src/dawn/IIR/Stage.cpp
@@ -78,7 +78,7 @@ std::unique_ptr<Stage> Stage::clone() const {
 
 bool Stage::isUnstructuredIIR() const {
   DAWN_ASSERT_MSG(
-      parent_,
+      parentIsSet() && (*parent_)->parentIsSet(),
       "can only decide if we are in an unstructured computation if the stage has parent set!");
   return getParent()->getParent()->getParent()->getGridType() == ast::GridType::Unstructured;
 }
@@ -374,11 +374,17 @@ void Stage::setLocationType(ast::LocationType type) { type_ = type; }
 std::optional<ast::LocationType> Stage::getLocationType() const { return type_; }
 
 void Stage::setIterationSpace(const IterationSpace& value) {
-  if(parent_ && isUnstructuredIIR()) {
-    DAWN_ASSERT_MSG(!value[1].has_value(),
-                    "unstructured iteration space only accepts first value!");
+  if(parentIsSet()) {
+    DAWN_ASSERT_MSG(!isUnstructuredIIR(), "only call this method on structured IIR!");
   }
   iterationSpace_ = value;
+}
+
+void Stage::setUnstructuredIterationSpace(const Interval& value) {
+  if(parentIsSet()) {
+    DAWN_ASSERT_MSG(isUnstructuredIIR(), "only call this method on unstructured IIR!");
+  }
+  iterationSpace_[0] = value;
 }
 
 const Stage::IterationSpace& Stage::getIterationSpace() const { return iterationSpace_; }

--- a/dawn/src/dawn/IIR/Stage.cpp
+++ b/dawn/src/dawn/IIR/Stage.cpp
@@ -14,12 +14,14 @@
 
 #include "dawn/IIR/Stage.h"
 #include "dawn/AST/ASTStmt.h"
+#include "dawn/AST/GridType.h"
 #include "dawn/AST/LocationType.h"
 #include "dawn/IIR/ASTVisitor.h"
 #include "dawn/IIR/DependencyGraphAccesses.h"
 #include "dawn/IIR/Extents.h"
 #include "dawn/IIR/IIR.h"
 #include "dawn/IIR/IIRNodeIterator.h"
+#include "dawn/IIR/Interval.h"
 #include "dawn/IIR/MultiStage.h"
 #include "dawn/IIR/Stencil.h"
 #include "dawn/IIR/StencilFunctionInstantiation.h"
@@ -72,6 +74,13 @@ std::unique_ptr<Stage> Stage::clone() const {
 
   cloneStage->cloneChildrenFrom(*this);
   return cloneStage;
+}
+
+bool Stage::isUnstructuredIIR() const {
+  DAWN_ASSERT_MSG(
+      parent_,
+      "can only decide if we are in an unstructured computation if the stage has parent set!");
+  return getParent()->getParent()->getParent()->getGridType() == ast::GridType::Unstructured;
 }
 
 DoMethod& Stage::getSingleDoMethod() {
@@ -364,9 +373,20 @@ void Stage::setLocationType(ast::LocationType type) { type_ = type; }
 
 std::optional<ast::LocationType> Stage::getLocationType() const { return type_; }
 
-void Stage::setIterationSpace(const IterationSpace& value) { iterationSpace_ = value; }
+void Stage::setIterationSpace(const IterationSpace& value) {
+  if(parent_ && isUnstructuredIIR()) {
+    DAWN_ASSERT_MSG(!value[1].has_value(),
+                    "unstructured iteration space only accepts first value!");
+  }
+  iterationSpace_ = value;
+}
 
 const Stage::IterationSpace& Stage::getIterationSpace() const { return iterationSpace_; }
+const std::optional<Interval> Stage::getUnstructuredIterationSpace() const {
+  DAWN_ASSERT_MSG(isUnstructuredIIR(),
+                  "unstructured iteration space only available in unstructured computations!");
+  return iterationSpace_[0];
+}
 
 bool Stage::hasIterationSpace() const {
   return std::any_of(iterationSpace_.cbegin(), iterationSpace_.cend(),

--- a/dawn/src/dawn/IIR/Stage.h
+++ b/dawn/src/dawn/IIR/Stage.h
@@ -74,6 +74,8 @@ class Stage : public IIRNode<MultiStage, Stage, DoMethod> {
 
   DerivedInfo derivedInfo_;
 
+  bool isUnstructuredIIR() const;
+
 public:
   static constexpr const char* name = "Stage";
 
@@ -238,6 +240,7 @@ public:
   /// @{
   void setIterationSpace(const IterationSpace& value);
   const IterationSpace& getIterationSpace() const;
+  const std::optional<Interval> getUnstructuredIterationSpace() const;
   bool hasIterationSpace() const;
   /// @}
 

--- a/dawn/src/dawn/IIR/Stage.h
+++ b/dawn/src/dawn/IIR/Stage.h
@@ -239,6 +239,7 @@ public:
   /// @brief Get the horizontal iteration space
   /// @{
   void setIterationSpace(const IterationSpace& value);
+  void setUnstructuredIterationSpace(const Interval& value);
   const IterationSpace& getIterationSpace() const;
   const std::optional<Interval> getUnstructuredIterationSpace() const;
   bool hasIterationSpace() const;

--- a/dawn/src/dawn/SIR/proto/SIR/statements.proto
+++ b/dawn/src/dawn/SIR/proto/SIR/statements.proto
@@ -109,7 +109,7 @@ message StencilFunctionArg {
   }
 }
 
-// @brief Representation of a vertical interval, given by a lower and upper
+// @brief Representation of a interval, given by a lower and upper
 // bound where a bound is represented by a level and an offset (`bound = level +
 // offset`)
 //

--- a/dawn/src/dawn/Unittest/IIRBuilder.h
+++ b/dawn/src/dawn/Unittest/IIRBuilder.h
@@ -266,9 +266,7 @@ public:
     DAWN_ASSERT(si_);
     auto ret = std::make_unique<iir::Stage>(si_->getMetaData(), si_->nextUID());
     ret->setLocationType(type);
-    iir::Stage::IterationSpace iterationSpace;
-    iterationSpace[0] = interval;
-    ret->setIterationSpace(iterationSpace);
+    ret->setUnstructuredIterationSpace(interval);
     [[maybe_unused]] int x[] = {(ret->insertChild(std::forward<DoMethods>(do_methods)), 0)...};
     (void)x;
     return ret;
@@ -302,7 +300,7 @@ public:
     return ret;
   }
 
-  // default builder for the stage that assumes stages are over cells
+  // default builder for the stage
   template <typename... DoMethods>
   std::unique_ptr<iir::Stage> stage(DoMethods&&... do_methods) {
     DAWN_ASSERT(si_);

--- a/dawn/src/dawn/Unittest/IIRBuilder.h
+++ b/dawn/src/dawn/Unittest/IIRBuilder.h
@@ -259,6 +259,21 @@ public:
     return ret;
   }
 
+  // specialized builder for the stage that accepts a location type and a global index
+  template <typename... DoMethods>
+  std::unique_ptr<iir::Stage> stage(ast::LocationType type, Interval interval,
+                                    DoMethods&&... do_methods) {
+    DAWN_ASSERT(si_);
+    auto ret = std::make_unique<iir::Stage>(si_->getMetaData(), si_->nextUID());
+    ret->setLocationType(type);
+    iir::Stage::IterationSpace iterationSpace;
+    iterationSpace[0] = interval;
+    ret->setIterationSpace(iterationSpace);
+    [[maybe_unused]] int x[] = {(ret->insertChild(std::forward<DoMethods>(do_methods)), 0)...};
+    (void)x;
+    return ret;
+  }
+
   // specialized builder for the stage that accepts a global index
   template <typename... DoMethods>
   std::unique_ptr<iir::Stage> stage(int direction, Interval interval, DoMethods&&... do_methods) {

--- a/dawn/src/dawn4py/serialization/utils.py
+++ b/dawn/src/dawn4py/serialization/utils.py
@@ -303,6 +303,25 @@ def make_interval(
     return interval
 
 
+def make_magic_num_interval(
+    lower_level, upper_level, lower_offset: int = 0, upper_offset: int = 0
+) -> Interval:
+    """ Create an Interval
+
+    Representation of a vertical interval, given by a lower and upper bound where a bound
+    is represented by a level and an offset (`bound = level + offset`)
+
+    """
+    interval = Interval()
+
+    interval.lower_level = lower_level
+    interval.upper_level = upper_level
+
+    interval.lower_offset = lower_offset
+    interval.upper_offset = upper_offset
+    return interval
+
+
 def make_vertical_region(
     ast: AST,
     interval: Interval,

--- a/dawn/src/driver-includes/cuda_utils.hpp
+++ b/dawn/src/driver-includes/cuda_utils.hpp
@@ -19,6 +19,7 @@
 #include <cuda.h>
 #include <cuda_runtime.h>
 
+#include "unstructured_domain.hpp"
 #include "unstructured_interface.hpp"
 
 #include <assert.h>
@@ -40,10 +41,15 @@ inline void gpuAssert(cudaError_t code, const char* file, int line, bool abort =
 namespace dawn {
 
 struct GlobalGpuTriMesh {
+  dawn::unstructured_domain Domain;
   int NumEdges;
   int NumCells;
   int NumVertices;
   std::map<std::vector<dawn::LocationType>, int*> NeighborTables;
+  void set_splitter_index(dawn::LocationType loc, dawn::UnstructuredIterationSpace space,
+                          int offset, int index) {
+    Domain.set_splitter_index({loc, space, offset}, index);
+  }
 };
 
 // Tag for no library (raw pointers)

--- a/dawn/src/driver-includes/unstructured_domain.hpp
+++ b/dawn/src/driver-includes/unstructured_domain.hpp
@@ -1,0 +1,34 @@
+//===--------------------------------------------------------------------------------*- C++ -*-===//
+//                          _
+//                         | |
+//                       __| | __ ___      ___ ___
+//                      / _` |/ _` \ \ /\ / / '_  |
+//                     | (_| | (_| |\ V  V /| | | |
+//                      \__,_|\__,_| \_/\_/ |_| |_| - Compiler Toolchain
+//
+//
+//  This file is distributed under the MIT License (MIT).
+//  See LICENSE.txt for details.
+//
+//===------------------------------------------------------------------------------------------===//
+
+#pragma once
+
+#include <map>
+
+#include "unstructured_interface.hpp"
+
+namespace dawn {
+
+enum class UnstructuredIterationSpace { LateralBoundary = 0, Nudging, Interior, Halo, End };
+
+class unstructured_domain {
+  using KeyType = std::tuple<::dawn::LocationType, UnstructuredIterationSpace, int>;
+  std::map<KeyType, int> iterationSpaceToIndex_;
+
+public:
+  int operator()(KeyType&& key) const { return iterationSpaceToIndex_.at(key); }
+  void set_splitter_index(KeyType&& key, int index) { iterationSpaceToIndex_[key] = index; }
+};
+
+} // namespace dawn

--- a/dawn/src/interface/atlas_interface.hpp
+++ b/dawn/src/interface/atlas_interface.hpp
@@ -165,6 +165,21 @@ inline auto getEdges(atlasTag, atlas::Mesh const& m) {
 inline auto getVertices(atlasTag, atlas::Mesh const& m) {
   return utility::irange(0, m.nodes().size());
 }
+inline auto getCells(atlasTag, atlas::Mesh const& m, int lo, int hi) {
+  assert(hi <= m.cells().size());
+  assert(lo >= 0);
+  return utility::irange(lo, hi);
+}
+inline auto getEdges(atlasTag, atlas::Mesh const& m, int lo, int hi) {
+  assert(hi <= m.edges().size());
+  assert(lo >= 0);
+  return utility::irange(lo, hi);
+}
+inline auto getVertices(atlasTag, atlas::Mesh const& m, int lo, int hi) {
+  assert(hi <= m.nodes().size());
+  assert(lo >= 0);
+  return utility::irange(lo, hi);
+}
 
 inline std::vector<int> getNeighs(const atlas::Mesh::HybridElements::Connectivity& conn, int idx) {
   std::vector<int> neighs;

--- a/dawn/test/integration-test/dawn4py-tests/data/ICON_laplacian_stencil_ref.cpp
+++ b/dawn/test/integration-test/dawn4py-tests/data/ICON_laplacian_stencil_ref.cpp
@@ -2,6 +2,7 @@
 #undef DAWN_BACKEND_T
 #define DAWN_BACKEND_T CXXNAIVEICO
 #include <driver-includes/unstructured_interface.hpp>
+#include <driver-includes/unstructured_domain.hpp>
 
 
 namespace dawn_generated{
@@ -11,48 +12,49 @@ class ICON_laplacian_stencil {
 private:
 
   struct stencil_68 {
-    dawn::mesh_t<LibTag> const& m_mesh;
+    ::dawn::mesh_t<LibTag> const& m_mesh;
     int m_k_size;
-    dawn::edge_field_t<LibTag, ::dawn::float_type>& m_vec;
-    dawn::cell_field_t<LibTag, ::dawn::float_type>& m_div_vec;
-    dawn::vertex_field_t<LibTag, ::dawn::float_type>& m_rot_vec;
-    dawn::edge_field_t<LibTag, ::dawn::float_type>& m_nabla2t1_vec;
-    dawn::edge_field_t<LibTag, ::dawn::float_type>& m_nabla2t2_vec;
-    dawn::edge_field_t<LibTag, ::dawn::float_type>& m_nabla2_vec;
-    dawn::edge_field_t<LibTag, ::dawn::float_type>& m_primal_edge_length;
-    dawn::edge_field_t<LibTag, ::dawn::float_type>& m_dual_edge_length;
-    dawn::edge_field_t<LibTag, ::dawn::float_type>& m_tangent_orientation;
-    dawn::sparse_vertex_field_t<LibTag, ::dawn::float_type>& m_geofac_rot;
-    dawn::sparse_cell_field_t<LibTag, ::dawn::float_type>& m_geofac_div;
+    ::dawn::edge_field_t<LibTag, ::dawn::float_type>& m_vec;
+    ::dawn::cell_field_t<LibTag, ::dawn::float_type>& m_div_vec;
+    ::dawn::vertex_field_t<LibTag, ::dawn::float_type>& m_rot_vec;
+    ::dawn::edge_field_t<LibTag, ::dawn::float_type>& m_nabla2t1_vec;
+    ::dawn::edge_field_t<LibTag, ::dawn::float_type>& m_nabla2t2_vec;
+    ::dawn::edge_field_t<LibTag, ::dawn::float_type>& m_nabla2_vec;
+    ::dawn::edge_field_t<LibTag, ::dawn::float_type>& m_primal_edge_length;
+    ::dawn::edge_field_t<LibTag, ::dawn::float_type>& m_dual_edge_length;
+    ::dawn::edge_field_t<LibTag, ::dawn::float_type>& m_tangent_orientation;
+    ::dawn::sparse_vertex_field_t<LibTag, ::dawn::float_type>& m_geofac_rot;
+    ::dawn::sparse_cell_field_t<LibTag, ::dawn::float_type>& m_geofac_div;
+    dawn::unstructured_domain   m_unstructured_domain ;
   public:
 
-    stencil_68(dawn::mesh_t<LibTag> const &mesh, int k_size, dawn::edge_field_t<LibTag, ::dawn::float_type>&vec, dawn::cell_field_t<LibTag, ::dawn::float_type>&div_vec, dawn::vertex_field_t<LibTag, ::dawn::float_type>&rot_vec, dawn::edge_field_t<LibTag, ::dawn::float_type>&nabla2t1_vec, dawn::edge_field_t<LibTag, ::dawn::float_type>&nabla2t2_vec, dawn::edge_field_t<LibTag, ::dawn::float_type>&nabla2_vec, dawn::edge_field_t<LibTag, ::dawn::float_type>&primal_edge_length, dawn::edge_field_t<LibTag, ::dawn::float_type>&dual_edge_length, dawn::edge_field_t<LibTag, ::dawn::float_type>&tangent_orientation, dawn::sparse_vertex_field_t<LibTag, ::dawn::float_type>&geofac_rot, dawn::sparse_cell_field_t<LibTag, ::dawn::float_type>&geofac_div) : m_mesh(mesh), m_k_size(k_size), m_vec(vec), m_div_vec(div_vec), m_rot_vec(rot_vec), m_nabla2t1_vec(nabla2t1_vec), m_nabla2t2_vec(nabla2t2_vec), m_nabla2_vec(nabla2_vec), m_primal_edge_length(primal_edge_length), m_dual_edge_length(dual_edge_length), m_tangent_orientation(tangent_orientation), m_geofac_rot(geofac_rot), m_geofac_div(geofac_div){}
+    stencil_68(::dawn::mesh_t<LibTag> const &mesh, int k_size, ::dawn::edge_field_t<LibTag, ::dawn::float_type>&vec, ::dawn::cell_field_t<LibTag, ::dawn::float_type>&div_vec, ::dawn::vertex_field_t<LibTag, ::dawn::float_type>&rot_vec, ::dawn::edge_field_t<LibTag, ::dawn::float_type>&nabla2t1_vec, ::dawn::edge_field_t<LibTag, ::dawn::float_type>&nabla2t2_vec, ::dawn::edge_field_t<LibTag, ::dawn::float_type>&nabla2_vec, ::dawn::edge_field_t<LibTag, ::dawn::float_type>&primal_edge_length, ::dawn::edge_field_t<LibTag, ::dawn::float_type>&dual_edge_length, ::dawn::edge_field_t<LibTag, ::dawn::float_type>&tangent_orientation, ::dawn::sparse_vertex_field_t<LibTag, ::dawn::float_type>&geofac_rot, ::dawn::sparse_cell_field_t<LibTag, ::dawn::float_type>&geofac_div) : m_mesh(mesh), m_k_size(k_size), m_vec(vec), m_div_vec(div_vec), m_rot_vec(rot_vec), m_nabla2t1_vec(nabla2t1_vec), m_nabla2t2_vec(nabla2t2_vec), m_nabla2_vec(nabla2_vec), m_primal_edge_length(primal_edge_length), m_dual_edge_length(dual_edge_length), m_tangent_orientation(tangent_orientation), m_geofac_rot(geofac_rot), m_geofac_div(geofac_div){}
 
     ~stencil_68() {
     }
 
     void sync_storages() {
     }
-    static constexpr dawn::driver::unstructured_extent vec_extent = {true, 0,0};
-    static constexpr dawn::driver::unstructured_extent div_vec_extent = {true, 0,0};
-    static constexpr dawn::driver::unstructured_extent rot_vec_extent = {true, 0,0};
-    static constexpr dawn::driver::unstructured_extent nabla2t1_vec_extent = {false, 0,0};
-    static constexpr dawn::driver::unstructured_extent nabla2t2_vec_extent = {false, 0,0};
-    static constexpr dawn::driver::unstructured_extent nabla2_vec_extent = {false, 0,0};
-    static constexpr dawn::driver::unstructured_extent primal_edge_length_extent = {false, 0,0};
-    static constexpr dawn::driver::unstructured_extent dual_edge_length_extent = {false, 0,0};
-    static constexpr dawn::driver::unstructured_extent tangent_orientation_extent = {false, 0,0};
-    static constexpr dawn::driver::unstructured_extent geofac_rot_extent = {true, 0,0};
-    static constexpr dawn::driver::unstructured_extent geofac_div_extent = {true, 0,0};
+    static constexpr ::dawn::driver::unstructured_extent vec_extent = {true, 0,0};
+    static constexpr ::dawn::driver::unstructured_extent div_vec_extent = {true, 0,0};
+    static constexpr ::dawn::driver::unstructured_extent rot_vec_extent = {true, 0,0};
+    static constexpr ::dawn::driver::unstructured_extent nabla2t1_vec_extent = {false, 0,0};
+    static constexpr ::dawn::driver::unstructured_extent nabla2t2_vec_extent = {false, 0,0};
+    static constexpr ::dawn::driver::unstructured_extent nabla2_vec_extent = {false, 0,0};
+    static constexpr ::dawn::driver::unstructured_extent primal_edge_length_extent = {false, 0,0};
+    static constexpr ::dawn::driver::unstructured_extent dual_edge_length_extent = {false, 0,0};
+    static constexpr ::dawn::driver::unstructured_extent tangent_orientation_extent = {false, 0,0};
+    static constexpr ::dawn::driver::unstructured_extent geofac_rot_extent = {true, 0,0};
+    static constexpr ::dawn::driver::unstructured_extent geofac_div_extent = {true, 0,0};
 
     void run() {
-      using dawn::deref;
+      using ::dawn::deref;
 {
     for(int k = 0+0; k <= ( m_k_size == 0 ? 0 : (m_k_size - 1)) + 0+0; ++k) {
       for(auto const& loc : getVertices(LibTag{}, m_mesh)) {
 {
 int sparse_dimension_idx0 = 0;
-m_rot_vec(deref(LibTag{}, loc),k+0) = reduce(LibTag{}, m_mesh,loc, (::dawn::float_type) 0.0, std::vector<dawn::LocationType>{dawn::LocationType::Vertices, dawn::LocationType::Edges}, [&](auto& lhs, auto red_loc1) { lhs += (m_vec(deref(LibTag{}, red_loc1),k+0) * m_geofac_rot(deref(LibTag{}, loc),sparse_dimension_idx0,k+0));
+m_rot_vec(deref(LibTag{}, loc),k+0) = reduce(LibTag{}, m_mesh,loc, (::dawn::float_type) 0.0, std::vector<::dawn::LocationType>{::dawn::LocationType::Vertices, ::dawn::LocationType::Edges}, [&](auto& lhs, auto red_loc1) { lhs += (m_vec(deref(LibTag{}, red_loc1),k+0) * m_geofac_rot(deref(LibTag{}, loc),sparse_dimension_idx0,k+0));
 sparse_dimension_idx0++;
 return lhs;
 });
@@ -60,7 +62,7 @@ return lhs;
       }      for(auto const& loc : getCells(LibTag{}, m_mesh)) {
 {
 int sparse_dimension_idx0 = 0;
-m_div_vec(deref(LibTag{}, loc),k+0) = reduce(LibTag{}, m_mesh,loc, (::dawn::float_type) 0.0, std::vector<dawn::LocationType>{dawn::LocationType::Cells, dawn::LocationType::Edges}, [&](auto& lhs, auto red_loc1) { lhs += (m_vec(deref(LibTag{}, red_loc1),k+0) * m_geofac_div(deref(LibTag{}, loc),sparse_dimension_idx0,k+0));
+m_div_vec(deref(LibTag{}, loc),k+0) = reduce(LibTag{}, m_mesh,loc, (::dawn::float_type) 0.0, std::vector<::dawn::LocationType>{::dawn::LocationType::Cells, ::dawn::LocationType::Edges}, [&](auto& lhs, auto red_loc1) { lhs += (m_vec(deref(LibTag{}, red_loc1),k+0) * m_geofac_div(deref(LibTag{}, loc),sparse_dimension_idx0,k+0));
 sparse_dimension_idx0++;
 return lhs;
 });
@@ -68,7 +70,7 @@ return lhs;
       }      for(auto const& loc : getEdges(LibTag{}, m_mesh)) {
 {
 int sparse_dimension_idx0 = 0;
-m_nabla2t1_vec(deref(LibTag{}, loc),k+0) = reduce(LibTag{}, m_mesh,loc, (::dawn::float_type) 0.0, std::vector<dawn::LocationType>{dawn::LocationType::Edges, dawn::LocationType::Vertices}, [&](auto& lhs, auto red_loc1, auto const& weight) {
+m_nabla2t1_vec(deref(LibTag{}, loc),k+0) = reduce(LibTag{}, m_mesh,loc, (::dawn::float_type) 0.0, std::vector<::dawn::LocationType>{::dawn::LocationType::Edges, ::dawn::LocationType::Vertices}, [&](auto& lhs, auto red_loc1, auto const& weight) {
 lhs += weight * m_rot_vec(deref(LibTag{}, red_loc1),k+0);
 sparse_dimension_idx0++;
 return lhs;
@@ -79,7 +81,7 @@ m_nabla2t1_vec(deref(LibTag{}, loc),k+0) = ((m_tangent_orientation(deref(LibTag{
       }      for(auto const& loc : getEdges(LibTag{}, m_mesh)) {
 {
 int sparse_dimension_idx0 = 0;
-m_nabla2t2_vec(deref(LibTag{}, loc),k+0) = reduce(LibTag{}, m_mesh,loc, (::dawn::float_type) 0.0, std::vector<dawn::LocationType>{dawn::LocationType::Edges, dawn::LocationType::Cells}, [&](auto& lhs, auto red_loc1, auto const& weight) {
+m_nabla2t2_vec(deref(LibTag{}, loc),k+0) = reduce(LibTag{}, m_mesh,loc, (::dawn::float_type) 0.0, std::vector<::dawn::LocationType>{::dawn::LocationType::Edges, ::dawn::LocationType::Cells}, [&](auto& lhs, auto red_loc1, auto const& weight) {
 lhs += weight * m_div_vec(deref(LibTag{}, red_loc1),k+0);
 sparse_dimension_idx0++;
 return lhs;
@@ -100,7 +102,11 @@ public:
 
   // Members
 
-  ICON_laplacian_stencil(const dawn::mesh_t<LibTag> &mesh, int k_size, dawn::edge_field_t<LibTag, ::dawn::float_type>& vec, dawn::cell_field_t<LibTag, ::dawn::float_type>& div_vec, dawn::vertex_field_t<LibTag, ::dawn::float_type>& rot_vec, dawn::edge_field_t<LibTag, ::dawn::float_type>& nabla2t1_vec, dawn::edge_field_t<LibTag, ::dawn::float_type>& nabla2t2_vec, dawn::edge_field_t<LibTag, ::dawn::float_type>& nabla2_vec, dawn::edge_field_t<LibTag, ::dawn::float_type>& primal_edge_length, dawn::edge_field_t<LibTag, ::dawn::float_type>& dual_edge_length, dawn::edge_field_t<LibTag, ::dawn::float_type>& tangent_orientation, dawn::sparse_vertex_field_t<LibTag, ::dawn::float_type>& geofac_rot, dawn::sparse_cell_field_t<LibTag, ::dawn::float_type>& geofac_div) : m_stencil_68(mesh, k_size,vec,div_vec,rot_vec,nabla2t1_vec,nabla2t2_vec,nabla2_vec,primal_edge_length,dual_edge_length,tangent_orientation,geofac_rot,geofac_div){}
+  void set_splitter_index(::dawn::LocationType loc, dawn::UnstructuredIterationSpace space, int offset, int index) {
+    m_stencil_68.m_unstructured_domain.set_splitter_index({loc, space, offset}, index);
+  }
+
+  ICON_laplacian_stencil(const ::dawn::mesh_t<LibTag> &mesh, int k_size, ::dawn::edge_field_t<LibTag, ::dawn::float_type>& vec, ::dawn::cell_field_t<LibTag, ::dawn::float_type>& div_vec, ::dawn::vertex_field_t<LibTag, ::dawn::float_type>& rot_vec, ::dawn::edge_field_t<LibTag, ::dawn::float_type>& nabla2t1_vec, ::dawn::edge_field_t<LibTag, ::dawn::float_type>& nabla2t2_vec, ::dawn::edge_field_t<LibTag, ::dawn::float_type>& nabla2_vec, ::dawn::edge_field_t<LibTag, ::dawn::float_type>& primal_edge_length, ::dawn::edge_field_t<LibTag, ::dawn::float_type>& dual_edge_length, ::dawn::edge_field_t<LibTag, ::dawn::float_type>& tangent_orientation, ::dawn::sparse_vertex_field_t<LibTag, ::dawn::float_type>& geofac_rot, ::dawn::sparse_cell_field_t<LibTag, ::dawn::float_type>& geofac_div) : m_stencil_68(mesh, k_size,vec,div_vec,rot_vec,nabla2t1_vec,nabla2t2_vec,nabla2_vec,primal_edge_length,dual_edge_length,tangent_orientation,geofac_rot,geofac_div){}
 
   void run() {
     m_stencil_68.run();

--- a/dawn/test/integration-test/dawn4py-tests/data/ICON_laplacian_stencil_ref.cpp
+++ b/dawn/test/integration-test/dawn4py-tests/data/ICON_laplacian_stencil_ref.cpp
@@ -25,7 +25,7 @@ private:
     ::dawn::edge_field_t<LibTag, ::dawn::float_type>& m_tangent_orientation;
     ::dawn::sparse_vertex_field_t<LibTag, ::dawn::float_type>& m_geofac_rot;
     ::dawn::sparse_cell_field_t<LibTag, ::dawn::float_type>& m_geofac_div;
-    dawn::unstructured_domain   m_unstructured_domain ;
+    ::dawn::unstructured_domain   m_unstructured_domain ;
   public:
 
     stencil_68(::dawn::mesh_t<LibTag> const &mesh, int k_size, ::dawn::edge_field_t<LibTag, ::dawn::float_type>&vec, ::dawn::cell_field_t<LibTag, ::dawn::float_type>&div_vec, ::dawn::vertex_field_t<LibTag, ::dawn::float_type>&rot_vec, ::dawn::edge_field_t<LibTag, ::dawn::float_type>&nabla2t1_vec, ::dawn::edge_field_t<LibTag, ::dawn::float_type>&nabla2t2_vec, ::dawn::edge_field_t<LibTag, ::dawn::float_type>&nabla2_vec, ::dawn::edge_field_t<LibTag, ::dawn::float_type>&primal_edge_length, ::dawn::edge_field_t<LibTag, ::dawn::float_type>&dual_edge_length, ::dawn::edge_field_t<LibTag, ::dawn::float_type>&tangent_orientation, ::dawn::sparse_vertex_field_t<LibTag, ::dawn::float_type>&geofac_rot, ::dawn::sparse_cell_field_t<LibTag, ::dawn::float_type>&geofac_div) : m_mesh(mesh), m_k_size(k_size), m_vec(vec), m_div_vec(div_vec), m_rot_vec(rot_vec), m_nabla2t1_vec(nabla2t1_vec), m_nabla2t2_vec(nabla2t2_vec), m_nabla2_vec(nabla2_vec), m_primal_edge_length(primal_edge_length), m_dual_edge_length(dual_edge_length), m_tangent_orientation(tangent_orientation), m_geofac_rot(geofac_rot), m_geofac_div(geofac_div){}
@@ -102,7 +102,7 @@ public:
 
   // Members
 
-  void set_splitter_index(::dawn::LocationType loc, dawn::UnstructuredIterationSpace space, int offset, int index) {
+  void set_splitter_index(::dawn::LocationType loc, ::dawn::UnstructuredIterationSpace space, int offset, int index) {
     m_stencil_68.m_unstructured_domain.set_splitter_index({loc, space, offset}, index);
   }
 

--- a/dawn/test/integration-test/dawn4py-tests/data/copy_stencil_ref.cpp
+++ b/dawn/test/integration-test/dawn4py-tests/data/copy_stencil_ref.cpp
@@ -131,8 +131,8 @@ public:
   public:
 
     stencil_11(const gridtools::dawn::domain& dom_, int rank, int xcols, int ycols) : sbase("stencil_11"), m_dom(dom_){}
-    static constexpr dawn::driver::cartesian_extent in_extent = {1,1, 0,0, 0,0};
-    static constexpr dawn::driver::cartesian_extent out_extent = {0,0, 0,0, 0,0};
+    static constexpr ::dawn::driver::cartesian_extent in_extent = {1,1, 0,0, 0,0};
+    static constexpr ::dawn::driver::cartesian_extent out_extent = {0,0, 0,0, 0,0};
 
     void run(storage_ijk_t in_ds, storage_ijk_t out_ds) {
 

--- a/dawn/test/integration-test/dawn4py-tests/data/hori_diff_stencil_ref.cpp
+++ b/dawn/test/integration-test/dawn4py-tests/data/hori_diff_stencil_ref.cpp
@@ -147,9 +147,9 @@ public:
   public:
 
     stencil_41(const gridtools::dawn::domain& dom_, int rank, int xcols, int ycols) : sbase("stencil_41"), m_dom(dom_), m_tmp_meta_data(32+2, 4+2, (dom_.isize()+ 32 - 1) / 32, (dom_.jsize()+ 4 - 1) / 4, dom_.ksize() + 2 * 0), m_lap(m_tmp_meta_data){}
-    static constexpr dawn::driver::cartesian_extent in_extent = {-2,2, -2,2, 0,0};
-    static constexpr dawn::driver::cartesian_extent out_extent = {0,0, 0,0, 0,0};
-    static constexpr dawn::driver::cartesian_extent coeff_extent = {-1,1, -1,1, 0,0};
+    static constexpr ::dawn::driver::cartesian_extent in_extent = {-2,2, -2,2, 0,0};
+    static constexpr ::dawn::driver::cartesian_extent out_extent = {0,0, 0,0, 0,0};
+    static constexpr ::dawn::driver::cartesian_extent coeff_extent = {-1,1, -1,1, 0,0};
 
     void run(storage_ijk_t in_ds, storage_ijk_t out_ds, storage_ijk_t coeff_ds) {
 

--- a/dawn/test/integration-test/dawn4py-tests/data/tridiagonal_solve_stencil_ref.cpp
+++ b/dawn/test/integration-test/dawn4py-tests/data/tridiagonal_solve_stencil_ref.cpp
@@ -261,10 +261,10 @@ public:
   public:
 
     stencil_49(const gridtools::dawn::domain& dom_, int rank, int xcols, int ycols) : sbase("stencil_49"), m_dom(dom_){}
-    static constexpr dawn::driver::cartesian_extent a_extent = {0,0, 0,0, 0,0};
-    static constexpr dawn::driver::cartesian_extent b_extent = {0,0, 0,0, 0,0};
-    static constexpr dawn::driver::cartesian_extent c_extent = {0,0, 0,0, -1,0};
-    static constexpr dawn::driver::cartesian_extent d_extent = {0,0, 0,0, -1,1};
+    static constexpr ::dawn::driver::cartesian_extent a_extent = {0,0, 0,0, 0,0};
+    static constexpr ::dawn::driver::cartesian_extent b_extent = {0,0, 0,0, 0,0};
+    static constexpr ::dawn::driver::cartesian_extent c_extent = {0,0, 0,0, -1,0};
+    static constexpr ::dawn::driver::cartesian_extent d_extent = {0,0, 0,0, -1,1};
 
     void run(storage_ijk_t a_ds, storage_ijk_t b_ds, storage_ijk_t c_ds, storage_ijk_t d_ds) {
 

--- a/dawn/test/integration-test/dawn4py-tests/global_index_stencil_unstr.py
+++ b/dawn/test/integration-test/dawn4py-tests/global_index_stencil_unstr.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python
+
+##===-----------------------------------------------------------------------------*- Python -*-===##
+# _
+# | |
+# __| | __ ___      ___ ___
+# / _` |/ _` \ \ /\ / / '_  |
+# | (_| | (_| |\ V  V /| | | |
+# \__,_|\__,_| \_/\_/ |_| |_| - Compiler Toolchain
+##
+##
+# This file is distributed under the MIT License (MIT).
+# See LICENSE.txt for details.
+##
+##===------------------------------------------------------------------------------------------===##
+
+"""Copy stencil SIR generator
+
+This program creates the SIR corresponding to a copy stencil exercising the unstrucutred iteration space conecpt using magic numbers, via
+the SIR serialization Python API.
+"""
+
+import argparse
+import os
+
+import dawn4py
+from dawn4py.serialization import SIR
+from dawn4py.serialization import utils as sir_utils
+
+OUTPUT_NAME = "global_index_stencil_unstr"
+OUTPUT_FILE = f"{OUTPUT_NAME}.cpp"
+OUTPUT_PATH = f"{OUTPUT_NAME}.cpp"
+
+# lb = 1,
+# nudging = 2,
+# interior = 3,
+# halo = 4
+
+
+def main(args: argparse.Namespace):
+    interval = sir_utils.make_interval(
+        SIR.Interval.Start, SIR.Interval.End, 0, 0)
+
+    # out = in_1 on inner cells
+    body_ast_1 = sir_utils.make_ast(
+        [
+            sir_utils.make_assignment_stmt(
+                sir_utils.make_field_access_expr("out"),
+                sir_utils.make_field_access_expr("in_1"),
+                "=",
+            )
+        ]
+    )
+    vertical_region_stmt_1 = sir_utils.make_vertical_region_decl_stmt(
+        body_ast_1, interval, SIR.VerticalRegion.Forward, sir_utils.make_magic_num_interval(
+            0, 1, 0, 0)
+    )
+
+    # out = out + in_2 on inner cells
+    #   should be merge-able to last stage
+    body_ast_2 = sir_utils.make_ast(
+        [
+            sir_utils.make_assignment_stmt(
+                sir_utils.make_field_access_expr("out"),
+                sir_utils.make_binary_operator(
+                    sir_utils.make_field_access_expr("out"),
+                    "+",
+                    sir_utils.make_field_access_expr("in_2"),
+                ),
+                "="
+            )
+        ]
+    )
+    vertical_region_stmt_2 = sir_utils.make_vertical_region_decl_stmt(
+        body_ast_2, interval, SIR.VerticalRegion.Forward, sir_utils.make_interval(
+            2, 3, 0, 0)
+    )
+
+    # out = out + in_3 on lateral boundary cells
+    # out = in_1 on inner cells
+    body_ast_3 = sir_utils.make_ast(
+        [
+            sir_utils.make_assignment_stmt(
+                sir_utils.make_field_access_expr("out"),
+                sir_utils.make_field_access_expr("in_3"),
+                "=",
+            )
+        ]
+    )
+    vertical_region_stmt_3 = sir_utils.make_vertical_region_decl_stmt(
+        body_ast_3, interval, SIR.VerticalRegion.Forward, sir_utils.make_interval(
+            3, 4, 0, 0)
+    )
+
+    sir = sir_utils.make_sir(
+        OUTPUT_FILE,
+        SIR.GridType.Value("Unstructured"),
+        [
+            sir_utils.make_stencil(
+                OUTPUT_NAME,
+                sir_utils.make_ast(
+                    [vertical_region_stmt_1, vertical_region_stmt_2, vertical_region_stmt_3]),
+                [
+                    sir_utils.make_field(
+                        "in_1",
+                        sir_utils.make_field_dimensions_unstructured(
+                            [SIR.LocationType.Value("Cell")], 1
+                        ),
+                    ),
+                    sir_utils.make_field(
+                        "in_2",
+                        sir_utils.make_field_dimensions_unstructured(
+                            [SIR.LocationType.Value("Cell")], 1
+                        ),
+                    ),
+                    sir_utils.make_field(
+                        "in_3",
+                        sir_utils.make_field_dimensions_unstructured(
+                            [SIR.LocationType.Value("Cell")], 1
+                        ),
+                    ),
+                    sir_utils.make_field(
+                        "out",
+                        sir_utils.make_field_dimensions_unstructured(
+                            [SIR.LocationType.Value("Cell")], 1
+                        ),
+                    ),
+                ],
+            )
+        ],
+    )
+
+    # print the SIR
+    if args.verbose:
+        sir_utils.pprint(sir)
+
+    # compile
+    pass_groups = dawn4py.default_pass_groups()
+    pass_groups.insert(1, dawn4py.PassGroup.MultiStageMerger)
+    pass_groups.insert(1, dawn4py.PassGroup.StageMerger)
+    # code = dawn4py.compile(sir, groups=pass_groups,
+    #                        backend=dawn4py.CodeGenBackend.CXXNaiveIco, merge_stages=True, merge_do_methods=True)
+    code = dawn4py.compile(sir, groups=pass_groups,
+                           backend=dawn4py.CodeGenBackend.CXXNaiveIco)
+
+    # write to file
+    print(f"Writing generated code to '{OUTPUT_PATH}'")
+    with open(OUTPUT_PATH, "w") as f:
+        f.write(code)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Generate a simple copy-shift stencil using Dawn compiler"
+    )
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        dest="verbose",
+        action="store_true",
+        default=False,
+        help="Print the generated SIR",
+    )
+    main(parser.parse_args())

--- a/dawn/test/integration-test/dawn4py-tests/unstructured_stencil.py
+++ b/dawn/test/integration-test/dawn4py-tests/unstructured_stencil.py
@@ -34,7 +34,8 @@ OUTPUT_PATH = f"{OUTPUT_NAME}.cpp"
 
 
 def main(args: argparse.Namespace):
-    interval = sir_utils.make_interval(SIR.Interval.Start, SIR.Interval.End, 0, 0)
+    interval = sir_utils.make_interval(
+        SIR.Interval.Start, SIR.Interval.End, 0, 0)
 
     # create the out = in[i+1] statement
     body_ast = sir_utils.make_ast(
@@ -43,9 +44,11 @@ def main(args: argparse.Namespace):
                 sir_utils.make_field_access_expr("out"),
                 sir_utils.make_reduction_over_neighbor_expr(
                     "+",
-                    sir_utils.make_literal_access_expr("1.0", SIR.BuiltinType.Float),
+                    sir_utils.make_literal_access_expr(
+                        "1.0", SIR.BuiltinType.Float),
                     sir_utils.make_field_access_expr("in"),
-                    chain=[SIR.LocationType.Value("Edge"), SIR.LocationType.Value("Cell")],
+                    chain=[SIR.LocationType.Value(
+                        "Edge"), SIR.LocationType.Value("Cell")],
                 ),
                 "=",
             )

--- a/dawn/test/integration-test/unstructured/AtlasIntegrationTestCompareOutput.cpp
+++ b/dawn/test/integration-test/unstructured/AtlasIntegrationTestCompareOutput.cpp
@@ -14,6 +14,9 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
+#include "driver-includes/unstructured_domain.hpp"
+#include "driver-includes/unstructured_interface.hpp"
+
 #include "AtlasCartesianWrapper.h"
 #include "UnstructuredVerifier.h"
 
@@ -24,7 +27,6 @@
 #include "atlas/meshgenerator.h"
 #include "atlas/option/Options.h"
 #include "atlas/output/Gmsh.h"
-#include "driver-includes/unstructured_interface.hpp"
 #include "interface/atlas_interface.hpp"
 
 #include <atlas/util/CoordinateEnums.h>
@@ -34,9 +36,7 @@
 #include <sstream>
 #include <tuple>
 
-#include <generated_copyCell.hpp>
 namespace {
-
 atlas::Mesh generateQuadMesh(size_t nx, size_t ny) {
   std::stringstream configStr;
   configStr << "L" << nx << "x" << ny;

--- a/dawn/test/integration-test/unstructured/ToylibIntegrationTestCompareOutput.cpp
+++ b/dawn/test/integration-test/unstructured/ToylibIntegrationTestCompareOutput.cpp
@@ -580,9 +580,9 @@ TEST(ToylibIntegrationTestCompareOutput, SparseAssignment3) {
     for(const auto& f : mesh.faces()) {
       size_t curIntpSize =
           toylibInterface::getNeighbors(toylibInterface::toylibTag{}, mesh,
-                                        {dawn::LocationType::Cells, dawn::LocationType::Edges,
-                                         dawn::LocationType::Cells, dawn::LocationType::Edges,
-                                         dawn::LocationType::Cells},
+                                        {::dawn::LocationType::Cells, ::dawn::LocationType::Edges,
+                                         ::dawn::LocationType::Cells, ::dawn::LocationType::Edges,
+                                         ::dawn::LocationType::Cells},
                                         &f)
               .size();
       for(size_t sparse = 0; sparse < curIntpSize; sparse++) {

--- a/dawn/test/integration-test/unstructured/ToylibIntegrationTestCompareOutput.cpp
+++ b/dawn/test/integration-test/unstructured/ToylibIntegrationTestCompareOutput.cpp
@@ -53,7 +53,6 @@ std::tuple<double, double> cellMidpoint(const toylib::Face& f) {
   double y = f.vertices()[0]->y() + f.vertices()[1]->y() + f.vertices()[2]->y();
   return {x / 3., y / 3.};
 }
-} // namespace
 
 namespace {
 #include <generated_copyCell.hpp>
@@ -73,7 +72,9 @@ TEST(ToylibIntegrationTestCompareOutput, CopyCell) {
   for(const auto& f : mesh.faces())
     ASSERT_EQ(out(f, 0), 1.0);
 }
+} // namespace
 
+namespace {
 #include <generated_copyEdge.hpp>
 TEST(ToylibIntegrationTestCompareOutput, CopyEdge) {
   toylib::Grid mesh(32, 32);
@@ -91,7 +92,9 @@ TEST(ToylibIntegrationTestCompareOutput, CopyEdge) {
   for(const auto& e : mesh.edges())
     ASSERT_EQ(out(e, 0), 1.0);
 }
+} // namespace
 
+namespace {
 #include <generated_verticalSum.hpp>
 TEST(ToylibIntegrationTestCompareOutput, VerticalCopy) {
   toylib::Grid mesh(32, 32);
@@ -113,7 +116,9 @@ TEST(ToylibIntegrationTestCompareOutput, VerticalCopy) {
     }
   }
 }
+} // namespace
 
+namespace {
 #include <generated_accumulateEdgeToCell.hpp>
 TEST(ToylibIntegrationTestCompareOutput, Accumulate) {
   toylib::Grid mesh(32, 32);
@@ -131,7 +136,9 @@ TEST(ToylibIntegrationTestCompareOutput, Accumulate) {
   for(const auto& f : mesh.faces())
     ASSERT_EQ(out(f, 0), 3.0);
 }
+} // namespace
 
+namespace {
 #include <generated_diffusion.hpp>
 #include <reference_diffusion.hpp>
 TEST(ToylibIntegrationTestCompareOutput, Diffusion) {
@@ -172,7 +179,9 @@ TEST(ToylibIntegrationTestCompareOutput, Diffusion) {
         << "while comparing output (on cells)";
   }
 }
+} // namespace
 
+namespace {
 #include <generated_gradient.hpp>
 #include <reference_gradient.hpp>
 TEST(ToylibIntegrationTestCompareOutput, Gradient) {
@@ -217,7 +226,9 @@ TEST(ToylibIntegrationTestCompareOutput, Gradient) {
         << "while comparing output (on cells)";
   }
 }
+} // namespace
 
+namespace {
 #include <generated_diamond.hpp>
 #include <reference_diamond.hpp>
 TEST(ToylibIntegrationTestCompareOutput, Diamond) {
@@ -246,7 +257,9 @@ TEST(ToylibIntegrationTestCompareOutput, Diamond) {
         << "while comparing output (on cells)";
   }
 }
+} // namespace
 
+namespace {
 #include <generated_diamondWeights.hpp>
 #include <reference_diamondWeights.hpp>
 TEST(ToylibIntegrationTestCompareOutput, DiamondWeights) {
@@ -286,7 +299,9 @@ TEST(ToylibIntegrationTestCompareOutput, DiamondWeights) {
         << "while comparing output (on cells)";
   }
 }
+} // namespace
 
+namespace {
 #include <generated_intp.hpp>
 #include <reference_intp.hpp>
 TEST(ToylibIntegrationTestCompareOutput, Intp) {
@@ -318,7 +333,9 @@ TEST(ToylibIntegrationTestCompareOutput, Intp) {
         << "while comparing output (on cells)";
   }
 }
+} // namespace
 
+namespace {
 #include <generated_tridiagonalSolve.hpp>
 TEST(ToylibIntegrationTestCompareOutput, verticalSolver) {
   const int numCell = 5;
@@ -354,7 +371,9 @@ TEST(ToylibIntegrationTestCompareOutput, verticalSolver) {
     }
   }
 }
+} // namespace
 
+namespace {
 #include <generated_nestedSimple.hpp>
 TEST(ToylibIntegrationTestCompareOutput, nestedSimple) {
   auto mesh = toylib::Grid(10, 10);
@@ -376,7 +395,9 @@ TEST(ToylibIntegrationTestCompareOutput, nestedSimple) {
     EXPECT_TRUE(fabs(cells(f, 0) - 6.) < 1e3 * std::numeric_limits<double>::epsilon());
   }
 }
+} // namespace
 
+namespace {
 #include <generated_nestedWithField.hpp>
 TEST(ToylibIntegrationTestCompareOutput, nestedWithField) {
   auto mesh = toylib::Grid(10, 10);
@@ -400,7 +421,9 @@ TEST(ToylibIntegrationTestCompareOutput, nestedWithField) {
     EXPECT_TRUE(fabs(cells(f, 0) - 606) < 1e3 * std::numeric_limits<double>::epsilon());
   }
 }
+} // namespace
 
+namespace {
 #include <generated_sparseDimension.hpp>
 TEST(ToylibIntegrationTestCompareOutput, sparseDimensions) {
   auto mesh = toylib::Grid(10, 10);
@@ -424,7 +447,9 @@ TEST(ToylibIntegrationTestCompareOutput, sparseDimensions) {
     EXPECT_TRUE(fabs(cells(f, 0) - 600) < 1e3 * std::numeric_limits<double>::epsilon());
   }
 }
+} // namespace
 
+namespace {
 #include <generated_nestedWithSparse.hpp>
 TEST(ToylibIntegrationTestCompareOutput, nestedReduceSparseDimensions) {
   auto mesh = toylib::Grid(10, 10);
@@ -458,7 +483,9 @@ TEST(ToylibIntegrationTestCompareOutput, nestedReduceSparseDimensions) {
     EXPECT_TRUE(fabs(cells(f, 0) - 4200) < 1e3 * std::numeric_limits<double>::epsilon());
   }
 }
+} // namespace
 
+namespace {
 #include <generated_sparseAssignment0.hpp>
 TEST(ToylibIntegrationTestCompareOutput, SparseAssignment0) {
   auto mesh = toylib::Grid(10, 10);
@@ -491,7 +518,9 @@ TEST(ToylibIntegrationTestCompareOutput, SparseAssignment0) {
     }
   }
 }
+} // namespace
 
+namespace {
 #include <generated_sparseAssignment1.hpp>
 TEST(ToylibIntegrationTestCompareOutput, SparseAssignment1) {
   auto mesh = toylib::Grid(10, 10);
@@ -524,7 +553,9 @@ TEST(ToylibIntegrationTestCompareOutput, SparseAssignment1) {
     }
   }
 }
+} // namespace
 
+namespace {
 #include <generated_sparseAssignment2.hpp>
 TEST(ToylibIntegrationTestCompareOutput, SparseAssignment2) {
   auto mesh = toylib::Grid(10, 10);
@@ -555,7 +586,9 @@ TEST(ToylibIntegrationTestCompareOutput, SparseAssignment2) {
     }
   }
 }
+} // namespace
 
+namespace {
 #include <generated_sparseAssignment3.hpp>
 TEST(ToylibIntegrationTestCompareOutput, SparseAssignment3) {
   auto mesh = toylib::Grid(10, 10);
@@ -592,7 +625,9 @@ TEST(ToylibIntegrationTestCompareOutput, SparseAssignment3) {
     }
   }
 }
+} // namespace
 
+namespace {
 #include <generated_sparseAssignment4.hpp>
 TEST(ToylibIntegrationTestCompareOutput, SparseAssignment4) {
   auto mesh = toylib::Grid(10, 10);
@@ -617,7 +652,9 @@ TEST(ToylibIntegrationTestCompareOutput, SparseAssignment4) {
     }
   }
 }
+} // namespace
 
+namespace {
 #include <generated_sparseAssignment5.hpp>
 TEST(ToylibIntegrationTestCompareOutput, SparseAssignment5) {
   auto mesh = toylib::Grid(10, 10);
@@ -649,7 +686,9 @@ TEST(ToylibIntegrationTestCompareOutput, SparseAssignment5) {
     }
   }
 }
+} // namespace
 
+namespace {
 #include <generated_sparseDimensionTwice.hpp>
 TEST(ToylibIntegrationTestCompareOutput, sparseDimensionsTwice) {
   auto mesh = toylib::Grid(10, 10);
@@ -673,7 +712,9 @@ TEST(ToylibIntegrationTestCompareOutput, sparseDimensionsTwice) {
     EXPECT_TRUE(fabs(cells(f, 0) - 600) < 1e3 * std::numeric_limits<double>::epsilon());
   }
 }
+} // namespace
 
+namespace {
 #include <generated_verticalIndirecion.hpp>
 TEST(ToylibIntegrationTestCompareOutput, verticalIndirection) {
   auto mesh = toylib::Grid(10, 10);
@@ -699,6 +740,6 @@ TEST(ToylibIntegrationTestCompareOutput, verticalIndirection) {
       EXPECT_TRUE(kidx(f, level) == level + 1);
     }
   }
+}
 } // namespace
-
-} // namespace
+}

--- a/dawn/test/integration-test/unstructured/ToylibIntegrationTestCompareOutput.cpp
+++ b/dawn/test/integration-test/unstructured/ToylibIntegrationTestCompareOutput.cpp
@@ -21,6 +21,9 @@
 //
 //===------------------------------------------------------------------------------------------===//
 
+#include "driver-includes/unstructured_domain.hpp"
+#include "driver-includes/unstructured_interface.hpp"
+
 #include "UnstructuredVerifier.h"
 #include "dawn/Support/Logger.h"
 #include "interface/toylib_interface.hpp"

--- a/dawn/test/integration-test/unstructured/reference/reference_diamond.hpp
+++ b/dawn/test/integration-test/unstructured/reference/reference_diamond.hpp
@@ -1,46 +1,51 @@
 #define DAWN_GENERATED 1
 #undef DAWN_BACKEND_T
 #define DAWN_BACKEND_T CXXNAIVEICO
+#include <driver-includes/unstructured_domain.hpp>
 #include <driver-includes/unstructured_interface.hpp>
+
 namespace dawn_generated {
 namespace cxxnaiveico {
 template <typename LibTag>
 class reference_diamond {
 private:
-  struct stencil_329 {
-    dawn::mesh_t<LibTag> const& m_mesh;
+  struct stencil_300 {
+    ::dawn::mesh_t<LibTag> const& m_mesh;
     int m_k_size;
-    dawn::edge_field_t<LibTag, double>& m_edge_field;
-    dawn::vertex_field_t<LibTag, double>& m_vertex_field;
+    ::dawn::edge_field_t<LibTag, ::dawn::float_type>& m_edge_field;
+    ::dawn::vertex_field_t<LibTag, ::dawn::float_type>& m_vertex_field;
+    dawn::unstructured_domain m_unstructured_domain;
 
   public:
-    stencil_329(dawn::mesh_t<LibTag> const& mesh, int k_size,
-                dawn::edge_field_t<LibTag, double>& edge_field,
-                dawn::vertex_field_t<LibTag, double>& vertex_field)
+    stencil_300(::dawn::mesh_t<LibTag> const& mesh, int k_size,
+                ::dawn::edge_field_t<LibTag, ::dawn::float_type>& edge_field,
+                ::dawn::vertex_field_t<LibTag, ::dawn::float_type>& vertex_field)
         : m_mesh(mesh), m_k_size(k_size), m_edge_field(edge_field), m_vertex_field(vertex_field) {}
 
-    ~stencil_329() {}
+    ~stencil_300() {}
 
     void sync_storages() {}
-    static constexpr dawn::driver::unstructured_extent edge_field_extent = {false, 0, 0};
-    static constexpr dawn::driver::unstructured_extent vertex_field_extent = {true, 0, 0};
+    static constexpr ::dawn::driver::unstructured_extent edge_field_extent = {false, 0, 0};
+    static constexpr ::dawn::driver::unstructured_extent vertex_field_extent = {true, 0, 0};
 
     void run() {
-      using dawn::deref;
+      using ::dawn::deref;
       {
         for(int k = 0 + 0; k <= (m_k_size == 0 ? 0 : (m_k_size - 1)) + 0 + 0; ++k) {
           for(auto const& loc : getEdges(LibTag{}, m_mesh)) {
-            int m_sparse_dimension_idx = 0;
-            m_edge_field(deref(LibTag{}, loc), k + 0) =
-                reduce(LibTag{}, m_mesh, loc, (::dawn::float_type)0.000000,
-                       std::vector<dawn::LocationType>{dawn::LocationType::Edges,
-                                                       dawn::LocationType::Cells,
-                                                       dawn::LocationType::Vertices},
-                       [&](auto& lhs, auto red_loc) {
-                         lhs += m_vertex_field(deref(LibTag{}, red_loc), k + 0);
-                         m_sparse_dimension_idx++;
-                         return lhs;
-                       });
+            {
+              int sparse_dimension_idx0 = 0;
+              m_edge_field(deref(LibTag{}, loc), k + 0) =
+                  reduce(LibTag{}, m_mesh, loc, (::dawn::float_type)0.000000,
+                         std::vector<::dawn::LocationType>{::dawn::LocationType::Edges,
+                                                           ::dawn::LocationType::Cells,
+                                                           ::dawn::LocationType::Vertices},
+                         [&](auto& lhs, auto red_loc1) {
+                           lhs += m_vertex_field(deref(LibTag{}, red_loc1), k + 0);
+                           sparse_dimension_idx0++;
+                           return lhs;
+                         });
+            }
           }
         }
       }
@@ -48,20 +53,25 @@ private:
     }
   };
   static constexpr const char* s_name = "diamond";
-  stencil_329 m_stencil_329;
+  stencil_300 m_stencil_300;
 
 public:
   reference_diamond(const reference_diamond&) = delete;
 
   // Members
 
-  reference_diamond(const dawn::mesh_t<LibTag>& mesh, int k_size,
-                    dawn::edge_field_t<LibTag, double>& edge_field,
-                    dawn::vertex_field_t<LibTag, double>& vertex_field)
-      : m_stencil_329(mesh, k_size, edge_field, vertex_field) {}
+  void set_splitter_index(::dawn::LocationType loc, dawn::UnstructuredIterationSpace space,
+                          int offset, int index) {
+    m_stencil_300.m_unstructured_domain.set_splitter_index({loc, space, offset}, index);
+  }
+
+  reference_diamond(const ::dawn::mesh_t<LibTag>& mesh, int k_size,
+                    ::dawn::edge_field_t<LibTag, ::dawn::float_type>& edge_field,
+                    ::dawn::vertex_field_t<LibTag, ::dawn::float_type>& vertex_field)
+      : m_stencil_300(mesh, k_size, edge_field, vertex_field) {}
 
   void run() {
-    m_stencil_329.run();
+    m_stencil_300.run();
     ;
   }
 };

--- a/dawn/test/integration-test/unstructured/reference/reference_diamondWeights.hpp
+++ b/dawn/test/integration-test/unstructured/reference/reference_diamondWeights.hpp
@@ -1,85 +1,95 @@
 #define DAWN_GENERATED 1
 #undef DAWN_BACKEND_T
 #define DAWN_BACKEND_T CXXNAIVEICO
+#include <driver-includes/unstructured_domain.hpp>
 #include <driver-includes/unstructured_interface.hpp>
+
 namespace dawn_generated {
 namespace cxxnaiveico {
 template <typename LibTag>
 class reference_diamondWeights {
 private:
-  struct stencil_388 {
-    dawn::mesh_t<LibTag> const& m_mesh;
+  struct stencil_347 {
+    ::dawn::mesh_t<LibTag> const& m_mesh;
     int m_k_size;
-    dawn::edge_field_t<LibTag, double>& m_out;
-    dawn::edge_field_t<LibTag, double>& m_inv_edge_length;
-    dawn::edge_field_t<LibTag, double>& m_inv_vert_length;
-    dawn::vertex_field_t<LibTag, double>& m_in;
+    ::dawn::edge_field_t<LibTag, ::dawn::float_type>& m_out;
+    ::dawn::edge_field_t<LibTag, ::dawn::float_type>& m_inv_edge_length;
+    ::dawn::edge_field_t<LibTag, ::dawn::float_type>& m_inv_vert_length;
+    ::dawn::vertex_field_t<LibTag, ::dawn::float_type>& m_in;
+    dawn::unstructured_domain m_unstructured_domain;
 
   public:
-    stencil_388(dawn::mesh_t<LibTag> const& mesh, int k_size,
-                dawn::edge_field_t<LibTag, double>& out,
-                dawn::edge_field_t<LibTag, double>& inv_edge_length,
-                dawn::edge_field_t<LibTag, double>& inv_vert_length,
-                dawn::vertex_field_t<LibTag, double>& in)
+    stencil_347(::dawn::mesh_t<LibTag> const& mesh, int k_size,
+                ::dawn::edge_field_t<LibTag, ::dawn::float_type>& out,
+                ::dawn::edge_field_t<LibTag, ::dawn::float_type>& inv_edge_length,
+                ::dawn::edge_field_t<LibTag, ::dawn::float_type>& inv_vert_length,
+                ::dawn::vertex_field_t<LibTag, ::dawn::float_type>& in)
         : m_mesh(mesh), m_k_size(k_size), m_out(out), m_inv_edge_length(inv_edge_length),
           m_inv_vert_length(inv_vert_length), m_in(in) {}
 
-    ~stencil_388() {}
+    ~stencil_347() {}
 
     void sync_storages() {}
-    static constexpr dawn::driver::unstructured_extent out_extent = {false, 0, 0};
-    static constexpr dawn::driver::unstructured_extent inv_edge_length_extent = {false, 0, 0};
-    static constexpr dawn::driver::unstructured_extent inv_vert_length_extent = {false, 0, 0};
-    static constexpr dawn::driver::unstructured_extent in_extent = {true, 0, 0};
+    static constexpr ::dawn::driver::unstructured_extent out_extent = {false, 0, 0};
+    static constexpr ::dawn::driver::unstructured_extent inv_edge_length_extent = {false, 0, 0};
+    static constexpr ::dawn::driver::unstructured_extent inv_vert_length_extent = {false, 0, 0};
+    static constexpr ::dawn::driver::unstructured_extent in_extent = {true, 0, 0};
 
     void run() {
-      using dawn::deref;
+      using ::dawn::deref;
       {
         for(int k = 0 + 0; k <= (m_k_size == 0 ? 0 : (m_k_size - 1)) + 0 + 0; ++k) {
           for(auto const& loc : getEdges(LibTag{}, m_mesh)) {
-            int m_sparse_dimension_idx = 0;
-            m_out(deref(LibTag{}, loc), k + 0) = reduce(
-                LibTag{}, m_mesh, loc, (::dawn::float_type)0.000000,
-                std::vector<dawn::LocationType>{dawn::LocationType::Edges,
-                                                dawn::LocationType::Cells,
-                                                dawn::LocationType::Vertices},
-                [&](auto& lhs, auto red_loc, auto const& weight) {
-                  lhs += weight * m_in(deref(LibTag{}, red_loc), k + 0);
-                  m_sparse_dimension_idx++;
-                  return lhs;
-                },
-                std::vector<::dawn::float_type>(
-                    {(m_inv_edge_length(deref(LibTag{}, loc), k + 0) *
-                      m_inv_edge_length(deref(LibTag{}, loc), k + 0)),
-                     (m_inv_edge_length(deref(LibTag{}, loc), k + 0) *
-                      m_inv_edge_length(deref(LibTag{}, loc), k + 0)),
-                     (m_inv_vert_length(deref(LibTag{}, loc), k + 0) *
-                      m_inv_vert_length(deref(LibTag{}, loc), k + 0)),
-                     (m_inv_vert_length(deref(LibTag{}, loc), k + 0) *
-                      m_inv_vert_length(deref(LibTag{}, loc), k + 0))}));
+            {
+              int sparse_dimension_idx0 = 0;
+              m_out(deref(LibTag{}, loc), k + 0) = reduce(
+                  LibTag{}, m_mesh, loc, (::dawn::float_type)0.000000,
+                  std::vector<::dawn::LocationType>{::dawn::LocationType::Edges,
+                                                    ::dawn::LocationType::Cells,
+                                                    ::dawn::LocationType::Vertices},
+                  [&](auto& lhs, auto red_loc1, auto const& weight) {
+                    lhs += weight * m_in(deref(LibTag{}, red_loc1), k + 0);
+                    sparse_dimension_idx0++;
+                    return lhs;
+                  },
+                  std::vector<::dawn::float_type>(
+                      {(m_inv_edge_length(deref(LibTag{}, loc), k + 0) *
+                        m_inv_edge_length(deref(LibTag{}, loc), k + 0)),
+                       (m_inv_edge_length(deref(LibTag{}, loc), k + 0) *
+                        m_inv_edge_length(deref(LibTag{}, loc), k + 0)),
+                       (m_inv_vert_length(deref(LibTag{}, loc), k + 0) *
+                        m_inv_vert_length(deref(LibTag{}, loc), k + 0)),
+                       (m_inv_vert_length(deref(LibTag{}, loc), k + 0) *
+                        m_inv_vert_length(deref(LibTag{}, loc), k + 0))}));
+            }
           }
         }
       }
       sync_storages();
     }
   };
-  static constexpr const char* s_name = "diamond";
-  stencil_388 m_stencil_388;
+  static constexpr const char* s_name = "diamondWeights";
+  stencil_347 m_stencil_347;
 
 public:
   reference_diamondWeights(const reference_diamondWeights&) = delete;
 
   // Members
 
-  reference_diamondWeights(const dawn::mesh_t<LibTag>& mesh, int k_size,
-                           dawn::edge_field_t<LibTag, double>& out,
-                           dawn::edge_field_t<LibTag, double>& inv_edge_length,
-                           dawn::edge_field_t<LibTag, double>& inv_vert_length,
-                           dawn::vertex_field_t<LibTag, double>& in)
-      : m_stencil_388(mesh, k_size, out, inv_edge_length, inv_vert_length, in) {}
+  void set_splitter_index(::dawn::LocationType loc, dawn::UnstructuredIterationSpace space,
+                          int offset, int index) {
+    m_stencil_347.m_unstructured_domain.set_splitter_index({loc, space, offset}, index);
+  }
+
+  reference_diamondWeights(const ::dawn::mesh_t<LibTag>& mesh, int k_size,
+                           ::dawn::edge_field_t<LibTag, ::dawn::float_type>& out,
+                           ::dawn::edge_field_t<LibTag, ::dawn::float_type>& inv_edge_length,
+                           ::dawn::edge_field_t<LibTag, ::dawn::float_type>& inv_vert_length,
+                           ::dawn::vertex_field_t<LibTag, ::dawn::float_type>& in)
+      : m_stencil_347(mesh, k_size, out, inv_edge_length, inv_vert_length, in) {}
 
   void run() {
-    m_stencil_388.run();
+    m_stencil_347.run();
     ;
   }
 };

--- a/dawn/test/integration-test/unstructured/reference/reference_diffusion.hpp
+++ b/dawn/test/integration-test/unstructured/reference/reference_diffusion.hpp
@@ -1,46 +1,64 @@
 #define DAWN_GENERATED 1
+#undef DAWN_BACKEND_T
 #define DAWN_BACKEND_T CXXNAIVEICO
+#include <driver-includes/unstructured_domain.hpp>
 #include <driver-includes/unstructured_interface.hpp>
+
 namespace dawn_generated {
 namespace cxxnaiveico {
 template <typename LibTag>
 class reference_diffusion {
 private:
-  struct stencil_129 {
-    dawn::mesh_t<LibTag> const& m_mesh;
+  struct stencil_237 {
+    ::dawn::mesh_t<LibTag> const& m_mesh;
     int m_k_size;
-    dawn::cell_field_t<LibTag, double>& m_in_field;
-    dawn::cell_field_t<LibTag, double>& m_out_field;
+    ::dawn::cell_field_t<LibTag, ::dawn::float_type>& m_in_field;
+    ::dawn::cell_field_t<LibTag, ::dawn::float_type>& m_out_field;
+    dawn::unstructured_domain m_unstructured_domain;
 
   public:
-    stencil_129(dawn::mesh_t<LibTag> const& mesh, int k_size,
-                dawn::cell_field_t<LibTag, double>& in_field,
-                dawn::cell_field_t<LibTag, double>& out_field)
+    stencil_237(::dawn::mesh_t<LibTag> const& mesh, int k_size,
+                ::dawn::cell_field_t<LibTag, ::dawn::float_type>& in_field,
+                ::dawn::cell_field_t<LibTag, ::dawn::float_type>& out_field)
         : m_mesh(mesh), m_k_size(k_size), m_in_field(in_field), m_out_field(out_field) {}
 
-    ~stencil_129() {}
+    ~stencil_237() {}
 
     void sync_storages() {}
+    static constexpr ::dawn::driver::unstructured_extent in_field_extent = {true, 0, 0};
+    static constexpr ::dawn::driver::unstructured_extent out_field_extent = {false, 0, 0};
 
     void run() {
-      using dawn::deref;
+      using ::dawn::deref;
       {
         for(int k = 0 + 0; k <= (m_k_size == 0 ? 0 : (m_k_size - 1)) + 0 + 0; ++k) {
-          for(auto loc : getCells(LibTag{}, m_mesh)) {
+          for(auto const& loc : getCells(LibTag{}, m_mesh)) {
             int cnt;
-            cnt = reduce(LibTag{}, m_mesh, loc, (int)0,
-                         std::vector<dawn::LocationType>{dawn::LocationType::Cells,
-                                                         dawn::LocationType::Edges,
-                                                         dawn::LocationType::Cells},
-                         [&](auto& lhs, auto red_loc) { return lhs += (int)1; });
-            m_out_field(deref(LibTag{}, loc), k + 0) =
-                reduce(LibTag{}, m_mesh, loc, ((-cnt) * m_in_field(deref(LibTag{}, loc), k + 0)),
-                       std::vector<dawn::LocationType>{dawn::LocationType::Cells,
-                                                       dawn::LocationType::Edges,
-                                                       dawn::LocationType::Cells},
-                       [&](auto& lhs, auto red_loc) {
-                         return lhs += m_in_field(deref(LibTag{}, red_loc), k + 0);
-                       });
+            {
+              int sparse_dimension_idx0 = 0;
+              cnt = reduce(LibTag{}, m_mesh, loc, (int)0,
+                           std::vector<::dawn::LocationType>{::dawn::LocationType::Cells,
+                                                             ::dawn::LocationType::Edges,
+                                                             ::dawn::LocationType::Cells},
+                           [&](auto& lhs, auto red_loc1) {
+                             lhs += (int)1;
+                             sparse_dimension_idx0++;
+                             return lhs;
+                           });
+            }
+            {
+              int sparse_dimension_idx0 = 0;
+              m_out_field(deref(LibTag{}, loc), k + 0) =
+                  reduce(LibTag{}, m_mesh, loc, ((-cnt) * m_in_field(deref(LibTag{}, loc), k + 0)),
+                         std::vector<::dawn::LocationType>{::dawn::LocationType::Cells,
+                                                           ::dawn::LocationType::Edges,
+                                                           ::dawn::LocationType::Cells},
+                         [&](auto& lhs, auto red_loc1) {
+                           lhs += m_in_field(deref(LibTag{}, red_loc1), k + 0);
+                           sparse_dimension_idx0++;
+                           return lhs;
+                         });
+            }
             m_out_field(deref(LibTag{}, loc), k + 0) =
                 (m_in_field(deref(LibTag{}, loc), k + 0) +
                  ((::dawn::float_type)0.100000 * m_out_field(deref(LibTag{}, loc), k + 0)));
@@ -51,20 +69,25 @@ private:
     }
   };
   static constexpr const char* s_name = "diffusion";
-  stencil_129 m_stencil_129;
+  stencil_237 m_stencil_237;
 
 public:
   reference_diffusion(const reference_diffusion&) = delete;
 
   // Members
 
-  reference_diffusion(const dawn::mesh_t<LibTag>& mesh, int k_size,
-                      dawn::cell_field_t<LibTag, double>& in_field,
-                      dawn::cell_field_t<LibTag, double>& out_field)
-      : m_stencil_129(mesh, k_size, in_field, out_field) {}
+  void set_splitter_index(::dawn::LocationType loc, dawn::UnstructuredIterationSpace space,
+                          int offset, int index) {
+    m_stencil_237.m_unstructured_domain.set_splitter_index({loc, space, offset}, index);
+  }
+
+  reference_diffusion(const ::dawn::mesh_t<LibTag>& mesh, int k_size,
+                      ::dawn::cell_field_t<LibTag, ::dawn::float_type>& in_field,
+                      ::dawn::cell_field_t<LibTag, ::dawn::float_type>& out_field)
+      : m_stencil_237(mesh, k_size, in_field, out_field) {}
 
   void run() {
-    m_stencil_129.run();
+    m_stencil_237.run();
     ;
   }
 };

--- a/dawn/test/integration-test/unstructured/reference/reference_gradient.hpp
+++ b/dawn/test/integration-test/unstructured/reference/reference_gradient.hpp
@@ -1,50 +1,69 @@
 #define DAWN_GENERATED 1
+#undef DAWN_BACKEND_T
 #define DAWN_BACKEND_T CXXNAIVEICO
+#include <driver-includes/unstructured_domain.hpp>
 #include <driver-includes/unstructured_interface.hpp>
+
 namespace dawn_generated {
 namespace cxxnaiveico {
 template <typename LibTag>
 class reference_gradient {
 private:
-  struct stencil_284 {
-    dawn::mesh_t<LibTag> const& m_mesh;
+  struct stencil_279 {
+    ::dawn::mesh_t<LibTag> const& m_mesh;
     int m_k_size;
-    dawn::cell_field_t<LibTag, double>& m_cell_field;
-    dawn::edge_field_t<LibTag, double>& m_edge_field;
+    ::dawn::cell_field_t<LibTag, ::dawn::float_type>& m_cell_field;
+    ::dawn::edge_field_t<LibTag, ::dawn::float_type>& m_edge_field;
+    dawn::unstructured_domain m_unstructured_domain;
 
   public:
-    stencil_284(dawn::mesh_t<LibTag> const& mesh, int k_size,
-                dawn::cell_field_t<LibTag, double>& cell_field,
-                dawn::edge_field_t<LibTag, double>& edge_field)
+    stencil_279(::dawn::mesh_t<LibTag> const& mesh, int k_size,
+                ::dawn::cell_field_t<LibTag, ::dawn::float_type>& cell_field,
+                ::dawn::edge_field_t<LibTag, ::dawn::float_type>& edge_field)
         : m_mesh(mesh), m_k_size(k_size), m_cell_field(cell_field), m_edge_field(edge_field) {}
 
-    ~stencil_284() {}
+    ~stencil_279() {}
 
     void sync_storages() {}
+    static constexpr ::dawn::driver::unstructured_extent cell_field_extent = {true, 0, 0};
+    static constexpr ::dawn::driver::unstructured_extent edge_field_extent = {true, 0, 0};
 
     void run() {
-      using dawn::deref;
+      using ::dawn::deref;
       {
         for(int k = 0 + 0; k <= (m_k_size == 0 ? 0 : (m_k_size - 1)) + 0 + 0; ++k) {
           for(auto const& loc : getEdges(LibTag{}, m_mesh)) {
-            m_edge_field(deref(LibTag{}, loc), k + 0) = reduce(
-                LibTag{}, m_mesh, loc, (::dawn::float_type)0.000000,
-                std::vector<dawn::LocationType>{dawn::LocationType::Edges,
-                                                dawn::LocationType::Cells},
-                [&](auto& lhs, auto red_loc, auto const& weight) {
-                  return lhs += weight * m_cell_field(deref(LibTag{}, red_loc), k + 0);
-                },
-                std::vector<float>({1.000000, -1.000000}));
+            {
+              int sparse_dimension_idx0 = 0;
+              m_edge_field(deref(LibTag{}, loc), k + 0) = reduce(
+                  LibTag{}, m_mesh, loc, (::dawn::float_type)0.000000,
+                  std::vector<::dawn::LocationType>{::dawn::LocationType::Edges,
+                                                    ::dawn::LocationType::Cells},
+                  [&](auto& lhs, auto red_loc1, auto const& weight) {
+                    lhs += weight * m_cell_field(deref(LibTag{}, red_loc1), k + 0);
+                    sparse_dimension_idx0++;
+                    return lhs;
+                  },
+                  std::vector<::dawn::float_type>(
+                      {(::dawn::float_type)1.000000, (::dawn::float_type)-1.000000}));
+            }
           }
           for(auto const& loc : getCells(LibTag{}, m_mesh)) {
-            m_cell_field(deref(LibTag{}, loc), k + 0) = reduce(
-                LibTag{}, m_mesh, loc, (::dawn::float_type)0.000000,
-                std::vector<dawn::LocationType>{dawn::LocationType::Cells,
-                                                dawn::LocationType::Edges},
-                [&](auto& lhs, auto red_loc, auto const& weight) {
-                  return lhs += weight * m_edge_field(deref(LibTag{}, red_loc), k + 0);
-                },
-                std::vector<float>({0.500000, 0.000000, 0.000000, 0.500000}));
+            {
+              int sparse_dimension_idx0 = 0;
+              m_cell_field(deref(LibTag{}, loc), k + 0) = reduce(
+                  LibTag{}, m_mesh, loc, (::dawn::float_type)0.000000,
+                  std::vector<::dawn::LocationType>{::dawn::LocationType::Cells,
+                                                    ::dawn::LocationType::Edges},
+                  [&](auto& lhs, auto red_loc1, auto const& weight) {
+                    lhs += weight * m_edge_field(deref(LibTag{}, red_loc1), k + 0);
+                    sparse_dimension_idx0++;
+                    return lhs;
+                  },
+                  std::vector<::dawn::float_type>(
+                      {(::dawn::float_type)0.500000, (::dawn::float_type)0.000000,
+                       (::dawn::float_type)0.000000, (::dawn::float_type)0.500000}));
+            }
           }
         }
       }
@@ -52,20 +71,25 @@ private:
     }
   };
   static constexpr const char* s_name = "gradient";
-  stencil_284 m_stencil_284;
+  stencil_279 m_stencil_279;
 
 public:
   reference_gradient(const reference_gradient&) = delete;
 
   // Members
 
-  reference_gradient(const dawn::mesh_t<LibTag>& mesh, int k_size,
-                     dawn::cell_field_t<LibTag, double>& cell_field,
-                     dawn::edge_field_t<LibTag, double>& edge_field)
-      : m_stencil_284(mesh, k_size, cell_field, edge_field) {}
+  void set_splitter_index(::dawn::LocationType loc, dawn::UnstructuredIterationSpace space,
+                          int offset, int index) {
+    m_stencil_279.m_unstructured_domain.set_splitter_index({loc, space, offset}, index);
+  }
+
+  reference_gradient(const ::dawn::mesh_t<LibTag>& mesh, int k_size,
+                     ::dawn::cell_field_t<LibTag, ::dawn::float_type>& cell_field,
+                     ::dawn::edge_field_t<LibTag, ::dawn::float_type>& edge_field)
+      : m_stencil_279(mesh, k_size, cell_field, edge_field) {}
 
   void run() {
-    m_stencil_284.run();
+    m_stencil_279.run();
     ;
   }
 };

--- a/dawn/test/integration-test/unstructured/reference/reference_intp.hpp
+++ b/dawn/test/integration-test/unstructured/reference/reference_intp.hpp
@@ -1,45 +1,52 @@
 #define DAWN_GENERATED 1
 #undef DAWN_BACKEND_T
 #define DAWN_BACKEND_T CXXNAIVEICO
+#include <driver-includes/unstructured_domain.hpp>
 #include <driver-includes/unstructured_interface.hpp>
+
 namespace dawn_generated {
 namespace cxxnaiveico {
 template <typename LibTag>
 class reference_intp {
 private:
-  struct stencil_350 {
-    dawn::mesh_t<LibTag> const& m_mesh;
+  struct stencil_368 {
+    ::dawn::mesh_t<LibTag> const& m_mesh;
     int m_k_size;
-    dawn::cell_field_t<LibTag, double>& m_in;
-    dawn::cell_field_t<LibTag, double>& m_out;
+    ::dawn::cell_field_t<LibTag, ::dawn::float_type>& m_in;
+    ::dawn::cell_field_t<LibTag, ::dawn::float_type>& m_out;
+    dawn::unstructured_domain m_unstructured_domain;
 
   public:
-    stencil_350(dawn::mesh_t<LibTag> const& mesh, int k_size,
-                dawn::cell_field_t<LibTag, double>& in, dawn::cell_field_t<LibTag, double>& out)
+    stencil_368(::dawn::mesh_t<LibTag> const& mesh, int k_size,
+                ::dawn::cell_field_t<LibTag, ::dawn::float_type>& in,
+                ::dawn::cell_field_t<LibTag, ::dawn::float_type>& out)
         : m_mesh(mesh), m_k_size(k_size), m_in(in), m_out(out) {}
 
-    ~stencil_350() {}
+    ~stencil_368() {}
 
     void sync_storages() {}
-    static constexpr dawn::driver::unstructured_extent in_extent = {true, 0, 0};
-    static constexpr dawn::driver::unstructured_extent out_extent = {false, 0, 0};
+    static constexpr ::dawn::driver::unstructured_extent in_extent = {true, 0, 0};
+    static constexpr ::dawn::driver::unstructured_extent out_extent = {false, 0, 0};
 
     void run() {
-      using dawn::deref;
+      using ::dawn::deref;
       {
         for(int k = 0 + 0; k <= (m_k_size == 0 ? 0 : (m_k_size - 1)) + 0 + 0; ++k) {
           for(auto const& loc : getCells(LibTag{}, m_mesh)) {
-            int m_sparse_dimension_idx = 0;
-            m_out(deref(LibTag{}, loc), k + 0) = reduce(
-                LibTag{}, m_mesh, loc, (::dawn::float_type)0.000000,
-                std::vector<dawn::LocationType>{
-                    dawn::LocationType::Cells, dawn::LocationType::Edges, dawn::LocationType::Cells,
-                    dawn::LocationType::Edges, dawn::LocationType::Cells},
-                [&](auto& lhs, auto red_loc) {
-                  lhs += m_in(deref(LibTag{}, red_loc), k + 0);
-                  m_sparse_dimension_idx++;
-                  return lhs;
-                });
+            {
+              int sparse_dimension_idx0 = 0;
+              m_out(deref(LibTag{}, loc), k + 0) =
+                  reduce(LibTag{}, m_mesh, loc, (::dawn::float_type)0.000000,
+                         std::vector<::dawn::LocationType>{
+                             ::dawn::LocationType::Cells, ::dawn::LocationType::Edges,
+                             ::dawn::LocationType::Cells, ::dawn::LocationType::Edges,
+                             ::dawn::LocationType::Cells},
+                         [&](auto& lhs, auto red_loc1) {
+                           lhs += m_in(deref(LibTag{}, red_loc1), k + 0);
+                           sparse_dimension_idx0++;
+                           return lhs;
+                         });
+            }
           }
         }
       }
@@ -47,19 +54,25 @@ private:
     }
   };
   static constexpr const char* s_name = "intp";
-  stencil_350 m_stencil_350;
+  stencil_368 m_stencil_368;
 
 public:
   reference_intp(const reference_intp&) = delete;
 
   // Members
 
-  reference_intp(const dawn::mesh_t<LibTag>& mesh, int k_size,
-                 dawn::cell_field_t<LibTag, double>& in, dawn::cell_field_t<LibTag, double>& out)
-      : m_stencil_350(mesh, k_size, in, out) {}
+  void set_splitter_index(::dawn::LocationType loc, dawn::UnstructuredIterationSpace space,
+                          int offset, int index) {
+    m_stencil_368.m_unstructured_domain.set_splitter_index({loc, space, offset}, index);
+  }
+
+  reference_intp(const ::dawn::mesh_t<LibTag>& mesh, int k_size,
+                 ::dawn::cell_field_t<LibTag, ::dawn::float_type>& in,
+                 ::dawn::cell_field_t<LibTag, ::dawn::float_type>& out)
+      : m_stencil_368(mesh, k_size, in, out) {}
 
   void run() {
-    m_stencil_350.run();
+    m_stencil_368.run();
     ;
   }
 };

--- a/dawn/test/unit-test/dawn/CodeGen/reference/conditional_stencil.cpp
+++ b/dawn/test/unit-test/dawn/CodeGen/reference/conditional_stencil.cpp
@@ -71,8 +71,8 @@ private:
   public:
 
     stencil_21(const gridtools::dawn::domain& dom_, const globals& globals_, int rank, int xcols, int ycols) : m_dom(dom_), m_globals(globals_){}
-    static constexpr dawn::driver::cartesian_extent in_extent = {-1,1, -1,1, 0,0};
-    static constexpr dawn::driver::cartesian_extent out_extent = {0,0, 0,0, 0,0};
+    static constexpr ::dawn::driver::cartesian_extent in_extent = {-1,1, -1,1, 0,0};
+    static constexpr ::dawn::driver::cartesian_extent out_extent = {0,0, 0,0, 0,0};
 
     void run(storage_ijk_t& in_, storage_ijk_t& out_) {
       int iMin = m_dom.iminus();

--- a/dawn/test/unit-test/dawn/CodeGen/reference/conditional_stencil.cu
+++ b/dawn/test/unit-test/dawn/CodeGen/reference/conditional_stencil.cu
@@ -150,8 +150,8 @@ public:
   public:
 
     stencil_21(const gridtools::dawn::domain& dom_, globals& globals_, int rank, int xcols, int ycols) : sbase("stencil_21"), m_dom(dom_), m_globals(globals_){}
-    static constexpr dawn::driver::cartesian_extent in_extent = {-1,1, -1,1, 0,0};
-    static constexpr dawn::driver::cartesian_extent out_extent = {0,0, 0,0, 0,0};
+    static constexpr ::dawn::driver::cartesian_extent in_extent = {-1,1, -1,1, 0,0};
+    static constexpr ::dawn::driver::cartesian_extent out_extent = {0,0, 0,0, 0,0};
 
     void run(storage_ijk_t in_ds, storage_ijk_t out_ds) {
 

--- a/dawn/test/unit-test/dawn/CodeGen/reference/global_indexing.cpp
+++ b/dawn/test/unit-test/dawn/CodeGen/reference/global_indexing.cpp
@@ -71,8 +71,8 @@ private:
   public:
 
     stencil_28(const gridtools::dawn::domain& dom_, int rank, int xcols, int ycols) : m_dom(dom_), stage14GlobalJIndices({dom_.jminus() + 0 , dom_.jminus() + 2}), globalOffsets({computeGlobalOffsets(rank, m_dom, xcols, ycols)}){}
-    static constexpr dawn::driver::cartesian_extent in_field_extent = {0,0, 0,0, 0,0};
-    static constexpr dawn::driver::cartesian_extent out_field_extent = {0,0, 0,0, 0,0};
+    static constexpr ::dawn::driver::cartesian_extent in_field_extent = {0,0, 0,0, 0,0};
+    static constexpr ::dawn::driver::cartesian_extent out_field_extent = {0,0, 0,0, 0,0};
 
     void run(storage_ijk_t& in_field_, storage_ijk_t& out_field_) {
       int iMin = m_dom.iminus();

--- a/dawn/test/unit-test/dawn/CodeGen/reference/global_indexing.cu
+++ b/dawn/test/unit-test/dawn/CodeGen/reference/global_indexing.cu
@@ -142,8 +142,8 @@ public:
   public:
 
     stencil_28(const gridtools::dawn::domain& dom_, int rank, int xcols, int ycols) : sbase("stencil_28"), m_dom(dom_), stage14GlobalJIndices({dom_.jminus() + 0 , dom_.jminus() + 2}), globalOffsets({computeGlobalOffsets(rank, m_dom, xcols, ycols)}){}
-    static constexpr dawn::driver::cartesian_extent in_field_extent = {0,0, 0,0, 0,0};
-    static constexpr dawn::driver::cartesian_extent out_field_extent = {0,0, 0,0, 0,0};
+    static constexpr ::dawn::driver::cartesian_extent in_field_extent = {0,0, 0,0, 0,0};
+    static constexpr ::dawn::driver::cartesian_extent out_field_extent = {0,0, 0,0, 0,0};
 
     void run(storage_ijk_t in_field_ds, storage_ijk_t out_field_ds) {
 

--- a/dawn/test/unit-test/dawn/CodeGen/reference/laplacian_stencil.cpp
+++ b/dawn/test/unit-test/dawn/CodeGen/reference/laplacian_stencil.cpp
@@ -58,8 +58,8 @@ private:
   public:
 
     stencil_47(const gridtools::dawn::domain& dom_, int rank, int xcols, int ycols) : m_dom(dom_){}
-    static constexpr dawn::driver::cartesian_extent in_extent = {-1,1, -1,1, 0,0};
-    static constexpr dawn::driver::cartesian_extent out_extent = {0,0, 0,0, 0,0};
+    static constexpr ::dawn::driver::cartesian_extent in_extent = {-1,1, -1,1, 0,0};
+    static constexpr ::dawn::driver::cartesian_extent out_extent = {0,0, 0,0, 0,0};
 
     void run(storage_ijk_t& in_, storage_ijk_t& out_) {
       int iMin = m_dom.iminus();

--- a/dawn/test/unit-test/dawn/CodeGen/reference/laplacian_stencil.cu
+++ b/dawn/test/unit-test/dawn/CodeGen/reference/laplacian_stencil.cu
@@ -125,8 +125,8 @@ public:
   public:
 
     stencil_47(const gridtools::dawn::domain& dom_, int rank, int xcols, int ycols) : sbase("stencil_47"), m_dom(dom_){}
-    static constexpr dawn::driver::cartesian_extent in_extent = {-1,1, -1,1, 0,0};
-    static constexpr dawn::driver::cartesian_extent out_extent = {0,0, 0,0, 0,0};
+    static constexpr ::dawn::driver::cartesian_extent in_extent = {-1,1, -1,1, 0,0};
+    static constexpr ::dawn::driver::cartesian_extent out_extent = {0,0, 0,0, 0,0};
 
     void run(storage_ijk_t in_ds, storage_ijk_t out_ds) {
 

--- a/dawn/test/unit-test/dawn/CodeGen/reference/laplacian_stencil_nosync.cu
+++ b/dawn/test/unit-test/dawn/CodeGen/reference/laplacian_stencil_nosync.cu
@@ -125,8 +125,8 @@ public:
   public:
 
     stencil_47(const gridtools::dawn::domain& dom_, int rank, int xcols, int ycols) : sbase("stencil_47"), m_dom(dom_){}
-    static constexpr dawn::driver::cartesian_extent in_extent = {-1,1, -1,1, 0,0};
-    static constexpr dawn::driver::cartesian_extent out_extent = {0,0, 0,0, 0,0};
+    static constexpr ::dawn::driver::cartesian_extent in_extent = {-1,1, -1,1, 0,0};
+    static constexpr ::dawn::driver::cartesian_extent out_extent = {0,0, 0,0, 0,0};
 
     void run(storage_ijk_t in_ds, storage_ijk_t out_ds) {
 

--- a/dawn/test/unit-test/dawn/CodeGen/reference/laplacian_stencil_opt.cpp
+++ b/dawn/test/unit-test/dawn/CodeGen/reference/laplacian_stencil_opt.cpp
@@ -59,8 +59,8 @@ private:
   public:
 
     stencil_47(const gridtools::dawn::domain& dom_, int rank, int xcols, int ycols) : m_dom(dom_){}
-    static constexpr dawn::driver::cartesian_extent in_extent = {-1,1, -1,1, 0,0};
-    static constexpr dawn::driver::cartesian_extent out_extent = {0,0, 0,0, 0,0};
+    static constexpr ::dawn::driver::cartesian_extent in_extent = {-1,1, -1,1, 0,0};
+    static constexpr ::dawn::driver::cartesian_extent out_extent = {0,0, 0,0, 0,0};
 
     void run(storage_ijk_t& in_, storage_ijk_t& out_) {
       int iMin = m_dom.iminus();

--- a/dawn/test/unit-test/dawn/CodeGen/reference/nonoverlapping_stencil.cpp
+++ b/dawn/test/unit-test/dawn/CodeGen/reference/nonoverlapping_stencil.cpp
@@ -58,8 +58,8 @@ private:
   public:
 
     stencil_59(const gridtools::dawn::domain& dom_, int rank, int xcols, int ycols) : m_dom(dom_){}
-    static constexpr dawn::driver::cartesian_extent in_extent = {-1,1, -1,1, 0,0};
-    static constexpr dawn::driver::cartesian_extent out_extent = {0,0, 0,0, 0,0};
+    static constexpr ::dawn::driver::cartesian_extent in_extent = {-1,1, -1,1, 0,0};
+    static constexpr ::dawn::driver::cartesian_extent out_extent = {0,0, 0,0, 0,0};
 
     void run(storage_ijk_t& in_, storage_ijk_t& out_) {
       int iMin = m_dom.iminus();

--- a/dawn/test/unit-test/dawn/CodeGen/reference/nonoverlapping_stencil.cu
+++ b/dawn/test/unit-test/dawn/CodeGen/reference/nonoverlapping_stencil.cu
@@ -161,8 +161,8 @@ public:
   public:
 
     stencil_59(const gridtools::dawn::domain& dom_, int rank, int xcols, int ycols) : sbase("stencil_59"), m_dom(dom_){}
-    static constexpr dawn::driver::cartesian_extent in_extent = {-1,1, -1,1, 0,0};
-    static constexpr dawn::driver::cartesian_extent out_extent = {0,0, 0,0, 0,0};
+    static constexpr ::dawn::driver::cartesian_extent in_extent = {-1,1, -1,1, 0,0};
+    static constexpr ::dawn::driver::cartesian_extent out_extent = {0,0, 0,0, 0,0};
 
     void run(storage_ijk_t in_ds, storage_ijk_t out_ds) {
 

--- a/dawn/test/unit-test/dawn/CodeGen/reference/update_dz_c.cpp
+++ b/dawn/test/unit-test/dawn/CodeGen/reference/update_dz_c.cpp
@@ -75,16 +75,16 @@ private:
   public:
 
     stencil_443(const gridtools::dawn::domain& dom_, const globals& globals_, int rank, int xcols, int ycols) : m_dom(dom_), m_globals(globals_), m_tmp_meta_data(dom_.isize() + 1, dom_.jsize() + 1, dom_.ksize() + 2*0), m_xfx(m_tmp_meta_data), m_yfx(m_tmp_meta_data), m_fx(m_tmp_meta_data), m_fy(m_tmp_meta_data){}
-    static constexpr dawn::driver::cartesian_extent dp_ref_extent = {0,1, 0,1, -2,1};
-    static constexpr dawn::driver::cartesian_extent zs_extent = {0,0, 0,0, 0,0};
-    static constexpr dawn::driver::cartesian_extent area_extent = {0,0, 0,0, 0,0};
-    static constexpr dawn::driver::cartesian_extent ut_extent = {0,1, 0,1, -2,1};
-    static constexpr dawn::driver::cartesian_extent vt_extent = {0,1, 0,1, -2,1};
-    static constexpr dawn::driver::cartesian_extent gz_extent = {0,0, 0,0, 0,0};
-    static constexpr dawn::driver::cartesian_extent gz_x_extent = {-1,1, 0,1, 0,0};
-    static constexpr dawn::driver::cartesian_extent gz_y_extent = {0,1, -1,1, 0,0};
-    static constexpr dawn::driver::cartesian_extent ws3_extent = {0,0, 0,0, 0,0};
-    static constexpr dawn::driver::cartesian_extent gz_0_extent = {0,0, 0,0, 0,1};
+    static constexpr ::dawn::driver::cartesian_extent dp_ref_extent = {0,1, 0,1, -2,1};
+    static constexpr ::dawn::driver::cartesian_extent zs_extent = {0,0, 0,0, 0,0};
+    static constexpr ::dawn::driver::cartesian_extent area_extent = {0,0, 0,0, 0,0};
+    static constexpr ::dawn::driver::cartesian_extent ut_extent = {0,1, 0,1, -2,1};
+    static constexpr ::dawn::driver::cartesian_extent vt_extent = {0,1, 0,1, -2,1};
+    static constexpr ::dawn::driver::cartesian_extent gz_extent = {0,0, 0,0, 0,0};
+    static constexpr ::dawn::driver::cartesian_extent gz_x_extent = {-1,1, 0,1, 0,0};
+    static constexpr ::dawn::driver::cartesian_extent gz_y_extent = {0,1, -1,1, 0,0};
+    static constexpr ::dawn::driver::cartesian_extent ws3_extent = {0,0, 0,0, 0,0};
+    static constexpr ::dawn::driver::cartesian_extent gz_0_extent = {0,0, 0,0, 0,1};
 
     void run(storage_ijk_t& dp_ref_, storage_ijk_t& zs_, storage_ijk_t& area_, storage_ijk_t& ut_, storage_ijk_t& vt_, storage_ijk_t& gz_, storage_ijk_t& gz_x_, storage_ijk_t& gz_y_, storage_ijk_t& ws3_, storage_ijk_t& gz_0_) {
       int iMin = m_dom.iminus();

--- a/dawn/test/unit-test/dawn/CodeGen/reference/update_dz_c.cu
+++ b/dawn/test/unit-test/dawn/CodeGen/reference/update_dz_c.cu
@@ -540,16 +540,16 @@ public:
   public:
 
     stencil_443(const gridtools::dawn::domain& dom_, globals& globals_, int rank, int xcols, int ycols) : sbase("stencil_443"), m_dom(dom_), m_globals(globals_), m_tmp_meta_data(32+1, 4+1, (dom_.isize()+ 32 - 1) / 32, (dom_.jsize()+ 4 - 1) / 4, dom_.ksize() + 2 * 0), m_xfx(m_tmp_meta_data), m_yfx(m_tmp_meta_data), m_fx(m_tmp_meta_data), m_fy(m_tmp_meta_data){}
-    static constexpr dawn::driver::cartesian_extent dp_ref_extent = {0,1, 0,1, -2,1};
-    static constexpr dawn::driver::cartesian_extent zs_extent = {0,0, 0,0, 0,0};
-    static constexpr dawn::driver::cartesian_extent area_extent = {0,0, 0,0, 0,0};
-    static constexpr dawn::driver::cartesian_extent ut_extent = {0,1, 0,1, -2,1};
-    static constexpr dawn::driver::cartesian_extent vt_extent = {0,1, 0,1, -2,1};
-    static constexpr dawn::driver::cartesian_extent gz_extent = {0,0, 0,0, 0,0};
-    static constexpr dawn::driver::cartesian_extent gz_x_extent = {-1,1, 0,1, 0,0};
-    static constexpr dawn::driver::cartesian_extent gz_y_extent = {0,1, -1,1, 0,0};
-    static constexpr dawn::driver::cartesian_extent ws3_extent = {0,0, 0,0, 0,0};
-    static constexpr dawn::driver::cartesian_extent gz_0_extent = {0,0, 0,0, 0,1};
+    static constexpr ::dawn::driver::cartesian_extent dp_ref_extent = {0,1, 0,1, -2,1};
+    static constexpr ::dawn::driver::cartesian_extent zs_extent = {0,0, 0,0, 0,0};
+    static constexpr ::dawn::driver::cartesian_extent area_extent = {0,0, 0,0, 0,0};
+    static constexpr ::dawn::driver::cartesian_extent ut_extent = {0,1, 0,1, -2,1};
+    static constexpr ::dawn::driver::cartesian_extent vt_extent = {0,1, 0,1, -2,1};
+    static constexpr ::dawn::driver::cartesian_extent gz_extent = {0,0, 0,0, 0,0};
+    static constexpr ::dawn::driver::cartesian_extent gz_x_extent = {-1,1, 0,1, 0,0};
+    static constexpr ::dawn::driver::cartesian_extent gz_y_extent = {0,1, -1,1, 0,0};
+    static constexpr ::dawn::driver::cartesian_extent ws3_extent = {0,0, 0,0, 0,0};
+    static constexpr ::dawn::driver::cartesian_extent gz_0_extent = {0,0, 0,0, 0,1};
 
     void run(storage_ijk_t dp_ref_ds, storage_ijk_t zs_ds, storage_ijk_t area_ds, storage_ijk_t ut_ds, storage_ijk_t vt_ds, storage_ijk_t gz_ds, storage_ijk_t gz_x_ds, storage_ijk_t gz_y_ds, storage_ijk_t ws3_ds, storage_ijk_t gz_0_ds) {
 


### PR DESCRIPTION
## Technical Description

This PR introduces horizontal subdomains for the unstructured case. The design is quite simple; it simply "hijacks" the first `Interval` of the iteration space for the structured case, but redefines it's semantic. Instead of indices, magic numbers are assigned to the lower and upper level of the Interval, which can then be set at runtime using additionally introduced setters in the generated code. This works because in ICON, subdomains are contiguous _in memory_, and ICON stencils are only ever over a single subdomain, or over subdomains which are adjacent in memory. Consider this picture:

![domains](https://user-images.githubusercontent.com/53755555/94805746-27839780-03ed-11eb-8a81-d6554d174237.png)

A ICON stencil may for example run over lateral boundary, the nudging zone, and the interior, but not over lateral boundary + halo. This entails that the contract for the `Interval` does not need to be adapted for the unstructured case and remains meaningful. 

### ToDo

- [x] namespace issues
- [x] Introduce checker that asserts that second interval of an unstructured iteration space is always `nullopt`?

### Testing

New tests have been added to 
* dawn4py integration test 
* unstructured integration test 

### Dependencies

This PR is independent


