### PR TITLE
Throw Instead of Assert in PassValidation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # IMAGE needs be be set to one of the docker/dawn-env.dockerfile images
 ARG IMAGE=gtclang/dawn-env-ubuntu20.04
 FROM $IMAGE
-ARG BUILD_TYPE=Release
+ARG BUILD_TYPE=Debug
 COPY . /usr/src/dawn
 RUN /usr/src/dawn/scripts/build-and-test \
     --dawn-install-dir /usr/local/dawn \

--- a/dawn/src/dawn/Optimizer/PassValidation.cpp
+++ b/dawn/src/dawn/Optimizer/PassValidation.cpp
@@ -87,7 +87,7 @@ bool PassValidation::run(const std::shared_ptr<dawn::SIR>& sir) {
     if(!checkResultDimensions)
       throw SemanticError("Dimensions in SIR are not consistent at line " +
                           std::to_string(errorLocationDimensions.Line));
-    ;
+    
     auto [checkResultWeights, errorLocationWeights] =
         UnstructuredDimensionChecker::checkDimensionsConsistency(*sir);
     if(!checkResultWeights)


### PR DESCRIPTION
## Technical Description

Exceptions give nicer error messages in Jupyter Notebooks and, as opposed to assertions, also work in dawns Release mode. The error handling in dawn needs an overhaul either way. I don't know if bubbling up an exception is the proper way to go, however, it does seem more reasonable in instances for syntax errors and the like. Hence, all assertions in the validation pass were replaced by throwing semantic exceptions. This could serve as a stepping stone to further improve dawn's error handling. 