### PR TITLE
Fix Scoping Issues In Naive Codegen

### DIFF
--- a/dawn/src/dawn/CodeGen/CXXNaive-ico/ASTStencilBody.cpp
+++ b/dawn/src/dawn/CodeGen/CXXNaive-ico/ASTStencilBody.cpp
@@ -380,8 +380,9 @@ void ASTStencilBody::visit(const std::shared_ptr<iir::ReductionOverNeighborExpr>
     ss_ << "weight * ";
   } else {
     ss_ << ", [&, " + ASTStencilBody::ReductionSparseIndexVarName(reductionDepth_) +
-               " = int(0)](auto& lhs, auto red_loc"
-        << (reductionDepth_ + 1) << ") mutable { ";
+               " = int(0)](auto& lhs, auto " 
+       << ASTStencilBody::ReductionIndexVarName(reductionDepth_ + 1)
+       << ") mutable { ";
     ss_ << "lhs " << expr->getOp() << "= ";
   }
 

--- a/dawn/src/dawn/CodeGen/CXXNaive-ico/ASTStencilBody.cpp
+++ b/dawn/src/dawn/CodeGen/CXXNaive-ico/ASTStencilBody.cpp
@@ -371,18 +371,17 @@ void ASTStencilBody::visit(const std::shared_ptr<iir::ReductionOverNeighborExpr>
 
   ss_ << ", " << nbhChainToVectorString(expr->getNbhChain());
   if(hasWeights) {
-    ss_ << ", [&](auto& lhs, auto " << ASTStencilBody::ReductionIndexVarName(reductionDepth_ + 1)
-        << ", auto const& weight) {\n";
+    ss_ << ", [&, " + ASTStencilBody::ReductionSparseIndexVarName(reductionDepth_) +
+               " = int(0)](auto& "
+               "lhs, auto "
+        << ASTStencilBody::ReductionIndexVarName(reductionDepth_ + 1)
+        << ", auto const& weight) mutable {\n";
     ss_ << "lhs " << expr->getOp() << "= ";
     ss_ << "weight * ";
   } else {
-    ss_ << ", [&](auto& lhs, auto red_loc" << (reductionDepth_ + 1) << ") { ";
-    // generate this next red_loc only if the rhs contains further reductions
-    FindReduceOverNeighborExpr redFinder;
-    expr->getRhs()->accept(redFinder);
-    if(redFinder.hasReduceOverNeighborExpr()) {
-      ss_ << "int " << ASTStencilBody::ReductionSparseIndexVarName(reductionDepth_ + 1) << " = 0;";
-    }
+    ss_ << ", [&, " + ASTStencilBody::ReductionSparseIndexVarName(reductionDepth_) +
+               " = int(0)](auto& lhs, auto red_loc"
+        << (reductionDepth_ + 1) << ") mutable { ";
     ss_ << "lhs " << expr->getOp() << "= ";
   }
 

--- a/dawn/src/dawn/CodeGen/CXXNaive-ico/CXXNaiveCodeGen.cpp
+++ b/dawn/src/dawn/CodeGen/CXXNaive-ico/CXXNaiveCodeGen.cpp
@@ -599,24 +599,8 @@ void CXXNaiveIcoCodeGen::generateStencilClasses(
                       continue;
 
                     for(const auto& stmt : doMethod.getAST().getStatements()) {
-
-                      // if this statement contains a ReduceOverNeighbrExpr but isnt the
-                      // first one we need to reset the neighborhood iterator
-                      FindReduceOverNeighborExpr findReduceOverNeighborExpr;
-                      stmt->accept(findReduceOverNeighborExpr);
-                      if(findReduceOverNeighborExpr.hasReduceOverNeighborExpr()) {
-                        StencilRunMethod.ss() << "{\n";
-                        StencilRunMethod.ss()
-                            << "int " << ASTStencilBody::ReductionSparseIndexVarName(0)
-                            << " = 0;\n";
-                      }
-
                       stmt->accept(stencilBodyCXXVisitor);
                       StencilRunMethod << stencilBodyCXXVisitor.getCodeAndResetStream();
-
-                      if(findReduceOverNeighborExpr.hasReduceOverNeighborExpr()) {
-                        StencilRunMethod.ss() << "}\n";
-                      }
                     }
                   }
                 });

