### PR TITLE
Made const visitor enforce constness of inner type of shared_ptr<T>

### DIFF
--- a/dawn/src/dawn/AST/ASTExpr.cpp
+++ b/dawn/src/dawn/AST/ASTExpr.cpp
@@ -397,7 +397,7 @@ void FieldAccessExpr::setPureOffset(const Offsets& offset) {
   argumentOffset_ = Array3i{{0, 0, 0}};
 }
 
-ArrayRef<std::shared_ptr<Expr>> FieldAccessExpr::getChildren() {
+ArrayRef<std::shared_ptr<Expr>> FieldAccessExpr::getChildren() const {
   if(offset_.hasVerticalIndirection()) {
     return ExprRangeType(offset_.getVerticalIndirectionFieldAsExpr());
   }
@@ -493,7 +493,7 @@ std::shared_ptr<Expr> ReductionOverNeighborExpr::clone() const {
   return std::make_shared<ReductionOverNeighborExpr>(*this);
 }
 
-ArrayRef<std::shared_ptr<Expr>> ReductionOverNeighborExpr::getChildren() {
+ArrayRef<std::shared_ptr<Expr>> ReductionOverNeighborExpr::getChildren() const {
   return ExprRangeType(operands_);
 } // namespace ast
 

--- a/dawn/src/dawn/AST/ASTExpr.h
+++ b/dawn/src/dawn/AST/ASTExpr.h
@@ -69,7 +69,7 @@ public:
   /// @}
 
   /// @brief Hook for Visitors
-  virtual void accept(ASTVisitor& visitor) = 0;
+  virtual void accept(ASTVisitor& visitor) const = 0;
   virtual void accept(ASTVisitorNonConst& visitor) = 0;
   virtual std::shared_ptr<Expr> acceptAndReplace(ASTVisitorPostOrder& visitor) = 0;
 
@@ -83,7 +83,7 @@ public:
   const SourceLocation& getSourceLocation() const { return loc_; }
 
   /// @brief Iterate children (if any)
-  virtual ExprRangeType getChildren() { return ExprRangeType(); }
+  virtual ExprRangeType getChildren() const { return ExprRangeType(); }
 
   virtual void replaceChildren(const std::shared_ptr<Expr>& old_,
                                const std::shared_ptr<Expr>& new_) {
@@ -150,7 +150,7 @@ public:
   virtual std::shared_ptr<Expr> clone() const override;
   virtual bool equals(const Expr* other, bool compareData = true) const override;
   static bool classof(const Expr* expr) { return expr->getKind() == Kind::UnaryOperator; }
-  virtual ExprRangeType getChildren() override { return ExprRangeType(operand_); }
+  virtual ExprRangeType getChildren() const override { return ExprRangeType(operand_); }
   virtual void replaceChildren(const std::shared_ptr<Expr>& oldExpr,
                                const std::shared_ptr<Expr>& newExpr) override;
   ACCEPTVISITOR(Expr, UnaryOperator)
@@ -191,7 +191,7 @@ public:
   virtual std::shared_ptr<Expr> clone() const override;
   virtual bool equals(const Expr* other, bool compareData = true) const override;
   static bool classof(const Expr* expr) { return expr->getKind() == Kind::BinaryOperator; }
-  virtual ExprRangeType getChildren() override { return ExprRangeType(operands_); }
+  virtual ExprRangeType getChildren() const override { return ExprRangeType(operands_); }
   virtual void replaceChildren(const std::shared_ptr<Expr>& oldExpr,
                                const std::shared_ptr<Expr>& newExpr) override;
 
@@ -282,7 +282,7 @@ public:
   virtual std::shared_ptr<Expr> clone() const override;
   virtual bool equals(const Expr* other, bool compareData = true) const override;
   static bool classof(const Expr* expr) { return expr->getKind() == Kind::TernaryOperator; }
-  virtual ExprRangeType getChildren() override { return ExprRangeType(operands_); }
+  virtual ExprRangeType getChildren() const override { return ExprRangeType(operands_); }
   virtual void replaceChildren(const std::shared_ptr<Expr>& oldExpr,
                                const std::shared_ptr<Expr>& newExpr) override;
   ACCEPTVISITOR(Expr, TernaryOperator)
@@ -328,7 +328,7 @@ public:
   virtual std::shared_ptr<Expr> clone() const override;
   virtual bool equals(const Expr* other, bool compareData = true) const override;
   static bool classof(const Expr* expr) { return expr->getKind() == Kind::FunCallExpr; }
-  virtual ExprRangeType getChildren() override { return ExprRangeType(arguments_); }
+  virtual ExprRangeType getChildren() const override { return ExprRangeType(arguments_); }
   virtual void replaceChildren(const std::shared_ptr<Expr>& oldExpr,
                                const std::shared_ptr<Expr>& newExpr) override;
   ACCEPTVISITOR(Expr, FunCallExpr)
@@ -463,7 +463,7 @@ public:
   virtual std::shared_ptr<Expr> clone() const override;
   virtual bool equals(const Expr* other, bool compareData = true) const override;
   static bool classof(const Expr* expr) { return expr->getKind() == Kind::VarAccessExpr; }
-  virtual ExprRangeType getChildren() override {
+  virtual ExprRangeType getChildren() const override {
     return (isArrayAccess() ? ExprRangeType(index_) : ExprRangeType());
   }
   virtual void replaceChildren(const std::shared_ptr<Expr>& oldExpr,
@@ -541,7 +541,7 @@ public:
     return (argumentMap_[0] != -1 || argumentMap_[1] != -1 || argumentMap_[2] != -1);
   }
 
-  ExprRangeType getChildren() override;
+  ExprRangeType getChildren() const override;
 
   /// @brief Set the `offset` and reset the argument and argument-offset maps
   ///
@@ -674,7 +674,7 @@ public:
   bool getIncludeCenter() const { return iterSpace_.IncludeCenter; };
   ast::UnstructuredIterationSpace getIterSpace() const { return iterSpace_; }
 
-  ExprRangeType getChildren() override;
+  ExprRangeType getChildren() const override;
 
   static bool classof(const Expr* expr) {
     return expr->getKind() == Kind::ReductionOverNeighborExpr;

--- a/dawn/src/dawn/AST/ASTStmt.cpp
+++ b/dawn/src/dawn/AST/ASTStmt.cpp
@@ -443,7 +443,8 @@ bool LoopStmt::equals(const Stmt* other, bool compareData) const {
          iterationDescr_->equals(otherPtr->iterationDescr_.get());
 }
 
-MutableArrayRef<std::shared_ptr<Stmt>> LoopStmt::getChildren() { return blockStmt_->getChildren(); }
+LoopStmt::StmtRangeType LoopStmt::getChildren() { return blockStmt_->getChildren(); }
+LoopStmt::StmtRangeTypeConst LoopStmt::getChildren() const { return blockStmt_->getChildren(); }
 void LoopStmt::replaceChildren(const std::shared_ptr<Stmt>& oldStmt,
                                const std::shared_ptr<Stmt>& newStmt) {
   blockStmt_->replaceChildren(oldStmt, newStmt);

--- a/dawn/src/dawn/AST/ASTStmt.h
+++ b/dawn/src/dawn/AST/ASTStmt.h
@@ -61,6 +61,7 @@ public:
   };
 
   using StmtRangeType = MutableArrayRef<std::shared_ptr<Stmt>>;
+  using StmtRangeTypeConst = ArrayRef<std::shared_ptr<Stmt>>;
 
   /// @name Constructor & Destructor
   /// @{
@@ -75,7 +76,7 @@ public:
   /// @}
 
   /// @brief Hook for Visitors
-  virtual void accept(ASTVisitor& visitor) = 0;
+  virtual void accept(ASTVisitor& visitor) const = 0;
   virtual void accept(ASTVisitorNonConst& visitor) = 0;
   virtual std::shared_ptr<Stmt> acceptAndReplace(ASTVisitorPostOrder& visitor) = 0;
 
@@ -111,6 +112,7 @@ public:
 
   /// @brief Iterate children (if any)
   virtual StmtRangeType getChildren() { return StmtRangeType(); }
+  virtual StmtRangeTypeConst getChildren() const { return StmtRangeTypeConst(); }
 
   virtual void replaceChildren(std::shared_ptr<Stmt> const& oldStmt,
                                std::shared_ptr<Stmt> const& newStmt) {}
@@ -227,6 +229,7 @@ public:
   virtual bool equals(const Stmt* other, bool compareData = true) const override;
   static bool classof(const Stmt* stmt) { return stmt->getKind() == Kind::BlockStmt; }
   virtual StmtRangeType getChildren() override { return StmtRangeType(statements_); }
+  virtual StmtRangeTypeConst getChildren() const override { return StmtRangeTypeConst(statements_); }
   virtual void replaceChildren(const std::shared_ptr<Stmt>& oldStmt,
                                const std::shared_ptr<Stmt>& newStmt) override;
 
@@ -505,6 +508,9 @@ public:
   virtual StmtRangeType getChildren() override {
     return hasElse() ? StmtRangeType(subStmts_) : StmtRangeType(&subStmts_[0], End - 1);
   }
+  virtual StmtRangeTypeConst getChildren() const override {
+    return hasElse() ? StmtRangeTypeConst(subStmts_) : StmtRangeTypeConst(&subStmts_[0], End - 1);
+  }
   virtual void replaceChildren(const std::shared_ptr<Stmt>& oldStmt,
                                const std::shared_ptr<Stmt>& newStmt) override;
   ACCEPTVISITOR(Stmt, IfStmt)
@@ -555,6 +561,7 @@ public:
   bool equals(const Stmt* other, bool compareData = true) const override;
   static bool classof(const Stmt* stmt) { return stmt->getKind() == Kind::LoopStmt; }
   virtual StmtRangeType getChildren() override;
+  virtual StmtRangeTypeConst getChildren() const override;
   virtual void replaceChildren(const std::shared_ptr<Stmt>& oldStmt,
                                const std::shared_ptr<Stmt>& newStmt) override;
 

--- a/dawn/src/dawn/AST/ASTStringifier.cpp
+++ b/dawn/src/dawn/AST/ASTStringifier.cpp
@@ -37,7 +37,7 @@ public:
   StringVisitor(int initialIndent, bool newLines)
       : curIndent_(initialIndent), scopeDepth_(0), newLines_(newLines) {}
 
-  void visit(const std::shared_ptr<BlockStmt>& stmt) override {
+  void visit(const std::shared_ptr<const BlockStmt>& stmt) override {
     scopeDepth_++;
     ss_ << std::string(curIndent_, ' ') << "{" << (newLines_ ? "\n" : "");
 
@@ -55,14 +55,14 @@ public:
     scopeDepth_--;
   }
 
-  void visit(const std::shared_ptr<LoopStmt>& stmt) override {
+  void visit(const std::shared_ptr<const LoopStmt>& stmt) override {
     scopeDepth_++;
     ss_ << "for (" << stmt->getIterationDescr().toString() << ")\n";
     stmt->getBlockStmt()->accept(*this);
     scopeDepth_--;
   }
 
-  void visit(const std::shared_ptr<ExprStmt>& stmt) override {
+  void visit(const std::shared_ptr<const ExprStmt>& stmt) override {
     if(scopeDepth_ == 0)
       ss_ << std::string(curIndent_, ' ');
 
@@ -70,7 +70,7 @@ public:
     ss_ << ";" << (newLines_ ? "\n" : "");
   }
 
-  void visit(const std::shared_ptr<ReturnStmt>& stmt) override {
+  void visit(const std::shared_ptr<const ReturnStmt>& stmt) override {
     if(scopeDepth_ == 0)
       ss_ << std::string(curIndent_, ' ');
 
@@ -79,7 +79,7 @@ public:
     ss_ << ";" << (newLines_ ? "\n" : "");
   }
 
-  void visit(const std::shared_ptr<VarDeclStmt>& stmt) override {
+  void visit(const std::shared_ptr<const VarDeclStmt>& stmt) override {
     if(scopeDepth_ == 0)
       ss_ << std::string(curIndent_, ' ');
 
@@ -104,7 +104,7 @@ public:
     ss_ << ";" << (newLines_ ? "\n" : "");
   }
 
-  virtual void visit(const std::shared_ptr<VerticalRegionDeclStmt>& stmt) override {
+  virtual void visit(const std::shared_ptr<const VerticalRegionDeclStmt>& stmt) override {
     if(scopeDepth_ == 0)
       ss_ << std::string(curIndent_, ' ');
 
@@ -129,7 +129,7 @@ public:
     ss_ << ASTStringifier::toString(*stmt->getVerticalRegion()->Ast, curIndent_);
   }
 
-  virtual void visit(const std::shared_ptr<StencilCallDeclStmt>& stmt) override {
+  virtual void visit(const std::shared_ptr<const StencilCallDeclStmt>& stmt) override {
     if(scopeDepth_ == 0)
       ss_ << std::string(curIndent_, ' ');
     ss_ << "stencil-call:";
@@ -139,7 +139,7 @@ public:
     ss_ << ";" << (newLines_ ? "\n" : "");
   }
 
-  virtual void visit(const std::shared_ptr<BoundaryConditionDeclStmt>& stmt) override {
+  virtual void visit(const std::shared_ptr<const BoundaryConditionDeclStmt>& stmt) override {
     if(scopeDepth_ == 0)
       ss_ << std::string(curIndent_, ' ');
     ss_ << "boundary-condition:";
@@ -148,7 +148,7 @@ public:
     ss_ << ";" << (newLines_ ? "\n" : "");
   }
 
-  void visit(const std::shared_ptr<IfStmt>& stmt) override {
+  void visit(const std::shared_ptr<const IfStmt>& stmt) override {
     if(scopeDepth_ == 0)
       ss_ << std::string(curIndent_, ' ');
     ss_ << "if(";
@@ -161,7 +161,7 @@ public:
       stmt->getElseStmt()->accept(*this);
     }
   }
-  void visit(const std::shared_ptr<ReductionOverNeighborExpr>& expr) override {
+  void visit(const std::shared_ptr<const ReductionOverNeighborExpr>& expr) override {
     auto getLocationTypeString = [](ast::LocationType type) {
       switch(type) {
       case ast::LocationType::Cells:
@@ -192,14 +192,14 @@ public:
     expr->getRhs()->accept(*this);
   }
 
-  void visit(const std::shared_ptr<UnaryOperator>& expr) override {
+  void visit(const std::shared_ptr<const UnaryOperator>& expr) override {
     ss_ << "(";
     ss_ << expr->getOp();
     expr->getOperand()->accept(*this);
     ss_ << ")";
   }
 
-  void visit(const std::shared_ptr<BinaryOperator>& expr) override {
+  void visit(const std::shared_ptr<const BinaryOperator>& expr) override {
     ss_ << "(";
     expr->getLeft()->accept(*this);
     ss_ << " " << expr->getOp() << " ";
@@ -207,13 +207,13 @@ public:
     ss_ << ")";
   }
 
-  void visit(const std::shared_ptr<AssignmentExpr>& expr) override {
+  void visit(const std::shared_ptr<const AssignmentExpr>& expr) override {
     expr->getLeft()->accept(*this);
     ss_ << " " << expr->getOp() << " ";
     expr->getRight()->accept(*this);
   }
 
-  void visit(const std::shared_ptr<TernaryOperator>& expr) override {
+  void visit(const std::shared_ptr<const TernaryOperator>& expr) override {
     ss_ << "(";
     expr->getCondition()->accept(*this);
     ss_ << " " << expr->getOp() << " ";
@@ -223,7 +223,7 @@ public:
     ss_ << ")";
   }
 
-  void visit(const std::shared_ptr<FunCallExpr>& expr) override {
+  void visit(const std::shared_ptr<const FunCallExpr>& expr) override {
     ss_ << "fun-call:" << expr->getCallee() << "(";
     for(std::size_t i = 0; i < expr->getArguments().size(); ++i) {
       expr->getArguments()[i]->accept(*this);
@@ -231,7 +231,7 @@ public:
     }
   }
 
-  void visit(const std::shared_ptr<StencilFunCallExpr>& expr) override {
+  void visit(const std::shared_ptr<const StencilFunCallExpr>& expr) override {
     ss_ << "stencil-fun-call:" << expr->getCallee() << "(";
     for(std::size_t i = 0; i < expr->getArguments().size(); ++i) {
       expr->getArguments()[i]->accept(*this);
@@ -239,7 +239,7 @@ public:
     }
   }
 
-  void visit(const std::shared_ptr<StencilFunArgExpr>& expr) override {
+  void visit(const std::shared_ptr<const StencilFunArgExpr>& expr) override {
     if(!expr->needsLazyEval()) {
       switch(expr->getDimension()) {
       case 0:
@@ -261,7 +261,7 @@ public:
       ss_ << (expr->getOffset() > 0 ? "+" : "") << expr->getOffset();
   }
 
-  void visit(const std::shared_ptr<VarAccessExpr>& expr) override {
+  void visit(const std::shared_ptr<const VarAccessExpr>& expr) override {
     ss_ << expr->getName();
     if(expr->isArrayAccess()) {
       ss_ << "[";
@@ -270,7 +270,7 @@ public:
     }
   }
 
-  void visit(const std::shared_ptr<FieldAccessExpr>& expr) override {
+  void visit(const std::shared_ptr<const FieldAccessExpr>& expr) override {
     auto offset = expr->getOffset();
 
     if(!expr->hasArguments()) {
@@ -298,7 +298,7 @@ public:
     }
   }
 
-  void visit(const std::shared_ptr<LiteralAccessExpr>& expr) override {
+  void visit(const std::shared_ptr<const LiteralAccessExpr>& expr) override {
     ss_ << expr->getBuiltinType() << " " << expr->getValue();
   }
 

--- a/dawn/src/dawn/AST/ASTUtil.cpp
+++ b/dawn/src/dawn/AST/ASTUtil.cpp
@@ -27,7 +27,7 @@ namespace ast {
 namespace {
 
 /// @brief Replace `oldExpr` with `newExpr`
-class ExprReplacer : public ASTVisitor {
+class ExprReplacer : public ASTVisitorNonConst {
   std::shared_ptr<Expr> oldExpr_;
   std::shared_ptr<Expr> newExpr_;
 
@@ -177,7 +177,7 @@ void replaceOldExprWithNewExprInStmt(const std::shared_ptr<Stmt>& stmt,
 namespace {
 
 /// @brief Replace `oldStmt` with `newStmt`
-class StmtReplacer : public ASTVisitorForwarding {
+class StmtReplacer : public ASTVisitorForwardingNonConst {
   std::shared_ptr<Stmt> oldStmt_;
   std::shared_ptr<Stmt> newStmt_;
 
@@ -325,7 +325,7 @@ bool evalBinary(const std::string& opStr, double& result, double op1, double op2
 /// @brief Evaluate `expr` treating everything as `double`s
 ///
 /// Given that we only have 32-bit integers it should be safe to treat them as double.
-class ExprEvaluator : public ASTVisitor {
+class ExprEvaluator : public ASTVisitorNonConst {
   const std::unordered_map<std::string, double>& variableMap_;
 
   bool valid_;

--- a/dawn/src/dawn/AST/ASTVisitor.cpp
+++ b/dawn/src/dawn/AST/ASTVisitor.cpp
@@ -19,15 +19,15 @@
 
 namespace dawn {
 namespace ast {
-ASTVisitor::~ASTVisitor() {}
-ASTVisitorNonConst::~ASTVisitorNonConst() {}
-ASTVisitorForwarding::~ASTVisitorForwarding() {}
-ASTVisitorForwardingNonConst::~ASTVisitorForwardingNonConst() {}
-ASTVisitorDisabled::~ASTVisitorDisabled() {}
-ASTVisitorPostOrder::~ASTVisitorPostOrder() {}
+ASTVisitor::~ASTVisitor() = default;
+ASTVisitorNonConst::~ASTVisitorNonConst() = default;
+ASTVisitorForwarding::~ASTVisitorForwarding() = default;
+ASTVisitorForwardingNonConst::~ASTVisitorForwardingNonConst() = default;
+ASTVisitorDisabled::~ASTVisitorDisabled() = default;
+ASTVisitorPostOrder::~ASTVisitorPostOrder() = default;
 
 #define ASTVISITORFORWARDING_VISIT_IMPL(Type)                                                      \
-  void ASTVisitorForwarding::visit(const std::shared_ptr<Type>& node) {                            \
+  void ASTVisitorForwarding::visit(const std::shared_ptr<const Type>& node) {                      \
     for(const auto& s : node->getChildren())                                                       \
       s->accept(*this);                                                                            \
   }
@@ -51,25 +51,25 @@ ASTVISITORFORWARDING_VISIT_IMPL(ReductionOverNeighborExpr)
 
 #undef ASTVISITORFORWARDING_VISIT_IMPL
 
-void ASTVisitorForwarding::visit(const std::shared_ptr<ExprStmt>& node) {
+void ASTVisitorForwarding::visit(const std::shared_ptr<const ExprStmt>& node) {
   node->getExpr()->accept(*this);
 }
 
-void ASTVisitorForwarding::visit(const std::shared_ptr<ReturnStmt>& node) {
+void ASTVisitorForwarding::visit(const std::shared_ptr<const ReturnStmt>& node) {
   node->getExpr()->accept(*this);
 }
 
-void ASTVisitorForwarding::visit(const std::shared_ptr<VarDeclStmt>& node) {
+void ASTVisitorForwarding::visit(const std::shared_ptr<const VarDeclStmt>& node) {
   for(const auto& expr : node->getInitList())
     expr->accept(*this);
 }
 
-void ASTVisitorForwarding::visit(const std::shared_ptr<VerticalRegionDeclStmt>& stmt) {
+void ASTVisitorForwarding::visit(const std::shared_ptr<const VerticalRegionDeclStmt>& stmt) {
   stmt->getVerticalRegion()->Ast->accept(*this);
 }
 
 #define ASTVISITORFORWARDINGNONCONST_VISIT_IMPL(Type)                                              \
-  void ASTVisitorForwardingNonConst::visit(std::shared_ptr<Type> node) {                           \
+  void ASTVisitorForwardingNonConst::visit(const std::shared_ptr<Type>& node) {                     \
     for(auto& s : node->getChildren())                                                             \
       s->accept(*this);                                                                            \
   }
@@ -93,20 +93,20 @@ ASTVISITORFORWARDINGNONCONST_VISIT_IMPL(ReductionOverNeighborExpr)
 
 #undef ASTVISITORFORWARDINGNONCONST_VISIT_IMPL
 
-void ASTVisitorForwardingNonConst::visit(std::shared_ptr<ExprStmt> node) {
+void ASTVisitorForwardingNonConst::visit(const std::shared_ptr<ExprStmt>& node) {
   node->getExpr()->accept(*this);
 }
 
-void ASTVisitorForwardingNonConst::visit(std::shared_ptr<ReturnStmt> node) {
+void ASTVisitorForwardingNonConst::visit(const std::shared_ptr<ReturnStmt>& node) {
   node->getExpr()->accept(*this);
 }
 
-void ASTVisitorForwardingNonConst::visit(std::shared_ptr<VarDeclStmt> node) {
+void ASTVisitorForwardingNonConst::visit(const std::shared_ptr<VarDeclStmt>& node) {
   for(const auto& expr : node->getInitList())
     expr->accept(*this);
 }
 
-void ASTVisitorForwardingNonConst::visit(std::shared_ptr<VerticalRegionDeclStmt> stmt) {
+void ASTVisitorForwardingNonConst::visit(const std::shared_ptr<VerticalRegionDeclStmt>& stmt) {
   stmt->getVerticalRegion()->Ast->accept(*this);
 }
 

--- a/dawn/src/dawn/AST/ASTVisitor.h
+++ b/dawn/src/dawn/AST/ASTVisitor.h
@@ -27,6 +27,42 @@ public:
 
   /// @brief Statements
   /// @{
+  virtual void visit(const std::shared_ptr<const BlockStmt>& stmt) = 0;
+  virtual void visit(const std::shared_ptr<const ExprStmt>& stmt) = 0;
+  virtual void visit(const std::shared_ptr<const ReturnStmt>& stmt) = 0;
+  virtual void visit(const std::shared_ptr<const VarDeclStmt>& stmt) = 0;
+  virtual void visit(const std::shared_ptr<const VerticalRegionDeclStmt>& stmt) = 0;
+  virtual void visit(const std::shared_ptr<const StencilCallDeclStmt>& stmt) = 0;
+  virtual void visit(const std::shared_ptr<const BoundaryConditionDeclStmt>& stmt) = 0;
+  virtual void visit(const std::shared_ptr<const IfStmt>& stmt) = 0;
+  virtual void visit(const std::shared_ptr<const LoopStmt>& stmt) = 0;
+  /// @}
+
+  /// @brief Expressions
+  /// @{
+  virtual void visit(const std::shared_ptr<const ReductionOverNeighborExpr>& expr) = 0;
+  virtual void visit(const std::shared_ptr<const NOPExpr>& expr) final {}
+  virtual void visit(const std::shared_ptr<const UnaryOperator>& expr) = 0;
+  virtual void visit(const std::shared_ptr<const BinaryOperator>& expr) = 0;
+  virtual void visit(const std::shared_ptr<const AssignmentExpr>& expr) = 0;
+  virtual void visit(const std::shared_ptr<const TernaryOperator>& expr) = 0;
+  virtual void visit(const std::shared_ptr<const FunCallExpr>& expr) = 0;
+  virtual void visit(const std::shared_ptr<const StencilFunCallExpr>& expr) = 0;
+  virtual void visit(const std::shared_ptr<const StencilFunArgExpr>& expr) = 0;
+  virtual void visit(const std::shared_ptr<const VarAccessExpr>& expr) = 0;
+  virtual void visit(const std::shared_ptr<const FieldAccessExpr>& expr) = 0;
+  virtual void visit(const std::shared_ptr<const LiteralAccessExpr>& expr) = 0;
+  /// @}
+};
+
+/// @brief Base class of all Visitor for ASTs and ASTNodes
+/// @ingroup ast
+class ASTVisitorNonConst {
+public:
+  virtual ~ASTVisitorNonConst();
+
+  /// @brief Statements
+  /// @{
   virtual void visit(const std::shared_ptr<BlockStmt>& stmt) = 0;
   virtual void visit(const std::shared_ptr<ExprStmt>& stmt) = 0;
   virtual void visit(const std::shared_ptr<ReturnStmt>& stmt) = 0;
@@ -41,7 +77,7 @@ public:
   /// @brief Expressions
   /// @{
   virtual void visit(const std::shared_ptr<ReductionOverNeighborExpr>& expr) = 0;
-  virtual void visit(const std::shared_ptr<NOPExpr>& stmt) final {}
+  virtual void visit(const std::shared_ptr<NOPExpr>& expr) final {}
   virtual void visit(const std::shared_ptr<UnaryOperator>& expr) = 0;
   virtual void visit(const std::shared_ptr<BinaryOperator>& expr) = 0;
   virtual void visit(const std::shared_ptr<AssignmentExpr>& expr) = 0;
@@ -55,42 +91,6 @@ public:
   /// @}
 };
 
-/// @brief Base class of all Visitor for ASTs and ASTNodes
-/// @ingroup ast
-class ASTVisitorNonConst {
-public:
-  virtual ~ASTVisitorNonConst();
-
-  /// @brief Statements
-  /// @{
-  virtual void visit(std::shared_ptr<BlockStmt> stmt) = 0;
-  virtual void visit(std::shared_ptr<ExprStmt> stmt) = 0;
-  virtual void visit(std::shared_ptr<ReturnStmt> stmt) = 0;
-  virtual void visit(std::shared_ptr<VarDeclStmt> stmt) = 0;
-  virtual void visit(std::shared_ptr<VerticalRegionDeclStmt> stmt) = 0;
-  virtual void visit(std::shared_ptr<StencilCallDeclStmt> stmt) = 0;
-  virtual void visit(std::shared_ptr<BoundaryConditionDeclStmt> stmt) = 0;
-  virtual void visit(std::shared_ptr<IfStmt> stmt) = 0;
-  virtual void visit(std::shared_ptr<LoopStmt> stmt) = 0;
-  /// @}
-
-  /// @brief Expressions
-  /// @{
-  virtual void visit(std::shared_ptr<ReductionOverNeighborExpr> expr) = 0;
-  virtual void visit(std::shared_ptr<NOPExpr> expr) final {}
-  virtual void visit(std::shared_ptr<UnaryOperator> expr) = 0;
-  virtual void visit(std::shared_ptr<BinaryOperator> expr) = 0;
-  virtual void visit(std::shared_ptr<AssignmentExpr> expr) = 0;
-  virtual void visit(std::shared_ptr<TernaryOperator> expr) = 0;
-  virtual void visit(std::shared_ptr<FunCallExpr> expr) = 0;
-  virtual void visit(std::shared_ptr<StencilFunCallExpr> expr) = 0;
-  virtual void visit(std::shared_ptr<StencilFunArgExpr> expr) = 0;
-  virtual void visit(std::shared_ptr<VarAccessExpr> expr) = 0;
-  virtual void visit(std::shared_ptr<FieldAccessExpr> expr) = 0;
-  virtual void visit(std::shared_ptr<LiteralAccessExpr> expr) = 0;
-  /// @}
-};
-
 /// @brief Visitor which forwards all calls to their children by default
 /// @ingroup ast
 class ASTVisitorForwarding : public ASTVisitor {
@@ -99,30 +99,30 @@ public:
 
   /// @brief Statements
   /// @{
-  virtual void visit(const std::shared_ptr<BlockStmt>& stmt) override;
-  virtual void visit(const std::shared_ptr<ExprStmt>& stmt) override;
-  virtual void visit(const std::shared_ptr<ReturnStmt>& stmt) override;
-  virtual void visit(const std::shared_ptr<VarDeclStmt>& stmt) override;
-  virtual void visit(const std::shared_ptr<VerticalRegionDeclStmt>& stmt) override;
-  virtual void visit(const std::shared_ptr<StencilCallDeclStmt>& stmt) override;
-  virtual void visit(const std::shared_ptr<BoundaryConditionDeclStmt>& stmt) override;
-  virtual void visit(const std::shared_ptr<IfStmt>& stmt) override;
-  virtual void visit(const std::shared_ptr<LoopStmt>& stmt) override;
+  virtual void visit(const std::shared_ptr<const BlockStmt>& stmt) override;
+  virtual void visit(const std::shared_ptr<const ExprStmt>& stmt) override;
+  virtual void visit(const std::shared_ptr<const ReturnStmt>& stmt) override;
+  virtual void visit(const std::shared_ptr<const VarDeclStmt>& stmt) override;
+  virtual void visit(const std::shared_ptr<const VerticalRegionDeclStmt>& stmt) override;
+  virtual void visit(const std::shared_ptr<const StencilCallDeclStmt>& stmt) override;
+  virtual void visit(const std::shared_ptr<const BoundaryConditionDeclStmt>& stmt) override;
+  virtual void visit(const std::shared_ptr<const IfStmt>& stmt) override;
+  virtual void visit(const std::shared_ptr<const LoopStmt>& stmt) override;
   /// @}
 
   /// @brief Expressions
   /// @{
-  virtual void visit(const std::shared_ptr<ReductionOverNeighborExpr>& expr) override;
-  virtual void visit(const std::shared_ptr<UnaryOperator>& expr) override;
-  virtual void visit(const std::shared_ptr<BinaryOperator>& expr) override;
-  virtual void visit(const std::shared_ptr<AssignmentExpr>& expr) override;
-  virtual void visit(const std::shared_ptr<TernaryOperator>& expr) override;
-  virtual void visit(const std::shared_ptr<FunCallExpr>& expr) override;
-  virtual void visit(const std::shared_ptr<StencilFunCallExpr>& expr) override;
-  virtual void visit(const std::shared_ptr<StencilFunArgExpr>& expr) override;
-  virtual void visit(const std::shared_ptr<VarAccessExpr>& expr) override;
-  virtual void visit(const std::shared_ptr<FieldAccessExpr>& expr) override;
-  virtual void visit(const std::shared_ptr<LiteralAccessExpr>& expr) override;
+  virtual void visit(const std::shared_ptr<const ReductionOverNeighborExpr>& expr) override;
+  virtual void visit(const std::shared_ptr<const UnaryOperator>& expr) override;
+  virtual void visit(const std::shared_ptr<const BinaryOperator>& expr) override;
+  virtual void visit(const std::shared_ptr<const AssignmentExpr>& expr) override;
+  virtual void visit(const std::shared_ptr<const TernaryOperator>& expr) override;
+  virtual void visit(const std::shared_ptr<const FunCallExpr>& expr) override;
+  virtual void visit(const std::shared_ptr<const StencilFunCallExpr>& expr) override;
+  virtual void visit(const std::shared_ptr<const StencilFunArgExpr>& expr) override;
+  virtual void visit(const std::shared_ptr<const VarAccessExpr>& expr) override;
+  virtual void visit(const std::shared_ptr<const FieldAccessExpr>& expr) override;
+  virtual void visit(const std::shared_ptr<const LiteralAccessExpr>& expr) override;
   /// @}
 };
 
@@ -247,30 +247,30 @@ public:
 
   /// @brief Statements
   /// @{
-  virtual void visit(std::shared_ptr<BlockStmt> stmt) override;
-  virtual void visit(std::shared_ptr<ExprStmt> stmt) override;
-  virtual void visit(std::shared_ptr<ReturnStmt> stmt) override;
-  virtual void visit(std::shared_ptr<VarDeclStmt> stmt) override;
-  virtual void visit(std::shared_ptr<VerticalRegionDeclStmt> stmt) override;
-  virtual void visit(std::shared_ptr<StencilCallDeclStmt> stmt) override;
-  virtual void visit(std::shared_ptr<BoundaryConditionDeclStmt> stmt) override;
-  virtual void visit(std::shared_ptr<IfStmt> stmt) override;
-  virtual void visit(std::shared_ptr<LoopStmt> stmt) override;
+  virtual void visit(const std::shared_ptr<BlockStmt>& stmt) override;
+  virtual void visit(const std::shared_ptr<ExprStmt>& stmt) override;
+  virtual void visit(const std::shared_ptr<ReturnStmt>& stmt) override;
+  virtual void visit(const std::shared_ptr<VarDeclStmt>& stmt) override;
+  virtual void visit(const std::shared_ptr<VerticalRegionDeclStmt>& stmt) override;
+  virtual void visit(const std::shared_ptr<StencilCallDeclStmt>& stmt) override;
+  virtual void visit(const std::shared_ptr<BoundaryConditionDeclStmt>& stmt) override;
+  virtual void visit(const std::shared_ptr<IfStmt>& stmt) override;
+  virtual void visit(const std::shared_ptr<LoopStmt>& stmt) override;
   /// @}
 
   /// @brief Expressions
   /// @{
-  virtual void visit(std::shared_ptr<ReductionOverNeighborExpr> expr) override;
-  virtual void visit(std::shared_ptr<UnaryOperator> expr) override;
-  virtual void visit(std::shared_ptr<BinaryOperator> expr) override;
-  virtual void visit(std::shared_ptr<AssignmentExpr> expr) override;
-  virtual void visit(std::shared_ptr<TernaryOperator> expr) override;
-  virtual void visit(std::shared_ptr<FunCallExpr> expr) override;
-  virtual void visit(std::shared_ptr<StencilFunCallExpr> expr) override;
-  virtual void visit(std::shared_ptr<StencilFunArgExpr> expr) override;
-  virtual void visit(std::shared_ptr<VarAccessExpr> expr) override;
-  virtual void visit(std::shared_ptr<FieldAccessExpr> expr) override;
-  virtual void visit(std::shared_ptr<LiteralAccessExpr> expr) override;
+  virtual void visit(const std::shared_ptr<ReductionOverNeighborExpr>& expr) override;
+  virtual void visit(const std::shared_ptr<UnaryOperator>& expr) override;
+  virtual void visit(const std::shared_ptr<BinaryOperator>& expr) override;
+  virtual void visit(const std::shared_ptr<AssignmentExpr>& expr) override;
+  virtual void visit(const std::shared_ptr<TernaryOperator>& expr) override;
+  virtual void visit(const std::shared_ptr<FunCallExpr>& expr) override;
+  virtual void visit(const std::shared_ptr<StencilFunCallExpr>& expr) override;
+  virtual void visit(const std::shared_ptr<StencilFunArgExpr>& expr) override;
+  virtual void visit(const std::shared_ptr<VarAccessExpr>& expr) override;
+  virtual void visit(const std::shared_ptr<FieldAccessExpr>& expr) override;
+  virtual void visit(const std::shared_ptr<LiteralAccessExpr>& expr) override;
   /// @}
 };
 
@@ -278,7 +278,7 @@ public:
 /// (in order to implement the corresponding functionality of a node, the method should be overrided
 /// by the inherited class)
 /// @ingroup ast
-class ASTVisitorDisabled : public ASTVisitor {
+class ASTVisitorDisabled : public ASTVisitorNonConst {
 public:
   virtual ~ASTVisitorDisabled();
 

--- a/dawn/src/dawn/AST/ASTVisitorHelpers.h
+++ b/dawn/src/dawn/AST/ASTVisitorHelpers.h
@@ -15,8 +15,8 @@
 #include "dawn/AST/ASTVisitor.h"
 
 #define ACCEPTVISITOR(subtype, type)                                                               \
-  virtual inline void accept(ASTVisitor& visitor) override {                                       \
-    visitor.visit(std::static_pointer_cast<type>(shared_from_this()));                             \
+  virtual inline void accept(ASTVisitor& visitor) const override {                                 \
+    visitor.visit(std::static_pointer_cast<const type>(shared_from_this()));                       \
   }                                                                                                \
   virtual inline void accept(ASTVisitorNonConst& visitor) override {                               \
     visitor.visit(std::static_pointer_cast<type>(shared_from_this()));                             \

--- a/dawn/src/dawn/AST/Offsets.cpp
+++ b/dawn/src/dawn/AST/Offsets.cpp
@@ -165,6 +165,10 @@ std::shared_ptr<Expr>& VerticalOffset::getIndirectionFieldAsExpr() {
   DAWN_ASSERT(hasIndirection());
   return verticalIndirection_;
 }
+const std::shared_ptr<Expr>& VerticalOffset::getIndirectionFieldAsExpr() const {
+  DAWN_ASSERT(hasIndirection());
+  return verticalIndirection_;
+}
 
 VerticalOffset VerticalOffset::operator+=(VerticalOffset const& other) {
   DAWN_ASSERT_MSG(!verticalIndirection_ && !other.verticalIndirection_,
@@ -231,6 +235,10 @@ std::optional<int> Offsets::getVerticalIndirectionAccessID() const {
   return verticalOffset_.getIndirectionAccessID();
 }
 std::shared_ptr<Expr>& Offsets::getVerticalIndirectionFieldAsExpr() {
+  DAWN_ASSERT(hasVerticalIndirection());
+  return verticalOffset_.getIndirectionFieldAsExpr();
+}
+const std::shared_ptr<Expr>& Offsets::getVerticalIndirectionFieldAsExpr() const {
   DAWN_ASSERT(hasVerticalIndirection());
   return verticalOffset_.getIndirectionFieldAsExpr();
 }

--- a/dawn/src/dawn/AST/Offsets.h
+++ b/dawn/src/dawn/AST/Offsets.h
@@ -183,6 +183,7 @@ public:
   std::shared_ptr<const FieldAccessExpr> getIndirectionField() const;
   // unfortunately we need this to be compatible with the visitor infrastructure
   std::shared_ptr<Expr>& getIndirectionFieldAsExpr();
+  const std::shared_ptr<Expr>& getIndirectionFieldAsExpr() const;
   void setIndirectionAccessID(int accessID);
   std::optional<int> getIndirectionAccessID() const;
   bool operator==(VerticalOffset const& other) const;
@@ -214,6 +215,7 @@ public:
   std::optional<int> getVerticalIndirectionAccessID() const;
   // unfortunately we need this to be compatible with the visitor infrastructure
   std::shared_ptr<Expr>& getVerticalIndirectionFieldAsExpr();
+  const std::shared_ptr<Expr>& getVerticalIndirectionFieldAsExpr() const;
   void setVerticalIndirection(const std::string& fieldName);
 
   HorizontalOffset const& horizontalOffset() const;

--- a/dawn/src/dawn/CodeGen/ASTCodeGenCXX.h
+++ b/dawn/src/dawn/CodeGen/ASTCodeGenCXX.h
@@ -24,7 +24,7 @@ namespace codegen {
 
 /// @brief Abstract base class of all C++ code generation visitor
 /// @ingroup codegen
-class ASTCodeGenCXX : public ast::ASTVisitor, public NonCopyable {
+class ASTCodeGenCXX : public ast::ASTVisitorNonConst, public NonCopyable {
 protected:
   /// Indent of each statement
   int indent_;

--- a/dawn/src/dawn/CodeGen/CXXNaive-ico/ASTStencilBody.h
+++ b/dawn/src/dawn/CodeGen/CXXNaive-ico/ASTStencilBody.h
@@ -33,7 +33,7 @@ namespace codegen {
 namespace cxxnaiveico {
 
 // quick visitor to check whether a statement contains a reduceOverNeighborExpr
-class FindReduceOverNeighborExpr : public ast::ASTVisitorForwarding {
+class FindReduceOverNeighborExpr : public ast::ASTVisitorForwardingNonConst {
   std::optional<std::shared_ptr<ast::ReductionOverNeighborExpr>> foundReduction_ = std::nullopt;
 
 public:

--- a/dawn/src/dawn/CodeGen/Cuda-ico/ASTStencilBody.h
+++ b/dawn/src/dawn/CodeGen/Cuda-ico/ASTStencilBody.h
@@ -34,7 +34,7 @@ class StencilMetaInformation;
 namespace codegen {
 namespace cudaico {
 
-class FindReduceOverNeighborExpr : public ast::ASTVisitorForwarding {
+class FindReduceOverNeighborExpr : public ast::ASTVisitorForwardingNonConst {
   std::vector<std::shared_ptr<ast::ReductionOverNeighborExpr>> foundReductions_;
 
 public:

--- a/dawn/src/dawn/CodeGen/Cuda-ico/CudaIcoCodeGen.cpp
+++ b/dawn/src/dawn/CodeGen/Cuda-ico/CudaIcoCodeGen.cpp
@@ -88,7 +88,7 @@ CudaIcoCodeGen::CudaIcoCodeGen(const StencilInstantiationContext& ctx, int maxHa
 
 CudaIcoCodeGen::~CudaIcoCodeGen() {}
 
-class CollectIterationSpaces : public ast::ASTVisitorForwarding {
+class CollectIterationSpaces : public ast::ASTVisitorForwardingNonConst {
 
 public:
   struct IterSpaceHash {

--- a/dawn/src/dawn/IIR/ASTConverter.h
+++ b/dawn/src/dawn/IIR/ASTConverter.h
@@ -29,7 +29,7 @@ namespace dawn {
 /// @brief Converts an AST with SIR data to one (duplicated) with IIR data.
 /// Can retrieve the converted nodes from the the stmt conversion map that is filled with the AST
 /// visit.
-class ASTConverter : public ast::ASTVisitorForwarding {
+class ASTConverter : public ast::ASTVisitorForwardingNonConst {
 public:
   using StmtMap = std::unordered_map<std::shared_ptr<ast::Stmt>, std::shared_ptr<ast::Stmt>>;
 

--- a/dawn/src/dawn/IIR/ASTMatcher.cpp
+++ b/dawn/src/dawn/IIR/ASTMatcher.cpp
@@ -156,7 +156,7 @@ void ASTMatcher::visit(const std::shared_ptr<ast::VarAccessExpr>& expr) { check(
 
 void ASTMatcher::visit(const std::shared_ptr<ast::FieldAccessExpr>& expr) {
   check(expr);
-  ASTVisitorForwarding::visit(expr);
+  ASTVisitorForwardingNonConst::visit(expr);
 }
 
 void ASTMatcher::visit(const std::shared_ptr<ast::LiteralAccessExpr>& expr) { check(expr); }

--- a/dawn/src/dawn/IIR/ASTMatcher.h
+++ b/dawn/src/dawn/IIR/ASTMatcher.h
@@ -24,7 +24,7 @@ namespace iir {
 //     ASTMatcher
 //===------------------------------------------------------------------------------------------===//
 /// @brief Traverses AST and return all matching statement or expression types
-class ASTMatcher : public ast::ASTVisitorForwarding {
+class ASTMatcher : public ast::ASTVisitorForwardingNonConst {
   iir::StencilInstantiation* instantiation_;
   iir::StencilMetaInformation& metadata_;
   ast::Stmt::Kind stmtKind_;

--- a/dawn/src/dawn/IIR/AccessComputation.cpp
+++ b/dawn/src/dawn/IIR/AccessComputation.cpp
@@ -28,7 +28,7 @@ namespace dawn {
 namespace {
 
 /// @brief Compute and fill the access map of the given statement
-class AccessMapper : public ast::ASTVisitor {
+class AccessMapper : public ast::ASTVisitorNonConst {
   const iir::StencilMetaInformation& metadata_;
 
   /// Keep track of the current statement

--- a/dawn/src/dawn/IIR/AccessToNameMapper.cpp
+++ b/dawn/src/dawn/IIR/AccessToNameMapper.cpp
@@ -24,7 +24,7 @@ namespace iir {
 
 void AccessToNameMapper::visit(const std::shared_ptr<ast::VarDeclStmt>& stmt) {
   insertAccessInfo(stmt);
-  ast::ASTVisitorForwarding::visit(stmt);
+  ast::ASTVisitorForwardingNonConst::visit(stmt);
 }
 
 void AccessToNameMapper::visit(const std::shared_ptr<ast::StencilFunCallExpr>& expr) {
@@ -39,7 +39,7 @@ void AccessToNameMapper::visit(const std::shared_ptr<ast::StencilFunCallExpr>& e
   curFunctionInstantiation_.top()->getAST()->accept(*this);
 
   curFunctionInstantiation_.pop();
-  ast::ASTVisitorForwarding::visit(expr);
+  ast::ASTVisitorForwardingNonConst::visit(expr);
 }
 
 void AccessToNameMapper::insertAccessInfo(const std::shared_ptr<ast::Expr>& expr) {
@@ -65,7 +65,7 @@ void AccessToNameMapper::visit(const std::shared_ptr<ast::VarAccessExpr>& expr) 
 
 void AccessToNameMapper::visit(const std::shared_ptr<ast::FieldAccessExpr>& expr) {
   insertAccessInfo(expr);
-  ASTVisitorForwarding::visit(expr);
+  ASTVisitorForwardingNonConst::visit(expr);
 }
 
 } // namespace iir

--- a/dawn/src/dawn/IIR/AccessToNameMapper.h
+++ b/dawn/src/dawn/IIR/AccessToNameMapper.h
@@ -26,7 +26,7 @@ class StencilFunctionInstantiation;
 class StencilMetaInformation;
 
 /// @brief Dump AST to string
-class AccessToNameMapper : public ast::ASTVisitorForwarding {
+class AccessToNameMapper : public ast::ASTVisitorForwardingNonConst {
   const StencilMetaInformation& metaData_;
   std::stack<StencilFunctionInstantiation*> curFunctionInstantiation_;
 

--- a/dawn/src/dawn/IIR/DoMethod.cpp
+++ b/dawn/src/dawn/IIR/DoMethod.cpp
@@ -34,7 +34,7 @@ namespace dawn {
 namespace iir {
 
 namespace {
-class ReplaceNamesVisitor : public ast::ASTVisitorForwarding, public NonCopyable {
+class ReplaceNamesVisitor : public ast::ASTVisitorForwardingNonConst, public NonCopyable {
   const StencilMetaInformation& metadata_;
 
 public:
@@ -293,7 +293,7 @@ void DoMethod::updateLevel() {
   }
 }
 
-class CheckNonNullStatementVisitor : public ast::ASTVisitorForwarding, public NonCopyable {
+class CheckNonNullStatementVisitor : public ast::ASTVisitorForwardingNonConst, public NonCopyable {
 private:
   bool result_ = false;
 
@@ -307,7 +307,7 @@ public:
     if(!isa<ast::NOPExpr>(expr->getExpr().get()))
       result_ = true;
     else {
-      ast::ASTVisitorForwarding::visit(expr);
+      ast::ASTVisitorForwardingNonConst::visit(expr);
     }
   }
 };

--- a/dawn/src/dawn/IIR/Stage.cpp
+++ b/dawn/src/dawn/IIR/Stage.cpp
@@ -189,7 +189,7 @@ bool Stage::overlaps(const Interval& interval, const std::unordered_map<int, Fie
 /// @brief The CaptureStencilFunctionCallGlobalParams class
 /// is an AST visitor used to capture accesses to global accessor from within
 /// stencil functions called from a stage
-class CaptureStencilFunctionCallGlobalParams : public ast::ASTVisitorForwarding {
+class CaptureStencilFunctionCallGlobalParams : public ast::ASTVisitorForwardingNonConst {
 
   std::unordered_set<int>& globalVariables_;
   const StencilMetaInformation& metaData_;

--- a/dawn/src/dawn/IIR/Stencil.cpp
+++ b/dawn/src/dawn/IIR/Stencil.cpp
@@ -537,7 +537,13 @@ std::optional<Interval> Stencil::getEnclosingIntervalTemporaries() const {
   return tmpInterval;
 }
 
-void Stencil::accept(ast::ASTVisitor& visitor) {
+void Stencil::accept(ast::ASTVisitor& visitor) const {
+  for(const auto& stmt : iterateIIROverStmt(*this)) {
+    stmt->accept(visitor);
+  }
+}
+
+void Stencil::accept(ast::ASTVisitorNonConst& visitor) const {
   for(const auto& stmt : iterateIIROverStmt(*this)) {
     stmt->accept(visitor);
   }

--- a/dawn/src/dawn/IIR/Stencil.h
+++ b/dawn/src/dawn/IIR/Stencil.h
@@ -278,7 +278,10 @@ public:
   const std::shared_ptr<sir::Stencil> getSIRStencil() const;
 
   /// @brief Apply the visitor to all statements in the stencil
-  void accept(ast::ASTVisitor& visitor);
+  void accept(ast::ASTVisitor& visitor) const;
+
+  /// @brief Apply the non const visitor to all statements in the stencil
+  void accept(ast::ASTVisitorNonConst& visitor) const;
 
   /// @brief Get the pair <AccessID, field> for the fields used within the multi-stage
   const std::unordered_map<int, FieldInfo>& getFields() const { return derivedInfo_.fields_; }

--- a/dawn/src/dawn/IIR/StencilInstantiation.cpp
+++ b/dawn/src/dawn/IIR/StencilInstantiation.cpp
@@ -125,7 +125,7 @@ namespace {
 
 /// @brief Get the orignal name of the field (or variable) given by AccessID and a list of
 /// SourceLocations where this field (or variable) was accessed.
-class OriginalNameGetter : public ast::ASTVisitorForwarding {
+class OriginalNameGetter : public ast::ASTVisitorForwardingNonConst {
   const int AccessID_;
   const bool captureLocation_;
 

--- a/dawn/src/dawn/Optimizer/Lowering.cpp
+++ b/dawn/src/dawn/Optimizer/Lowering.cpp
@@ -50,7 +50,7 @@ using namespace iir;
 
 /// @brief Map the statements of the stencil description AST to a flat list of statements and
 /// inline all calls to other stencils
-class StencilDescStatementMapper : public ast::ASTVisitor {
+class StencilDescStatementMapper : public ast::ASTVisitorNonConst {
 
   /// @brief Record of the current scope (each StencilCall will create a new scope)
   struct Scope : public NonCopyable {
@@ -190,7 +190,7 @@ public:
 
     // We only need to remove "nested" nodes as the top-level VerticalRegions or StencilCalls are
     // not inserted into the statement list in the frist place
-    class RemoveStencilDescNodes : public ast::ASTVisitorForwarding {
+    class RemoveStencilDescNodes : public ast::ASTVisitorForwardingNonConst {
     public:
       RemoveStencilDescNodes() {}
 

--- a/dawn/src/dawn/Optimizer/PassDataLocalityMetric.cpp
+++ b/dawn/src/dawn/Optimizer/PassDataLocalityMetric.cpp
@@ -33,7 +33,7 @@ namespace {
 
 static constexpr int TERMINAL_CHAR_WIDTH = 70;
 
-class ReadWriteCounter : public ast::ASTVisitorForwarding {
+class ReadWriteCounter : public ast::ASTVisitorForwardingNonConst {
   const iir::StencilMetaInformation& metadata_;
   const Options& options_;
 

--- a/dawn/src/dawn/Optimizer/PassFieldVersioning.cpp
+++ b/dawn/src/dawn/Optimizer/PassFieldVersioning.cpp
@@ -34,7 +34,7 @@ namespace dawn {
 namespace {
 
 /// @brief Register all referenced AccessIDs
-struct AccessIDGetter : public ast::ASTVisitorForwarding {
+struct AccessIDGetter : public ast::ASTVisitorForwardingNonConst {
   const iir::StencilMetaInformation& metadata_;
   std::set<int> AccessIDs;
 

--- a/dawn/src/dawn/Optimizer/PassFixVersionedInputFields.cpp
+++ b/dawn/src/dawn/Optimizer/PassFixVersionedInputFields.cpp
@@ -122,7 +122,7 @@ createAssignmentMultiStage(int assignmentID, std::shared_ptr<iir::StencilInstant
 }
 
 /// @brief Collects AccessIDs from versioned fields in the IIR.
-struct CollectVersionedIDs : public ast::ASTVisitorForwarding {
+struct CollectVersionedIDs : public ast::ASTVisitorForwardingNonConst {
   const iir::StencilMetaInformation& metadata_;
   std::set<int> versionedAccessIDs;
 

--- a/dawn/src/dawn/Optimizer/PassInlining.cpp
+++ b/dawn/src/dawn/Optimizer/PassInlining.cpp
@@ -39,7 +39,7 @@ static std::pair<bool, std::shared_ptr<Inliner>> tryInlineStencilFunction(
     int AccessIDOfCaller, const std::shared_ptr<iir::StencilInstantiation>& stencilInstantiation);
 
 /// @brief Perform the inlining of a stencil-function
-class Inliner : public ast::ASTVisitor {
+class Inliner : public ast::ASTVisitorNonConst {
   PassInlining::InlineStrategy strategy_;
   const std::shared_ptr<iir::StencilFunctionInstantiation>& curStencilFunctioninstantiation_;
   const std::shared_ptr<iir::StencilInstantiation>& instantiation_;
@@ -322,7 +322,7 @@ public:
 };
 
 /// @brief Detect inline candidates
-class DetectInlineCandiates : public ast::ASTVisitorForwarding {
+class DetectInlineCandiates : public ast::ASTVisitorForwardingNonConst {
   PassInlining::InlineStrategy strategy_;
   const std::shared_ptr<iir::StencilInstantiation>& instantiation_;
 
@@ -351,7 +351,7 @@ class DetectInlineCandiates : public ast::ASTVisitorForwarding {
   std::stack<ArgListScope> argListScope_;
 
 public:
-  using Base = ast::ASTVisitorForwarding;
+  using Base = ast::ASTVisitorForwardingNonConst;
 
   DetectInlineCandiates(PassInlining::InlineStrategy strategy,
                         const std::shared_ptr<iir::StencilInstantiation>& instantiation)

--- a/dawn/src/dawn/Optimizer/PassLocalVarType.cpp
+++ b/dawn/src/dawn/Optimizer/PassLocalVarType.cpp
@@ -23,7 +23,7 @@
 namespace dawn {
 namespace {
 
-class VarTypeFinder : public ast::ASTVisitorForwarding {
+class VarTypeFinder : public ast::ASTVisitorForwardingNonConst {
 
   iir::StencilMetaInformation& metadata_;
   // AccessID of variable being processed.
@@ -202,7 +202,7 @@ public:
     }
     // If we encounter an assignment to a local variable inside the then and else blocks, we
     // should impose the recorded type.
-    ast::ASTVisitorForwarding::visit(ifStmt);
+    ast::ASTVisitorForwardingNonConst::visit(ifStmt);
     // Reset as we are exiting the visit of the (outermost) if statement
     if(outerIf) {
       conditionalType_ = std::nullopt;
@@ -256,7 +256,7 @@ public:
       recordVariablePair(accessedVariableID, *curVarID_, stmt->getSourceLocation());
     }
     // Visit rhs
-    ast::ASTVisitorForwarding::visit(stmt);
+    ast::ASTVisitorForwardingNonConst::visit(stmt);
     // Reset as we are exiting the VarDeclStmt's visit
     curVarID_ = std::nullopt;
   }

--- a/dawn/src/dawn/Optimizer/PassRemoveScalars.cpp
+++ b/dawn/src/dawn/Optimizer/PassRemoveScalars.cpp
@@ -28,7 +28,7 @@
 namespace dawn {
 namespace {
 
-class ExprScalarChecker : public ast::ASTVisitorForwarding {
+class ExprScalarChecker : public ast::ASTVisitorForwardingNonConst {
   const iir::StencilMetaInformation& metadata_;
   bool isScalar_ = true;
 

--- a/dawn/src/dawn/Optimizer/PassSetBoundaryCondition.cpp
+++ b/dawn/src/dawn/Optimizer/PassSetBoundaryCondition.cpp
@@ -62,7 +62,7 @@ enum FieldType { NotOriginal = -1 };
 /// @brief The VisitStencilCalls class traverses the StencilDescAST to determine an order of the
 /// stencil calls. This is required to properly evaluate boundary conditions
 ///
-class VisitStencilCalls : public ast::ASTVisitorForwarding {
+class VisitStencilCalls : public ast::ASTVisitorForwardingNonConst {
   std::vector<std::shared_ptr<ast::StencilCallDeclStmt>> stencilCallsInOrder_;
 
 public:
@@ -81,7 +81,7 @@ public:
 /// @brief The AddBoundaryConditions class traverses the StencilDescAST to extract all the
 /// StencilCallStmts for a stencili with a given ID. This is required to properly insert boundary
 /// conditions.
-class AddBoundaryConditions : public ast::ASTVisitorForwarding {
+class AddBoundaryConditions : public ast::ASTVisitorForwardingNonConst {
   std::shared_ptr<iir::StencilInstantiation> instantiation_;
   iir::StencilMetaInformation& metadata_;
   int StencilID_;

--- a/dawn/src/dawn/Optimizer/PassTemporaryFirstAccess.cpp
+++ b/dawn/src/dawn/Optimizer/PassTemporaryFirstAccess.cpp
@@ -26,7 +26,7 @@ namespace dawn {
 
 namespace {
 
-class UnusedFieldVisitor : public ast::ASTVisitorForwarding {
+class UnusedFieldVisitor : public ast::ASTVisitorForwardingNonConst {
   int AccessID_;
   bool fieldIsUnused_;
   const std::shared_ptr<iir::StencilInstantiation>& instantiation_;
@@ -54,7 +54,7 @@ public:
     funCall->getAST()->accept(*this);
 
     // Visit arguments
-    ast::ASTVisitorForwarding::visit(expr);
+    ast::ASTVisitorForwardingNonConst::visit(expr);
     functionInstantiationStack_.pop();
   }
 

--- a/dawn/src/dawn/Optimizer/PassTemporaryType.cpp
+++ b/dawn/src/dawn/Optimizer/PassTemporaryType.cpp
@@ -31,7 +31,7 @@ namespace dawn {
 
 namespace {
 
-class StencilFunArgumentDetector : public ast::ASTVisitorForwarding {
+class StencilFunArgumentDetector : public ast::ASTVisitorForwardingNonConst {
   int AccessID_;
 
   int argListNesting_;
@@ -43,7 +43,7 @@ public:
 
   virtual void visit(const std::shared_ptr<ast::StencilFunCallExpr>& expr) override {
     argListNesting_++;
-    ast::ASTVisitorForwarding::visit(expr);
+    ast::ASTVisitorForwardingNonConst::visit(expr);
     argListNesting_--;
   }
 

--- a/dawn/src/dawn/Optimizer/Renaming.cpp
+++ b/dawn/src/dawn/Optimizer/Renaming.cpp
@@ -29,7 +29,7 @@ namespace {
 
 /// @brief Remap all accesses from `oldAccessID` to `newAccessID` in all statements
 template <class InstantiationType>
-class AccessIDRemapper : public ast::ASTVisitorForwarding {
+class AccessIDRemapper : public ast::ASTVisitorForwardingNonConst {
   InstantiationType* instantiation_;
 
   int oldAccessID_;
@@ -44,7 +44,7 @@ public:
     if(varAccessID == oldAccessID_) {
       varAccessID = newAccessID_;
     }
-    ast::ASTVisitorForwarding::visit(stmt);
+    ast::ASTVisitorForwardingNonConst::visit(stmt);
     stmt->getName() = instantiation_->getNameFromAccessID(varAccessID);
   }
 
@@ -52,7 +52,7 @@ public:
     std::shared_ptr<iir::StencilFunctionInstantiation> fun =
         instantiation_->getStencilFunctionInstantiation(expr);
     renameCallerAccessIDInStencilFunction(fun.get(), oldAccessID_, newAccessID_);
-    ast::ASTVisitorForwarding::visit(expr);
+    ast::ASTVisitorForwardingNonConst::visit(expr);
   }
 
   void visit(const std::shared_ptr<ast::VarAccessExpr>& expr) override {

--- a/dawn/src/dawn/Optimizer/Replacing.cpp
+++ b/dawn/src/dawn/Optimizer/Replacing.cpp
@@ -26,7 +26,7 @@ namespace dawn {
 namespace {
 
 /// @brief Get all field and variable accesses identifier by `AccessID`
-class GetFieldAndVarAccesses : public ast::ASTVisitorForwarding {
+class GetFieldAndVarAccesses : public ast::ASTVisitorForwardingNonConst {
   int AccessID_;
 
   std::vector<std::shared_ptr<ast::FieldAccessExpr>> fieldAccessExprToReplace_;
@@ -103,7 +103,7 @@ void replaceVarWithFieldAccessInStmts(iir::Stencil* stencil, int AccessID,
 namespace {
 
 /// @brief Get all field and variable accesses identifier by `AccessID`
-class GetStencilCalls : public ast::ASTVisitorForwarding {
+class GetStencilCalls : public ast::ASTVisitorForwardingNonConst {
   const std::shared_ptr<iir::StencilInstantiation>& instantiation_;
   int StencilID_;
 

--- a/dawn/src/dawn/Optimizer/StatementMapper.h
+++ b/dawn/src/dawn/Optimizer/StatementMapper.h
@@ -23,7 +23,7 @@ namespace dawn {
 //===------------------------------------------------------------------------------------------===//
 /// @brief Map the statements of the AST to a flat list of statements and assign AccessIDs to all
 /// field, variable and literal accesses. In addition, stencil functions are instantiated.
-class StatementMapper : public ast::ASTVisitor {
+class StatementMapper : public ast::ASTVisitorNonConst {
 
   /// @brief Representation of the current scope which keeps track of the binding of field and
   /// variable names

--- a/dawn/src/dawn/SIR/VerticalRegion.cpp
+++ b/dawn/src/dawn/SIR/VerticalRegion.cpp
@@ -7,7 +7,7 @@ namespace dawn {
 
 namespace {
 /// @brief Allow direct comparison of the Stmts of an AST
-class DiffWriter final : public ast::ASTVisitorForwarding {
+class DiffWriter final : public ast::ASTVisitorForwardingNonConst {
 public:
   virtual void visit(const std::shared_ptr<ast::VerticalRegionDeclStmt>& stmt) override {
     statements_.push_back(stmt);
@@ -16,27 +16,27 @@ public:
 
   virtual void visit(const std::shared_ptr<ast::ReturnStmt>& stmt) override {
     statements_.push_back(stmt);
-    ast::ASTVisitorForwarding::visit(stmt);
+    ast::ASTVisitorForwardingNonConst::visit(stmt);
   }
 
   virtual void visit(const std::shared_ptr<ast::ExprStmt>& stmt) override {
     statements_.push_back(stmt);
-    ast::ASTVisitorForwarding::visit(stmt);
+    ast::ASTVisitorForwardingNonConst::visit(stmt);
   }
 
   virtual void visit(const std::shared_ptr<ast::BlockStmt>& stmt) override {
     statements_.push_back(stmt);
-    ast::ASTVisitorForwarding::visit(stmt);
+    ast::ASTVisitorForwardingNonConst::visit(stmt);
   }
 
   virtual void visit(const std::shared_ptr<ast::VarDeclStmt>& stmt) override {
     statements_.push_back(stmt);
-    ast::ASTVisitorForwarding::visit(stmt);
+    ast::ASTVisitorForwardingNonConst::visit(stmt);
   }
 
   virtual void visit(const std::shared_ptr<ast::IfStmt>& stmt) override {
     statements_.push_back(stmt);
-    ast::ASTVisitorForwarding::visit(stmt);
+    ast::ASTVisitorForwardingNonConst::visit(stmt);
   }
 
   std::vector<std::shared_ptr<ast::Stmt>> getStatements() const { return statements_; }

--- a/dawn/src/dawn/Serialization/ASTSerializer.h
+++ b/dawn/src/dawn/Serialization/ASTSerializer.h
@@ -54,7 +54,7 @@ void setAccesses(dawn::proto::statements::Accesses* protoAccesses,
 
 iir::Extents makeExtents(const dawn::proto::statements::Extents* protoExtents);
 
-class ProtoStmtBuilder : public ast::ASTVisitor {
+class ProtoStmtBuilder : public ast::ASTVisitorNonConst {
   std::stack<dawn::proto::statements::Stmt*> currentStmtProto_;
   std::stack<dawn::proto::statements::Expr*> currentExprProto_;
   const dawn::ast::StmtData::DataType dataType_;

--- a/dawn/src/dawn/Serialization/IIRSerializer.cpp
+++ b/dawn/src/dawn/Serialization/IIRSerializer.cpp
@@ -543,17 +543,17 @@ void IIRSerializer::deserializeMetaData(std::shared_ptr<iir::StencilInstantiatio
     }
   }
 
-  struct DeclStmtFinder : public ast::ASTVisitorForwarding {
+  struct DeclStmtFinder : public ast::ASTVisitorForwardingNonConst {
     DeclStmtFinder(int& maxid) : maxID(maxid) {}
     void visit(const std::shared_ptr<ast::StencilCallDeclStmt>& stmt) override {
       stencilCallDecl.insert(std::make_pair(stmt->getID(), stmt));
       maxID = std::max(std::abs(stmt->getID()), maxID);
-      ASTVisitorForwarding::visit(stmt);
+      ASTVisitorForwardingNonConst::visit(stmt);
     }
     void visit(const std::shared_ptr<ast::BoundaryConditionDeclStmt>& stmt) override {
       boundaryConditionDecl.insert(std::make_pair(stmt->getID(), stmt));
       maxID = std::max(std::abs(stmt->getID()), maxID);
-      ASTVisitorForwarding::visit(stmt);
+      ASTVisitorForwardingNonConst::visit(stmt);
     }
     std::map<int, std::shared_ptr<ast::StencilCallDeclStmt>> stencilCallDecl;
     std::map<int, std::shared_ptr<ast::BoundaryConditionDeclStmt>> boundaryConditionDecl;

--- a/dawn/src/dawn/Validator/GridTypeChecker.cpp
+++ b/dawn/src/dawn/Validator/GridTypeChecker.cpp
@@ -121,7 +121,7 @@ void GridTypeChecker::TypeCheckerImpl::visit(const std::shared_ptr<ast::FieldAcc
   }
   typesConsistent_ &= hOffset.getGridType() == prescribedType_;
 
-  ast::ASTVisitorForwarding::visit(expr);
+  ast::ASTVisitorForwardingNonConst::visit(expr);
 }
 
 } // namespace dawn

--- a/dawn/src/dawn/Validator/GridTypeChecker.h
+++ b/dawn/src/dawn/Validator/GridTypeChecker.h
@@ -25,7 +25,7 @@
 namespace dawn {
 class GridTypeChecker {
 private:
-  class TypeCheckerImpl : public ast::ASTVisitorForwarding {
+  class TypeCheckerImpl : public ast::ASTVisitorForwardingNonConst {
     ast::GridType prescribedType_;
     bool typesConsistent_ = true;
 

--- a/dawn/src/dawn/Validator/IndirectionChecker.h
+++ b/dawn/src/dawn/Validator/IndirectionChecker.h
@@ -24,14 +24,14 @@ namespace dawn {
 
 class IndirectionChecker {
 
-  class IndirectionCheckerImpl : public ast::ASTVisitorForwarding {
+  class IndirectionCheckerImpl : public ast::ASTVisitorForwardingNonConst {
   private:
     bool indirectionsValid_ = true;
     bool lhs_ = false;
 
   public:
-    void visit(const std::shared_ptr<ast::FieldAccessExpr>& expr);
-    void visit(const std::shared_ptr<ast::AssignmentExpr>& expr);
+    void visit(const std::shared_ptr<ast::FieldAccessExpr>& expr) override;
+    void visit(const std::shared_ptr<ast::AssignmentExpr>& expr) override;
     bool indirectionsAreValid() const { return indirectionsValid_; }
   };
 

--- a/dawn/src/dawn/Validator/IntegrityChecker.cpp
+++ b/dawn/src/dawn/Validator/IntegrityChecker.cpp
@@ -157,7 +157,7 @@ void IntegrityChecker::visit(const std::shared_ptr<ast::FieldAccessExpr>& expr) 
     throw SemanticError("Attempting to read with vertical offset from horizontal field!");
   }
 
-  ast::ASTVisitorForwarding::visit(expr);
+  ast::ASTVisitorForwardingNonConst::visit(expr);
 
   curDimensions_ = metadata_.getFieldDimensions(accessID).numSpatialDimensions();
 }

--- a/dawn/src/dawn/Validator/IntegrityChecker.h
+++ b/dawn/src/dawn/Validator/IntegrityChecker.h
@@ -25,7 +25,7 @@ namespace dawn {
 //     IntegrityChecker
 //===------------------------------------------------------------------------------------------===//
 /// @brief Perform basic integrity checks on the AST.
-class IntegrityChecker : public ast::ASTVisitorForwarding {
+class IntegrityChecker : public ast::ASTVisitorForwardingNonConst {
   iir::StencilInstantiation* instantiation_;
   iir::StencilMetaInformation& metadata_;
   // are we in a loop or reduction expression?

--- a/dawn/src/dawn/Validator/UnstructuredDimensionChecker.h
+++ b/dawn/src/dawn/Validator/UnstructuredDimensionChecker.h
@@ -28,7 +28,7 @@ namespace dawn {
 class UnstructuredDimensionChecker {
 
 private:
-  class UnstructuredDimensionCheckerImpl : public ast::ASTVisitorForwarding {
+  class UnstructuredDimensionCheckerImpl : public ast::ASTVisitorForwardingNonConst {
   public:
     enum class checkType { runOnIIR, runOnSIR };
     struct UnstructuredDimensionCheckerConfig {

--- a/dawn/src/dawn/Validator/WeightChecker.h
+++ b/dawn/src/dawn/Validator/WeightChecker.h
@@ -38,7 +38,7 @@ namespace dawn {
 
 class WeightChecker {
 private:
-  class WeightCheckerImpl : public dawn::ast::ASTVisitorForwarding {
+  class WeightCheckerImpl : public dawn::ast::ASTVisitorForwardingNonConst {
   private:
     bool weightsValid_ = true;
     bool parentIsWeight_ = false;

--- a/dawn/test/integration-test/unstructured/testMutator.cpp
+++ b/dawn/test/integration-test/unstructured/testMutator.cpp
@@ -11,7 +11,7 @@
 #include <map>
 #include <optional>
 
-class accessMutator : public dawn::ast::ASTVisitorForwarding {
+class accessMutator : public dawn::ast::ASTVisitorForwardingNonConst {
   void visit(const std::shared_ptr<dawn::ast::FieldAccessExpr>& expr) override {
     if(mutatedFields_.count(expr->getName())) {
       expr->getOffset().setVerticalIndirection(expr->getName() + "_indirection");

--- a/dawn/test/unit-test/dawn/SIR/TestASTVisitor.cpp
+++ b/dawn/test/unit-test/dawn/SIR/TestASTVisitor.cpp
@@ -49,7 +49,7 @@ public:
   }
 };
 
-class CheckVisitor : public ast::ASTVisitorForwarding, public NonCopyable {
+class CheckVisitor : public ast::ASTVisitorForwardingNonConst, public NonCopyable {
 
   bool result_ = true;
 
@@ -156,7 +156,7 @@ public:
   }
 };
 
-class CheckAssignVisitor : public ast::ASTVisitorForwarding, public NonCopyable {
+class CheckAssignVisitor : public ast::ASTVisitorForwardingNonConst, public NonCopyable {
 
   bool result_ = true;
 
@@ -213,7 +213,7 @@ public:
   }
 };
 
-class CheckIfVisitor : public ast::ASTVisitorForwarding, public NonCopyable {
+class CheckIfVisitor : public ast::ASTVisitorForwardingNonConst, public NonCopyable {
 
   bool result_ = true;
 

--- a/gtclang/src/gtclang/Unittest/ParsingComparison.cpp
+++ b/gtclang/src/gtclang/Unittest/ParsingComparison.cpp
@@ -183,9 +183,9 @@ private:
   std::string filename_;
 };
 
-class FieldFinder : public dawn::ast::ASTVisitorForwarding {
+class FieldFinder : public dawn::ast::ASTVisitorForwardingNonConst {
 public:
-  virtual void visit(const std::shared_ptr<dawn::ast::FieldAccessExpr>& expr) {
+  virtual void visit(const std::shared_ptr<dawn::ast::FieldAccessExpr>& expr) override {
     auto fieldFromExpression = dawn::sir::Field(
         expr->getName(),
         dawn::sir::FieldDimensions(
@@ -194,10 +194,10 @@ public:
     auto iter = std::find(allFields_.begin(), allFields_.end(), fieldFromExpression);
     if(iter == allFields_.end())
       allFields_.push_back(fieldFromExpression);
-    dawn::ast::ASTVisitorForwarding::visit(expr);
+    dawn::ast::ASTVisitorForwardingNonConst::visit(expr);
   }
 
-  virtual void visit(const std::shared_ptr<dawn::ast::VerticalRegionDeclStmt>& stmt) {
+  virtual void visit(const std::shared_ptr<dawn::ast::VerticalRegionDeclStmt>& stmt) override {
     stmt->getVerticalRegion()->Ast->accept(*this);
   }
 


### PR DESCRIPTION
## Technical Description

As explained in #617, the current visitor interface
```
ASTVisitor::visit(const std::shared_ptr<T>& stmt);
ASTVisitorNonConst::visit(std::shared_ptr<T> stmt);
```
does not respect the constness of the inner type `T` wrapped by the `shared_ptr`.
The proposed solution is to switch to the following interface:
```
ASTVisitor::visit(const T& stmt);
ASTVisitorNonConst::visit(T& stmt);
```
Unfortunately, this would lead to a massive global refactoring, since the visitors are also used to pass around `shared_ptr` from datastructure to datastructure, for example all of the StencilMetaInformation is generated by visiting the AST and generating `shared_ptr`s through the visitor interface.
Instead I propose to change to this interface:
```
ASTVisitor::visit(const std::shared_ptr<const T>& stmt);
ASTVisitorNonConst::visit(const std::shared_ptr<T>& stmt);
```
Note that `ASTVisitorNonConst` now provides the exact same interface as `ASTVisitor` before the changes. Meanwhile `ASTVisitor` now respects the constness of the inner type wrapped by `shared_ptr`.

### Resolves / Enhances

#617

### Example

As a first example, the `ASTStringifier` is now visited by the const visitor. All other visitors in the project now use the `ASTVisitorNonConst` interface.

### Followups

1. Only `ASTStringifier` uses the new `const` visitor interface. Most other visitor usages probably could use the `const` interfaces. However, some work is still to be done here since some methods, which probably could be `const`, do not respect constness, such as `Expr::getData` or `IIR::getAccessID`.
2. Since constness in C++ is a shallow property (i.e. does not propagate downwards through nested datastructures), even with the new const visitor interface some class members of AST classes can still be changed. For example, for `AST::BinaryOperator' the following operation is now prevented by the `const` visitor:
```
void visit(const std::shared_ptr<const BinaryOperator>& expr) override {
    expr->getLeft() = expr->getRight();
```
The following unfortunately still compiles:
```
void visit(const std::shared_ptr<const BinaryOperator>& expr) override {
    *(expr->getLeft()) = *(expr->getRight());
```
One possible way to prevent this behavior is using `std::experimental::propagate_const`. We can evaluate if this is worth it. It has to work with gcc 8 since that is our target compiler.