### PR TITLE
Ensure Location Type Consistency in IfStmt

### DIFF
--- a/dawn/src/dawn/SIR/SIR.cpp
+++ b/dawn/src/dawn/SIR/SIR.cpp
@@ -582,6 +582,7 @@ UnstructuredFieldDimension::UnstructuredFieldDimension(const ast::NeighborChain 
 }
 
 const ast::NeighborChain& UnstructuredFieldDimension::getNeighborChain() const {
+  DAWN_ASSERT(isSparse());
   return neighborChain_;
 }
 

--- a/dawn/src/dawn/SIR/SIR.cpp
+++ b/dawn/src/dawn/SIR/SIR.cpp
@@ -582,7 +582,6 @@ UnstructuredFieldDimension::UnstructuredFieldDimension(const ast::NeighborChain 
 }
 
 const ast::NeighborChain& UnstructuredFieldDimension::getNeighborChain() const {
-  DAWN_ASSERT(isSparse());
   return neighborChain_;
 }
 

--- a/dawn/src/dawn/Validator/UnstructuredDimensionChecker.cpp
+++ b/dawn/src/dawn/Validator/UnstructuredDimensionChecker.cpp
@@ -223,7 +223,17 @@ void UnstructuredDimensionChecker::UnstructuredDimensionCheckerImpl::visit(
 }
 
 void UnstructuredDimensionChecker::UnstructuredDimensionCheckerImpl::visit(
-    const std::shared_ptr<iir::IfStmt>& stmt) {
+    const std::shared_ptr<iir::IfStmt>& ifStmt) {
+  visit(std::static_pointer_cast<iir::Stmt>(ifStmt));
+}
+
+void UnstructuredDimensionChecker::UnstructuredDimensionCheckerImpl::visit(
+    const std::shared_ptr<iir::BlockStmt>& blockStmt) {
+  visit(std::static_pointer_cast<iir::Stmt>(blockStmt));
+}
+
+void UnstructuredDimensionChecker::UnstructuredDimensionCheckerImpl::visit(
+    const std::shared_ptr<iir::Stmt>& stmt) {
   std::optional<sir::FieldDimensions> prevDims = curDimensions_;
   for(auto& s : stmt->getChildren()) {
     s->accept(*this);

--- a/dawn/src/dawn/Validator/UnstructuredDimensionChecker.h
+++ b/dawn/src/dawn/Validator/UnstructuredDimensionChecker.h
@@ -60,6 +60,8 @@ private:
     void visit(const std::shared_ptr<iir::VarDeclStmt>& stmt) override;
     void visit(const std::shared_ptr<iir::VarAccessExpr>& stmt) override;
     void visit(const std::shared_ptr<iir::IfStmt>& stmt) override;
+    void visit(const std::shared_ptr<iir::BlockStmt>& stmt) override;
+    void visit(const std::shared_ptr<iir::Stmt>& stmt);
 
     void setCurDimensionFromLocType(iir::LocalVariableType&& type);
     bool isConsistent() const { return dimensionsConsistent_; }

--- a/dawn/src/dawn/Validator/UnstructuredDimensionChecker.h
+++ b/dawn/src/dawn/Validator/UnstructuredDimensionChecker.h
@@ -59,6 +59,7 @@ private:
     void visit(const std::shared_ptr<iir::LoopStmt>& stmt) override;
     void visit(const std::shared_ptr<iir::VarDeclStmt>& stmt) override;
     void visit(const std::shared_ptr<iir::VarAccessExpr>& stmt) override;
+    void visit(const std::shared_ptr<iir::IfStmt>& stmt) override;
 
     void setCurDimensionFromLocType(iir::LocalVariableType&& type);
     bool isConsistent() const { return dimensionsConsistent_; }

--- a/dawn/src/dawn4py/_dawn4py.cpp
+++ b/dawn/src/dawn4py/_dawn4py.cpp
@@ -227,49 +227,52 @@ PYBIND11_MODULE(_dawn4py, m) {
         "Set the dawn logging level [default: LogLevel::Warnings]",
         py::arg("level") = dawn::log::Level::Warnings);
 
-  m.def("run_optimizer_sir",
-        [](const std::string& sir, dawn::SIRSerializer::Format format,
-           const std::list<dawn::PassGroup>& groups,
-           const dawn::Options& options) { return dawn::run(sir, format, groups, options); },
-        "Lower the stencil IR to a stencil instantiation map and (optionally) run optimization "
-        "passes.",
-        "A list of default optimization passes is returned from default_pass_groups().",
-        py::arg("sir"), py::arg("format") = dawn::SIRSerializer::Format::Byte,
-        py::arg("groups") = std::list<dawn::PassGroup>(), py::arg("options") = dawn::Options());
+  m.def(
+      "run_optimizer_sir",
+      [](const std::string& sir, dawn::SIRSerializer::Format format,
+         const std::list<dawn::PassGroup>& groups,
+         const dawn::Options& options) { return dawn::run(sir, format, groups, options); },
+      "Lower the stencil IR to a stencil instantiation map and (optionally) run optimization "
+      "passes.",
+      "A list of default optimization passes is returned from default_pass_groups().",
+      py::arg("sir"), py::arg("format") = dawn::SIRSerializer::Format::Byte,
+      py::arg("groups") = std::list<dawn::PassGroup>(), py::arg("options") = dawn::Options());
 
-  m.def("run_optimizer_iir",
-        [](const std::map<std::string, std::string>& stencilInstantiationMap,
-           dawn::IIRSerializer::Format format, const std::list<dawn::PassGroup>& groups,
-           const dawn::Options& options) {
-          return dawn::run(stencilInstantiationMap, format, groups, options);
-        },
-        "Optimize the stencil instantiation map.",
-        "A list of default optimization passes is returned from default_pass_groups().",
-        py::arg("stencil_instantiation_map"), py::arg("format") = dawn::IIRSerializer::Format::Byte,
-        py::arg("groups") = std::list<dawn::PassGroup>(), py::arg("options") = dawn::Options());
+  m.def(
+      "run_optimizer_iir",
+      [](const std::map<std::string, std::string>& stencilInstantiationMap,
+         dawn::IIRSerializer::Format format, const std::list<dawn::PassGroup>& groups,
+         const dawn::Options& options) {
+        return dawn::run(stencilInstantiationMap, format, groups, options);
+      },
+      "Optimize the stencil instantiation map.",
+      "A list of default optimization passes is returned from default_pass_groups().",
+      py::arg("stencil_instantiation_map"), py::arg("format") = dawn::IIRSerializer::Format::Byte,
+      py::arg("groups") = std::list<dawn::PassGroup>(), py::arg("options") = dawn::Options());
 
-  m.def("run_codegen",
-        [](const std::map<std::string, std::string>& stencilInstantiationMap,
-           dawn::IIRSerializer::Format format, dawn::codegen::Backend backend,
-           const dawn::codegen::Options& options) {
-          return dawn::codegen::run(stencilInstantiationMap, format, backend, options);
-        },
-        "Generate code from the stencil instantiation map.", py::arg("stencil_instantiation_map"),
-        py::arg("format") = dawn::IIRSerializer::Format::Byte,
-        py::arg("backend") = dawn::codegen::Backend::GridTools,
-        py::arg("options") = dawn::codegen::Options());
+  m.def(
+      "run_codegen",
+      [](const std::map<std::string, std::string>& stencilInstantiationMap,
+         dawn::IIRSerializer::Format format, dawn::codegen::Backend backend,
+         const dawn::codegen::Options& options) {
+        return dawn::codegen::run(stencilInstantiationMap, format, backend, options);
+      },
+      "Generate code from the stencil instantiation map.", py::arg("stencil_instantiation_map"),
+      py::arg("format") = dawn::IIRSerializer::Format::Byte,
+      py::arg("backend") = dawn::codegen::Backend::GridTools,
+      py::arg("options") = dawn::codegen::Options());
 
-  m.def("compile_sir",
-        [](const std::string& sir, dawn::SIRSerializer::Format format,
-           const std::list<dawn::PassGroup>& groups, const dawn::Options& optimizerOptions,
-           dawn::codegen::Backend backend, const dawn::codegen::Options& codegenOptions) {
-          return dawn::compile(sir, format, groups, optimizerOptions, backend, codegenOptions);
-        },
-        "Compile the stencil IR: lower, optimize, and generate code.",
-        "Runs the default_pass_groups() unless the 'groups' argument is passed.", py::arg("sir"),
-        py::arg("format") = dawn::SIRSerializer::Format::Byte,
-        py::arg("groups") = dawn::defaultPassGroups(),
-        py::arg("optimizer_options") = dawn::Options(),
-        py::arg("backend") = dawn::codegen::Backend::GridTools,
-        py::arg("codegen_options") = dawn::codegen::Options());
+  m.def(
+      "compile_sir",
+      [](const std::string& sir, dawn::SIRSerializer::Format format,
+         const std::list<dawn::PassGroup>& groups, const dawn::Options& optimizerOptions,
+         dawn::codegen::Backend backend, const dawn::codegen::Options& codegenOptions) {
+        return dawn::compile(sir, format, groups, optimizerOptions, backend, codegenOptions);
+      },
+      "Compile the stencil IR: lower, optimize, and generate code.",
+      "Runs the default_pass_groups() unless the 'groups' argument is passed.", py::arg("sir"),
+      py::arg("format") = dawn::SIRSerializer::Format::Byte,
+      py::arg("groups") = dawn::defaultPassGroups(), py::arg("optimizer_options") = dawn::Options(),
+      py::arg("backend") = dawn::codegen::Backend::GridTools,
+      py::arg("codegen_options") = dawn::codegen::Options());
 }

--- a/dawn/test/integration-test/unstructured/AtlasIntegrationTestCompareOutput.cpp
+++ b/dawn/test/integration-test/unstructured/AtlasIntegrationTestCompareOutput.cpp
@@ -1095,7 +1095,7 @@ TEST(AtlasIntegrationTestCompareOutput, globalVar) {
   // Run the stencil
   auto stencil = dawn_generated::cxxnaiveico::globalVar<atlasInterface::atlasTag>(
       mesh, static_cast<int>(nb_levels), in_v, out_v);
-  stencil.set_dt(dt);  
+  stencil.set_dt(dt);
   stencil.run();
 
   // Check correctness of the output

--- a/dawn/test/unit-test/dawn/Optimizer/TestPassLocalVarType.cpp
+++ b/dawn/test/unit-test/dawn/Optimizer/TestPassLocalVarType.cpp
@@ -774,39 +774,6 @@ TEST(TestLocalVarType, test_throw_unstructured_06) {
   EXPECT_THROW(passLocalVarType.run(stencil), std::runtime_error);
 }
 
-TEST(TestLocalVarType, test_throw_nested_if_01) {
-  using namespace dawn::iir;
-
-  UnstructuredIIRBuilder b;
-  auto f_c = b.field("f_c", ast::LocationType::Cells);
-  auto f_e = b.field("f_e", ast::LocationType::Edges);
-  auto varA = b.localvar("varA", dawn::BuiltinTypeID::Double, {b.lit(2.0)});
-
-  /// field(cells) f_c;
-  /// field(edges) f_e;
-  /// double varA = 2.0;
-  /// if(f_e > 0.0) {
-  ///    if(f_c > 0.0) {
-  ///       varA = 1.0;
-  ///    }
-  /// }
-
-  auto stencil = b.build(
-      "generated",
-      b.stencil(b.multistage(
-          dawn::iir::LoopOrderKind::Forward,
-          b.stage(b.doMethod(
-              dawn::sir::Interval::Start, dawn::sir::Interval::End, b.declareVar(varA),
-              b.ifStmt(
-                  b.binaryExpr(b.at(f_e), b.lit(0.0), Op::greater),
-                  b.block(b.ifStmt(b.binaryExpr(b.at(f_c), b.lit(0.0), Op::greater),
-                                   b.block(b.stmt(b.assignExpr(b.at(varA), b.lit(1.0))))))))))));
-
-  // run single pass (PassLocalVarType) and expect exception to be thrown
-  PassLocalVarType passLocalVarType;
-  EXPECT_THROW(passLocalVarType.run(stencil), std::runtime_error);
-}
-
 TEST(TestLocalVarType, test_throw_nested_if_02) {
   using namespace dawn::iir;
 

--- a/dawn/test/unit-test/dawn/Validator/TestUnstructuredDimensionChecker.cpp
+++ b/dawn/test/unit-test/dawn/Validator/TestUnstructuredDimensionChecker.cpp
@@ -607,7 +607,7 @@ TEST(UnstructuredDimensionCheckerTest, IfStmtNestPass) {
   auto inner_body = b.field("inner_body", LocType::Edges);
 
   auto stencil = b.build(
-      "fail",
+      "pass",
       b.stencil(b.multistage(
           LoopOrderKind::Parallel,
           b.stage(b.doMethod(dawn::sir::Interval::Start, dawn::sir::Interval::End,
@@ -619,5 +619,69 @@ TEST(UnstructuredDimensionCheckerTest, IfStmtNestPass) {
                                                                          stencil->getMetaData());
   EXPECT_EQ(result, UnstructuredDimensionChecker::ConsistencyResult(true, dawn::SourceLocation()));
 }
+
+TEST(UnstructuredDimensionCheckerTest, IfStmtNestPassVert) {
+  using namespace dawn::iir;
+  using LocType = dawn::ast::LocationType;
+
+  UnstructuredIIRBuilder b;
+  auto cond = b.vertical_field("cond");
+  auto inner_cond = b.field("inner_cond", LocType::Edges);
+  auto inner_body = b.field("inner_body", LocType::Edges);
+
+  auto stencil = b.build(
+      "pass",
+      b.stencil(b.multistage(
+          LoopOrderKind::Parallel,
+          b.stage(b.doMethod(dawn::sir::Interval::Start, dawn::sir::Interval::End,
+                             b.ifStmt(b.at(cond), b.ifStmt(b.at(inner_cond),
+                                                           b.stmt(b.assignExpr(b.at(inner_body),
+                                                                               b.lit(1.))))))))));
+  {
+    auto result = UnstructuredDimensionChecker::checkDimensionsConsistency(*stencil->getIIR(),
+                                                                           stencil->getMetaData());
+    EXPECT_EQ(result,
+              UnstructuredDimensionChecker::ConsistencyResult(true, dawn::SourceLocation()));
+  }
+
+  {
+    auto result = UnstructuredDimensionChecker::checkStageLocTypeConsistency(
+        *stencil->getIIR(), stencil->getMetaData());
+    EXPECT_EQ(result,
+              UnstructuredDimensionChecker::ConsistencyResult(true, dawn::SourceLocation()));
+  }
+}
+
+// TEST(UnstructuredDimensionCheckerTest, IfStmtNestPass2) {
+//   using namespace dawn::iir;
+//   using LocType = dawn::ast::LocationType;
+
+//   UnstructuredIIRBuilder b;
+//   auto cond = b.field("cond", LocType::Edges);
+//   auto inner_cond = b.field("inner_cond", LocType::Edges);
+//   auto inner_body = b.field("inner_body", LocType::Edges);
+//   auto eField = b.field("eField", LocType::Edges);
+//   auto cField = b.field("cField", LocType::Cells);
+//   auto sparse = b.field("sparse", {LocType::Edges, LocType::Cells});
+
+//   auto stencil = b.build(
+//       "pass", b.stencil(b.multistage(
+//                   LoopOrderKind::Parallel,
+//                   b.stage(b.doMethod(
+//                       dawn::sir::Interval::Start, dawn::sir::Interval::End,
+//                       b.stmt(b.assignExpr(
+//                           b.at(eField),
+//                           b.reduceOverNeighborExpr(
+//                               Op::plus, b.binaryExpr(b.at(sparse), b.at(cField), Op::multiply),
+//                               b.lit(0), {LocType::Edges, LocType::Cells}))),
+//                       b.ifStmt(b.at(cond),
+//                                b.ifStmt(b.at(inner_cond),
+//                                         b.stmt(b.assignExpr(b.at(inner_body), b.lit(1.))))))))));
+
+//   auto result = UnstructuredDimensionChecker::checkDimensionsConsistency(*stencil->getIIR(),
+//                                                                          stencil->getMetaData());
+//   EXPECT_EQ(result, UnstructuredDimensionChecker::ConsistencyResult(true,
+//   dawn::SourceLocation()));
+// }
 
 } // namespace

--- a/dawn/test/unit-test/dawn/Validator/TestUnstructuredDimensionChecker.cpp
+++ b/dawn/test/unit-test/dawn/Validator/TestUnstructuredDimensionChecker.cpp
@@ -633,7 +633,8 @@ TEST(UnstructuredDimensionCheckerTest, IfStmtNestPassVert) {
       "pass",
       b.stencil(b.multistage(
           LoopOrderKind::Parallel,
-          b.stage(b.doMethod(dawn::sir::Interval::Start, dawn::sir::Interval::End,
+          b.stage(LocType::Edges,
+                  b.doMethod(dawn::sir::Interval::Start, dawn::sir::Interval::End,
                              b.ifStmt(b.at(cond), b.ifStmt(b.at(inner_cond),
                                                            b.stmt(b.assignExpr(b.at(inner_body),
                                                                                b.lit(1.))))))))));
@@ -651,37 +652,5 @@ TEST(UnstructuredDimensionCheckerTest, IfStmtNestPassVert) {
               UnstructuredDimensionChecker::ConsistencyResult(true, dawn::SourceLocation()));
   }
 }
-
-// TEST(UnstructuredDimensionCheckerTest, IfStmtNestPass2) {
-//   using namespace dawn::iir;
-//   using LocType = dawn::ast::LocationType;
-
-//   UnstructuredIIRBuilder b;
-//   auto cond = b.field("cond", LocType::Edges);
-//   auto inner_cond = b.field("inner_cond", LocType::Edges);
-//   auto inner_body = b.field("inner_body", LocType::Edges);
-//   auto eField = b.field("eField", LocType::Edges);
-//   auto cField = b.field("cField", LocType::Cells);
-//   auto sparse = b.field("sparse", {LocType::Edges, LocType::Cells});
-
-//   auto stencil = b.build(
-//       "pass", b.stencil(b.multistage(
-//                   LoopOrderKind::Parallel,
-//                   b.stage(b.doMethod(
-//                       dawn::sir::Interval::Start, dawn::sir::Interval::End,
-//                       b.stmt(b.assignExpr(
-//                           b.at(eField),
-//                           b.reduceOverNeighborExpr(
-//                               Op::plus, b.binaryExpr(b.at(sparse), b.at(cField), Op::multiply),
-//                               b.lit(0), {LocType::Edges, LocType::Cells}))),
-//                       b.ifStmt(b.at(cond),
-//                                b.ifStmt(b.at(inner_cond),
-//                                         b.stmt(b.assignExpr(b.at(inner_body), b.lit(1.))))))))));
-
-//   auto result = UnstructuredDimensionChecker::checkDimensionsConsistency(*stencil->getIIR(),
-//                                                                          stencil->getMetaData());
-//   EXPECT_EQ(result, UnstructuredDimensionChecker::ConsistencyResult(true,
-//   dawn::SourceLocation()));
-// }
 
 } // namespace

--- a/dawn/test/unit-test/dawn/Validator/TestUnstructuredDimensionChecker.cpp
+++ b/dawn/test/unit-test/dawn/Validator/TestUnstructuredDimensionChecker.cpp
@@ -653,4 +653,35 @@ TEST(UnstructuredDimensionCheckerTest, IfStmtNestPassVert) {
   }
 }
 
+TEST(UnstructuredDimensionCheckerTest, IfStmtVarAccess) {
+  using namespace dawn::iir;
+
+  UnstructuredIIRBuilder b;
+  auto f_c = b.field("f_c", ast::LocationType::Cells);
+  auto f_e = b.field("f_e", ast::LocationType::Edges);
+  auto varA = b.localvar("varA", dawn::BuiltinTypeID::Double, {b.lit(2.0)});
+
+  /// field(cells) f_c;
+  /// field(edges) f_e;
+  /// double varA = 2.0;
+  /// if(f_e > 0.0) {
+  ///    if(f_c > 0.0) {
+  ///       varA = 1.0;
+  ///    }
+  /// }
+
+  EXPECT_DEATH(
+      auto stencil = b.build(
+          "generated",
+          b.stencil(b.multistage(
+              dawn::iir::LoopOrderKind::Forward,
+              b.stage(b.doMethod(
+                  dawn::sir::Interval::Start, dawn::sir::Interval::End, b.declareVar(varA),
+                  b.ifStmt(b.binaryExpr(b.at(f_e), b.lit(0.0), Op::greater),
+                           b.block(b.ifStmt(
+                               b.binaryExpr(b.at(f_c), b.lit(0.0), Op::greater),
+                               b.block(b.stmt(b.assignExpr(b.at(varA), b.lit(1.0)))))))))))),
+      ".*Dimensions consistency check failed.*");
+}
+
 } // namespace

--- a/dawn/test/unit-test/dawn/Validator/TestUnstructuredDimensionChecker.cpp
+++ b/dawn/test/unit-test/dawn/Validator/TestUnstructuredDimensionChecker.cpp
@@ -558,5 +558,22 @@ TEST(UnstructuredDimensionCheckerTest, VerticalIndirection) {
                                                                            1, "kidx"})))))))),
       ".*Dimensions consistency check failed.*");
 }