--- a/dawn/test/integration-test/dawn4py-tests/data/ICON_laplacian_stencil_ref.cpp
+++ b/dawn/test/integration-test/dawn4py-tests/data/ICON_laplacian_stencil_ref.cpp
@@ -54,41 +54,29 @@ private:
 {
     for(int k = 0+0; k <= ( m_k_size == 0 ? 0 : (m_k_size - 1)) + 0+0; ++k) {
       for(auto const& loc : getVertices(LibTag{}, m_mesh)) {
-{
-int sparse_dimension_idx0 = 0;
-m_rot_vec(deref(LibTag{}, loc), (k + 0)) = reduce(LibTag{}, m_mesh,loc, (::dawn::float_type) 0.0, std::vector<::dawn::LocationType>{::dawn::LocationType::Vertices, ::dawn::LocationType::Edges}, [&](auto& lhs, auto red_loc1) { lhs += (m_vec(deref(LibTag{}, red_loc1), (k + 0)) * m_geofac_rot(deref(LibTag{}, loc),sparse_dimension_idx0, (k + 0)));
+m_rot_vec(deref(LibTag{}, loc), (k + 0)) = reduce(LibTag{}, m_mesh,loc, (::dawn::float_type) 0.0, std::vector<::dawn::LocationType>{::dawn::LocationType::Vertices, ::dawn::LocationType::Edges}, [&, sparse_dimension_idx0 = int(0)](auto& lhs, auto red_loc1) mutable { lhs += (m_vec(deref(LibTag{}, red_loc1), (k + 0)) * m_geofac_rot(deref(LibTag{}, loc),sparse_dimension_idx0, (k + 0)));
 sparse_dimension_idx0++;
 return lhs;
 });
-}
       }      for(auto const& loc : getCells(LibTag{}, m_mesh)) {
-{
-int sparse_dimension_idx0 = 0;
-m_div_vec(deref(LibTag{}, loc), (k + 0)) = reduce(LibTag{}, m_mesh,loc, (::dawn::float_type) 0.0, std::vector<::dawn::LocationType>{::dawn::LocationType::Cells, ::dawn::LocationType::Edges}, [&](auto& lhs, auto red_loc1) { lhs += (m_vec(deref(LibTag{}, red_loc1), (k + 0)) * m_geofac_div(deref(LibTag{}, loc),sparse_dimension_idx0, (k + 0)));
+m_div_vec(deref(LibTag{}, loc), (k + 0)) = reduce(LibTag{}, m_mesh,loc, (::dawn::float_type) 0.0, std::vector<::dawn::LocationType>{::dawn::LocationType::Cells, ::dawn::LocationType::Edges}, [&, sparse_dimension_idx0 = int(0)](auto& lhs, auto red_loc1) mutable { lhs += (m_vec(deref(LibTag{}, red_loc1), (k + 0)) * m_geofac_div(deref(LibTag{}, loc),sparse_dimension_idx0, (k + 0)));
 sparse_dimension_idx0++;
 return lhs;
 });
-}
       }      for(auto const& loc : getEdges(LibTag{}, m_mesh)) {
-{
-int sparse_dimension_idx0 = 0;
-m_nabla2t1_vec(deref(LibTag{}, loc), (k + 0)) = reduce(LibTag{}, m_mesh,loc, (::dawn::float_type) 0.0, std::vector<::dawn::LocationType>{::dawn::LocationType::Edges, ::dawn::LocationType::Vertices}, [&](auto& lhs, auto red_loc1, auto const& weight) {
+m_nabla2t1_vec(deref(LibTag{}, loc), (k + 0)) = reduce(LibTag{}, m_mesh,loc, (::dawn::float_type) 0.0, std::vector<::dawn::LocationType>{::dawn::LocationType::Edges, ::dawn::LocationType::Vertices}, [&, sparse_dimension_idx0 = int(0)](auto& lhs, auto red_loc1, auto const& weight) mutable {
 lhs += weight * m_rot_vec(deref(LibTag{}, red_loc1), (k + 0));
 sparse_dimension_idx0++;
 return lhs;
 }, std::vector<::dawn::float_type>({(::dawn::float_type) -1.0, (::dawn::float_type) 1.0}));
-}
       }      for(auto const& loc : getEdges(LibTag{}, m_mesh)) {
 m_nabla2t1_vec(deref(LibTag{}, loc), (k + 0)) = ((m_tangent_orientation(deref(LibTag{}, loc), (k + 0)) * m_nabla2t1_vec(deref(LibTag{}, loc), (k + 0))) / m_primal_edge_length(deref(LibTag{}, loc), (k + 0)));
       }      for(auto const& loc : getEdges(LibTag{}, m_mesh)) {
-{
-int sparse_dimension_idx0 = 0;
-m_nabla2t2_vec(deref(LibTag{}, loc), (k + 0)) = reduce(LibTag{}, m_mesh,loc, (::dawn::float_type) 0.0, std::vector<::dawn::LocationType>{::dawn::LocationType::Edges, ::dawn::LocationType::Cells}, [&](auto& lhs, auto red_loc1, auto const& weight) {
+m_nabla2t2_vec(deref(LibTag{}, loc), (k + 0)) = reduce(LibTag{}, m_mesh,loc, (::dawn::float_type) 0.0, std::vector<::dawn::LocationType>{::dawn::LocationType::Edges, ::dawn::LocationType::Cells}, [&, sparse_dimension_idx0 = int(0)](auto& lhs, auto red_loc1, auto const& weight) mutable {
 lhs += weight * m_div_vec(deref(LibTag{}, red_loc1), (k + 0));
 sparse_dimension_idx0++;
 return lhs;
 }, std::vector<::dawn::float_type>({(::dawn::float_type) -1.0, (::dawn::float_type) 1.0}));
-}
       }      for(auto const& loc : getEdges(LibTag{}, m_mesh)) {
 m_nabla2t2_vec(deref(LibTag{}, loc), (k + 0)) = (m_nabla2t2_vec(deref(LibTag{}, loc), (k + 0)) / m_dual_edge_length(deref(LibTag{}, loc), (k + 0)));
       }      for(auto const& loc : getEdges(LibTag{}, m_mesh)) {

--- a/dawn/test/integration-test/unstructured/CMakeLists.txt
+++ b/dawn/test/integration-test/unstructured/CMakeLists.txt
@@ -34,17 +34,11 @@ set(generated_stencil_codes generated_accumulateEdgeToCell.hpp
   generated_nestedWithSparse.hpp
   generated_reductionInIfConditional.hpp
   generated_sparseAssignment0.hpp
-  generated_SparseAssignment0.hpp
   generated_sparseAssignment1.hpp
-  generated_SparseAssignment1.hpp
   generated_sparseAssignment2.hpp
-  generated_SparseAssignment2.hpp
   generated_sparseAssignment3.hpp
-  generated_SparseAssignment3.hpp
   generated_sparseAssignment4.hpp
-  generated_SparseAssignment4.hpp
   generated_sparseAssignment5.hpp
-  generated_SparseAssignment5.hpp
   generated_sparseDimension.hpp
   generated_sparseDimensionTwice.hpp
   generated_sparseTempFieldAllocation.hpp

--- a/dawn/test/integration-test/unstructured/CMakeLists.txt
+++ b/dawn/test/integration-test/unstructured/CMakeLists.txt
@@ -21,25 +21,38 @@ set(generated_stencil_codes generated_accumulateEdgeToCell.hpp
   generated_copyEdge.hpp
   generated_diamond.hpp
   generated_diamondWeights.hpp
+  generated_diffusionCuda.hpp
   generated_diffusion.hpp
+  generated_globalVar.hpp
   generated_gradient.hpp
   generated_horizontalVertical.hpp
   generated_intp.hpp
+  generated_iterationSpaceUnstructured.hpp
   generated_nestedSimple.hpp
+  generated_NestedSparse.hpp
   generated_nestedWithField.hpp
   generated_nestedWithSparse.hpp
+  generated_reductionInIfConditional.hpp
   generated_sparseAssignment0.hpp
+  generated_SparseAssignment0.hpp
   generated_sparseAssignment1.hpp
+  generated_SparseAssignment1.hpp
   generated_sparseAssignment2.hpp
+  generated_SparseAssignment2.hpp
   generated_sparseAssignment3.hpp
+  generated_SparseAssignment3.hpp
   generated_sparseAssignment4.hpp
+  generated_SparseAssignment4.hpp
   generated_sparseAssignment5.hpp
+  generated_SparseAssignment5.hpp
   generated_sparseDimension.hpp
   generated_sparseDimensionTwice.hpp
+  generated_sparseTempFieldAllocation.hpp
+  generated_tempFieldAllocation.hpp
+  generated_tempField.hpp
   generated_tridiagonalSolve.hpp
   generated_verticalIndirecion.hpp
   generated_verticalSum.hpp
-  generated_globalVar.hpp
 )
 
 set(reference_stencil_codes reference_diffusion.hpp


### PR DESCRIPTION
## Technical Description

In the naive backend, each reduction was wrapped into its own scope. This caused some problems in if statements where a reduction was part of the condition, as well as situations where a temporary field was demoted to a local variable. This PR addresses this by removing the scope. The local linear index is now introduced in the lambda capture, which is made possible by marking the lambda as `mutable`. 

### Resolves / Enhances

Fixes #1065 

### Example

A real life example could be
```
  with levels_downward:
    if sum_over(Cell > Edge, 1) < 4:
        f_x = ... #do something at the boundary
    else:
        f_x = sum_over(Cell > Edge, L)
```

### Testing

A test to the effect of the above was added to the unstructured integration checking. 

### Dependencies

This PR is independent


