### PR TITLE
Fix a Stage Merger Problem on Unstructured Stencils 

### DIFF
--- a/dawn/src/dawn/Optimizer/PassStageMerger.cpp
+++ b/dawn/src/dawn/Optimizer/PassStageMerger.cpp
@@ -87,8 +87,16 @@ bool PassStageMerger::run(const std::shared_ptr<iir::StencilInstantiation>& sten
 
             // can only merge stages with same location type (for Cartesian they are both
             // std::nullopt)
-            if(candidateStage.getLocationType() != curStage.getLocationType())
-              continue;
+            //
+            // whether or not we need to break or we can continue and considers stages futher
+            // abovedepends if the candidate stage can savely be moved below the current stage
+            if(candidateStage.getLocationType() != curStage.getLocationType()) {
+              if(stageDAG.depends(curStage.getStageID(), candidateStage.getStageID())) {
+                break;
+              } else {
+                continue;
+              }
+            }
 
             // Does the interval of `curDoMethod` overlap with any DoMethod interval in
             // `candidateStage`?

--- a/dawn/test/unit-test/dawn/Optimizer/TestPassStageMerger.cpp
+++ b/dawn/test/unit-test/dawn/Optimizer/TestPassStageMerger.cpp
@@ -169,4 +169,23 @@ TEST_F(TestPassStageMerger, MergerTestTwoCopiesMixed) {
   runTest("input/StageMergerTestTwoCopiesMixed.iir", 1, {1}, {2}, {1, 1});
 }
 
+TEST_F(TestPassStageMerger, MergerTestUnstrIndependent) {
+  // here, the stage sandwiched in the middle is independent from the stage
+  // on edges above and below. we thus expect the stage merger to pass through
+  // and merge eout1 = .... into eout= = ....
+  //   eout0 = sum_over(Edge > Cell > Edge, ein0[Edge > Cell > Edge])
+  //   cout0 = sum_over(Cell > Edge > Cell, cin0[Cell > Edge > Cell])
+  //   eout1 = sum_over(Edge > Cell > Edge, ein1[Edge > Cell > Edge])
+  runTest("input/StageMergerTestIndependent.iir", 1, {1}, {2}, {1, 1});
+}
+
+TEST_F(TestPassStageMerger, MergerTestUnstrDependent) {
+  // here, the stage sandwiched in the middle has a dependency to the stage below
+  // the stage merger hence must break and not try to merge eout1 = .... into eout= = ....
+  //   eout0 = sum_over(Edge > Cell > Edge, ein0[Edge > Cell > Edge])
+  //   cout0 = sum_over(Cell > Edge > Cell, cin0[Cell > Edge > Cell])
+  //   eout1 = sum_over(Edge > Cell, cout0)
+  runTest("input/StageMergerTestDependent.iir", 1, {1}, {3}, {1, 1, 1});
+}
+
 } // anonymous namespace

