### PR TITLE
Improves daint-test.

### DIFF
--- a/dawn/test/integration-test/unstructured/CMakeLists.txt
+++ b/dawn/test/integration-test/unstructured/CMakeLists.txt
@@ -13,7 +13,7 @@
 ##===------------------------------------------------------------------------------------------===##
 include(GoogleTest)
 
-if (${CMAKE_BUILD_TYPE} STREQUAL "Debug")
+if (CMAKE_BUILD_TYPE STREQUAL "Debug")
 
 # Need to specify here the names of the stencil codes that are going to be generated.
 set(generated_stencil_codes generated_accumulateEdgeToCell.hpp

--- a/scripts/daint-test
+++ b/scripts/daint-test
@@ -37,8 +37,7 @@ srun --job-name=dawn_PR \
     sarus run --mount=type=bind,source=$root_dir,destination=$dawn_dir \
     --mount=type=bind,source=$(pwd)/clang-gridtools,destination=/usr/src/clang-gridtools \
     $image \
-    bash -c "mkdir $dawn_dir/gtest_output && \
-    export GTEST_OUTPUT=\"xml:$dawn_dir/gtest_output/\" &&
+    bash -c "export GTEST_OUTPUT=\"xml:$dawn_dir/gtest_output/\" &&
     /usr/src/dawn/scripts/build-and-test \
     --dawn-build-dir /usr/src/dawn-build \
     --dawn-install-dir /usr/local/dawn \


### PR DESCRIPTION
I wasn't able to run "./scripts/daint-test" on the commit this branch is based on. Although CI approved of it.
These commits let me run "./scripts/daint-test".
Let's see what CI thinks of it.