### PR TITLE
Prohibit Vertically Offset Writes

### DIFF
--- a/dawn/src/dawn/Validator/IndirectionChecker.cpp
+++ b/dawn/src/dawn/Validator/IndirectionChecker.cpp
@@ -15,9 +15,8 @@ void IndirectionChecker::IndirectionCheckerImpl::visit(
     return;
   }
 
-  if(lhs_ &&
-     (expr->getOffset().hasVerticalIndirection() || expr->getOffset().verticalShift() != 0)) {
-    // indirections and offsets on lhs (i.e. vertically indirected or offset writes) are prohibited
+  if(lhs_ && expr->getOffset().hasVerticalIndirection()) {
+    // indirections on lhs (i.e. vertically indirected wriste) are prohibited
     indirectionsValid_ = false;
     return;
   }

--- a/dawn/src/dawn/Validator/IndirectionChecker.cpp
+++ b/dawn/src/dawn/Validator/IndirectionChecker.cpp
@@ -15,8 +15,9 @@ void IndirectionChecker::IndirectionCheckerImpl::visit(
     return;
   }
 
-  if(lhs_ && expr->getOffset().hasVerticalIndirection()) {
-    // indirections on lhs (i.e. vertically indirected wriste) are prohibited
+  if(lhs_ &&
+     (expr->getOffset().hasVerticalIndirection() || expr->getOffset().verticalShift() != 0)) {
+    // indirections and offsets on lhs (i.e. vertically indirected or offset writes) are prohibited
     indirectionsValid_ = false;
     return;
   }

--- a/dawn/src/dawn/Validator/IntegrityChecker.cpp
+++ b/dawn/src/dawn/Validator/IntegrityChecker.cpp
@@ -95,6 +95,13 @@ void IntegrityChecker::visit(const std::shared_ptr<iir::AssignmentExpr>& expr) {
                         expr->getSourceLocation().Line);
   }
 
+  if(iir::FieldAccessExpr::classof(left.get())) {
+    if(dyn_cast<iir::FieldAccessExpr>(left.get())->getOffset().verticalShift() != 0) {
+      throw SemanticError("Attempt to write vertically offset ", metadata_.getFileName(),
+                          expr->getSourceLocation().Line);
+    }
+  }
+
   int oldDim = curDimensions_;
   expr->getLeft()->accept(*this);
   int leftDim = curDimensions_;
@@ -114,15 +121,16 @@ void IntegrityChecker::visit(const std::shared_ptr<iir::AssignmentExpr>& expr) {
     }
   };
 
-  // we leave the unstrucutred world alone for now
+  // we leave the strucutred world alone for now
   if(instantiation_->getIIR()->getGridType() == ast::GridType::Unstructured &&
      !dimensionsCompatible(leftDim, rightDim)) {
     throw SemanticError("trying to assign " + dimToStr(leftDim) + "d field to " +
-                        dimToStr(rightDim) + "d field!");
+                            dimToStr(rightDim) + "d field!",
+                        metadata_.getFileName(), expr->getSourceLocation().Line);
   }
 
   curDimensions_ = oldDim;
-}
+} // namespace dawn
 
 void IntegrityChecker::visit(const std::shared_ptr<iir::FieldAccessExpr>& expr) {
 

--- a/dawn/test/unit-test/dawn/Validator/TestIndirectionChecker.cpp
+++ b/dawn/test/unit-test/dawn/Validator/TestIndirectionChecker.cpp
@@ -98,30 +98,8 @@ TEST(IndirectionCheckerTest, Case_Fail2) {
                   b.stage(b.doMethod(
                       dawn::sir::Interval::Start, dawn::sir::Interval::End,
                       b.stmt(b.assignExpr(b.at(out, AccessType::rw,
-                                               ast::Offsets{ast::unstructured, false, 1, "kidx"}),
+                                               ast::Offsets{ast::unstructured, false, 0, "kidx"}),
                                           b.at(in))))))));