--- a/dawn/test/unit-test/dawn/Optimizer/input/StageMergerTestDependent.iir
+++ b/dawn/test/unit-test/dawn/Optimizer/input/StageMergerTestDependent.iir
@@ -1,0 +1,638 @@
+{
+ "metadata": {
+  "accessIDToName": {
+   "48": "cin0",
+   "49": "eout1",
+   "45": "eout0",
+   "46": "ein0",
+   "47": "cout0"
+  },
+  "accessIDToType": {
+   "45": 6,
+   "46": 6,
+   "47": 6,
+   "48": 6,
+   "49": 6
+  },
+  "literalIDToName": {
+   "-72": "0",
+   "-71": "0",
+   "-70": "0"
+  },
+  "fieldAccessIDs": [
+   45,
+   46,
+   47,
+   48,
+   49
+  ],
+  "APIFieldIDs": [
+   45,
+   46,
+   47,
+   48,
+   49
+  ],
+  "temporaryFieldIDs": [],
+  "globalVariableIDs": [],
+  "versionedFields": {
+   "variableVersionMap": {}
+  },
+  "fieldnameToBoundaryCondition": {},
+  "fieldIDtoDimensions": {
+   "48": {
+    "unstructured_horizontal_dimension": {
+     "dense_location_type": "Cell",
+     "sparse_part": []
+    },
+    "mask_k": 0
+   },
+   "49": {
+    "unstructured_horizontal_dimension": {
+     "dense_location_type": "Edge",
+     "sparse_part": []
+    },
+    "mask_k": 0
+   },
+   "45": {
+    "unstructured_horizontal_dimension": {
+     "dense_location_type": "Edge",
+     "sparse_part": []
+    },
+    "mask_k": 0
+   },
+   "46": {
+    "unstructured_horizontal_dimension": {
+     "dense_location_type": "Edge",
+     "sparse_part": []
+    },
+    "mask_k": 0
+   },
+   "47": {
+    "unstructured_horizontal_dimension": {
+     "dense_location_type": "Cell",
+     "sparse_part": []
+    },
+    "mask_k": 0
+   }
+  },
+  "idToStencilCall": {
+   "50": {
+    "stencil_call_decl_stmt": {
+     "stencil_call": {
+      "loc": {
+       "Line": -1,
+       "Column": -1
+      },
+      "callee": "__code_gen_50",
+      "arguments": []
+     },
+     "loc": {
+      "Line": -1,
+      "Column": -1
+     },
+     "data": {},
+     "ID": 51
+    }
+   }
+  },
+  "boundaryCallToExtent": {},
+  "allocatedFieldIDs": [],
+  "stencilLocation": {
+   "Line": -1,
+   "Column": -1
+  },
+  "stencilName": "dependent"
+ },
+ "internalIR": {
+  "gridType": "Unstructured",
+  "globalVariableToValue": {},
+  "stencils": [
+   {
+    "multiStages": [
+     {
+      "stages": [
+       {
+        "doMethods": [
+         {
+          "ast": {
+           "block_stmt": {
+            "statements": [
+             {
+              "expr_stmt": {
+               "expr": {
+                "assignment_expr": {
+                 "left": {
+                  "field_access_expr": {
+                   "name": "eout0",
+                   "vertical_shift": 0,
+                   "vertical_indirection": "",
+                   "zero_offset": {},
+                   "argument_map": [
+                    -1,
+                    -1,
+                    -1
+                   ],
+                   "argument_offset": [
+                    0,
+                    0,
+                    0
+                   ],
+                   "negate_offset": false,
+                   "loc": {
+                    "Line": -1,
+                    "Column": -1
+                   },
+                   "data": {
+                    "accessID": 45
+                   },
+                   "ID": 53
+                  }
+                 },
+                 "op": "=",
+                 "right": {
+                  "reduction_over_neighbor_expr": {
+                   "op": "+",
+                   "rhs": {
+                    "field_access_expr": {
+                     "name": "ein0",
+                     "vertical_shift": 0,
+                     "vertical_indirection": "",
+                     "unstructured_offset": {
+                      "has_offset": true
+                     },
+                     "argument_map": [
+                      -1,
+                      -1,
+                      -1
+                     ],
+                     "argument_offset": [
+                      0,
+                      0,
+                      0
+                     ],
+                     "negate_offset": false,
+                     "loc": {
+                      "Line": -1,
+                      "Column": -1
+                     },
+                     "data": {
+                      "accessID": 46
+                     },
+                     "ID": 27
+                    }
+                   },
+                   "init": {
+                    "literal_access_expr": {
+                     "value": "0",
+                     "type": {
+                      "type_id": "Double"
+                     },
+                     "loc": {
+                      "Line": -1,
+                      "Column": -1
+                     },
+                     "data": {
+                      "accessID": -70
+                     },
+                     "ID": 26
+                    }
+                   },
+                   "weights": [],
+                   "chain": [
+                    "Edge",
+                    "Cell",
+                    "Edge"
+                   ]
+                  }
+                 },
+                 "loc": {
+                  "Line": -1,
+                  "Column": -1
+                 },
+                 "ID": 54
+                }
+               },
+               "loc": {
+                "Line": -1,
+                "Column": -1
+               },
+               "data": {
+                "accesses": {
+                 "writeAccess": {
+                  "45": {
+                   "zero_extent": {},
+                   "vertical_extent": {
+                    "minus": 0,
+                    "plus": 0,
+                    "undefined": false
+                   }
+                  }
+                 },
+                 "readAccess": {
+                  "46": {
+                   "unstructured_extent": {
+                    "has_extent": true
+                   },
+                   "vertical_extent": {
+                    "minus": 0,
+                    "plus": 0,
+                    "undefined": false
+                   }
+                  },
+                  "-70": {
+                   "zero_extent": {},
+                   "vertical_extent": {
+                    "minus": 0,
+                    "plus": 0,
+                    "undefined": false
+                   }
+                  }
+                 }
+                }
+               },
+               "ID": 55
+              }
+             }
+            ],
+            "loc": {
+             "Line": -1,
+             "Column": -1
+            },
+            "data": {},
+            "ID": 74
+           }
+          },
+          "doMethodID": 1,
+          "interval": {
+           "lower_offset": 0,
+           "upper_offset": 0,
+           "special_lower_level": "Start",
+           "special_upper_level": "End"
+          }
+         }
+        ],
+        "stageID": 73,
+        "locationType": "Edge"
+       },
+       {
+        "doMethods": [
+         {
+          "ast": {
+           "block_stmt": {
+            "statements": [
+             {
+              "expr_stmt": {
+               "expr": {
+                "assignment_expr": {
+                 "left": {
+                  "field_access_expr": {
+                   "name": "cout0",
+                   "vertical_shift": 0,
+                   "vertical_indirection": "",
+                   "zero_offset": {},
+                   "argument_map": [
+                    -1,
+                    -1,
+                    -1
+                   ],
+                   "argument_offset": [
+                    0,
+                    0,
+                    0
+                   ],
+                   "negate_offset": false,
+                   "loc": {
+                    "Line": -1,
+                    "Column": -1
+                   },
+                   "data": {
+                    "accessID": 47
+                   },
+                   "ID": 57
+                  }
+                 },
+                 "op": "=",
+                 "right": {
+                  "reduction_over_neighbor_expr": {
+                   "op": "+",
+                   "rhs": {
+                    "field_access_expr": {
+                     "name": "cin0",
+                     "vertical_shift": 0,
+                     "vertical_indirection": "",
+                     "unstructured_offset": {
+                      "has_offset": true
+                     },
+                     "argument_map": [
+                      -1,
+                      -1,
+                      -1
+                     ],
+                     "argument_offset": [
+                      0,
+                      0,
+                      0
+                     ],
+                     "negate_offset": false,
+                     "loc": {
+                      "Line": -1,
+                      "Column": -1
+                     },
+                     "data": {
+                      "accessID": 48
+                     },
+                     "ID": 33
+                    }
+                   },
+                   "init": {
+                    "literal_access_expr": {
+                     "value": "0",
+                     "type": {
+                      "type_id": "Double"
+                     },
+                     "loc": {
+                      "Line": -1,
+                      "Column": -1
+                     },
+                     "data": {
+                      "accessID": -71
+                     },
+                     "ID": 32
+                    }
+                   },
+                   "weights": [],
+                   "chain": [
+                    "Cell",
+                    "Edge",
+                    "Cell"
+                   ]
+                  }
+                 },
+                 "loc": {
+                  "Line": -1,
+                  "Column": -1
+                 },
+                 "ID": 58
+                }
+               },
+               "loc": {
+                "Line": -1,
+                "Column": -1
+               },
+               "data": {
+                "accesses": {
+                 "writeAccess": {
+                  "47": {
+                   "zero_extent": {},
+                   "vertical_extent": {
+                    "minus": 0,
+                    "plus": 0,
+                    "undefined": false
+                   }
+                  }
+                 },
+                 "readAccess": {
+                  "48": {
+                   "unstructured_extent": {
+                    "has_extent": true
+                   },
+                   "vertical_extent": {
+                    "minus": 0,
+                    "plus": 0,
+                    "undefined": false
+                   }
+                  },
+                  "-71": {
+                   "zero_extent": {},
+                   "vertical_extent": {
+                    "minus": 0,
+                    "plus": 0,
+                    "undefined": false
+                   }
+                  }
+                 }
+                }
+               },
+               "ID": 59
+              }
+             }
+            ],
+            "loc": {
+             "Line": -1,
+             "Column": -1
+            },
+            "data": {},
+            "ID": 76
+           }
+          },
+          "doMethodID": 2,
+          "interval": {
+           "lower_offset": 0,
+           "upper_offset": 0,
+           "special_lower_level": "Start",
+           "special_upper_level": "End"
+          }
+         }
+        ],
+        "stageID": 75,
+        "locationType": "Cell"
+       },
+       {
+        "doMethods": [
+         {
+          "ast": {
+           "block_stmt": {
+            "statements": [
+             {
+              "expr_stmt": {
+               "expr": {
+                "assignment_expr": {
+                 "left": {
+                  "field_access_expr": {
+                   "name": "eout1",
+                   "vertical_shift": 0,
+                   "vertical_indirection": "",
+                   "zero_offset": {},
+                   "argument_map": [
+                    -1,
+                    -1,
+                    -1
+                   ],
+                   "argument_offset": [
+                    0,
+                    0,
+                    0
+                   ],
+                   "negate_offset": false,
+                   "loc": {
+                    "Line": -1,
+                    "Column": -1
+                   },
+                   "data": {
+                    "accessID": 49
+                   },
+                   "ID": 61
+                  }
+                 },
+                 "op": "=",
+                 "right": {
+                  "reduction_over_neighbor_expr": {
+                   "op": "+",
+                   "rhs": {
+                    "field_access_expr": {
+                     "name": "cout0",
+                     "vertical_shift": 0,
+                     "vertical_indirection": "",
+                     "unstructured_offset": {
+                      "has_offset": true
+                     },
+                     "argument_map": [
+                      -1,
+                      -1,
+                      -1
+                     ],
+                     "argument_offset": [
+                      0,
+                      0,
+                      0
+                     ],
+                     "negate_offset": false,
+                     "loc": {
+                      "Line": -1,
+                      "Column": -1
+                     },
+                     "data": {
+                      "accessID": 47
+                     },
+                     "ID": 39
+                    }
+                   },
+                   "init": {
+                    "literal_access_expr": {
+                     "value": "0",
+                     "type": {
+                      "type_id": "Double"
+                     },
+                     "loc": {
+                      "Line": -1,
+                      "Column": -1
+                     },
+                     "data": {
+                      "accessID": -72
+                     },
+                     "ID": 38
+                    }
+                   },
+                   "weights": [],
+                   "chain": [
+                    "Edge",
+                    "Cell"
+                   ]
+                  }
+                 },
+                 "loc": {
+                  "Line": -1,
+                  "Column": -1
+                 },
+                 "ID": 62
+                }
+               },
+               "loc": {
+                "Line": -1,
+                "Column": -1
+               },
+               "data": {
+                "accesses": {
+                 "writeAccess": {
+                  "49": {
+                   "zero_extent": {},
+                   "vertical_extent": {
+                    "minus": 0,
+                    "plus": 0,
+                    "undefined": false
+                   }
+                  }
+                 },
+                 "readAccess": {
+                  "47": {
+                   "unstructured_extent": {
+                    "has_extent": true
+                   },
+                   "vertical_extent": {
+                    "minus": 0,
+                    "plus": 0,
+                    "undefined": false
+                   }
+                  },
+                  "-72": {
+                   "zero_extent": {},
+                   "vertical_extent": {
+                    "minus": 0,
+                    "plus": 0,
+                    "undefined": false
+                   }
+                  }
+                 }
+                }
+               },
+               "ID": 63
+              }
+             }
+            ],
+            "loc": {
+             "Line": -1,
+             "Column": -1
+            },
+            "data": {},
+            "ID": 78
+           }
+          },
+          "doMethodID": 3,
+          "interval": {
+           "lower_offset": 0,
+           "upper_offset": 0,
+           "special_lower_level": "Start",
+           "special_upper_level": "End"
+          }
+         }
+        ],
+        "stageID": 77,
+        "locationType": "Edge"
+       }
+      ],
+      "loopOrder": "Forward",
+      "multiStageID": 67,
+      "Caches": {}
+     }
+    ],
+    "stencilID": 50,
+    "attr": {
+     "attributes": []
+    }
+   }
+  ],
+  "controlFlowStatements": [
+   {
+    "stencil_call_decl_stmt": {
+     "stencil_call": {
+      "loc": {
+       "Line": -1,
+       "Column": -1
+      },
+      "callee": "__code_gen_50",
+      "arguments": []
+     },
+     "loc": {
+      "Line": -1,
+      "Column": -1
+     },
+     "data": {},
+     "ID": 51
+    }
+   }
+  ],
+  "boundaryConditions": []
+ },
+ "filename": "tests/stencils/test_reduce.py"
+}

