### PR TITLE
Fix rank calculation in F90 interface generator

### DIFF
--- a/dawn/src/dawn/CodeGen/Cuda-ico/CudaIcoCodeGen.cpp
+++ b/dawn/src/dawn/CodeGen/Cuda-ico/CudaIcoCodeGen.cpp
@@ -1158,18 +1158,13 @@ generateF90InterfaceSI(FortranInterfaceModuleGen& fimGen,
     api.addArg("mesh", FortranInterfaceAPI::InterfaceType::OBJ);
     api.addArg("k_size", FortranInterfaceAPI::InterfaceType::INTEGER);
     for(auto fieldID : stencilInstantiation->getMetaData().getAPIFields()) {
-      const int spatialDims =
-          stencilInstantiation->getMetaData().getFieldDimensions(fieldID).numSpatialDimensions();
-      const int n = spatialDims > 1
-                        ? spatialDims - 1 // The horizontal counts as 1 dimension (dense)
-                        : spatialDims;
 
       api.addArg(
           stencilInstantiation->getMetaData().getNameFromAccessID(fieldID),
           FortranInterfaceAPI::InterfaceType::DOUBLE /* Unfortunately we need to know at codegen
                                                         time whether we have fields in SP/DP */
           ,
-          n);
+          stencilInstantiation->getMetaData().getFieldDimensions(fieldID).rank());
     }
 
     fimGen.addAPI(std::move(api));

--- a/dawn/src/dawn/SIR/SIR.cpp
+++ b/dawn/src/dawn/SIR/SIR.cpp
@@ -650,6 +650,22 @@ int FieldDimensions::numSpatialDimensions() const {
   }
 }
 
+int FieldDimensions::rank() const {
+  const int spatialDims = numSpatialDimensions();
+  int rank;
+  if(sir::dimension_isa<sir::UnstructuredFieldDimension>(getHorizontalFieldDimension())) {
+    rank = spatialDims > 1 ? spatialDims - 1 // The horizontal counts as 1 dimension (dense)
+                           : spatialDims;
+    // Need to account for sparse dimension, if present
+    if(sir::dimension_cast<sir::UnstructuredFieldDimension const&>(getHorizontalFieldDimension())
+           .isSparse()) {
+      ++rank;
+    }
+  } else { // Cartesian
+    rank = spatialDims;
+  }
+  return rank;
+}
 } // namespace sir
 
 std::ostream& operator<<(std::ostream& os, const SIR& Sir) {

--- a/dawn/src/dawn/SIR/SIR.cpp
+++ b/dawn/src/dawn/SIR/SIR.cpp
@@ -652,6 +652,9 @@ int FieldDimensions::numSpatialDimensions() const {
 
 int FieldDimensions::rank() const {
   const int spatialDims = numSpatialDimensions();
+  if(isVertical()) {
+    return 1;
+  }
   int rank;
   if(sir::dimension_isa<sir::UnstructuredFieldDimension>(getHorizontalFieldDimension())) {
     rank = spatialDims > 1 ? spatialDims - 1 // The horizontal counts as 1 dimension (dense)

--- a/dawn/src/dawn/SIR/SIR.h
+++ b/dawn/src/dawn/SIR/SIR.h
@@ -313,6 +313,9 @@ public:
   // returns number of dimensions (1-3)
   int numSpatialDimensions() const;
 
+  // returns the rank of the corresponding storage (multidimensional array)
+  int rank() const;
+
 private:
   std::optional<HorizontalFieldDimension> horizontalFieldDimension_;
   bool maskK_;


### PR DESCRIPTION
## Technical Description

As the title says, before it was not counting the sparse dimension. Rank computation moved inside `FieldDimensions`.

### Testing
Testing through icondusk-e2e PR: https://github.com/dawn-ico/icondusk-e2e/pull/34
