### PR TITLE
Disallow Vertical Offsets in Horizontal Fields

### DIFF
--- a/dawn/src/dawn/Unittest/IIRBuilder.cpp
+++ b/dawn/src/dawn/Unittest/IIRBuilder.cpp
@@ -278,12 +278,12 @@ std::shared_ptr<iir::Expr> CartesianIIRBuilder::at(IIRBuilder::Field const& fiel
   return at(field, AccessType::r, ast::Offsets{ast::cartesian, offset});
 }
 
-IIRBuilder::Field UnstructuredIIRBuilder::field(std::string const& name,
-                                                ast::LocationType location) {
+IIRBuilder::Field UnstructuredIIRBuilder::field(std::string const& name, ast::LocationType location,
+                                                bool maskK) {
   DAWN_ASSERT(si_);
   int id = si_->getMetaData().addField(
       iir::FieldAccessType::APIField, name,
-      sir::FieldDimensions(sir::HorizontalFieldDimension{ast::unstructured, location}, true));
+      sir::FieldDimensions(sir::HorizontalFieldDimension{ast::unstructured, location}, maskK));
   return {id, name};
 }
 

--- a/dawn/src/dawn/Unittest/IIRBuilder.h
+++ b/dawn/src/dawn/Unittest/IIRBuilder.h
@@ -346,7 +346,7 @@ public:
   std::shared_ptr<iir::Expr> at(Field const& field, HOffsetType hOffset, int vOffset);
   std::shared_ptr<iir::Expr> at(Field const& field, AccessType access = AccessType::r);
 
-  Field field(std::string const& name, ast::LocationType denseLocation);
+  Field field(std::string const& name, ast::LocationType denseLocation, bool maskK = true);
   Field field(std::string const& name, ast::NeighborChain sparseChain, bool maskK = true);
   Field vertical_field(std::string const& name);
 };

--- a/dawn/src/dawn/Validator/IntegrityChecker.cpp
+++ b/dawn/src/dawn/Validator/IntegrityChecker.cpp
@@ -111,6 +111,12 @@ void IntegrityChecker::visit(const std::shared_ptr<iir::FieldAccessExpr>& expr) 
     }
   }
 
+  auto dim = metadata_.getFieldDimensions(metadata_.getNameToAccessIDMap().at(expr->getName()));
+  if(!dim.K() &&
+     (expr->getOffset().hasVerticalIndirection() || expr->getOffset().verticalShift() != 0)) {
+    throw SemanticError("Attempting to read with vertical offset from 2 dimensional field!");
+  }
+
   ast::ASTVisitorForwarding::visit(expr);
 }
 

--- a/dawn/src/dawn/Validator/IntegrityChecker.cpp
+++ b/dawn/src/dawn/Validator/IntegrityChecker.cpp
@@ -114,7 +114,7 @@ void IntegrityChecker::visit(const std::shared_ptr<iir::FieldAccessExpr>& expr) 
   auto dim = metadata_.getFieldDimensions(metadata_.getNameToAccessIDMap().at(expr->getName()));
   if(!dim.K() &&
      (expr->getOffset().hasVerticalIndirection() || expr->getOffset().verticalShift() != 0)) {
-    throw SemanticError("Attempting to read with vertical offset from 2 dimensional field!");
+    throw SemanticError("Attempting to read with vertical offset from horizontal field!");
   }
 
   ast::ASTVisitorForwarding::visit(expr);

--- a/dawn/src/dawn/Validator/UnstructuredDimensionChecker.cpp
+++ b/dawn/src/dawn/Validator/UnstructuredDimensionChecker.cpp
@@ -151,17 +151,6 @@ void UnstructuredDimensionChecker::UnstructuredDimensionCheckerImpl::visit(
                        .hasOffset();
 
   auto fieldName = fieldAccessExpr->getName();
-  // the name in the FieldAccessExpr may be stale if the there are nested stencils
-  // in this case we need to look up the new AccessID in the data of the fieldAccessExpr
-  if(checkType_ == checkType::runOnIIR) {
-    DAWN_ASSERT(fieldAccessExpr->hasData());
-    auto newAccessID = fieldAccessExpr->getData<iir::IIRAccessExprData>().AccessID;
-    if(newAccessID.has_value()) {
-      DAWN_ASSERT(idToNameMap_.count(newAccessID.value()));
-      fieldName = idToNameMap_.at(newAccessID.value());
-    }
-  }
-
   DAWN_ASSERT(nameToDimensions_.count(fieldName));
 
   curDimensions_ = nameToDimensions_.at(fieldName);

--- a/dawn/test/unit-test/dawn/Validator/TestIntegrityChecker.cpp
+++ b/dawn/test/unit-test/dawn/Validator/TestIntegrityChecker.cpp
@@ -79,7 +79,7 @@ TEST(TestIntegrityChecker, OffsetReadsIn2DField) {
             b.stage(b.doMethod(dawn::sir::Interval::Start, dawn::sir::Interval::End,
                                b.stmt(b.assignExpr(
                                    b.at(out), b.at(in, AccessType::r,
-                                                   ast::Offsets{ast::unstructured, true, 1}))))))));
+                                                   ast::Offsets{ast::unstructured, false, 1}))))))));
     FAIL() << "Semantic error not thrown";
   } catch(SemanticError& error) {
     SUCCEED();

--- a/dawn/test/unit-test/dawn/Validator/TestIntegrityChecker.cpp
+++ b/dawn/test/unit-test/dawn/Validator/TestIntegrityChecker.cpp
@@ -63,4 +63,27 @@ TEST(TestIntegrityChecker, OffsetReadsInCorrectContext) {
   }
 }
 
+TEST(TestIntegrityChecker, OffsetReadsIn2DField) {
+  using namespace dawn::iir;
+  using LocType = dawn::ast::LocationType;
+
+  UnstructuredIIRBuilder b;
+  auto in = b.field("in", LocType::Cells, false);
+  auto out = b.field("out", LocType::Cells, false);
+
+  try {
+    auto stencil = b.build(
+        "OffsetReadsIn2DField",
+        b.stencil(b.multistage(
+            LoopOrderKind::Parallel,
+            b.stage(b.doMethod(dawn::sir::Interval::Start, dawn::sir::Interval::End,
+                               b.stmt(b.assignExpr(
+                                   b.at(out), b.at(in, AccessType::r,
+                                                   ast::Offsets{ast::unstructured, true, 1}))))))));
+    FAIL() << "Semantic error not thrown";
+  } catch(SemanticError& error) {
+    SUCCEED();
+  }
+}
+
 } // anonymous namespace


### PR DESCRIPTION
## Technical Description

Stuff like 
```
inField: Field[Edge] #2D Field
outField: Field[Edge] #2D Field
with levels_upward:
  inField = outField[k+1]
```
was legal in dawn. This PR rectifies that oversight.

### Resolves / Enhances

fixes issue #1031

### Testing

New test in `TestIntegrityChecker`

### Dependencies

This PR is independent. 


