### PR TITLE
Hot Fix for the Ongoing Workshop (Dense Indexing)

### DIFF
--- a/dawn/src/dawn/CodeGen/CXXNaive-ico/ASTStencilBody.h
+++ b/dawn/src/dawn/CodeGen/CXXNaive-ico/ASTStencilBody.h
@@ -19,6 +19,7 @@
 #include "dawn/IIR/ASTFwd.h"
 #include "dawn/IIR/Interval.h"
 #include "dawn/Support/StringUtil.h"
+#include "driver-includes/unstructured_interface.hpp"
 #include <stack>
 #include <unordered_map>
 
@@ -61,6 +62,7 @@ protected:
 
   bool parentIsReduction_ = false;
   bool parentIsForLoop_ = false;
+  std::vector<ast::LocationType> currentChain_;
 
   size_t reductionDepth_ = 0;
 


### PR DESCRIPTION
## Technical Description

During the workshop a problem w.r.t to dense indices in reductions was noticed, quite possibly introduced by [this refactoring](https://github.com/MeteoSwiss-APN/dawn/commit/35209afd9942e7cefd6915c03b0335f82897e70d)

### Example

`grad_of_curl = sum_over(Edge > Vertex, uv_curl*tangent_orientation, weights=[-1., 1, ])/L`
vs
`grad_of_curl = sum_over(Edge > Vertex, uv_curl, weights=[-1., 1, ])/L*tangent_orientation`

both of these stencils should be equal. however, the first version tried to access `tangent_orientation` with `red_loc`, which is the vertex index (while `tangent_orientation` lives on edges).

### Testing

Currently the fix is not tested, need to act fast because of the ongoing workshop


