### PR TITLE
Introduce Persistent Temporary Fields and Mesh to the Cuda Backend

### DIFF
--- a/dawn/src/dawn/AST/ASTExpr.h
+++ b/dawn/src/dawn/AST/ASTExpr.h
@@ -647,7 +647,7 @@ private:
   // due to current design limitations (getChildren() returning a view into memory), the operands
   // hold a copy of the (shared pointer to) the weights
   std::vector<std::shared_ptr<Expr>> operands_ = std::vector<std::shared_ptr<Expr>>(2);
-  bool chainIsValid() const;
+  bool chainIsValid() const;  
 
 public:
   /// @name Constructor & Destructor

--- a/dawn/src/dawn/CodeGen/Cuda-ico/CudaIcoCodeGen.cpp
+++ b/dawn/src/dawn/CodeGen/Cuda-ico/CudaIcoCodeGen.cpp
@@ -880,13 +880,11 @@ void CudaIcoCodeGen::generateStaticMembersTrailer(
                           .getAccessesOfType<iir::FieldAccessType::InterStencilTemporary,
                                              iir::FieldAccessType::StencilTemporary>()) {
     auto fname = stencil->getMetadata().getFieldNameFromAccessID(accessID);
-    ssSW << "::dawn::float_type *dawn_generated::cuda_ico::" << fullStencilName << "::" << fname
-         << "_;\n";
+    ssSW << "::dawn::float_type *" << fullStencilName << "::" << fname << "_;\n";
   }
-  ssSW << "int dawn_generated::cuda_ico::" << fullStencilName << "::"
+  ssSW << "int " << fullStencilName << "::"
        << "kSize_;\n";
-  ssSW << "dawn_generated::cuda_ico::interpolation_sph::GpuTriMesh dawn_generated::cuda_ico::"
-       << fullStencilName << "::"
+  ssSW << "dawn_generated::cuda_ico::interpolation_sph::GpuTriMesh " << fullStencilName << "::"
        << "mesh_;\n";
 }
 

--- a/dawn/src/dawn/CodeGen/Cuda-ico/CudaIcoCodeGen.cpp
+++ b/dawn/src/dawn/CodeGen/Cuda-ico/CudaIcoCodeGen.cpp
@@ -858,6 +858,9 @@ void CudaIcoCodeGen::generateMemMgmtFunctions(
     setupFun.addStatement(fullStencilName + "::setup(mesh, k_size)");
   }
   setupFun.commit();
+  if(onlyDecl) {
+    ssSW << ";";
+  }
 
   MemberFunction freeFun("void", "free_" + wrapperName, ssSW, 0, onlyDecl);
   freeFun.finishArgs();
@@ -866,6 +869,9 @@ void CudaIcoCodeGen::generateMemMgmtFunctions(
     freeFun.addStatement(fullStencilName + "::free()");
   }
   freeFun.commit();
