### PR TITLE
Cuda-ICO Backend Assumed that every API Field is a Stencil Field

### DIFF
--- a/dawn/src/dawn/CodeGen/Cuda-ico/CudaIcoCodeGen.cpp
+++ b/dawn/src/dawn/CodeGen/Cuda-ico/CudaIcoCodeGen.cpp
@@ -505,8 +505,17 @@ void CudaIcoCodeGen::generateCopyMemoryFun(MemberFunction& copyFun,
                                            const iir::Stencil& stencil) const {
 
   const auto& APIFields = stencil.getMetadata().getAPIFields();
+  const auto& fields = stencil.getOrderedFields();
+
+  for(auto field : fields) {
+    auto fname = field.second.Name;
+    copyFun.addArg("::dawn::float_type* " + fname);
+  }
 
   for(auto fieldID : APIFields) {
+    if(fields.count(fieldID) == 0) {
+      continue;
+    }
     auto fname = stencil.getMetadata().getFieldNameFromAccessID(fieldID);
     copyFun.addArg("::dawn::float_type* " + fname);
   }
@@ -514,6 +523,9 @@ void CudaIcoCodeGen::generateCopyMemoryFun(MemberFunction& copyFun,
 
   // call initField on each field
   for(auto fieldID : APIFields) {
+    if(fields.count(fieldID) == 0) {
+      continue;
+    }
     auto fname = stencil.getMetadata().getFieldNameFromAccessID(fieldID);
     auto dims = stencil.getMetadata().getFieldDimensions(fieldID);
     if(dims.isVertical()) {
@@ -543,14 +555,21 @@ void CudaIcoCodeGen::generateCopyPtrFun(MemberFunction& copyFun,
                                         const iir::Stencil& stencil) const {
 
   const auto& APIFields = stencil.getMetadata().getAPIFields();
+  const auto& fields = stencil.getOrderedFields();
 
   for(auto fieldID : APIFields) {
+    if(fields.count(fieldID) == 0) {
+      continue;
+    }
     auto fname = stencil.getMetadata().getFieldNameFromAccessID(fieldID);
     copyFun.addArg("::dawn::float_type* " + fname);
   }
 
   // copy pointer to each field storage
   for(auto fieldID : APIFields) {
+    if(fields.count(fieldID) == 0) {
+      continue;
+    }
     auto fname = stencil.getMetadata().getFieldNameFromAccessID(fieldID);
     copyFun.addStatement(fname + "_ = " + fname);
   }
@@ -563,6 +582,9 @@ void CudaIcoCodeGen::generateCopyBackFun(MemberFunction& copyBackFun, const iir:
 
   // signature
   for(auto fieldID : APIFields) {
+    if(stenFields.count(fieldID) == 0) {
+      continue;
+    }
     auto field = stenFields.at(fieldID);
     if(field.field.getIntend() == dawn::iir::Field::IntendKind::Output ||
        field.field.getIntend() == dawn::iir::Field::IntendKind::InputOutput) {
@@ -620,6 +642,9 @@ void CudaIcoCodeGen::generateCopyBackFun(MemberFunction& copyBackFun, const iir:
 
   // function body
   for(auto fieldID : APIFields) {
+    if(stenFields.count(fieldID) == 0) {
+      continue;
+    }
     auto field = stenFields.at(fieldID);
     if(field.field.getIntend() == dawn::iir::Field::IntendKind::Output ||
        field.field.getIntend() == dawn::iir::Field::IntendKind::InputOutput) {
@@ -777,6 +802,9 @@ void CudaIcoCodeGen::generateAllAPIRunFunctions(
     {
       bool first = true;
       for(auto fieldID : APIFields) {
+        if(fields.count(fieldID) == 0) {
+          continue;
+        }
         if(!first) {
           fieldsStr << ", ";
         }
@@ -789,6 +817,9 @@ void CudaIcoCodeGen::generateAllAPIRunFunctions(
     std::stringstream ioFieldStr;
     bool first = true;
     for(auto fieldID : APIFields) {
+      if(fields.count(fieldID) == 0) {
+        continue;
+      }
       auto field = fields.at(fieldID);
       if(field.field.getIntend() == dawn::iir::Field::IntendKind::Output ||
          field.field.getIntend() == dawn::iir::Field::IntendKind::InputOutput) {


### PR DESCRIPTION
## Technical Description

The Cuda ICO backend assumed that every API field is also a stencil field. It did this while trying to figure out which fields are being written to in order to not clutter the functions copying fields back to the host. This is now fixed.

### Resolves / Enhances

Fixes #1068 

### Example

Examples like:
```
@stencil
def vert_offset_write(
    a: Field[Edge,K], b: Field[Edge,K], unused: Field[Edge, K]):
    with levels_downward as k:
        a = b
```
should not break at cuda code gen time anymore.

### Testing

Unfortunately can not be tested in dawn because we do not support compiling of generated cuda code in the current testing. Manually tested in icondusk-e2e.

### Dependencies

This PR is independent. 


