### PR TITLE
Set Dockerfile to Debug Build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # IMAGE needs be be set to one of the docker/dawn-env.dockerfile images
 ARG IMAGE=gtclang/dawn-env-ubuntu20.04
 FROM $IMAGE
-ARG BUILD_TYPE=Release
+ARG BUILD_TYPE=Debug
 COPY . /usr/src/dawn
 RUN /usr/src/dawn/scripts/build-and-test \
     --dawn-install-dir /usr/local/dawn \


### PR DESCRIPTION
## Technical Description

We rely quite a bit on assertions for error handling in dawn. This breaks apart if dawn is used in the release build. For the workshop, we rely on error messages being generated in order to not confuse the students. This can be rolled back after the workshop 