--- a/dawn/test/unit-test/dawn/Optimizer/input/StageMergerTestIndependent.iir
+++ b/dawn/test/unit-test/dawn/Optimizer/input/StageMergerTestIndependent.iir
@@ -1,0 +1,650 @@
+{
+ "metadata": {
+  "accessIDToName": {
+   "48": "cin0",
+   "49": "eout1",
+   "50": "ein1",
+   "45": "eout0",
+   "46": "ein0",
+   "47": "cout0"
+  },
+  "accessIDToType": {
+   "45": 6,
+   "46": 6,
+   "47": 6,
+   "48": 6,
+   "49": 6,
+   "50": 6
+  },
+  "literalIDToName": {
+   "-72": "0",
+   "-71": "0",
+   "-73": "0"
+  },
+  "fieldAccessIDs": [
+   45,
+   46,
+   47,
+   48,
+   49,
+   50
+  ],
+  "APIFieldIDs": [
+   45,
+   46,
+   47,
+   48,
+   49,
+   50
+  ],
+  "temporaryFieldIDs": [],
+  "globalVariableIDs": [],
+  "versionedFields": {
+   "variableVersionMap": {}
+  },
+  "fieldnameToBoundaryCondition": {},
+  "fieldIDtoDimensions": {
+   "45": {
+    "unstructured_horizontal_dimension": {
+     "dense_location_type": "Edge",
+     "sparse_part": []
+    },
+    "mask_k": 0
+   },
+   "46": {
+    "unstructured_horizontal_dimension": {
+     "dense_location_type": "Edge",
+     "sparse_part": []
+    },
+    "mask_k": 0
+   },
+   "47": {
+    "unstructured_horizontal_dimension": {
+     "dense_location_type": "Cell",
+     "sparse_part": []
+    },
+    "mask_k": 0
+   },
+   "48": {
+    "unstructured_horizontal_dimension": {
+     "dense_location_type": "Cell",
+     "sparse_part": []
+    },
+    "mask_k": 0
+   },
+   "49": {
+    "unstructured_horizontal_dimension": {
+     "dense_location_type": "Edge",
+     "sparse_part": []
+    },
+    "mask_k": 0
+   },
+   "50": {
+    "unstructured_horizontal_dimension": {
+     "dense_location_type": "Edge",
+     "sparse_part": []
+    },
+    "mask_k": 0
+   }
+  },
+  "idToStencilCall": {
+   "51": {
+    "stencil_call_decl_stmt": {
+     "stencil_call": {
+      "loc": {
+       "Line": -1,
+       "Column": -1
+      },
+      "callee": "__code_gen_51",
+      "arguments": []
+     },
+     "loc": {
+      "Line": -1,
+      "Column": -1
+     },
+     "data": {},
+     "ID": 52
+    }
+   }
+  },
+  "boundaryCallToExtent": {},
+  "allocatedFieldIDs": [],
+  "stencilLocation": {
+   "Line": -1,
+   "Column": -1
+  },
+  "stencilName": "ws_shallow_water"
+ },
+ "internalIR": {
+  "gridType": "Unstructured",
+  "globalVariableToValue": {},
+  "stencils": [
+   {
+    "multiStages": [
+     {
+      "stages": [
+       {
+        "doMethods": [
+         {
+          "ast": {
+           "block_stmt": {
+            "statements": [
+             {
+              "expr_stmt": {
+               "expr": {
+                "assignment_expr": {
+                 "left": {
+                  "field_access_expr": {
+                   "name": "eout0",
+                   "vertical_shift": 0,
+                   "vertical_indirection": "",
+                   "zero_offset": {},
+                   "argument_map": [
+                    -1,
+                    -1,
+                    -1
+                   ],
+                   "argument_offset": [
+                    0,
+                    0,
+                    0
+                   ],
+                   "negate_offset": false,
+                   "loc": {
+                    "Line": -1,
+                    "Column": -1
+                   },
+                   "data": {
+                    "accessID": 45
+                   },
+                   "ID": 54
+                  }
+                 },
+                 "op": "=",
+                 "right": {
+                  "reduction_over_neighbor_expr": {
+                   "op": "+",
+                   "rhs": {
+                    "field_access_expr": {
+                     "name": "ein0",
+                     "vertical_shift": 0,
+                     "vertical_indirection": "",
+                     "unstructured_offset": {
+                      "has_offset": true
+                     },
+                     "argument_map": [
+                      -1,
+                      -1,
+                      -1
+                     ],
+                     "argument_offset": [
+                      0,
+                      0,
+                      0
+                     ],
+                     "negate_offset": false,
+                     "loc": {
+                      "Line": -1,
+                      "Column": -1
+                     },
+                     "data": {
+                      "accessID": 46
+                     },
+                     "ID": 27
+                    }
+                   },
+                   "init": {
+                    "literal_access_expr": {
+                     "value": "0",
+                     "type": {
+                      "type_id": "Double"
+                     },
+                     "loc": {
+                      "Line": -1,
+                      "Column": -1
+                     },
+                     "data": {
+                      "accessID": -71
+                     },
+                     "ID": 26
+                    }
+                   },
+                   "weights": [],
+                   "chain": [
+                    "Edge",
+                    "Cell",
+                    "Edge"
+                   ]
+                  }
+                 },
+                 "loc": {
+                  "Line": -1,
+                  "Column": -1
+                 },
+                 "ID": 55
+                }
+               },
+               "loc": {
+                "Line": -1,
+                "Column": -1
+               },
+               "data": {
+                "accesses": {
+                 "writeAccess": {
+                  "45": {
+                   "zero_extent": {},
+                   "vertical_extent": {
+                    "minus": 0,
+                    "plus": 0,
+                    "undefined": false
+                   }
+                  }
+                 },
+                 "readAccess": {
+                  "-71": {
+                   "zero_extent": {},
+                   "vertical_extent": {
+                    "minus": 0,
+                    "plus": 0,
+                    "undefined": false
+                   }
+                  },
+                  "46": {
+                   "unstructured_extent": {
+                    "has_extent": true
+                   },
+                   "vertical_extent": {
+                    "minus": 0,
+                    "plus": 0,
+                    "undefined": false
+                   }
+                  }
+                 }
+                }
+               },
+               "ID": 56
+              }
+             }
+            ],
+            "loc": {
+             "Line": -1,
+             "Column": -1
+            },
+            "data": {},
+            "ID": 75
+           }
+          },
+          "doMethodID": 1,
+          "interval": {
+           "lower_offset": 0,
+           "upper_offset": 0,
+           "special_lower_level": "Start",
+           "special_upper_level": "End"
+          }
+         }
+        ],
+        "stageID": 74,
+        "locationType": "Edge"
+       },
+       {
+        "doMethods": [
+         {
+          "ast": {
+           "block_stmt": {
+            "statements": [
+             {
+              "expr_stmt": {
+               "expr": {
+                "assignment_expr": {
+                 "left": {
+                  "field_access_expr": {
+                   "name": "cout0",
+                   "vertical_shift": 0,
+                   "vertical_indirection": "",
+                   "zero_offset": {},
+                   "argument_map": [
+                    -1,
+                    -1,
+                    -1
+                   ],
+                   "argument_offset": [
+                    0,
+                    0,
+                    0
+                   ],
+                   "negate_offset": false,
+                   "loc": {
+                    "Line": -1,
+                    "Column": -1
+                   },
+                   "data": {
+                    "accessID": 47
+                   },
+                   "ID": 58
+                  }
+                 },
+                 "op": "=",
+                 "right": {
+                  "reduction_over_neighbor_expr": {
+                   "op": "+",
+                   "rhs": {
+                    "field_access_expr": {
+                     "name": "cin0",
+                     "vertical_shift": 0,
+                     "vertical_indirection": "",
+                     "unstructured_offset": {
+                      "has_offset": true
+                     },
+                     "argument_map": [
+                      -1,
+                      -1,
+                      -1
+                     ],
+                     "argument_offset": [
+                      0,
+                      0,
+                      0
+                     ],
+                     "negate_offset": false,
+                     "loc": {
+                      "Line": -1,
+                      "Column": -1
+                     },
+                     "data": {
+                      "accessID": 48
+                     },
+                     "ID": 33
+                    }
+                   },
+                   "init": {
+                    "literal_access_expr": {
+                     "value": "0",
+                     "type": {
+                      "type_id": "Double"
+                     },
+                     "loc": {
+                      "Line": -1,
+                      "Column": -1
+                     },
+                     "data": {
+                      "accessID": -72
+                     },
+                     "ID": 32
+                    }
+                   },
+                   "weights": [],
+                   "chain": [
+                    "Cell",
+                    "Edge",
+                    "Cell"
+                   ]
+                  }
+                 },
+                 "loc": {
+                  "Line": -1,
+                  "Column": -1
+                 },
+                 "ID": 59
+                }
+               },
+               "loc": {
+                "Line": -1,
+                "Column": -1
+               },
+               "data": {
+                "accesses": {
+                 "writeAccess": {
+                  "47": {
+                   "zero_extent": {},
+                   "vertical_extent": {
+                    "minus": 0,
+                    "plus": 0,
+                    "undefined": false
+                   }
+                  }
+                 },
+                 "readAccess": {
+                  "48": {
+                   "unstructured_extent": {
+                    "has_extent": true
+                   },
+                   "vertical_extent": {
+                    "minus": 0,
+                    "plus": 0,
+                    "undefined": false
+                   }
+                  },
+                  "-72": {
+                   "zero_extent": {},
+                   "vertical_extent": {
+                    "minus": 0,
+                    "plus": 0,
+                    "undefined": false
+                   }
+                  }
+                 }
+                }
+               },
+               "ID": 60
+              }
+             }
+            ],
+            "loc": {
+             "Line": -1,
+             "Column": -1
+            },
+            "data": {},
+            "ID": 77
+           }
+          },
+          "doMethodID": 2,
+          "interval": {
+           "lower_offset": 0,
+           "upper_offset": 0,
+           "special_lower_level": "Start",
+           "special_upper_level": "End"
+          }
+         }
+        ],
+        "stageID": 76,
+        "locationType": "Cell"
+       },
+       {
+        "doMethods": [
+         {
+          "ast": {
+           "block_stmt": {
+            "statements": [
+             {
+              "expr_stmt": {
+               "expr": {
+                "assignment_expr": {
+                 "left": {
+                  "field_access_expr": {
+                   "name": "eout1",
+                   "vertical_shift": 0,
+                   "vertical_indirection": "",
+                   "zero_offset": {},
+                   "argument_map": [
+                    -1,
+                    -1,
+                    -1
+                   ],
+                   "argument_offset": [
+                    0,
+                    0,
+                    0
+                   ],
+                   "negate_offset": false,
+                   "loc": {
+                    "Line": -1,
+                    "Column": -1
+                   },
+                   "data": {
+                    "accessID": 49
+                   },
+                   "ID": 62
+                  }
+                 },
+                 "op": "=",
+                 "right": {
+                  "reduction_over_neighbor_expr": {
+                   "op": "+",
+                   "rhs": {
+                    "field_access_expr": {
+                     "name": "ein1",
+                     "vertical_shift": 0,
+                     "vertical_indirection": "",
+                     "unstructured_offset": {
+                      "has_offset": true
+                     },
+                     "argument_map": [
+                      -1,
+                      -1,
+                      -1
+                     ],
+                     "argument_offset": [
+                      0,
+                      0,
+                      0
+                     ],
+                     "negate_offset": false,
+                     "loc": {
+                      "Line": -1,
+                      "Column": -1
+                     },
+                     "data": {
+                      "accessID": 50
+                     },
+                     "ID": 39
+                    }
+                   },
+                   "init": {
+                    "literal_access_expr": {
+                     "value": "0",
+                     "type": {
+                      "type_id": "Double"
+                     },
+                     "loc": {
+                      "Line": -1,
+                      "Column": -1
+                     },
+                     "data": {
+                      "accessID": -73
+                     },
+                     "ID": 38
+                    }
+                   },
+                   "weights": [],
+                   "chain": [
+                    "Edge",
+                    "Cell",
+                    "Edge"
+                   ]
+                  }
+                 },
+                 "loc": {
+                  "Line": -1,
+                  "Column": -1
+                 },
+                 "ID": 63
+                }
+               },
+               "loc": {
+                "Line": -1,
+                "Column": -1
+               },
+               "data": {
+                "accesses": {
+                 "writeAccess": {
+                  "49": {
+                   "zero_extent": {},
+                   "vertical_extent": {
+                    "minus": 0,
+                    "plus": 0,
+                    "undefined": false
+                   }
+                  }
+                 },
+                 "readAccess": {
+                  "50": {
+                   "unstructured_extent": {
+                    "has_extent": true
+                   },
+                   "vertical_extent": {
+                    "minus": 0,
+                    "plus": 0,
+                    "undefined": false
+                   }
+                  },
+                  "-73": {
+                   "zero_extent": {},
+                   "vertical_extent": {
+                    "minus": 0,
+                    "plus": 0,
+                    "undefined": false
+                   }
+                  }
+                 }
+                }
+               },
+               "ID": 64
+              }
+             }
+            ],
+            "loc": {
+             "Line": -1,
+             "Column": -1
+            },
+            "data": {},
+            "ID": 79
+           }
+          },
+          "doMethodID": 3,
+          "interval": {
+           "lower_offset": 0,
+           "upper_offset": 0,
+           "special_lower_level": "Start",
+           "special_upper_level": "End"
+          }
+         }
+        ],
+        "stageID": 78,
+        "locationType": "Edge"
+       }
+      ],
+      "loopOrder": "Forward",
+      "multiStageID": 68,
+      "Caches": {}
+     }
+    ],
+    "stencilID": 51,
+    "attr": {
+     "attributes": []
+    }
+   }
+  ],
+  "controlFlowStatements": [
+   {
+    "stencil_call_decl_stmt": {
+     "stencil_call": {
+      "loc": {
+       "Line": -1,
+       "Column": -1
+      },
+      "callee": "__code_gen_51",
+      "arguments": []
+     },
+     "loc": {
+      "Line": -1,
+      "Column": -1
+     },
+     "data": {},
+     "ID": 52
+    }
+   }
+  ],
+  "boundaryConditions": []
+ },
+ "filename": "tests/stencils/test_reduce.py"
+}