+  if(onlyDecl) {
+    ssSW << ";";
+  }
 }
 
 void CudaIcoCodeGen::generateStaticMembersTrailer(

--- a/dawn/src/dawn/CodeGen/Cuda-ico/CudaIcoCodeGen.cpp
+++ b/dawn/src/dawn/CodeGen/Cuda-ico/CudaIcoCodeGen.cpp
@@ -175,7 +175,6 @@ void CudaIcoCodeGen::generateRunFun(
 
   const auto& globalsMap = stencilInstantiation->getIIR()->getGlobalVariableMap();
 
-  // runFun.addBlockStatement();
   runFun.addBlockStatement("if (!is_setup_)", [&]() {
     std::string stencilName = stencilInstantiation->getName();
     runFun.addStatement("printf(\"" + stencilName +

--- a/dawn/src/dawn/CodeGen/Cuda-ico/CudaIcoCodeGen.cpp
+++ b/dawn/src/dawn/CodeGen/Cuda-ico/CudaIcoCodeGen.cpp
@@ -1111,8 +1111,8 @@ std::string CudaIcoCodeGen::generateStencilInstantiation(
   generateAllAPIRunFunctions(ssSW, stencilInstantiation, codeGenProperties, fromHost);
   generateAllAPIRunFunctions(ssSW, stencilInstantiation, codeGenProperties, !fromHost);
   generateMemMgmtFunctions(ssSW, stencilInstantiation, codeGenProperties);
-  generateStaticMembersTrailer(ssSW, stencilInstantiation, codeGenProperties);
   ssSW << "}\n";
+  generateStaticMembersTrailer(ssSW, stencilInstantiation, codeGenProperties);
 
   return ssSW.str();
 }

--- a/dawn/src/dawn/CodeGen/Cuda-ico/CudaIcoCodeGen.cpp
+++ b/dawn/src/dawn/CodeGen/Cuda-ico/CudaIcoCodeGen.cpp
@@ -144,8 +144,8 @@ void CudaIcoCodeGen::generateGpuMesh(
   }
   {
     auto gpuMeshDefaultCtor = gpuMeshClass.addConstructor();
-    gpuMeshDafultCtor.startBody();
-    gpuMeshDafultCtor.commit();
+    gpuMeshDefaultCtor.startBody();
+    gpuMeshDefaultCtor.commit();
   }
   {
     auto gpuMeshFromGlobalCtor = gpuMeshClass.addConstructor();
@@ -739,22 +739,16 @@ void CudaIcoCodeGen::generateAllAPIRunFunctions(
       if(!globalsMap.empty()) {
         apiRunFuns[0]->addArg("globals globals");
       }
-      addExplodedGlobals(globalsMap, *apiRunFuns[1]);
-      for(auto& apiRunFun : apiRunFuns) {
-        for(auto accessID : stencilInstantiation->getMetaData().getAPIFields()) {
-          apiRunFun->addArg("::dawn::float_type *" +
-                            stencilInstantiation->getMetaData().getNameFromAccessID(accessID));
-        }
-      }
+      addExplodedGlobals(globalsMap, *apiRunFuns[1]);      
     } else {
       addExplodedGlobals(globalsMap, *apiRunFuns[0]);
-      for(auto& apiRunFun : apiRunFuns) {
+    }
+    for(auto& apiRunFun : apiRunFuns) {
         for(auto accessID : stencilInstantiation->getMetaData().getAPIFields()) {
           apiRunFun->addArg("::dawn::float_type *" +
                             stencilInstantiation->getMetaData().getNameFromAccessID(accessID));
         }
       }
-    }
     for(auto& apiRunFun : apiRunFuns) {
       apiRunFun->finishArgs();
     }
@@ -858,11 +852,11 @@ void CudaIcoCodeGen::generateAllAPIRunFunctions(
       }
 
     } else {
-      for(auto& apiRunFun : apiRunFuns) {
-        apiRunFun->commit();
-      }
       for(const auto& stream : apiRunFunStreams) {
         ssSW << stream.str() << ";\n";
+      }
+      for(auto& apiRunFun : apiRunFuns) {
+        apiRunFun->commit();
       }
     }
   }
@@ -884,10 +878,10 @@ void CudaIcoCodeGen::generateMemMgmtFunctions(
   if(!onlyDecl) {
     setupFun.addStatement(fullStencilName + "::setup(mesh, k_size)");
   }
-  setupFun.commit();
   if(onlyDecl) {
     ssSW << ";";
   }
+  setupFun.commit();
 
   MemberFunction freeFun("void", "free_" + wrapperName, ssSW, 0, onlyDecl);
   freeFun.finishArgs();
@@ -895,10 +889,10 @@ void CudaIcoCodeGen::generateMemMgmtFunctions(
     freeFun.startBody();
     freeFun.addStatement(fullStencilName + "::free()");
   }
-  freeFun.commit();
   if(onlyDecl) {
     ssSW << ";";
   }
+  freeFun.commit();
 }
 
 void CudaIcoCodeGen::generateStaticMembersTrailer(
@@ -1191,7 +1185,7 @@ generateF90InterfaceSI(FortranInterfaceModuleGen& fimGen,
   auto globalTypeToFortType = [](const sir::Global& global) {
     switch(global.getType()) {
     case sir::Value::Kind::Boolean:
-      return FortranInterfaceAPI::InterfaceType::CHAR;
+      return FortranInterfaceAPI::InterfaceType::BOOLEAN;
     case sir::Value::Kind::Double:
       return FortranInterfaceAPI::InterfaceType::DOUBLE;
     case sir::Value::Kind::Float:

--- a/dawn/src/dawn/CodeGen/Cuda-ico/CudaIcoCodeGen.cpp
+++ b/dawn/src/dawn/CodeGen/Cuda-ico/CudaIcoCodeGen.cpp
@@ -739,7 +739,9 @@ void CudaIcoCodeGen::generateAllAPIRunFunctions(
         apiRunFun->addArg("dawn::GlobalGpuTriMesh *mesh");
         apiRunFun->addArg("int k_size");
       }
-      apiRunFuns[0]->addArg("globals globals");
+      if(!globalsMap.empty()) {
+        apiRunFuns[0]->addArg("globals globals");
+      }
       addExplodedGlobals(globalsMap, *apiRunFuns[1]);
       for(auto& apiRunFun : apiRunFuns) {
         for(auto accessID : stencilInstantiation->getMetaData().getAPIFields()) {

--- a/dawn/src/dawn/CodeGen/Cuda-ico/CudaIcoCodeGen.cpp
+++ b/dawn/src/dawn/CodeGen/Cuda-ico/CudaIcoCodeGen.cpp
@@ -414,6 +414,7 @@ static void allocTempFields(MemberFunction& ctor, const iir::Stencil& stencil, P
 }
 
 void CudaIcoCodeGen::generateStencilFree(MemberFunction& stencilFree, const iir::Stencil& stencil) {
+  stencilFree.startBody();
   for(auto accessID : stencil.getMetadata()
                           .getAccessesOfType<iir::FieldAccessType::InterStencilTemporary,
                                              iir::FieldAccessType::StencilTemporary>()) {

--- a/dawn/src/dawn/CodeGen/Cuda-ico/CudaIcoCodeGen.cpp
+++ b/dawn/src/dawn/CodeGen/Cuda-ico/CudaIcoCodeGen.cpp
@@ -643,10 +643,7 @@ void CudaIcoCodeGen::generateStencilClasses(
       stencilClass.addMember("globals", "m_globals");
     }
 
-    // constructor from library
-    // auto stencilClassConstructor = stencilClass.addConstructor();
-    // generateStencilClassCtr(stencilClassConstructor, stencil, globalsMap, codeGenProperties);
-    // stencilClassConstructor.commit();
+    // constructor from library    
     auto stencilClassFree = stencilClass.addMemberFunction("static void", "free");
     generateStencilFree(stencilClassFree, stencil);
     stencilClassFree.commit();

--- a/dawn/src/dawn/CodeGen/Cuda-ico/CudaIcoCodeGen.cpp
+++ b/dawn/src/dawn/CodeGen/Cuda-ico/CudaIcoCodeGen.cpp
@@ -853,12 +853,14 @@ void CudaIcoCodeGen::generateMemMgmtFunctions(
   MemberFunction setupFun("void", "setup_" + wrapperName, ssSW, 0, onlyDecl);
   setupFun.addArg("dawn::GlobalGpuTriMesh *mesh");
   setupFun.addArg("int k_size");
+  setupFun.finishArgs();
   if(!onlyDecl) {
     setupFun.addStatement(fullStencilName + "::setup(mesh, k_size)");
   }
   setupFun.commit();
 
   MemberFunction freeFun("void", "free_" + wrapperName, ssSW, 0, onlyDecl);
+  freeFun.finishArgs();
   if(!onlyDecl) {
     freeFun.startBody();
     freeFun.addStatement(fullStencilName + "::free()");

--- a/dawn/src/dawn/CodeGen/Cuda-ico/CudaIcoCodeGen.cpp
+++ b/dawn/src/dawn/CodeGen/Cuda-ico/CudaIcoCodeGen.cpp
@@ -884,7 +884,7 @@ void CudaIcoCodeGen::generateStaticMembersTrailer(
   }
   ssSW << "int " << fullStencilName << "::"
        << "kSize_;\n";
-  ssSW << "dawn_generated::cuda_ico::interpolation_sph::GpuTriMesh " << fullStencilName << "::"
+  ssSW << "dawn_generated::cuda_ico::" + wrapperName << "::GpuTriMesh " << fullStencilName << "::"
        << "mesh_;\n";
 }
 

--- a/dawn/src/dawn/CodeGen/Cuda-ico/CudaIcoCodeGen.cpp
+++ b/dawn/src/dawn/CodeGen/Cuda-ico/CudaIcoCodeGen.cpp
@@ -1240,7 +1240,7 @@ generateF90InterfaceSI(FortranInterfaceModuleGen& fimGen,
   }
 
   // memory management functions for production interface
-  FortranInterfaceAPI setup("setup_" + stencilInstantiation->getName(), std::nullopt);
+  FortranInterfaceAPI setup("setup_" + stencilInstantiation->getName());
   FortranInterfaceAPI free("free_" + stencilInstantiation->getName());
   setup.addArg("mesh", FortranInterfaceAPI::InterfaceType::OBJ);
   setup.addArg("k_size", FortranInterfaceAPI::InterfaceType::INTEGER);

--- a/dawn/src/dawn/CodeGen/Cuda-ico/CudaIcoCodeGen.cpp
+++ b/dawn/src/dawn/CodeGen/Cuda-ico/CudaIcoCodeGen.cpp
@@ -1241,7 +1241,7 @@ generateF90InterfaceSI(FortranInterfaceModuleGen& fimGen,
 
   // memory management functions for production interface
   FortranInterfaceAPI setup("setup_" + stencilInstantiation->getName(), std::nullopt);
-  FortranInterfaceAPI free("free_" + stencilInstantiation->getName(), std::nullopt);
+  FortranInterfaceAPI free("free_" + stencilInstantiation->getName());
   setup.addArg("mesh", FortranInterfaceAPI::InterfaceType::OBJ);
   setup.addArg("k_size", FortranInterfaceAPI::InterfaceType::INTEGER);
 

--- a/dawn/src/dawn/CodeGen/Cuda-ico/CudaIcoCodeGen.h
+++ b/dawn/src/dawn/CodeGen/Cuda-ico/CudaIcoCodeGen.h
@@ -78,6 +78,16 @@ private:
                              CodeGenProperties& codeGenProperties, bool fromHost,
                              bool onlyDecl = false) const;
 
+  void
+  generateMemMgmtFunctions(std::stringstream& ssSW,
+                           const std::shared_ptr<iir::StencilInstantiation>& stencilInstantiation,
+                           CodeGenProperties& codeGenProperties, bool onlyDecl = false) const;
+
+  void generateStaticMembersTrailer(
+      std::stringstream& ssSW,
+      const std::shared_ptr<iir::StencilInstantiation>& stencilInstantiation,
+      CodeGenProperties& codeGenProperties) const;
+
   void generateGpuMesh(const std::shared_ptr<iir::StencilInstantiation>& stencilInstantiation,
                        Class& stencilWrapperClass, CodeGenProperties& codeGenProperties);
 
@@ -86,18 +96,8 @@ private:
 
   void generateGridFun(MemberFunction& runFun);
 
-  void generateStencilClassCtr(MemberFunction& stencilClassCtor, const iir::Stencil& stencil,
-                               const sir::GlobalVariableMap& globalsMap,
-                               CodeGenProperties& codeGenProperties) const;
-
-  void generateStencilClassDtr(MemberFunction& stencilClassDtor, const iir::Stencil& stencil);
-
-  void generateStencilClassCtrMinimal(MemberFunction& stencilClassCtor, const iir::Stencil& stencil,
-                                      const sir::GlobalVariableMap& globalsMap,
-                                      CodeGenProperties& codeGenProperties) const;
-
-  void generateStencilClassRawPtrCtr(MemberFunction& stencilClassCtor, const iir::Stencil& stencil,
-                                     CodeGenProperties& codeGenProperties) const;
+  void generateStencilFree(MemberFunction& stencilClassDtor, const iir::Stencil& stencil);
+  void generateStencilSetup(MemberFunction& stencilClassDtor, const iir::Stencil& stencil);
 
   void generateCopyBackFun(MemberFunction& copyBackFun, const iir::Stencil& stencil,
                            bool rawPtrs) const;

--- a/dawn/src/dawn/CodeGen/F90Util.h
+++ b/dawn/src/dawn/CodeGen/F90Util.h
@@ -105,7 +105,10 @@ protected:
   void streamInterface(IndentedStringStream& ss) const {
     bool isFunction = returnType_ != "";
     ss << (isFunction ? returnType_ + " function" : std::string("subroutine")) << " &" << endline;
-    ss << name_ << "( &";
+    ss << name_ << "( ";
+    if(args_.size() > 0) {
+      ss << "&";
+    }
     {
       std::string sep;
       for(const auto& arg : args_) {
@@ -113,7 +116,9 @@ protected:
         sep = ", &";
       }
     }
-    ss << " &" << endline;
+    if(args_.size() > 0) {
+      ss << " &" << endline;
+    }
     ss << ") bind(c)" << endline;
 
     ss.increaseIndent();

--- a/dawn/src/dawn/CodeGen/F90Util.h
+++ b/dawn/src/dawn/CodeGen/F90Util.h
@@ -130,7 +130,20 @@ protected:
       if(std::get<2>(arg) == 0) {
         ss << "value";
       } else {
-        ss << "dimension(*)";               
+        ss << "dimension(*)";
+        // NOTE: this is what we would want. However, this leads to seg faults when being called
+        //       from  a FORTRAN host (but not with OpenACC ptrs for reasons currentyl not well
+        //       understood). We can re-introduce rank safety on the wrap() / verify() level
+        //
+        // ss << "dimension(";
+        // {
+        //   std::string sep;
+        //   for(int c = 0; c < std::get<2>(arg); ++c) {
+        //     ss << sep << ":";
+        //     sep = ",";
+        //   }
+        // }
+        // ss << ")";
       }
       ss << ", target :: " << std::get<0>(arg) << endline;
     });

--- a/dawn/src/dawn/CodeGen/F90Util.h
+++ b/dawn/src/dawn/CodeGen/F90Util.h
@@ -128,15 +128,7 @@ protected:
       if(std::get<2>(arg) == 0) {
         ss << "value";
       } else {
-        ss << "dimension(";
-        {
-          std::string sep;
-          for(int c = 0; c < std::get<2>(arg); ++c) {
-            ss << sep << ":";
-            sep = ",";
-          }
-        }
-        ss << ")";
+        ss << "dimension(*)";               
       }
       ss << ", target :: " << std::get<0>(arg) << endline;
     });

--- a/dawn/src/dawn/CodeGen/F90Util.h
+++ b/dawn/src/dawn/CodeGen/F90Util.h
@@ -74,7 +74,7 @@ public:
 
 class FortranInterfaceAPI {
 public:
-  enum class InterfaceType { INTEGER, FLOAT, DOUBLE, CHAR, OBJ };
+  enum class InterfaceType { INTEGER, FLOAT, DOUBLE, CHAR, BOOLEAN, OBJ };
   FortranInterfaceAPI(std::string name, std::optional<InterfaceType> returnType = std::nullopt)
       : name_(name) {
     if(returnType) {
@@ -96,6 +96,8 @@ protected:
       return "real(c_float)";
     case InterfaceType::CHAR:
       return "character(kind=c_char)";
+    case InterfaceType::BOOLEAN:
+      return "logical(c_bool)";
     case InterfaceType::OBJ:
       return "type(c_ptr)";
     }

--- a/dawn/test/integration-test/unstructured/GenerateUnstructuredStencils.cpp
+++ b/dawn/test/integration-test/unstructured/GenerateUnstructuredStencils.cpp
@@ -1161,8 +1161,9 @@ int main() {
                                                b.stmt(b.assignExpr(b.at(c_f), b.lit(1.))))),
             b.stage(LocType::Edges, b.doMethod(dawn::sir::Interval::Start, dawn::sir::Interval::End,
                                                b.stmt(b.assignExpr(b.at(e_f), b.lit(1.))))),
-            b.stage(LocType::Vertices, b.doMethod(dawn::sir::Interval::Start, dawn::sir::Interval::End,
-                                               b.stmt(b.assignExpr(b.at(v_f), b.lit(1.))))))));
+            b.stage(LocType::Vertices,
+                    b.doMethod(dawn::sir::Interval::Start, dawn::sir::Interval::End,
+                               b.stmt(b.assignExpr(b.at(v_f), b.lit(1.))))))));
 
     std::ofstream of("generated/generated_" + stencilName + ".hpp");
     DAWN_ASSERT_MSG(of, "couldn't open output file!\n");


### PR DESCRIPTION
## Technical Description

Currently, temporary fields are allocated in the constructor of the generated class. Since the API functions to the FORTRAN and cpp drivers hold the stencil on the stack, this leads to memory (de-)allocation on each call. This is fine for debugging, but not for production runs. Thus, this PR keeps that behavior for the convenience wrappers starting from host memory, but introduces static `setup` and `free` functions which have to be called by the host when using the production interface which assumes device pointers. 

Additionally, since the APIs are touched either way, globals can now be communicated from FORTRAN to the CUDA backend. 

Furthermore this PR contains a small refactoring and removes the (now) superfluous template parameter from the generated stencil class

### Resolves / Enhances

Addresses part of #1038 
Fixes #1042
### Testing

Since this affects the CUDA-ico backend this is tested by `icondusk-e2e`


