### PR TITLE
Properly Version Sparse Fields

### DIFF
--- a/dawn/test/unit-test/dawn/Optimizer/TestPassFieldVersioning.cpp
+++ b/dawn/test/unit-test/dawn/Optimizer/TestPassFieldVersioning.cpp
@@ -11,10 +11,17 @@
 //  See LICENSE.txt for details.
 //
 //===------------------------------------------------------------------------------------------===//
+#include "dawn/IIR/ASTFwd.h"
+#include "dawn/IIR/ASTStmt.h"
 #include "dawn/IIR/IIR.h"
+#include "dawn/IIR/IIRNodeIterator.h"
 #include "dawn/IIR/StencilInstantiation.h"
 #include "dawn/Optimizer/PassFieldVersioning.h"
+#include "dawn/Optimizer/PassFixVersionedInputFields.h"
 #include "dawn/Serialization/IIRSerializer.h"
+#include "dawn/Unittest/IIRBuilder.h"
+#include "dawn/Unittest/UnittestUtils.h"
+#include "dawn/Validator/UnstructuredDimensionChecker.h"
 
 #include <gtest/gtest.h>
 #include <memory>
@@ -199,4 +206,71 @@ TEST_F(TestPassFieldVersioning, VersioningTest7) {
   int idA = instantiation->getMetaData().getAccessIDFromName("field_a");
   ASSERT_TRUE(instantiation->getMetaData().isMultiVersionedField(idA));
 }
+
+TEST_F(TestPassFieldVersioning, VersionSparseField) {
+  // when a sparse field is fixed due to double buffering it needs to be filled. for sparse fields,
+  // this fill requires a loop statement to be generated
+
+  using namespace dawn::iir;
+  using LocType = dawn::ast::LocationType;
+
+  UnstructuredIIRBuilder b;
+  auto dense = b.field("dense", LocType::Edges);
+  auto sparse =
+      b.field("sparse", {LocType::Edges, LocType::Cells, LocType::Vertices, LocType::Edges});
+
+  auto stencil = b.build(
+      "OffsetReadsInCorrectContext",
+      b.stencil(b.multistage(
+          LoopOrderKind::Parallel,
+          b.stage(b.doMethod(
+              dawn::sir::Interval::Start, dawn::sir::Interval::End,
+              b.stmt(b.assignExpr(b.at(dense),
+                                  b.reduceOverNeighborExpr(Op::plus, b.at(sparse), b.lit(0.),
+                                                           {LocType::Edges, LocType::Cells,
+                                                            LocType::Vertices, LocType::Edges}))),
+              b.loopStmtChain(
+                  b.stmt(b.assignExpr(b.at(sparse), b.at(dense, HOffsetType::noOffset, 0),
+                                      Op::assign)),
+                  {LocType::Edges, LocType::Cells, LocType::Vertices, LocType::Edges}))))));
+
+  PassFieldVersioning passFieldVersioning;
+  PassFixVersionedInputFields passFixVersionedInputFields;
+  passFieldVersioning.run(stencil);
+  passFixVersionedInputFields.run(stencil);
+
+  // check that sparse was versioned
+  int idSparse = stencil->getMetaData().getAccessIDFromName("sparse");
+  EXPECT_TRUE(stencil->getMetaData().isMultiVersionedField(idSparse));
+
+  // check that a multistage to fill sparse was generated, i.e there are 2 Multistages now
+  EXPECT_EQ(stencil->getStencils().begin()->get()->getChildren().size(), 2);
+
+  // first statement now needs to be a for loop
+  auto firstStatement = getNthStmt(getFirstDoMethod(stencil), 0);
+  EXPECT_EQ(firstStatement->getKind(), ast::Stmt::Kind::LoopStmt);
+
+  // lets look at the assign expression therein...
+  auto assignExpr = std::dynamic_pointer_cast<iir::AssignmentExpr>(
+      std::dynamic_pointer_cast<iir::ExprStmt>(
+          std::dynamic_pointer_cast<iir::LoopStmt>(firstStatement)
+              ->getBlockStmt()
+              ->getStatements()
+              .front())
+          ->getExpr());
+
+  auto fieldAccessLeft = std::dynamic_pointer_cast<iir::FieldAccessExpr>(assignExpr->getLeft());
+  auto fieldAccessRight = std::dynamic_pointer_cast<iir::FieldAccessExpr>(assignExpr->getRight());
+
+  // ... and ensure that we indeed fill the versioned sparse field here
+  EXPECT_EQ(fieldAccessRight->getName(), "sparse");
+  EXPECT_EQ(stencil->getMetaData().getOriginalVersionOfAccessID(iir::getAccessID(fieldAccessLeft)),
+            idSparse);
+
+  // finally, lets make sure that everything is ok w.r.t to the dimensions
+  auto result = UnstructuredDimensionChecker::checkDimensionsConsistency(*stencil->getIIR(),
+                                                                         stencil->getMetaData());
+  ASSERT_EQ(result, UnstructuredDimensionChecker::ConsistencyResult(true, dawn::SourceLocation()));
+}
+
 } // anonymous namespace

--- a/dawn/test/unit-test/dawn/Optimizer/TestPassFieldVersioning.cpp
+++ b/dawn/test/unit-test/dawn/Optimizer/TestPassFieldVersioning.cpp
@@ -230,7 +230,7 @@ TEST_F(TestPassFieldVersioning, VersionSparseField) {
                                                            {LocType::Edges, LocType::Cells,
                                                             LocType::Vertices, LocType::Edges}))),
               b.loopStmtChain(
-                  b.stmt(b.assignExpr(b.at(sparse), b.at(dense, HOffsetType::noOffset, 0),
+                  b.stmt(b.assignExpr(b.at(sparse), b.at(dense, HOffsetType::withOffset, 0),
                                       Op::assign)),
                   {LocType::Edges, LocType::Cells, LocType::Vertices, LocType::Edges}))))));
 


### PR DESCRIPTION
## Technical Description

This dusk code
```
@stencil
def various_expression(
    edge_3d_field1: Field[Edge, K],
    sparse_3d_field1: Field[Edge > Cell > Vertex > Edge, K],
):
    with levels_upward:
        edge_3d_field1 = min_over(Edge > Cell > Vertex > Edge, sparse_3d_field1)
        with sparse[Edge > Cell > Vertex > Edge]:
            sparse_3d_field1 = edge_3d_field1[Edge]
```
leads to two stages
```
sparse_3d_field1_0[<no_horizontal_offset>,0] = sparse_3d_field1[<no_horizontal_offset>,0]
```
and
```
edge_3d_field1[<no_horizontal_offset>,0] = Reduce (min, init = double_type 1.79769313486231571e+308, location = {Edge, Cell, Vertex, Edge}): sparse_3d_field1_0[<has_horizontal_offset>,0];",
for ({Edges, Cell, Vertices, Edges) {
	sparse_3d_field1[<has_horizontal_offset>,0] = edge_3d_field1[<no_horizontal_offset>,0];
}
```

Which trips up the `UnstructuredDimensionsChecker` in the first stage (since assigning to sparse fields is only allowed in `ForLoopStmt`s. This PR makes sure that dawn inserts a proper `ForLoopStmt` in this case. 

### Resolves / Enhances

Fixes #1032

### Testing

A new test added to `TestPassFieldVersioning` in the style of `TestPassRemoveScalars`.

### Dependencies

This PR is independent. 