--- a/dawn/test/unit-test/dawn/Optimizer/samples/StageMergerIndependent.py
+++ b/dawn/test/unit-test/dawn/Optimizer/samples/StageMergerIndependent.py
@@ -1,0 +1,15 @@
+from dusk.script import *
+
+@stencil
+def independent(
+    eout0: Field[Edge],    
+    ein0: Field[Edge],    
+    cout0: Field[Cell],    
+    cin0: Field[Cell],    
+    eout1: Field[Edge],    
+    ein1: Field[Edge],    
+):
+    with levels_upward:        
+        eout0 = sum_over(Edge > Cell > Edge, ein0[Edge > Cell > Edge])
+        cout0 = sum_over(Cell > Edge > Cell, cin0[Cell > Edge > Cell])
+        eout1 = sum_over(Edge > Cell > Edge, ein1[Edge > Cell > Edge])

--- a/dawn/test/unit-test/dawn/Optimizer/samples/StagemergerDependent.py
+++ b/dawn/test/unit-test/dawn/Optimizer/samples/StagemergerDependent.py
@@ -1,0 +1,14 @@
+from dusk.script import *
+
+@stencil
+def dependent(
+    eout0: Field[Edge],    
+    ein0: Field[Edge],    
+    cout0: Field[Cell],    
+    cin0: Field[Cell],    
+    eout1: Field[Edge],        
+):
+    with levels_upward:        
+        eout0 = sum_over(Edge > Cell > Edge, ein0[Edge > Cell > Edge])
+        cout0 = sum_over(Cell > Edge > Cell, cin0[Cell > Edge > Cell])
+        eout1 = sum_over(Edge > Cell, cout0)