-
-  auto result = IndirectionChecker::checkIndirections(*stencil->getIIR());
-  EXPECT_EQ(result, IndirectionChecker::IndirectionResult(false, dawn::SourceLocation()));
-}
-
-TEST(IndirectionCheckerTest, Case_Fail3) {
-  using namespace dawn::iir;
-  using LocType = dawn::ast::LocationType;
-
-  UnstructuredIIRBuilder b;
-  auto in = b.field("in", LocType::Cells);
-  auto out = b.field("out", LocType::Cells);
-
-  // vertically indirected _write_, which is prohibited!
-  auto stencil = b.build(
-      "fail",
-      b.stencil(b.multistage(
-          LoopOrderKind::Parallel,
-          b.stage(b.doMethod(dawn::sir::Interval::Start, dawn::sir::Interval::End,
-                             b.stmt(b.assignExpr(b.at(out, AccessType::rw,
-                                                      ast::Offsets{ast::unstructured, false, 1}),
-                                                 b.at(in))))))));
 
   auto result = IndirectionChecker::checkIndirections(*stencil->getIIR());
   EXPECT_EQ(result, IndirectionChecker::IndirectionResult(false, dawn::SourceLocation()));

--- a/dawn/test/unit-test/dawn/Validator/TestIndirectionChecker.cpp
+++ b/dawn/test/unit-test/dawn/Validator/TestIndirectionChecker.cpp
@@ -105,4 +105,26 @@ TEST(IndirectionCheckerTest, Case_Fail2) {
   EXPECT_EQ(result, IndirectionChecker::IndirectionResult(false, dawn::SourceLocation()));
 }
 
+TEST(IndirectionCheckerTest, Case_Fail3) {
+  using namespace dawn::iir;
+  using LocType = dawn::ast::LocationType;
+
+  UnstructuredIIRBuilder b;
+  auto in = b.field("in", LocType::Cells);
+  auto out = b.field("out", LocType::Cells);
+
+  // vertically indirected _write_, which is prohibited!
+  auto stencil = b.build(
+      "fail",
+      b.stencil(b.multistage(
+          LoopOrderKind::Parallel,
+          b.stage(b.doMethod(dawn::sir::Interval::Start, dawn::sir::Interval::End,
+                             b.stmt(b.assignExpr(b.at(out, AccessType::rw,
+                                                      ast::Offsets{ast::unstructured, false, 1}),
+                                                 b.at(in))))))));
+
+  auto result = IndirectionChecker::checkIndirections(*stencil->getIIR());
+  EXPECT_EQ(result, IndirectionChecker::IndirectionResult(false, dawn::SourceLocation()));
+}
+
 } // namespace

--- a/dawn/test/unit-test/dawn/Validator/TestIntegrityChecker.cpp
+++ b/dawn/test/unit-test/dawn/Validator/TestIntegrityChecker.cpp
@@ -117,9 +117,33 @@ TEST(TestIntegrityChecker, OffsetReadsIn2DField) {
         b.stencil(b.multistage(
             LoopOrderKind::Parallel,
             b.stage(b.doMethod(dawn::sir::Interval::Start, dawn::sir::Interval::End,
-                               b.stmt(b.assignExpr(
-                                   b.at(out), b.at(in, AccessType::r,
-                                                   ast::Offsets{ast::unstructured, false, 1}))))))));
+                               b.stmt(b.assignExpr(b.at(out), b.at(in, AccessType::r,
+                                                                   ast::Offsets{ast::unstructured,
+                                                                                false, 1}))))))));
+    FAIL() << "Semantic error not thrown";
+  } catch(SemanticError& error) {
+    SUCCEED();
+  }
+}
+
+TEST(TestIntegrityChecker, WriteVerticallyOffset) {
+  using namespace dawn::iir;
+  using LocType = dawn::ast::LocationType;
+
+  UnstructuredIIRBuilder b;
+  auto in = b.field("in", LocType::Cells);
+  auto out = b.field("out", LocType::Cells);
+
+  // vertically shifted _write_, which is prohibited!
+  try {
+    auto stencil = b.build(
+        "fail",
+        b.stencil(b.multistage(
+            LoopOrderKind::Parallel,
+            b.stage(b.doMethod(dawn::sir::Interval::Start, dawn::sir::Interval::End,
+                               b.stmt(b.assignExpr(b.at(out, AccessType::rw,
+                                                        ast::Offsets{ast::unstructured, false, 1}),
+                                                   b.at(in))))))));
     FAIL() << "Semantic error not thrown";
   } catch(SemanticError& error) {
     SUCCEED();


### PR DESCRIPTION
# NOTE

* A (1) vertically offset _write_ test case exists in the clang-gridtools tests. `gt4py` is set to support it, reasoning that there may be valid use cases. Long term goal there seems to be to support arbitrary computations along the vertical (even double loops etc.)
* Note 07.12.2020: Rechecked the part of the ICON dycore we are set to translate. Vertically offset writes **NO NOT** appear!
* Note 10.12.2020: We decided to **not** support vertically offset writes for now. 

## Technical Description

So far, writes using a vertical indirections (i.e. using an `IndexField`)  were correctly prohibited, but writes using a compile time offset in the vertical only were accidentally allowed. This caused code like 

```
@stencil
def vert_offset_write(
    outF: Field[Edge,K], inF: Field[Edge,K]):
    with levels_downward as k:
        outF[k+1] = inF
```

to go through the pipeline, with dangerous code being generated.

### Resolves / Enhances

Fixes #1066 

### Testing

A new test was added to ensure that the case above fails in the validation pass

### Dependencies

This PR depends on this [clang-gridtools PR](https://github.com/MeteoSwiss-APN/clang-gridtools/pull/166)