+TEST(UnstructuredDimensionCheckerTest, IfStmt) {
+  using namespace dawn::iir;
+  using LocType = dawn::ast::LocationType;
+
+  UnstructuredIIRBuilder b;
+  auto cond = b.field("cond", LocType::Cells);
+  auto body = b.field("body", LocType::Edges);
+
+  EXPECT_DEATH(
+      auto stencil = b.build(
+          "fail", b.stencil(b.multistage(
+                      LoopOrderKind::Parallel,
+                      b.stage(b.doMethod(
+                          dawn::sir::Interval::Start, dawn::sir::Interval::End,
+                          b.ifStmt(b.at(cond), b.stmt(b.assignExpr(b.at(body), b.lit(1.))))))))),
+      ".*Dimensions consistency check failed.*");
+}
 
 } // namespace


### PR DESCRIPTION
## Technical Description

So far we failed to ensure location type consistency in between the conditional, then and else branch of of an `IfStmt`. This allowed code like:
```
@stencil
def if_condition(hC_x: Field[Cell],
                boundary_edges: Field[Edge]):
    with levels_downward:
        if boundary_edges:
            hC_x = 0
```
To go through the pipeline, being generated into potentially unsafe code. 

### Resolves / Enhances

Fixes #1064 

### Example

See above

### Testing

Death- and positive tests added to `TestUnstructuredDimensionsChecker` with simple as well as nested if statements 

### Dependencies

This PR is independent. 