### PR DESCRIPTION
## Technical Description

When the stage merger encountered a candidate stage not on the same location as the current stage, it would simply proceed to the next stage further above. However, this is only legal if the stage to be skipped is independent of the current stage. 

### Resolves / Enhances

Fixes #1053

### Example

Consider this Example
```
        eout0 = sum_over(Edge > Cell > Edge, ein0[Edge > Cell > Edge])
        cout0 = sum_over(Cell > Edge > Cell, cin0[Cell > Edge > Cell])
        eout1 = sum_over(Edge > Cell, cout0)
```
here, `eout1` depends on `cout0`. We are thus not allowed to merge the last stage into the very first 

Consider on the other hand:
```
        eout0 = sum_over(Edge > Cell > Edge, ein0[Edge > Cell > Edge])
        cout0 = sum_over(Cell > Edge > Cell, cin0[Cell > Edge > Cell])
        eout1 = sum_over(Edge > Cell > Edge, ein1[Edge > Cell > Edge]) 
```
here, the stage in the middle is completely independent of stage number 3. The stage merger is thus allowed to proceed to look for other candidates to merge with further above. Indeed, we expect this to be merged as follows:
```
stage 0:
  eout0 = ...
  eout1 = ...
stage 1:
  cout0 = ...
```

### Testing

Tests reflecting the two examples above have been introduced

### Dependencies

This PR is independent. 


