### PR TITLE
SIR <-> AST refactoring part 2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ _local_/*
 .vscode/
 **/compile_commands.json
 .clangd/
+venv/
 
 # Ignore python editable installs
 *.egg-info/

--- a/dawn/examples/python/copy_stencil.py
+++ b/dawn/examples/python/copy_stencil.py
@@ -33,7 +33,7 @@ import os
 
 import dawn4py
 from dawn4py.serialization import SIR
-from dawn4py.serialization import utils as sir_utils
+from dawn4py.serialization import utils as serial_utils
 
 OUTPUT_NAME = "copy_stencil"
 OUTPUT_FILE = f"{OUTPUT_NAME}.cpp"
@@ -41,33 +41,33 @@ OUTPUT_PATH = f"{OUTPUT_NAME}.cpp"
 
 
 def main(args: argparse.Namespace):
-    interval = sir_utils.make_interval(SIR.Interval.Start, SIR.Interval.End, 0, 0)
+    interval = serial_utils.make_interval(SIR.Interval.Start, SIR.Interval.End, 0, 0)
 
     # create the out = in[i+1] statement
-    body_ast = sir_utils.make_ast(
+    body_ast = serial_utils.make_ast(
         [
-            sir_utils.make_assignment_stmt(
-                sir_utils.make_field_access_expr("out", [0, 0, 0]),
-                sir_utils.make_field_access_expr("in", [1, 0, 0]),
+            serial_utils.make_assignment_stmt(
+                serial_utils.make_field_access_expr("out", [0, 0, 0]),
+                serial_utils.make_field_access_expr("in", [1, 0, 0]),
                 "=",
             )
         ]
     )
 
-    vertical_region_stmt = sir_utils.make_vertical_region_decl_stmt(
+    vertical_region_stmt = serial_utils.make_vertical_region_decl_stmt(
         body_ast, interval, SIR.VerticalRegion.Forward
     )
 
-    sir = sir_utils.make_sir(
+    sir = serial_utils.make_sir(
         OUTPUT_FILE,
         SIR.GridType.Value("Cartesian"),
         [
-            sir_utils.make_stencil(
+            serial_utils.make_stencil(
                 OUTPUT_NAME,
-                sir_utils.make_ast([vertical_region_stmt]),
+                serial_utils.make_ast([vertical_region_stmt]),
                 [
-                    sir_utils.make_field("in", sir_utils.make_field_dimensions_cartesian()),
-                    sir_utils.make_field("out", sir_utils.make_field_dimensions_cartesian()),
+                    serial_utils.make_field("in", serial_utils.make_field_dimensions_cartesian()),
+                    serial_utils.make_field("out", serial_utils.make_field_dimensions_cartesian()),
                 ],
             )
         ],
@@ -75,7 +75,7 @@ def main(args: argparse.Namespace):
 
     # print the SIR
     if args.verbose:
-        sir_utils.pprint(sir)
+        serial_utils.pprint(sir)
 
     # compile
     code = dawn4py.compile(sir, backend=dawn4py.CodeGenBackend.CUDA)

--- a/dawn/examples/python/unstructured_stencil.py
+++ b/dawn/examples/python/unstructured_stencil.py
@@ -26,7 +26,7 @@ import os
 
 import dawn4py
 from dawn4py.serialization import SIR
-from dawn4py.serialization import utils as sir_utils
+from dawn4py.serialization import utils as serial_utils
 
 OUTPUT_NAME = "unstructured_stencil"
 OUTPUT_FILE = f"{OUTPUT_NAME}.cpp"
@@ -34,16 +34,16 @@ OUTPUT_PATH = f"{OUTPUT_NAME}.cpp"
 
 
 def main(args: argparse.Namespace):
-    interval = sir_utils.make_interval(SIR.Interval.Start, SIR.Interval.End, 0, 0)
+    interval = serial_utils.make_interval(SIR.Interval.Start, SIR.Interval.End, 0, 0)
 
-    body_ast = sir_utils.make_ast(
+    body_ast = serial_utils.make_ast(
         [
-            sir_utils.make_assignment_stmt(
-                sir_utils.make_field_access_expr("out"),
-                sir_utils.make_reduction_over_neighbor_expr(
+            serial_utils.make_assignment_stmt(
+                serial_utils.make_field_access_expr("out"),
+                serial_utils.make_reduction_over_neighbor_expr(
                     "+",
-                    sir_utils.make_literal_access_expr("1.0", SIR.BuiltinType.Float),
-                    sir_utils.make_field_access_expr("in"),
+                    serial_utils.make_literal_access_expr("1.0", SIR.BuiltinType.Float),
+                    serial_utils.make_field_access_expr("in"),
                     chain=[SIR.LocationType.Value("Edge"), SIR.LocationType.Value("Cell")],
                 ),
                 "=",
@@ -51,27 +51,27 @@ def main(args: argparse.Namespace):
         ]
     )
 
-    vertical_region_stmt = sir_utils.make_vertical_region_decl_stmt(
+    vertical_region_stmt = serial_utils.make_vertical_region_decl_stmt(
         body_ast, interval, SIR.VerticalRegion.Forward
     )
 
-    sir = sir_utils.make_sir(
+    sir = serial_utils.make_sir(
         OUTPUT_FILE,
         SIR.GridType.Value("Unstructured"),
         [
-            sir_utils.make_stencil(
+            serial_utils.make_stencil(
                 OUTPUT_NAME,
-                sir_utils.make_ast([vertical_region_stmt]),
+                serial_utils.make_ast([vertical_region_stmt]),
                 [
-                    sir_utils.make_field(
+                    serial_utils.make_field(
                         "in",
-                        sir_utils.make_field_dimensions_unstructured(
+                        serial_utils.make_field_dimensions_unstructured(
                             [SIR.LocationType.Value("Cell")], 1
                         ),
                     ),
-                    sir_utils.make_field(
+                    serial_utils.make_field(
                         "out",
-                        sir_utils.make_field_dimensions_unstructured(
+                        serial_utils.make_field_dimensions_unstructured(
                             [SIR.LocationType.Value("Edge")], 1
                         ),
                     ),
@@ -82,7 +82,7 @@ def main(args: argparse.Namespace):
 
     # print the SIR
     if args.verbose:
-        sir_utils.pprint(sir)
+        serial_utils.pprint(sir)
 
     # compile
     code = dawn4py.compile(sir, backend=dawn4py.CodeGenBackend.CXXNaiveIco)

--- a/dawn/examples/tutorial/laplacian_stencil.py
+++ b/dawn/examples/tutorial/laplacian_stencil.py
@@ -34,7 +34,7 @@ import os
 
 import dawn4py
 from dawn4py.serialization import SIR
-from dawn4py.serialization import utils as sir_utils
+from dawn4py.serialization import utils as serial_utils
 
 OUTPUT_NAME = "laplacian_stencil"
 OUTPUT_FILE = f"{OUTPUT_NAME}_from_python.cpp"
@@ -42,42 +42,42 @@ OUTPUT_PATH = os.path.join(os.path.dirname(__file__), OUTPUT_FILE)
 
 
 def main(args: argparse.Namespace):
-    interval = sir_utils.make_interval(SIR.Interval.Start, SIR.Interval.End, 0, 0)
+    interval = serial_utils.make_interval(SIR.Interval.Start, SIR.Interval.End, 0, 0)
 
     # create the laplace statement
-    body_ast = sir_utils.make_ast(
+    body_ast = serial_utils.make_ast(
         [
-            sir_utils.make_assignment_stmt(
-                sir_utils.make_field_access_expr("out", [0, 0, 0]),
-                sir_utils.make_binary_operator(
-                    sir_utils.make_binary_operator(
-                        sir_utils.make_binary_operator(
-                            sir_utils.make_field_access_expr("in", [0, 0, 0]),
+            serial_utils.make_assignment_stmt(
+                serial_utils.make_field_access_expr("out", [0, 0, 0]),
+                serial_utils.make_binary_operator(
+                    serial_utils.make_binary_operator(
+                        serial_utils.make_binary_operator(
+                            serial_utils.make_field_access_expr("in", [0, 0, 0]),
                             "*",
-                            sir_utils.make_literal_access_expr(
-                                "-4.0", sir_utils.BuiltinType.Float
+                            serial_utils.make_literal_access_expr(
+                                "-4.0", serial_utils.BuiltinType.Float
                             ),
                         ),
                         "+",
-                        sir_utils.make_binary_operator(
-                            sir_utils.make_field_access_expr("in", [1, 0, 0]),
+                        serial_utils.make_binary_operator(
+                            serial_utils.make_field_access_expr("in", [1, 0, 0]),
                             "+",
-                            sir_utils.make_binary_operator(
-                                sir_utils.make_field_access_expr("in", [-1, 0, 0]),
+                            serial_utils.make_binary_operator(
+                                serial_utils.make_field_access_expr("in", [-1, 0, 0]),
                                 "+",
-                                sir_utils.make_binary_operator(
-                                    sir_utils.make_field_access_expr("in", [0, 1, 0]),
+                                serial_utils.make_binary_operator(
+                                    serial_utils.make_field_access_expr("in", [0, 1, 0]),
                                     "+",
-                                    sir_utils.make_field_access_expr("in", [0, -1, 0]),
+                                    serial_utils.make_field_access_expr("in", [0, -1, 0]),
                                 ),
                             ),
                         ),
                     ),
                     "/",
-                    sir_utils.make_binary_operator(
-                        sir_utils.make_var_access_expr("dx", is_external=True),
+                    serial_utils.make_binary_operator(
+                        serial_utils.make_var_access_expr("dx", is_external=True),
                         "*",
-                        sir_utils.make_var_access_expr("dx", is_external=True),
+                        serial_utils.make_var_access_expr("dx", is_external=True),
                     ),
                 ),
                 "=",
@@ -85,23 +85,23 @@ def main(args: argparse.Namespace):
         ]
     )
 
-    vertical_region_stmt = sir_utils.make_vertical_region_decl_stmt(
+    vertical_region_stmt = serial_utils.make_vertical_region_decl_stmt(
         body_ast, interval, SIR.VerticalRegion.Forward
     )
 
-    stencils_globals = sir_utils.GlobalVariableMap()
+    stencils_globals = serial_utils.GlobalVariableMap()
     stencils_globals.map["dx"].double_value = 0.0
 
-    sir = sir_utils.make_sir(
+    sir = serial_utils.make_sir(
         OUTPUT_FILE,
         SIR.GridType.Value("Cartesian"),
         [
-            sir_utils.make_stencil(
+            serial_utils.make_stencil(
                 OUTPUT_NAME,
-                sir_utils.make_ast([vertical_region_stmt]),
+                serial_utils.make_ast([vertical_region_stmt]),
                 [
-                    sir_utils.make_field("out", sir_utils.make_field_dimensions_cartesian()),
-                    sir_utils.make_field("in", sir_utils.make_field_dimensions_cartesian()),
+                    serial_utils.make_field("out", serial_utils.make_field_dimensions_cartesian()),
+                    serial_utils.make_field("in", serial_utils.make_field_dimensions_cartesian()),
                 ],
             )
         ],
@@ -110,11 +110,11 @@ def main(args: argparse.Namespace):
 
     # print the SIR
     if args.verbose:
-        sir_utils.pprint(sir)
+        serial_utils.pprint(sir)
 
     # serialize the SIR to file
     sir_file = open("./laplacian_stencil_from_python.sir", "wb")
-    sir_file.write(sir_utils.to_json(sir))
+    sir_file.write(serial_utils.to_json(sir))
     sir_file.close()
 
     # compile

--- a/dawn/src/dawn/AST/CMakeLists.txt
+++ b/dawn/src/dawn/AST/CMakeLists.txt
@@ -12,6 +12,35 @@
 ##
 ##===------------------------------------------------------------------------------------------===##
 
+# Defines dawn_ast_proto_files
+include(proto/DawnAST.cmake)
+
+include(DawnProtobufGenerate)
+dawn_protobuf_generate(
+  OUT_FILES ast_proto_cpp_files
+  WDIR ${CMAKE_CURRENT_SOURCE_DIR}/proto
+  PROTOS ${dawn_ast_proto_files}
+  PACKG AST
+  LANGUAGE cpp
+)
+
+set(ast_proto_header_files ${ast_proto_cpp_files})
+list(FILTER ast_proto_header_files INCLUDE REGEX ".+\\.h?h$")
+install(FILES ${ast_proto_header_files} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/dawn/AST/AST)
+
+add_library(DawnASTProto OBJECT ${ast_proto_cpp_files})
+target_compile_features(DawnASTProto PUBLIC cxx_std_11)
+set_target_properties(DawnASTProto PROPERTIES ${DAWN_TARGET_PROPERTIES})
+
+# Generated files need to be compiled with the protobuf headers
+target_include_directories(DawnASTProto
+        PUBLIC
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
+        )
+
+# ... and linked to protobuf
+target_link_libraries(DawnASTProto PUBLIC protobuf::libprotobuf)
+
 add_library(DawnAST OBJECT
   AST.h
   AST.cpp
@@ -38,7 +67,13 @@ add_library(DawnAST OBJECT
   Tags.h
   Value.cpp
   Value.h
+  $<TARGET_OBJECTS:DawnASTProto>
 )
 
 target_add_dawn_standard_props(DawnAST)
-target_link_libraries(DawnAST PUBLIC DawnSupport)
+target_link_libraries(DawnAST PUBLIC DawnSupport DawnASTProto)
+
+# The include path below is necessary for the C++ proto headers
+target_include_directories(DawnAST
+        PUBLIC $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/dawn/AST>
+        )

--- a/dawn/src/dawn/AST/CMakeLists.txt
+++ b/dawn/src/dawn/AST/CMakeLists.txt
@@ -57,11 +57,13 @@ add_library(DawnAST OBJECT
   ASTVisitor.h
   ASTVisitorHelpers.h
   Attr.h
+  FieldDimension.h
+  FieldDimension.cpp
+  GridType.h
+  GridType.cpp
   Interval.h
   Interval.cpp
   LocationType.h
-  GridType.h
-  GridType.cpp
   Offsets.h
   Offsets.cpp
   Tags.h

--- a/dawn/src/dawn/AST/FieldDimension.cpp
+++ b/dawn/src/dawn/AST/FieldDimension.cpp
@@ -1,0 +1,108 @@
+#include "FieldDimension.h"
+
+#include "dawn/Support/Casting.h"
+#include "dawn/Support/Format.h"
+#include "dawn/Support/Unreachable.h"
+
+namespace dawn {
+namespace ast {
+
+UnstructuredFieldDimension::UnstructuredFieldDimension(ast::NeighborChain neighborChain,
+                                                       bool includeCenter)
+    : iterSpace_(std::move(neighborChain), includeCenter) {}
+
+const ast::NeighborChain& UnstructuredFieldDimension::getNeighborChain() const {
+  DAWN_ASSERT(isSparse());
+  return iterSpace_.Chain;
+}
+
+std::string UnstructuredFieldDimension::toString() const {
+  auto getLocationTypeString = [](const ast::LocationType type) {
+    switch(type) {
+    case ast::LocationType::Cells:
+      return std::string("cell");
+      break;
+    case ast::LocationType::Vertices:
+      return std::string("vertex");
+      break;
+    case ast::LocationType::Edges:
+      return std::string("edge");
+      break;
+    default:
+      dawn_unreachable("unexpected type");
+    }
+  };
+
+  std::string output = "", separator = "";
+  for(const auto elem : iterSpace_.Chain) {
+    if(iterSpace_.IncludeCenter && separator == "") {
+      output += separator + "[" + getLocationTypeString(elem) + "]";
+    } else {
+      output += separator + getLocationTypeString(elem);
+    }
+    separator = "->";
+  }
+  return output;
+}
+
+ast::GridType HorizontalFieldDimension::getType() const {
+  if(dimension_isa<CartesianFieldDimension>(*this)) {
+    return ast::GridType::Cartesian;
+  } else {
+    return ast::GridType::Unstructured;
+  }
+}
+
+std::string FieldDimensions::toString() const {
+  if(dimension_isa<CartesianFieldDimension>(getHorizontalFieldDimension())) {
+    const auto& cartesianDimensions =
+    dimension_cast<CartesianFieldDimension const&>(getHorizontalFieldDimension());
+    return format("[%i,%i,%i]", cartesianDimensions.I(), cartesianDimensions.J(), K());
+
+  } else if(dimension_isa<UnstructuredFieldDimension>(getHorizontalFieldDimension())) {
+    const auto& unstructuredDimension =
+    dimension_cast<UnstructuredFieldDimension const&>(getHorizontalFieldDimension());
+    return format("[%s,%i]", unstructuredDimension.toString(), K());
+
+  } else {
+    dawn_unreachable("Invalid horizontal field dimension");
+  }
+}
+
+int FieldDimensions::numSpatialDimensions() const {
+  if(!horizontalFieldDimension_) {
+    return 1;
+  }
+  if(dimension_isa<CartesianFieldDimension>(getHorizontalFieldDimension())) {
+    const auto& cartesianDimensions =
+    dimension_cast<CartesianFieldDimension const&>(getHorizontalFieldDimension());
+    return int(cartesianDimensions.I()) + int(cartesianDimensions.J()) + int(K());
+  } else if(dimension_isa<UnstructuredFieldDimension>(getHorizontalFieldDimension())) {
+    return 2 + int(K());
+  } else {
+    dawn_unreachable("Invalid horizontal field dimension");
+  }
+}
+
+int FieldDimensions::rank() const {
+  const int spatialDims = numSpatialDimensions();
+  if(isVertical()) {
+    return 1;
+  }
+  int rank;
+  if(dimension_isa<UnstructuredFieldDimension>(getHorizontalFieldDimension())) {
+    rank = spatialDims > 1 ? spatialDims - 1 // The horizontal counts as 1 dimension (dense)
+                           : spatialDims;
+    // Need to account for sparse dimension, if present
+    if(dimension_cast<UnstructuredFieldDimension const&>(getHorizontalFieldDimension())
+        .isSparse()) {
+      ++rank;
+    }
+  } else { // Cartesian
+    rank = spatialDims;
+  }
+  return rank;
+}
+
+} // namespace ast
+} // namespace dawn

--- a/dawn/src/dawn/AST/FieldDimension.h
+++ b/dawn/src/dawn/AST/FieldDimension.h
@@ -1,0 +1,183 @@
+#pragma once
+
+#include "GridType.h"
+#include "IterationSpace.h"
+#include "Tags.h"
+
+#include <memory>
+#include <optional>
+
+namespace dawn {
+namespace ast {
+
+class FieldDimensionImpl {
+public:
+  std::unique_ptr<FieldDimensionImpl> clone() const { return cloneImpl(); }
+  virtual ~FieldDimensionImpl() = default;
+  bool operator==(const FieldDimensionImpl& other) { return equalityImpl(other); }
+
+private:
+  virtual std::unique_ptr<FieldDimensionImpl> cloneImpl() const = 0;
+  virtual bool equalityImpl(const FieldDimensionImpl& other) const = 0;
+};
+
+/// @brief In the cartesian case, the horizontal dimension is an IJ-mask describing if the
+/// field is allowed to have extents in I and/or J: [1,0] is a storage_i and cannot be
+/// accessed with field[j+1]
+///
+/// @ingroup sir
+class CartesianFieldDimension : public FieldDimensionImpl {
+  const std::array<bool, 2> mask_;
+  std::unique_ptr<FieldDimensionImpl> cloneImpl() const override {
+    return std::make_unique<CartesianFieldDimension>(mask_);
+  }
+  virtual bool equalityImpl(const FieldDimensionImpl& other) const override {
+    auto const& otherCartesian = dynamic_cast<CartesianFieldDimension const&>(other);
+    return otherCartesian.I() == I() && otherCartesian.J() == J();
+  }
+
+public:
+  bool I() const { return mask_[0]; }
+  bool J() const { return mask_[1]; }
+  explicit CartesianFieldDimension(std::array<bool, 2> mask) : mask_(mask) {}
+};
+
+/// @brief In the unstructured case, the horizontal dimension can be either dense or sparse.
+/// A field on dense corresponds to 1 value for each location of type defined by the "dense location
+/// type". A field on sparse corresponds to as many values as indirect neighbors defined through a
+/// neighbor chain.
+///
+/// Construct with a neighbor chain. If it is of size = 1, then the dimension is dense (with
+/// location type = single element of chain), otherwise sparse (with dense location type being the
+/// first element of the chain).
+///
+/// @ingroup sir
+class UnstructuredFieldDimension : public FieldDimensionImpl {
+  std::unique_ptr<FieldDimensionImpl> cloneImpl() const override {
+    return std::make_unique<UnstructuredFieldDimension>(iterSpace_.Chain, iterSpace_.IncludeCenter);
+  }
+  virtual bool equalityImpl(const FieldDimensionImpl& other) const override {
+    auto const& otherUnstructured = dynamic_cast<UnstructuredFieldDimension const&>(other);
+    return iterSpace_ == otherUnstructured.iterSpace_;
+  }
+  const ast::UnstructuredIterationSpace iterSpace_;
+
+public:
+  explicit UnstructuredFieldDimension(ast::NeighborChain neighborChain, bool includeCenter = false);
+  /// @brief Returns the neighbor chain encoding the sparse part (isSparse() must be true!).
+  const ast::NeighborChain& getNeighborChain() const;
+  /// @brief Returns the dense location (always present)
+  ast::LocationType getDenseLocationType() const { return iterSpace_.Chain[0]; }
+  /// @brief Returns the last sparse location type if there is a sparse part, otherwise returns the
+  /// dense part.
+  ast::LocationType getLastSparseLocationType() const { return iterSpace_.Chain.back(); }
+  bool isSparse() const { return iterSpace_.Chain.size() > 1; }
+  bool isDense() const { return !isSparse(); }
+  bool getIncludeCenter() const { return iterSpace_.IncludeCenter; }
+  ast::UnstructuredIterationSpace getIterSpace() const { return iterSpace_; }
+  std::string toString() const;
+};
+
+class HorizontalFieldDimension {
+  std::unique_ptr<FieldDimensionImpl> impl_;
+
+public:
+  // Construct a Cartesian horizontal field dimension with specified ij mask.
+  HorizontalFieldDimension(dawn::ast::cartesian_, std::array<bool, 2> mask)
+      : impl_(std::make_unique<CartesianFieldDimension>(mask)) {}
+
+  // Construct a Unstructured horizontal field sparse dimension with specified neighbor chain
+  // (sparse part). Dense part is the first element of the chain.
+  HorizontalFieldDimension(dawn::ast::unstructured_, ast::NeighborChain neighborChain,
+                           bool includeCenter = false)
+      : impl_(std::make_unique<UnstructuredFieldDimension>(neighborChain, includeCenter)) {}
+  // Construct a Unstructured horizontal field dense dimension with specified (dense) location type.
+  HorizontalFieldDimension(dawn::ast::unstructured_, ast::LocationType locationType,
+                           bool includeCenter = false)
+      : impl_(std::make_unique<UnstructuredFieldDimension>(ast::NeighborChain{locationType},
+                                                           includeCenter)) {}
+
+  HorizontalFieldDimension(const HorizontalFieldDimension& other) { *this = other; }
+  HorizontalFieldDimension(HorizontalFieldDimension&& other) { *this = other; };
+
+  HorizontalFieldDimension& operator=(const HorizontalFieldDimension& other) {
+    impl_ = other.impl_->clone();
+    return *this;
+  }
+  HorizontalFieldDimension& operator=(HorizontalFieldDimension&& other) {
+    impl_ = std::move(other.impl_);
+    return *this;
+  }
+
+  bool operator==(const HorizontalFieldDimension& other) const { return *impl_ == *other.impl_; }
+
+  ast::GridType getType() const;
+
+  template <typename T>
+  friend T dimension_cast(HorizontalFieldDimension const& dimension);
+  template <typename T>
+  friend bool dimension_isa(HorizontalFieldDimension const& dimension);
+};
+
+template <typename T>
+T dimension_cast(HorizontalFieldDimension const& dimension) {
+  using PlainT = std::remove_reference_t<T>;
+  static_assert(std::is_base_of_v<FieldDimensionImpl, PlainT>,
+                "Can only be casted to a valid field dimension implementation");
+  static_assert(std::is_const_v<PlainT>, "Can only be casted to const");
+  return *dynamic_cast<std::add_pointer_t<T>>(dimension.impl_.get());
+}
+
+template <typename T>
+bool dimension_isa(HorizontalFieldDimension const& dimension) {
+  using PlainT = std::remove_pointer_t<std::remove_reference_t<T>>;
+  static_assert(std::is_base_of_v<FieldDimensionImpl, PlainT>,
+                "Can only be casted to a valid field dimension implementation");
+  return static_cast<bool>(dynamic_cast<PlainT*>(dimension.impl_.get()));
+}
+
+class FieldDimensions {
+public:
+  FieldDimensions(HorizontalFieldDimension&& horizontalFieldDimension, bool maskK)
+      : horizontalFieldDimension_(horizontalFieldDimension), maskK_(maskK) {
+    if(!maskK && dimension_isa<CartesianFieldDimension>(*horizontalFieldDimension_)) {
+      auto cartDims = dimension_cast<const CartesianFieldDimension&>(*horizontalFieldDimension_);
+      DAWN_ASSERT_MSG(cartDims.I() || cartDims.J(),
+                      "a field cant' have all dimensions masked out!");
+    }
+  }
+  FieldDimensions(bool maskK) : maskK_(maskK) {
+    DAWN_ASSERT_MSG(
+        maskK_, "a field can't have null horizontal dimensions as well as masked out k dimension!");
+  }
+  FieldDimensions(const FieldDimensions&) = default;
+  FieldDimensions(FieldDimensions&&) = default;
+
+  FieldDimensions& operator=(const FieldDimensions&) = default;
+  FieldDimensions& operator=(FieldDimensions&&) = default;
+
+  bool operator==(const FieldDimensions& other) const {
+    return (maskK_ == other.maskK_ && horizontalFieldDimension_ == other.horizontalFieldDimension_);
+  }
+
+  bool K() const { return maskK_; }
+  const HorizontalFieldDimension& getHorizontalFieldDimension() const {
+    DAWN_ASSERT_MSG(!isVertical(), "attempted to get horizontal dimension of a vertical field!");
+    return horizontalFieldDimension_.value();
+  }
+  bool isVertical() const { return !horizontalFieldDimension_.has_value(); }
+  std::string toString() const;
+
+  // returns number of dimensions (1-3)
+  int numSpatialDimensions() const;
+
+  // returns the rank of the corresponding storage (multidimensional array)
+  int rank() const;
+
+private:
+  std::optional<HorizontalFieldDimension> horizontalFieldDimension_;
+  bool maskK_;
+};
+
+} // namespace ast
+} // namespace dawn

--- a/dawn/src/dawn/AST/Interval.cpp
+++ b/dawn/src/dawn/AST/Interval.cpp
@@ -57,5 +57,5 @@ std::ostream& operator<<(std::ostream& os, const Interval& interval) {
   return os;
 }
 
-} // namespace sir
+} // namespace ast
 } // namespace dawn

--- a/dawn/src/dawn/AST/Interval.h
+++ b/dawn/src/dawn/AST/Interval.h
@@ -52,5 +52,5 @@ struct Interval {
   /// @}
 };
 
-} // namespace sir
+} // namespace ast
 } // namespace dawn

--- a/dawn/src/dawn/AST/IterationSpace.h
+++ b/dawn/src/dawn/AST/IterationSpace.h
@@ -57,7 +57,7 @@ struct UnstructuredIterationSpace {
   bool operator==(const UnstructuredIterationSpace& other) const {
     return Chain == other.Chain && IncludeCenter == other.IncludeCenter;
   }
-}; // namespace ast
+};
 
 } // namespace ast
 } // namespace dawn

--- a/dawn/src/dawn/AST/Value.cpp
+++ b/dawn/src/dawn/AST/Value.cpp
@@ -89,5 +89,5 @@ std::string Value::toString() const {
 
 bool Value::operator==(const Value& rhs) const { return bool(comparison(rhs)); }
 
-} // namespace sir
+} // namespace ast
 } // namespace dawn

--- a/dawn/src/dawn/AST/Value.h
+++ b/dawn/src/dawn/AST/Value.h
@@ -140,7 +140,7 @@ public:
 // Using ordered map to guarantee the same backend code will be generated
 using GlobalVariableMap = std::map<std::string, Global>;
 
-} // namespace sir
+} // namespace ast
 
 namespace {
 

--- a/dawn/src/dawn/AST/proto/AST/enums.proto
+++ b/dawn/src/dawn/AST/proto/AST/enums.proto
@@ -13,8 +13,8 @@ proto -*-===*\
  *
 \*===------------------------------------------------------------------------------------------===*/
 
-// @defgroup sir_proto SIR protobuf
-// @brief This is a SIR description for Google's protocol buffers library
+// @defgroup ast_proto AST protobuf
+// @brief This is a AST description for Google's protocol buffers library
 // <a href="https://developers.google.com/protocol-buffers/">Protobuf</a>.
 
 syntax = "proto3";

--- a/dawn/src/dawn/AST/proto/AST/enums.proto
+++ b/dawn/src/dawn/AST/proto/AST/enums.proto
@@ -18,7 +18,7 @@ proto -*-===*\
 // <a href="https://developers.google.com/protocol-buffers/">Protobuf</a>.
 
 syntax = "proto3";
-package dawn.proto.enums;
+package dawn.proto.ast;
 
 // Don't use the 0 value, because it's the default and doesn't get serialized,
 // see https://developers.google.com/protocol-buffers/docs/proto3#default

--- a/dawn/src/dawn/AST/proto/AST/statements.proto
+++ b/dawn/src/dawn/AST/proto/AST/statements.proto
@@ -726,3 +726,38 @@ message ReductionOverNeighborExpr {
 message AST {
   Stmt root = 1; // Root node
 }
+
+/*===------------------------------------------------------------------------------------------===*\
+ *     GlobalVariableMap
+\*===------------------------------------------------------------------------------------------===*/
+
+// TODO this needs to be changed to accept a type independent of a value if we
+// want it to be 1-to-1 with the SIR structures.
+// @brief Value of a global variable
+message GlobalVariableValue {
+  // Type and value of the variable
+  oneof Value {
+    bool boolean_value = 1;
+    int32 integer_value = 2;
+    double double_value = 3;
+    string string_value = 4;
+    float float_value = 5;
+  }
+
+  // Is the value a a compile time constant?
+  bool is_constexpr = 6;
+}
+
+// @brief Map of global variables
+//
+// The support of global variables is essential for scientific models to store switches to
+// control the flow of the execution, like the order of the horizontal advection, or simulation
+// parameters such as the time step of the model. A global variable is identified by a unique
+// name and a value which can either be set statically at compile time or dynamically at run
+// time.
+//
+// @ingroup sir_proto
+message GlobalVariableMap {
+  map<string, GlobalVariableValue> map = 1; // Mape of global variables (name to value)
+}
+

--- a/dawn/src/dawn/AST/proto/AST/statements.proto
+++ b/dawn/src/dawn/AST/proto/AST/statements.proto
@@ -18,7 +18,7 @@
 // <a href="https://developers.google.com/protocol-buffers/">Protobuf</a>.
 
 syntax = "proto3";
-package dawn.proto.statements;
+package dawn.proto.ast;
 import "AST/enums.proto";
 
 import "google/protobuf/wrappers.proto";
@@ -251,7 +251,7 @@ message Accesses {
 }
 
 message UnstructuredIterationSpace {
-  repeated dawn.proto.enums.LocationType chain = 1;
+  repeated dawn.proto.ast.LocationType chain = 1;
   bool include_center = 2;
 }
 

--- a/dawn/src/dawn/AST/proto/AST/statements.proto
+++ b/dawn/src/dawn/AST/proto/AST/statements.proto
@@ -13,20 +13,20 @@
  *
 \*===------------------------------------------------------------------------------------------===*/
 
-// @defgroup sir_proto SIR protobuf
-// @brief This is a SIR description using Google's protocol buffers library
+// @defgroup ast_proto AST protobuf
+// @brief This is a AST description using Google's protocol buffers library
 // <a href="https://developers.google.com/protocol-buffers/">Protobuf</a>.
 
 syntax = "proto3";
 package dawn.proto.statements;
-import "SIR/enums.proto";
+import "AST/enums.proto";
 
 import "google/protobuf/wrappers.proto";
 
 // @brief Source information
 //
 // `(-1,-1)` indicates an invalid location.
-// @ingroup sir_proto
+// @ingroup ast_proto
 message SourceLocation {
   int32 Line = 1;   // Source line
   int32 Column = 2; // Column in the `Line`
@@ -36,7 +36,7 @@ message SourceLocation {
 //
 // For a cartesian grid we enable/disable the I and J components through their
 // respective masks.
-// @ingroup sir_proto
+// @ingroup ast_proto
 message CartesianDimension {
   int32 mask_cart_i = 1; // mask for cartesian component i
   int32 mask_cart_j = 2; // mask for cartesian component j
@@ -47,7 +47,7 @@ message CartesianDimension {
 // For a unstructured grid we need to specify the dense location type.
 // It could also have a sparse dimension. In such case the sparse part is
 // non-empty.
-// @ingroup sir_proto
+// @ingroup ast_proto
 message UnstructuredDimension {
   UnstructuredIterationSpace iter_space = 1;
 }
@@ -57,7 +57,7 @@ message UnstructuredDimension {
 // This is a condensed representation of the dimensions of a field.
 // A field has a vertical component iff maskK=1.
 // On the horizontal we distinguish between cartesian and unstructured grids.
-// @ingroup sir_proto
+// @ingroup ast_proto
 message FieldDimensions {
   oneof horizontal_dimension {
     CartesianDimension cartesian_horizontal_dimension = 1;
@@ -68,7 +68,7 @@ message FieldDimensions {
 }
 
 // @brief Description of a field argument of a Stencil or StencilFunction
-// @ingroup sir_proto
+// @ingroup ast_proto
 message Field {
   string name = 1;                      // Name of the field
   SourceLocation loc = 2;               // Source location
@@ -80,7 +80,7 @@ message Field {
 //
 // Note that this message is merely a placeholder as the actual arguments is
 // encoded as an AST node.
-// @ingroup sir_proto
+// @ingroup ast_proto
 message Direction {
   string name = 1;        // Name of the directional argument
   SourceLocation loc = 2; // Source location
@@ -90,14 +90,14 @@ message Direction {
 //
 // Note that this message is merely a placeholder as the actual arguments is
 // encoded as an AST node.
-// @ingroup sir_proto
+// @ingroup ast_proto
 message Offset {
   string name = 1;        // Name of the offset argument
   SourceLocation loc = 2; // Source location
 }
 
 // @brief Directional argument of a StencilFunction
-// @ingroup sir_proto
+// @ingroup ast_proto
 message StencilFunctionArg {
   // One of Field, Direction or Offset
   oneof Arg {
@@ -116,7 +116,7 @@ message StencilFunctionArg {
 //  - `upper_level <= Interval::End`
 //  - `(lower_level + lower_offset) <= (upper_level + upper_offset)`
 //
-// @ingroup sir_proto
+// @ingroup ast_proto
 message Interval {
   // Indication of a special level
   enum SpecialLevel {
@@ -147,7 +147,7 @@ message Interval {
 }
 
 // @brief Supported builtin types
-// @ingroup sir_proto
+// @ingroup ast_proto
 message BuiltinType {
   enum TypeID {
     Invalid = 0;
@@ -162,7 +162,7 @@ message BuiltinType {
 }
 
 // @brief Supported builtin types
-// @ingroup sir_proto
+// @ingroup ast_proto
 message Dimension {
   enum Direction {
     I = 0;
@@ -175,7 +175,7 @@ message Dimension {
 }
 
 // @brief Supported builtin types
-// @ingroup sir_proto
+// @ingroup ast_proto
 message Type {
   // Underlying type (either a custom type given by `name` or a `BuiltinType`)
   oneof type {
@@ -188,7 +188,7 @@ message Type {
 }
 
 // @brief Declaration of a vertical region
-// @ingroup sir_proto
+// @ingroup ast_proto
 message VerticalRegion {
   enum LoopOrder {
     Forward = 0;
@@ -204,7 +204,7 @@ message VerticalRegion {
 }
 
 // @brief Stencil call declaration
-// @ingroup sir_proto
+// @ingroup ast_proto
 message StencilCall {
   SourceLocation loc = 1; // Source location of the stencil call
   string callee = 2;      // Name of the called stencil (i.e callee)
@@ -261,13 +261,13 @@ message UnstructuredIterationSpace {
 
 // @brief Data of Stmts
 //
-// @ingroup sir_proto
+// @ingroup ast_proto
 message StmtData {
   Accesses accesses = 1; // All the accesses of the statement
 }
 
 // @brief This is a union of all the statements
-// @ingroup sir_proto
+// @ingroup ast_proto
 message Stmt {
   oneof stmt {
     BlockStmt block_stmt = 1;
@@ -283,7 +283,7 @@ message Stmt {
 }
 
 // @brief This is a union of all the expressions
-// @ingroup sir_proto
+// @ingroup ast_proto
 message Expr {
   oneof expr {
     UnaryOperator unary_operator = 1;
@@ -311,7 +311,7 @@ message Expr {
 //  statement_N
 // }
 // @endcode
-// @ingroup sir_proto
+// @ingroup ast_proto
 message BlockStmt {
   repeated Stmt statements = 1; // List of statements
   SourceLocation loc = 2;       // Source location
@@ -344,7 +344,7 @@ message LoopStmt {
 
 // @brief A statement wrapping an expression
 //
-// @ingroup sir_proto
+// @ingroup ast_proto
 message ExprStmt {
   Expr expr = 1;          // Expression
   SourceLocation loc = 2; // Source location
@@ -354,7 +354,7 @@ message ExprStmt {
 
 // @brief Return statement
 //
-// @ingroup sir_proto
+// @ingroup ast_proto
 message ReturnStmt {
   Expr expr = 1;          // Expression to return
   SourceLocation loc = 2; // Source location
@@ -364,7 +364,7 @@ message ReturnStmt {
 
 // @brief Data of a VarDeclStmt
 //
-// @ingroup sir_proto
+// @ingroup ast_proto
 message VarDeclStmtData {
   google.protobuf.Int32Value accessID =
       1; // ID of the variable declared in the statement
@@ -394,7 +394,7 @@ message VarDeclStmtData {
 //  - init_list: {LiteralAccessExpr{"2.3"}, LiteralAccessExpr{"5.3"}}
 // @endcode
 //
-// @ingroup sir_proto
+// @ingroup ast_proto
 message VarDeclStmt {
   Type type = 1;       // Type of the variable
   string name = 2;     // Name of the variable
@@ -413,7 +413,7 @@ message VarDeclStmt {
 
 // @brief Declaration of a vertical region
 //
-// @ingroup sir_proto
+// @ingroup ast_proto
 message VerticalRegionDeclStmt {
   VerticalRegion vertical_region = 1;
   SourceLocation loc = 2; // Source location
@@ -423,7 +423,7 @@ message VerticalRegionDeclStmt {
 
 // @brief Declaration of a stencil call
 //
-// @ingroup sir_proto
+// @ingroup ast_proto
 message StencilCallDeclStmt {
   StencilCall stencil_call = 1;
   SourceLocation loc = 2; // Source location
@@ -433,7 +433,7 @@ message StencilCallDeclStmt {
 
 // @brief Declaration of a boundary condition
 //
-// @ingroup sir_proto
+// @ingroup ast_proto
 message BoundaryConditionDeclStmt {
   string functor = 1;         // Identifier of the boundary condition functor
   repeated string fields = 2; // List of field arguments to apply the functor to
@@ -452,7 +452,7 @@ message BoundaryConditionDeclStmt {
 //    else_part
 // @endcode
 //
-// @ingroup sir_proto
+// @ingroup ast_proto
 message IfStmt {
   Stmt cond_part = 1;     // Condition (needs to be an `ExprStmt`)
   Stmt then_part = 2;     // Then part
@@ -468,7 +468,7 @@ message IfStmt {
 // @code{.cpp}
 //  op operand
 // @endcode
-// @ingroup sir_proto
+// @ingroup ast_proto
 message UnaryOperator {
   string op = 1;          // Operation (e.g "+" or "-")
   Expr operand = 2;       // Expression to apply the operation
@@ -482,7 +482,7 @@ message UnaryOperator {
 // @code{.cpp}
 //  left op right
 // @endcode
-// @ingroup sir_proto
+// @ingroup ast_proto
 message BinaryOperator {
   Expr left = 1;          // Left-hand side
   string op = 2;          // Operation (e.g "+" or "-")
@@ -497,7 +497,7 @@ message BinaryOperator {
 // @code{.cpp}
 //  left = right
 // @endcode
-// @ingroup sir_proto
+// @ingroup ast_proto
 message AssignmentExpr {
   Expr left = 1;          // Left-hand side
   string op = 2;          // Operation (e.g "=" or "+=")
@@ -512,7 +512,7 @@ message AssignmentExpr {
 // @code{.cpp}
 //  cond ? left : right
 // @endcode
-// @ingroup sir_proto
+// @ingroup ast_proto
 message TernaryOperator {
   Expr cond = 1;          // Condition
   Expr left = 2;          // Left-hand side
@@ -527,7 +527,7 @@ message TernaryOperator {
 // @code{.cpp}
 //  callee(arg0, ..., argN)
 // @endcode
-// @ingroup sir_proto
+// @ingroup ast_proto
 message FunCallExpr {
   string callee = 1;           // Identifier of the function (i.e callee)
   repeated Expr arguments = 2; // List of arguments
@@ -541,7 +541,7 @@ message FunCallExpr {
 // @code{.cpp}
 //  callee(arg0, ..., argN)
 // @endcode
-// @ingroup sir_proto
+// @ingroup ast_proto
 message StencilFunCallExpr {
   string callee = 1; // Identifier of the stencil function (i.e callee)
   repeated Expr arguments = 2; // List of arguments
@@ -556,7 +556,7 @@ message StencilFunCallExpr {
 // stencil function is called within the scope of another stencil function
 // (nested calls).
 //
-// @ingroup sir_proto
+// @ingroup ast_proto
 message StencilFunArgExpr {
   // Dimension of the argument
   Dimension dimension = 1;
@@ -599,7 +599,7 @@ message StencilFunArgExpr {
 
 // @brief Data of an access expression
 //
-// @ingroup sir_proto
+// @ingroup ast_proto
 message AccessExprData {
   google.protobuf.Int32Value accessID =
       1; // Access ID of variable/literal/field accessed
@@ -607,7 +607,7 @@ message AccessExprData {
 
 // @brief Access to a variable
 //
-// @ingroup sir_proto
+// @ingroup ast_proto
 message VarAccessExpr {
   string name = 1; // Name of the variable
   Expr index = 2;  // Is it an array access (i.e var[2])?
@@ -627,7 +627,7 @@ message ZeroOffset {}
 
 // @brief Access to a field
 //
-// @ingroup sir_proto
+// @ingroup ast_proto
 message FieldAccessExpr {
   // Name of the field
   string name = 1;
@@ -696,7 +696,7 @@ message FieldAccessExpr {
 
 // @brief Access of a literal
 //
-// @ingroup sir_proto
+// @ingroup ast_proto
 message LiteralAccessExpr {
   string value = 1;        // Value of the literal (e.g "1.24324")
   BuiltinType type = 2;    // Type of the literal
@@ -707,7 +707,7 @@ message LiteralAccessExpr {
 
 // @brief Reduction operation over neighbors
 //
-// @ingroup sir_proto
+// @ingroup ast_proto
 message ReductionOverNeighborExpr {
   string op = 1; // Reduction operation
   Expr rhs = 2;  // Operation to be applied for each neighbor
@@ -720,9 +720,9 @@ message ReductionOverNeighborExpr {
   SourceLocation loc = 6;  
 }
 
-// @brief Abstract syntax tree of the SIR
+// @brief Abstract syntax tree of the AST
 //
-// @ingroup sir_proto
+// @ingroup ast_proto
 message AST {
   Stmt root = 1; // Root node
 }

--- a/dawn/src/dawn/AST/proto/DawnAST.cmake
+++ b/dawn/src/dawn/AST/proto/DawnAST.cmake
@@ -1,0 +1,1 @@
+set(dawn_ast_proto_files AST/statements.proto AST/enums.proto)

--- a/dawn/src/dawn/CMakeLists.txt
+++ b/dawn/src/dawn/CMakeLists.txt
@@ -56,14 +56,11 @@ endfunction()
 add_subdirectory(Support)
 add_dawn_library(DawnSupport)
 
-# AST and SIR have a circular dependency, only building one library -- DawnSIR
-# {
 add_subdirectory(AST)
-add_dawn_library(DawnAST)
+add_dawn_library(DawnASTProto DawnAST)
 
 add_subdirectory(SIR)
 add_dawn_library(DawnSIRProto DawnSIR)
-# }
 
 add_subdirectory(IIR)
 add_dawn_library(DawnIIRProto DawnIIR)

--- a/dawn/src/dawn/CodeGen/CXXNaive-ico/ASTStencilBody.cpp
+++ b/dawn/src/dawn/CodeGen/CXXNaive-ico/ASTStencilBody.cpp
@@ -198,7 +198,7 @@ std::string ASTStencilBody::makeIndexString(const std::shared_ptr<ast::FieldAcce
 
   bool isHorizontal = !metadata_.getFieldDimensions(iir::getAccessID(expr)).K();
   bool isFullField = !isHorizontal && !isVertical;
-  auto unstrDims = sir::dimension_cast<const sir::UnstructuredFieldDimension&>(
+  auto unstrDims = ast::dimension_cast<const ast::UnstructuredFieldDimension&>(
       metadata_.getFieldDimensions(iir::getAccessID(expr)).getHorizontalFieldDimension());
   bool isDense = unstrDims.isDense();
   bool isSparse = unstrDims.isSparse();

--- a/dawn/src/dawn/CodeGen/CXXNaive-ico/CXXNaiveCodeGen.cpp
+++ b/dawn/src/dawn/CodeGen/CXXNaive-ico/CXXNaiveCodeGen.cpp
@@ -204,7 +204,7 @@ void CXXNaiveIcoCodeGen::generateStencilWrapperCtr(
                                        metadata.getNameFromAccessID(APIfieldID));
       continue;
     }
-    if(sir::dimension_cast<const sir::UnstructuredFieldDimension&>(
+    if(ast::dimension_cast<const ast::UnstructuredFieldDimension&>(
            metadata.getFieldDimensions(APIfieldID).getHorizontalFieldDimension())
            .isDense()) {
       std::string typeString =
@@ -260,11 +260,11 @@ void CXXNaiveIcoCodeGen::generateStencilWrapperCtr(
         if(field.getFieldDimensions().isVertical()) {
           allocString = "allocateField(LibTag{}, k_size)";
         } else {
-          auto hdims = sir::dimension_cast<sir::UnstructuredFieldDimension const&>(
+          auto hdims = ast::dimension_cast<ast::UnstructuredFieldDimension const&>(
               field.getFieldDimensions().getHorizontalFieldDimension());
 
           auto getPaddedNumElCall =
-              [&](const sir::UnstructuredFieldDimension& hdims) -> std::string {
+              [&](const ast::UnstructuredFieldDimension& hdims) -> std::string {
             switch(hdims.getDenseLocationType()) {
             case ast::LocationType::Cells:
               return "numCells(LibTag{}, mesh) + " +
@@ -336,7 +336,7 @@ void CXXNaiveIcoCodeGen::generateStencilWrapperMembers(
       if(dims.isVertical()) {
         fieldType = "vertical_field_t<LibTag, ::dawn::float_type>";
       } else {
-        auto hdims = sir::dimension_cast<sir::UnstructuredFieldDimension const&>(
+        auto hdims = ast::dimension_cast<ast::UnstructuredFieldDimension const&>(
             dims.getHorizontalFieldDimension());
         fieldType = hdims.isSparse() ? "::dawn::sparse_" : "::dawn::";
         switch(hdims.getDenseLocationType()) {
@@ -408,7 +408,7 @@ void CXXNaiveIcoCodeGen::generateStencilClasses(
         return std::string("::dawn::vertical_field_t<LibTag, ::dawn::float_type>");
       }
 
-      const auto& unstructuredDims = sir::dimension_cast<sir::UnstructuredFieldDimension const&>(
+      const auto& unstructuredDims = ast::dimension_cast<ast::UnstructuredFieldDimension const&>(
           info.field.getFieldDimensions().getHorizontalFieldDimension());
       if(unstructuredDims.isDense()) {
         switch(unstructuredDims.getDenseLocationType()) {

--- a/dawn/src/dawn/CodeGen/CodeGen.cpp
+++ b/dawn/src/dawn/CodeGen/CodeGen.cpp
@@ -298,12 +298,12 @@ void CodeGen::generateStencilWrapperSyncMethod(Class& stencilWrapperClass) const
   syncStoragesMethod.commit();
 }
 
-std::string CodeGen::getStorageType(const sir::FieldDimensions& dimensions) {
+std::string CodeGen::getStorageType(const ast::FieldDimensions& dimensions) {
   DAWN_ASSERT_MSG(
-      sir::dimension_isa<sir::CartesianFieldDimension>(dimensions.getHorizontalFieldDimension()),
+      ast::dimension_isa<ast::CartesianFieldDimension>(dimensions.getHorizontalFieldDimension()),
       "Storage type requested for a non cartesian horizontal dimension");
   auto const& cartesianDimensions =
-      dawn::sir::dimension_cast<dawn::sir::CartesianFieldDimension const&>(
+      dawn::ast::dimension_cast<dawn::ast::CartesianFieldDimension const&>(
           dimensions.getHorizontalFieldDimension());
 
   std::string storageType = "storage_";

--- a/dawn/src/dawn/CodeGen/CodeGen.h
+++ b/dawn/src/dawn/CodeGen/CodeGen.h
@@ -85,7 +85,7 @@ public:
 
   static std::string getStorageType(const sir::Field& field);
   static std::string getStorageType(const iir::Stencil::FieldInfo& field);
-  static std::string getStorageType(const sir::FieldDimensions& dimensions);
+  static std::string getStorageType(const ast::FieldDimensions& dimensions);
 
   void generateBoundaryConditionFunctions(
       Class& stencilWrapperClass,

--- a/dawn/src/dawn/CodeGen/Cuda-ico/ASTStencilBody.cpp
+++ b/dawn/src/dawn/CodeGen/Cuda-ico/ASTStencilBody.cpp
@@ -107,7 +107,7 @@ std::string ASTStencilBody::makeIndexString(const std::shared_ptr<ast::FieldAcce
 
   bool isHorizontal = !metadata_.getFieldDimensions(iir::getAccessID(expr)).K();
   bool isFullField = !isHorizontal && !isVertical;
-  auto unstrDims = sir::dimension_cast<const sir::UnstructuredFieldDimension&>(
+  auto unstrDims = ast::dimension_cast<const ast::UnstructuredFieldDimension&>(
       metadata_.getFieldDimensions(iir::getAccessID(expr)).getHorizontalFieldDimension());
   bool isDense = unstrDims.isDense();
   bool isSparse = unstrDims.isSparse();

--- a/dawn/src/dawn/CodeGen/Cuda-ico/CudaIcoCodeGen.cpp
+++ b/dawn/src/dawn/CodeGen/Cuda-ico/CudaIcoCodeGen.cpp
@@ -340,7 +340,7 @@ void CudaIcoCodeGen::generateRunFun(
         if(field.second.getFieldDimensions().isVertical()) {
           continue;
         }
-        auto dims = sir::dimension_cast<sir::UnstructuredFieldDimension const&>(
+        auto dims = ast::dimension_cast<ast::UnstructuredFieldDimension const&>(
             field.second.getFieldDimensions().getHorizontalFieldDimension());
         // dont add sizes twice
         if(dims.getDenseLocationType() == *stage->getLocationType()) {
@@ -405,7 +405,7 @@ static void allocTempFields(MemberFunction& ctor, const iir::Stencil& stencil, P
       bool isHorizontal = !dims.K();
       std::string kSizeStr = (isHorizontal) ? "1" : "kSize_";
 
-      auto hdims = sir::dimension_cast<sir::UnstructuredFieldDimension const&>(
+      auto hdims = ast::dimension_cast<ast::UnstructuredFieldDimension const&>(
           dims.getHorizontalFieldDimension());
       if(hdims.isDense()) {
         ctor.addStatement("::dawn::allocField(&" + fname + "_, mesh_." +
@@ -463,7 +463,7 @@ void CudaIcoCodeGen::generateCopyMemoryFun(MemberFunction& copyFun,
     bool isHorizontal = !dims.K();
     std::string kSizeStr = (isHorizontal) ? "1" : "kSize_";
 
-    auto hdims = sir::dimension_cast<sir::UnstructuredFieldDimension const&>(
+    auto hdims = ast::dimension_cast<ast::UnstructuredFieldDimension const&>(
         dims.getHorizontalFieldDimension());
     if(hdims.isDense()) {
       copyFun.addStatement(
@@ -518,7 +518,7 @@ void CudaIcoCodeGen::generateCopyBackFun(MemberFunction& copyBackFun, const iir:
         continue;
       }
 
-      auto dims = sir::dimension_cast<sir::UnstructuredFieldDimension const&>(
+      auto dims = ast::dimension_cast<ast::UnstructuredFieldDimension const&>(
           field.field.getFieldDimensions().getHorizontalFieldDimension());
       if(rawPtrs) {
         copyBackFun.addArg("::dawn::float_type* " + field.Name);
@@ -541,7 +541,7 @@ void CudaIcoCodeGen::generateCopyBackFun(MemberFunction& copyBackFun, const iir:
         return "kSize_";
       }
 
-      auto hdims = sir::dimension_cast<sir::UnstructuredFieldDimension const&>(
+      auto hdims = ast::dimension_cast<ast::UnstructuredFieldDimension const&>(
           field.field.getFieldDimensions().getHorizontalFieldDimension());
 
       std::string sizestr = "(mesh_.";
@@ -577,7 +577,7 @@ void CudaIcoCodeGen::generateCopyBackFun(MemberFunction& copyBackFun, const iir:
                                  "*sizeof(::dawn::float_type), cudaMemcpyDeviceToHost))");
 
         if(!field.field.getFieldDimensions().isVertical()) {
-          auto dims = sir::dimension_cast<sir::UnstructuredFieldDimension const&>(
+          auto dims = ast::dimension_cast<ast::UnstructuredFieldDimension const&>(
               field.field.getFieldDimensions().getHorizontalFieldDimension());
 
           bool isHorizontal = !field.field.getFieldDimensions().K();
@@ -978,7 +978,7 @@ void CudaIcoCodeGen::generateAllCudaKernels(
         if(field.second.getFieldDimensions().isVertical()) {
           continue;
         }
-        auto dims = sir::dimension_cast<sir::UnstructuredFieldDimension const&>(
+        auto dims = ast::dimension_cast<ast::UnstructuredFieldDimension const&>(
             field.second.getFieldDimensions().getHorizontalFieldDimension());
         if(dims.getDenseLocationType() == loc) {
           continue;

--- a/dawn/src/dawn/CodeGen/Cuda/CodeGeneratorHelper.cpp
+++ b/dawn/src/dawn/CodeGen/Cuda/CodeGeneratorHelper.cpp
@@ -67,11 +67,11 @@ std::vector<std::string> CodeGeneratorHelper::generateStrideArguments(
     for(const auto& fieldInfo : ms->getParent()->getFields()) {
       if(fieldInfo.second.field.getAccessID() == fieldPair.second.getAccessID()) {
         DAWN_ASSERT_MSG(
-            dawn::sir::dimension_isa<dawn::sir::CartesianFieldDimension>(
+            dawn::ast::dimension_isa<dawn::ast::CartesianFieldDimension>(
                 fieldInfo.second.field.getFieldDimensions().getHorizontalFieldDimension()),
             "Field has non cartesian horizontal dimension");
         auto const& dimCartesian =
-            dawn::sir::dimension_cast<dawn::sir::CartesianFieldDimension const&>(
+            dawn::ast::dimension_cast<dawn::ast::CartesianFieldDimension const&>(
                 fieldInfo.second.field.getFieldDimensions().getHorizontalFieldDimension());
         dims[0] = dimCartesian.I() == 1;
         dims[1] = dimCartesian.J() == 1;

--- a/dawn/src/dawn/CodeGen/Cuda/MSCodeGen.cpp
+++ b/dawn/src/dawn/CodeGen/Cuda/MSCodeGen.cpp
@@ -901,10 +901,10 @@ void MSCodeGen::generateCudaKernelCode() {
     for(const auto& fieldInfo : ms_->getParent()->getFields()) {
       if(fieldInfo.second.field.getAccessID() == fieldPair.second.getAccessID()) {
         DAWN_ASSERT_MSG(
-            dawn::sir::dimension_isa<dawn::sir::CartesianFieldDimension>(
+            dawn::ast::dimension_isa<dawn::ast::CartesianFieldDimension>(
                 fieldInfo.second.field.getFieldDimensions().getHorizontalFieldDimension()),
             "Field has non cartesian horizontal dimension");
-        auto const& cartDim = sir::dimension_cast<sir::CartesianFieldDimension const&>(
+        auto const& cartDim = ast::dimension_cast<ast::CartesianFieldDimension const&>(
             fieldInfo.second.field.getFieldDimensions().getHorizontalFieldDimension());
         dims[0] = cartDim.I() == 1;
         dims[1] = cartDim.J() == 1;

--- a/dawn/src/dawn/IIR/AccessUtils.cpp
+++ b/dawn/src/dawn/IIR/AccessUtils.cpp
@@ -23,7 +23,7 @@ void recordWriteAccess(std::unordered_map<int, iir::Field>& inputOutputFields,
                        std::unordered_map<int, iir::Field>& outputFields, int AccessID,
                        const std::optional<iir::Extents>& writeExtents,
                        iir::Interval const& doMethodInterval,
-                       sir::FieldDimensions&& fieldDimensions) {
+                       ast::FieldDimensions&& fieldDimensions) {
   // Field was recorded as `InputOutput`, state can't change ...
   if(inputOutputFields.count(AccessID)) {
     inputOutputFields.at(AccessID).extendInterval(doMethodInterval);
@@ -55,7 +55,7 @@ void recordReadAccess(std::unordered_map<int, iir::Field>& inputOutputFields,
                       std::unordered_map<int, iir::Field>& outputFields, int AccessID,
                       std::optional<iir::Extents> const& readExtents,
                       const iir::Interval& doMethodInterval,
-                      sir::FieldDimensions&& fieldDimensions) {
+                      ast::FieldDimensions&& fieldDimensions) {
 
   // Field was recorded as `InputOutput`, state can't change ...
   if(inputOutputFields.count(AccessID)) {

--- a/dawn/src/dawn/IIR/AccessUtils.h
+++ b/dawn/src/dawn/IIR/AccessUtils.h
@@ -32,7 +32,7 @@ void recordWriteAccess(std::unordered_map<int, iir::Field>& inputOutputFields,
                        std::unordered_map<int, iir::Field>& outputFields, int AccessID,
                        const std::optional<iir::Extents>& extents,
                        iir::Interval const& doMethodInterval,
-                       sir::FieldDimensions&& fieldDimensions);
+                       ast::FieldDimensions&& fieldDimensions);
 
 /// @brief given a read access, with AccessID, it will recorded in the corresponding map of input,
 /// output or inputOutput
@@ -44,7 +44,7 @@ void recordReadAccess(std::unordered_map<int, iir::Field>& inputOutputFields,
                       std::unordered_map<int, iir::Field>& outputFields, int AccessID,
                       const std::optional<iir::Extents>& extents,
                       iir::Interval const& doMethodInterval,
-                      sir::FieldDimensions&& fieldDimensions);
+                      ast::FieldDimensions&& fieldDimensions);
 
 } // namespace AccessUtils
 } // namespace dawn

--- a/dawn/src/dawn/IIR/CMakeLists.txt
+++ b/dawn/src/dawn/IIR/CMakeLists.txt
@@ -19,7 +19,7 @@ include(DawnProtobufGenerate)
 dawn_protobuf_generate(
   OUT_FILES iir_proto_cpp_files
   PROTOS ${dawn_iir_proto_files}
-  INC_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../SIR/proto/
+  INC_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../AST/proto/
   WDIR ${CMAKE_CURRENT_SOURCE_DIR}/proto
   PACKG IIR
   LANGUAGE cpp
@@ -39,7 +39,7 @@ target_include_directories(DawnIIRProto
 )
 
 # ... and linked to protobuf
-target_link_libraries(DawnIIRProto PUBLIC DawnSIRProto protobuf::libprotobuf)
+target_link_libraries(DawnIIRProto PUBLIC DawnASTProto protobuf::libprotobuf)
 
 add_library(DawnIIR
   AccessComputation.h
@@ -112,7 +112,7 @@ add_library(DawnIIR
   )
 
 target_add_dawn_standard_props(DawnIIR)
-target_link_libraries(DawnIIR PUBLIC DawnSupport DawnSIR DawnIIRProto)
+target_link_libraries(DawnIIR PUBLIC DawnSupport DawnASTProto DawnAST DawnSIR DawnIIRProto)
 # The include path below is necessary for the C++ proto headers
 target_include_directories(DawnIIR
   PUBLIC $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/dawn/IIR>

--- a/dawn/src/dawn/IIR/DoMethod.cpp
+++ b/dawn/src/dawn/IIR/DoMethod.cpp
@@ -194,9 +194,9 @@ json::json DoMethod::jsonDump(const StencilMetaInformation& metaData) const {
   return node;
 }
 
-const std::unordered_map<std::string, sir::FieldDimensions>
+const std::unordered_map<std::string, ast::FieldDimensions>
 DoMethod::getFieldDimensionsByName() const {
-  std::unordered_map<std::string, sir::FieldDimensions> fieldDimensionsByName;
+  std::unordered_map<std::string, ast::FieldDimensions> fieldDimensionsByName;
   for(const auto& it : getFields()) {
     fieldDimensionsByName.insert(
         {metaData_.getFieldNameFromAccessID(it.first), it.second.getFieldDimensions()});

--- a/dawn/src/dawn/IIR/DoMethod.h
+++ b/dawn/src/dawn/IIR/DoMethod.h
@@ -108,7 +108,7 @@ public:
   /// @brief Get a map from field name to its dimensions for each field referenced in the DoMethod
   ///
   /// The fields are computed during `DoMethod::update`.
-  const std::unordered_map<std::string, sir::FieldDimensions> getFieldDimensionsByName() const;
+  const std::unordered_map<std::string, ast::FieldDimensions> getFieldDimensionsByName() const;
 
   bool hasField(int accessID) const { return derivedInfo_.fields_.count(accessID); }
 

--- a/dawn/src/dawn/IIR/Field.h
+++ b/dawn/src/dawn/IIR/Field.h
@@ -46,7 +46,7 @@ private:
   /// redundant computation of a block
   Interval interval_;                    ///< Enclosing Interval from the iteration space
                                          ///  from where the Field has been accessed
-  sir::FieldDimensions fieldDimensions_; ///< Field dimensions: horizontal (either Cartesian or
+  ast::FieldDimensions fieldDimensions_; ///< Field dimensions: horizontal (either Cartesian or
                                          ///  Unstructured) + vertical
 
 public:
@@ -57,7 +57,7 @@ public:
 
   Field(int accessID, IntendKind intend, std::optional<Extents> const& readExtents,
         std::optional<Extents> const& writeExtents, Interval const& interval,
-        sir::FieldDimensions&& fieldDimensions)
+        ast::FieldDimensions&& fieldDimensions)
       : accessID_(accessID), intend_(intend), extents_(readExtents, writeExtents),
         extentsRB_(readExtents, writeExtents), interval_(interval),
         fieldDimensions_(fieldDimensions) {}
@@ -129,10 +129,10 @@ public:
   ///
   void extendInterval(Interval const& interval) { interval_.merge(interval); }
 
-  const sir::FieldDimensions& getFieldDimensions() const { return fieldDimensions_; }
+  const ast::FieldDimensions& getFieldDimensions() const { return fieldDimensions_; }
 
   bool isUnstructured() {
-    return !sir::dimension_isa<sir::CartesianFieldDimension>(
+    return !ast::dimension_isa<ast::CartesianFieldDimension>(
         fieldDimensions_.getHorizontalFieldDimension());
   }
 };

--- a/dawn/src/dawn/IIR/Stencil.h
+++ b/dawn/src/dawn/IIR/Stencil.h
@@ -45,7 +45,7 @@ class Stencil : public IIRNode<IIR, Stencil, MultiStage, impl::StdList> {
 public:
   // FieldInfo desribes the properties of a given Field
   struct FieldInfo {
-    FieldInfo(bool t, std::string fieldName, dawn::sir::FieldDimensions dim, const Field& f)
+    FieldInfo(bool t, std::string fieldName, dawn::ast::FieldDimensions dim, const Field& f)
         : Name(fieldName), field(f), IsTemporary(t) {}
 
     std::string Name;

--- a/dawn/src/dawn/IIR/StencilFunctionInstantiation.cpp
+++ b/dawn/src/dawn/IIR/StencilFunctionInstantiation.cpp
@@ -395,8 +395,8 @@ void StencilFunctionInstantiation::update() {
         continue;
       auto&& dims = metadata_.isAccessType(FieldAccessType::Field, AccessID)
                         ? metadata_.getFieldDimensions(AccessID)
-                        : sir::FieldDimensions(
-                              sir::HorizontalFieldDimension(ast::cartesian, {true, true}),
+                        : ast::FieldDimensions(
+                              ast::HorizontalFieldDimension(ast::cartesian, {true, true}),
                               true); // TODO sparse_dim: this is a hack. Ideally we don't want
                                      // to create Field when the argument is a function call.
       AccessUtils::recordWriteAccess(inputOutputFields, inputFields, outputFields, AccessID,
@@ -413,8 +413,8 @@ void StencilFunctionInstantiation::update() {
 
       auto&& dims = metadata_.isAccessType(FieldAccessType::Field, AccessID)
                         ? metadata_.getFieldDimensions(AccessID)
-                        : sir::FieldDimensions(
-                              sir::HorizontalFieldDimension(ast::cartesian, {true, true}),
+                        : ast::FieldDimensions(
+                              ast::HorizontalFieldDimension(ast::cartesian, {true, true}),
                               true); // TODO sparse_dim: this is a hack. Ideally we don't want
                                      // to create Field when the argument is a function call.
       AccessUtils::recordReadAccess(inputOutputFields, inputFields, outputFields, AccessID,
@@ -429,8 +429,8 @@ void StencilFunctionInstantiation::update() {
        !inputOutputFields.count(AccessID)) {
       auto&& dims = metadata_.isAccessType(FieldAccessType::Field, AccessID)
                         ? metadata_.getFieldDimensions(AccessID)
-                        : sir::FieldDimensions(
-                              sir::HorizontalFieldDimension(ast::cartesian, {true, true}),
+                        : ast::FieldDimensions(
+                              ast::HorizontalFieldDimension(ast::cartesian, {true, true}),
                               true); // TODO sparse_dim: this is a hack. Ideally we don't want
                                      // to create Field when the argument is a function call.
       inputFields.emplace(AccessID, Field(AccessID, Field::IntendKind::Input, Extents{}, Extents{},

--- a/dawn/src/dawn/IIR/StencilMetaInformation.cpp
+++ b/dawn/src/dawn/IIR/StencilMetaInformation.cpp
@@ -331,7 +331,7 @@ bool StencilMetaInformation::isFieldType(FieldAccessType accessType) const {
          accessType == FieldAccessType::InterStencilTemporary;
 }
 
-sir::FieldDimensions StencilMetaInformation::getFieldDimensions(int fieldID) const {
+ast::FieldDimensions StencilMetaInformation::getFieldDimensions(int fieldID) const {
   if(isAccessIDAVersion(fieldID)) {
     fieldID = getOriginalVersionOfAccessID(fieldID);
   }
@@ -341,7 +341,7 @@ sir::FieldDimensions StencilMetaInformation::getFieldDimensions(int fieldID) con
 }
 
 void StencilMetaInformation::setFieldDimensions(int fieldID,
-                                                sir::FieldDimensions&& fieldDimensions) {
+                                                ast::FieldDimensions&& fieldDimensions) {
   fieldIDToInitializedDimensionsMap_.emplace(fieldID, std::move(fieldDimensions));
 }
 
@@ -367,7 +367,7 @@ void StencilMetaInformation::addAccessIDNamePair(int accessID, const std::string
 }
 
 int StencilMetaInformation::addField(FieldAccessType type, const std::string& name,
-                                     sir::FieldDimensions&& fieldDimensions,
+                                     ast::FieldDimensions&& fieldDimensions,
                                      std::optional<int> accessID) {
   if(!accessID.has_value()) {
     accessID = UIDGenerator::getInstance()->get();
@@ -382,7 +382,7 @@ int StencilMetaInformation::addField(FieldAccessType type, const std::string& na
 }
 
 int StencilMetaInformation::addTmpField(FieldAccessType type, const std::string& basename,
-                                        sir::FieldDimensions&& fieldDimensions,
+                                        ast::FieldDimensions&& fieldDimensions,
                                         std::optional<int> accessID) {
   if(!accessID.has_value()) {
     accessID = UIDGenerator::getInstance()->get();
@@ -405,10 +405,10 @@ ast::LocationType StencilMetaInformation::getDenseLocationTypeFromAccessID(int A
     AccessID = fieldAccessMetadata_.variableVersions_.getOriginalVersionOfAccessID(AccessID);
   }
   DAWN_ASSERT_MSG(
-      sir::dimension_isa<sir::UnstructuredFieldDimension>(
+      ast::dimension_isa<ast::UnstructuredFieldDimension>(
           fieldIDToInitializedDimensionsMap_.at(AccessID).getHorizontalFieldDimension()),
       "Location type requested for Cartesian dimension");
-  const auto& dim = sir::dimension_cast<sir::UnstructuredFieldDimension const&>(
+  const auto& dim = ast::dimension_cast<ast::UnstructuredFieldDimension const&>(
       fieldIDToInitializedDimensionsMap_.at(AccessID).getHorizontalFieldDimension());
   return dim.getDenseLocationType();
 }

--- a/dawn/src/dawn/IIR/StencilMetaInformation.h
+++ b/dawn/src/dawn/IIR/StencilMetaInformation.h
@@ -156,8 +156,8 @@ public:
   std::string getNameFromAccessID(int accessID) const;
 
   /// @brief returns the dimensions (see sir::FieldDimensions) of field with id fieldID
-  sir::FieldDimensions getFieldDimensions(int fieldID) const;
-  void setFieldDimensions(int fieldID, sir::FieldDimensions&& fieldDimensions);
+  ast::FieldDimensions getFieldDimensions(int fieldID) const;
+  void setFieldDimensions(int fieldID, ast::FieldDimensions&& fieldDimensions);
 
   template <FieldAccessType... TFieldAccessType>
   bool hasAccessesOfType() const {
@@ -176,10 +176,10 @@ public:
   void insertAccessOfType(FieldAccessType type, int AccessID, const std::string& name);
 
   int addField(FieldAccessType type, const std::string& name,
-               sir::FieldDimensions&& fieldDimensions, std::optional<int> accessID = std::nullopt);
+               ast::FieldDimensions&& fieldDimensions, std::optional<int> accessID = std::nullopt);
 
   int addTmpField(FieldAccessType type, const std::string& basename,
-                  sir::FieldDimensions&& fieldDimensions,
+                  ast::FieldDimensions&& fieldDimensions,
                   std::optional<int> accessID = std::nullopt);
 
   /// @brief Adds an existing variable declaration to the metadata: assigns an accessID to the
@@ -386,7 +386,7 @@ public:
     stencilFunInstantiationCandidate_.emplace(stencilFun, candidate);
   }
 
-  const std::unordered_map<int, sir::FieldDimensions>& getFieldIDToDimsMap() const {
+  const std::unordered_map<int, ast::FieldDimensions>& getFieldIDToDimsMap() const {
     return fieldIDToInitializedDimensionsMap_;
   }
 
@@ -437,7 +437,7 @@ private:
       fieldnameToBoundaryConditionMap_;
 
   /// Map of Field ID's to their respecive legal dimensions for offsets if specified in the code
-  std::unordered_map<int, dawn::sir::FieldDimensions> fieldIDToInitializedDimensionsMap_;
+  std::unordered_map<int, dawn::ast::FieldDimensions> fieldIDToInitializedDimensionsMap_;
 
   /// Can be filled from the StencilIDToStencilCallMap that is in Metainformation
   DoubleSidedMap<int, std::shared_ptr<ast::StencilCallDeclStmt>> StencilIDToStencilCallMap_;

--- a/dawn/src/dawn/IIR/proto/IIR/IIR.proto
+++ b/dawn/src/dawn/IIR/proto/IIR/IIR.proto
@@ -19,8 +19,8 @@
 syntax = "proto3";
 
 package dawn.proto.iir;
-import "SIR/statements.proto";
-import "SIR/enums.proto";
+import "AST/statements.proto";
+import "AST/enums.proto";
 
 /* ===-----------------------------------------------------------------------------------------===*/
 //      Caches

--- a/dawn/src/dawn/IIR/proto/IIR/IIR.proto
+++ b/dawn/src/dawn/IIR/proto/IIR/IIR.proto
@@ -48,10 +48,10 @@ message Cache {
     int32 accessID = 3;
 
     // optional field: Interval on which cache is used
-    dawn.proto.statements.Interval interval = 4;
+    dawn.proto.ast.Interval interval = 4;
 
     // optional field: Interval that is the union of all the accessIntervals
-    dawn.proto.statements.Interval enclosingAccessInterval = 5;
+    dawn.proto.ast.Interval enclosingAccessInterval = 5;
 
     // optional field: Window on which we need to fill and flush
     Window cacheWindow = 6;
@@ -65,9 +65,9 @@ message Cache {
 //
 // A Do-method contains an AST (BlockStmt) of a specific vertical region
 message DoMethod {
-    dawn.proto.statements.Stmt ast = 1; // ast is of type BlockStmt
+    dawn.proto.ast.Stmt ast = 1; // ast is of type BlockStmt
     int32 doMethodID = 2;
-    dawn.proto.statements.Interval interval = 3;
+    dawn.proto.ast.Interval interval = 3;
 }
 
 // @brief The Protobuf description of all the required members to describe a Stage of the IIR
@@ -77,9 +77,9 @@ message DoMethod {
 message Stage {
     repeated DoMethod doMethods = 1;
     int32 stageID = 2;
-    dawn.proto.statements.Interval i_range = 3; // Global index space in the I dimension
-    dawn.proto.statements.Interval j_range = 4; // Global index space in the J dimension
-    dawn.proto.enums.LocationType locationType = 5;
+    dawn.proto.ast.Interval i_range = 3; // Global index space in the I dimension
+    dawn.proto.ast.Interval j_range = 4; // Global index space in the J dimension
+    dawn.proto.ast.LocationType locationType = 5;
 }
 
 // @brief The Protobuf description of all the required members to describe a MultiStage of the IIR
@@ -127,7 +127,7 @@ message Stencil {
 message BoundaryConditionFunctor {
     string name = 1;
     repeated string args = 2;
-    dawn.proto.statements.Stmt ASTStmt = 3;
+    dawn.proto.ast.Stmt ASTStmt = 3;
 }
 
 // @brief The Protobuf description of the root node of the IIR
@@ -135,7 +135,7 @@ message BoundaryConditionFunctor {
 // The root node of the tree, holding multiple stencils. There is one IIR object for each user
 // defined Stencil.
 message IIR {
-    dawn.proto.enums.GridType gridType = 1;
+    dawn.proto.ast.GridType gridType = 1;
 
     // Map of the globally defined variable names to their Values
     map<string, GlobalValueAndType> globalVariableToValue = 2;
@@ -143,7 +143,7 @@ message IIR {
     repeated Stencil stencils = 3;
 
     // Stencil description statements for the overall program flow
-    repeated dawn.proto.statements.Stmt controlFlowStatements = 4;
+    repeated dawn.proto.ast.Stmt controlFlowStatements = 4;
 
     repeated BoundaryConditionFunctor boundaryConditions = 5;
 }
@@ -215,22 +215,22 @@ message StencilMetaInfo {
     VariableVersions versionedFields = 8;
 
     // Map of field names to their respective Boundary Condition
-    map<string, dawn.proto.statements.Stmt> fieldnameToBoundaryCondition = 9;
+    map<string, dawn.proto.ast.Stmt> fieldnameToBoundaryCondition = 9;
 
     // Map of field ID's to the user-specified dimensions
-    map<int32, dawn.proto.statements.FieldDimensions> fieldIDtoDimensions = 10;
+    map<int32, dawn.proto.ast.FieldDimensions> fieldIDtoDimensions = 10;
 
     // Map of the StencilID's to their respective StencilCall
-    map<int32, dawn.proto.statements.Stmt> idToStencilCall = 11;
+    map<int32, dawn.proto.ast.Stmt> idToStencilCall = 11;
 
     // Map of the BoundaryConditionCall to its extent
-    map<int32, dawn.proto.statements.Extents> boundaryCallToExtent = 12;
+    map<int32, dawn.proto.ast.Extents> boundaryCallToExtent = 12;
 
     // AccessIDs of allocated fields
     repeated int32 allocatedFieldIDs = 13;
 
     // The source-location of the stencil (for better error-handeling)
-    dawn.proto.statements.SourceLocation stencilLocation = 14;
+    dawn.proto.ast.SourceLocation stencilLocation = 14;
 
     // The user-given name of the stencil
     // (remember the 1-1 mapping of user-stencil - StencilInstantiation)

--- a/dawn/src/dawn/Optimizer/Lowering.cpp
+++ b/dawn/src/dawn/Optimizer/Lowering.cpp
@@ -467,7 +467,7 @@ public:
         // We add a new temporary field for each temporary field argument
         AccessID = metadata_.addTmpField(
             iir::FieldAccessType::StencilTemporary, stencil.Fields[stencilArgIdx]->Name,
-            sir::FieldDimensions(stencil.Fields[stencilArgIdx]->Dimensions));
+            ast::FieldDimensions(stencil.Fields[stencilArgIdx]->Dimensions));
       } else {
         AccessID = curScope->LocalFieldnameToAccessIDMap.at(stencilCall->Args[stencilCallArgIdx]);
         stencilCallArgIdx++;
@@ -614,7 +614,7 @@ void fillIIRFromSIR(std::shared_ptr<iir::StencilInstantiation> stencilInstantiat
   for(const auto& field : SIRStencil->Fields) {
     metadata.addField((field->IsTemporary ? iir::FieldAccessType::StencilTemporary
                                           : iir::FieldAccessType::APIField),
-                      field->Name, sir::FieldDimensions(field->Dimensions));
+                      field->Name, ast::FieldDimensions(field->Dimensions));
   }
 
   StencilDescStatementMapper stencilDeclMapper(stencilInstantiation, SIRStencil.get(),

--- a/dawn/src/dawn/Optimizer/PassFixVersionedInputFields.cpp
+++ b/dawn/src/dawn/Optimizer/PassFixVersionedInputFields.cpp
@@ -48,11 +48,11 @@ createAssignmentStatement(int assignmentID, int assigneeID,
   // If the field is sparse, we need to wrap it in a for loop statement
   auto hDimensions = metadata.getFieldDimensions(assignmentID).getHorizontalFieldDimension();
   if(hDimensions.getType() == ast::GridType::Unstructured &&
-     sir::dimension_cast<const sir::UnstructuredFieldDimension&>(hDimensions).isSparse()) {
+     ast::dimension_cast<const ast::UnstructuredFieldDimension&>(hDimensions).isSparse()) {
     auto blockAssignmentStatement =
         iir::makeBlockStmt(std::vector<std::shared_ptr<ast::Stmt>>{assignmentStmt});
     auto chain =
-        sir::dimension_cast<const sir::UnstructuredFieldDimension&>(hDimensions).getNeighborChain();
+        ast::dimension_cast<const ast::UnstructuredFieldDimension&>(hDimensions).getNeighborChain();
     auto wrappedAssignmentStatement =
         iir::makeLoopStmt(std::move(chain), std::move(blockAssignmentStatement));
     return wrappedAssignmentStatement;

--- a/dawn/src/dawn/Optimizer/PassInlining.cpp
+++ b/dawn/src/dawn/Optimizer/PassInlining.cpp
@@ -154,7 +154,7 @@ public:
       if(instantiation_->getIIR()->getGridType() != ast::GridType::Cartesian)
         dawn_unreachable(
             "Currently promotion to temporary field is not supported for unstructured grids.");
-      sir::FieldDimensions fieldDims{sir::HorizontalFieldDimension(ast::cartesian, {true, true}),
+      ast::FieldDimensions fieldDims{ast::HorizontalFieldDimension(ast::cartesian, {true, true}),
                                      true};
       // Register the temporary in the metadata
       metadata_.insertAccessOfType(iir::FieldAccessType::StencilTemporary, AccessIDOfCaller_,

--- a/dawn/src/dawn/Optimizer/PassLocalVarType.cpp
+++ b/dawn/src/dawn/Optimizer/PassLocalVarType.cpp
@@ -117,7 +117,7 @@ class VarTypeFinder : public ast::ASTVisitorForwardingNonConst {
       return iir::LocalVariableType::Scalar;
     }
 
-    if(sir::dimension_isa<sir::CartesianFieldDimension>(
+    if(ast::dimension_isa<ast::CartesianFieldDimension>(
            metadata_.getFieldDimensions(fieldAccessID).getHorizontalFieldDimension())) {
       // Cartesian case
       return iir::LocalVariableType::OnIJ;

--- a/dawn/src/dawn/Optimizer/PassSetNonTempCaches.cpp
+++ b/dawn/src/dawn/Optimizer/PassSetNonTempCaches.cpp
@@ -134,7 +134,7 @@ private:
       if(instantiation_->getIIR()->getGridType() != ast::GridType::Cartesian)
         dawn_unreachable(
             "Currently creating a new temporary field is not supported for unstructured grids.");
-      sir::FieldDimensions fieldDims{sir::HorizontalFieldDimension(ast::cartesian, {true, true}),
+      ast::FieldDimensions fieldDims{ast::HorizontalFieldDimension(ast::cartesian, {true, true}),
                                      true};
       // Register the new temporary in the metadata
       int newID = metadata_.insertAccessOfType(iir::FieldAccessType::StencilTemporary,

--- a/dawn/src/dawn/Optimizer/PassTemporaryToStencilFunction.cpp
+++ b/dawn/src/dawn/Optimizer/PassTemporaryToStencilFunction.cpp
@@ -207,7 +207,7 @@ public:
 
       int genLineKey = static_cast<std::underlying_type<SourceLocation::ReservedSL>::type>(
           SourceLocation::ReservedSL::Generated);
-      sir::FieldDimensions&& dims =
+      ast::FieldDimensions&& dims =
           metadata_.getFieldDimensions(*expr->getData<iir::IIRAccessExprData>().AccessID);
       tmpFunction_->Args.push_back(std::make_shared<sir::Field>(
           expr->getName(), std::move(dims), SourceLocation(genLineKey, genLineKey)));

--- a/dawn/src/dawn/Optimizer/PassTemporaryType.cpp
+++ b/dawn/src/dawn/Optimizer/PassTemporaryType.cpp
@@ -182,7 +182,7 @@ bool PassTemporaryType::run(const std::shared_ptr<iir::StencilInstantiation>& in
           auto hDims =
               metadata.getFieldIDToDimsMap().at(temporary.accessID_).getHorizontalFieldDimension();
           if(hDims.getType() == ast::GridType::Unstructured) {
-            sparse = sir::dimension_cast<sir::UnstructuredFieldDimension const&>(hDims).isSparse();
+            sparse = ast::dimension_cast<ast::UnstructuredFieldDimension const&>(hDims).isSparse();
           }
         }
         if(temporary.lifetime_.Begin.inSameDoMethod(temporary.lifetime_.End) &&

--- a/dawn/src/dawn/Optimizer/TemporaryHandling.cpp
+++ b/dawn/src/dawn/Optimizer/TemporaryHandling.cpp
@@ -26,15 +26,15 @@
 namespace dawn {
 
 namespace {
-sir::HorizontalFieldDimension
+ast::HorizontalFieldDimension
 getHorizontalFieldDimensionFromVar(iir::StencilInstantiation const* instantiation, int accessID) {
   auto cartesian = instantiation->getIIR()->getGridType() == ast::GridType::Cartesian;
   if(cartesian) {
-    return sir::HorizontalFieldDimension(ast::cartesian, {true, true});
+    return ast::HorizontalFieldDimension(ast::cartesian, {true, true});
   } else {
     auto locType =
         instantiation->getMetaData().getLocalVariableDataFromAccessID(accessID).getLocationType();
-    return sir::HorizontalFieldDimension(ast::unstructured, locType);
+    return ast::HorizontalFieldDimension(ast::unstructured, locType);
   }
 }
 } // namespace
@@ -46,8 +46,8 @@ void promoteLocalVariableToTemporaryField(iir::StencilInstantiation* instantiati
   std::string varname = instantiation->getMetaData().getFieldNameFromAccessID(accessID);
 
   // Figure out dimensions
-  sir::FieldDimensions fieldDims =
-      sir::FieldDimensions{getHorizontalFieldDimensionFromVar(instantiation, accessID), true};
+  ast::FieldDimensions fieldDims =
+      ast::FieldDimensions{getHorizontalFieldDimensionFromVar(instantiation, accessID), true};
 
   // Compute name of field
   std::string fieldname = iir::InstantiationHelper::makeTemporaryFieldname(

--- a/dawn/src/dawn/SIR/CMakeLists.txt
+++ b/dawn/src/dawn/SIR/CMakeLists.txt
@@ -18,6 +18,7 @@ include(proto/DawnSIR.cmake)
 include(DawnProtobufGenerate)
 dawn_protobuf_generate(
   OUT_FILES sir_proto_cpp_files
+  INC_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../AST/proto/
   WDIR ${CMAKE_CURRENT_SOURCE_DIR}/proto
   PROTOS ${dawn_sir_proto_files}
   PACKG SIR
@@ -38,7 +39,7 @@ target_include_directories(DawnSIRProto
 )
 
 # ... and linked to protobuf
-target_link_libraries(DawnSIRProto PUBLIC protobuf::libprotobuf)
+target_link_libraries(DawnSIRProto PUBLIC DawnASTProto protobuf::libprotobuf)
 
 # Builds one library for both SIR and AST
 add_library(DawnSIR

--- a/dawn/src/dawn/SIR/SIR.h
+++ b/dawn/src/dawn/SIR/SIR.h
@@ -15,6 +15,7 @@
 #pragma once
 
 #include "dawn/AST/Attr.h"
+#include "dawn/AST/FieldDimension.h"
 #include "dawn/AST/GridType.h"
 #include "dawn/AST/Interval.h"
 #include "dawn/AST/IterationSpace.h"
@@ -53,185 +54,16 @@ struct StencilFunctionArg {
   CompareResult comparison(const sir::StencilFunctionArg& rhs) const;
 };
 
-class FieldDimensionImpl {
-public:
-  std::unique_ptr<FieldDimensionImpl> clone() const { return cloneImpl(); }
-  virtual ~FieldDimensionImpl() = default;
-  bool operator==(const FieldDimensionImpl& other) { return equalityImpl(other); }
-
-private:
-  virtual std::unique_ptr<FieldDimensionImpl> cloneImpl() const = 0;
-  virtual bool equalityImpl(const FieldDimensionImpl& other) const = 0;
-};
-
-/// @brief In the cartesian case, the horizontal dimension is an IJ-mask describing if the
-/// field is allowed to have extents in I and/or J: [1,0] is a storage_i and cannot be
-/// accessed with field[j+1]
-///
-/// @ingroup sir
-class CartesianFieldDimension : public FieldDimensionImpl {
-  const std::array<bool, 2> mask_;
-  std::unique_ptr<FieldDimensionImpl> cloneImpl() const override {
-    return std::make_unique<CartesianFieldDimension>(mask_);
-  }
-  virtual bool equalityImpl(const FieldDimensionImpl& other) const override {
-    auto const& otherCartesian = dynamic_cast<CartesianFieldDimension const&>(other);
-    return otherCartesian.I() == I() && otherCartesian.J() == J();
-  }
-
-public:
-  bool I() const { return mask_[0]; }
-  bool J() const { return mask_[1]; }
-  explicit CartesianFieldDimension(std::array<bool, 2> mask) : mask_(mask) {}
-};
-
-/// @brief In the unstructured case, the horizontal dimension can be either dense or sparse.
-/// A field on dense corresponds to 1 value for each location of type defined by the "dense location
-/// type". A field on sparse corresponds to as many values as indirect neighbors defined through a
-/// neighbor chain.
-///
-/// Construct with a neighbor chain. If it is of size = 1, then the dimension is dense (with
-/// location type = single element of chain), otherwise sparse (with dense location type being the
-/// first element of the chain).
-///
-/// @ingroup sir
-class UnstructuredFieldDimension : public FieldDimensionImpl {
-  std::unique_ptr<FieldDimensionImpl> cloneImpl() const override {
-    return std::make_unique<UnstructuredFieldDimension>(iterSpace_.Chain, iterSpace_.IncludeCenter);
-  }
-  virtual bool equalityImpl(const FieldDimensionImpl& other) const override {
-    auto const& otherUnstructured = dynamic_cast<UnstructuredFieldDimension const&>(other);
-    return iterSpace_ == otherUnstructured.iterSpace_;
-  }
-  const ast::UnstructuredIterationSpace iterSpace_;
-
-public:
-  explicit UnstructuredFieldDimension(ast::NeighborChain neighborChain, bool includeCenter = false);
-  /// @brief Returns the neighbor chain encoding the sparse part (isSparse() must be true!).
-  const ast::NeighborChain& getNeighborChain() const;
-  /// @brief Returns the dense location (always present)
-  ast::LocationType getDenseLocationType() const { return iterSpace_.Chain[0]; }
-  /// @brief Returns the last sparse location type if there is a sparse part, otherwise returns the
-  /// dense part.
-  ast::LocationType getLastSparseLocationType() const { return iterSpace_.Chain.back(); }
-  bool isSparse() const { return iterSpace_.Chain.size() > 1; }
-  bool isDense() const { return !isSparse(); }
-  bool getIncludeCenter() const { return iterSpace_.IncludeCenter; }
-  ast::UnstructuredIterationSpace getIterSpace() const { return iterSpace_; }
-  std::string toString() const;
-};
-
-class HorizontalFieldDimension {
-  std::unique_ptr<FieldDimensionImpl> impl_;
-
-public:
-  // Construct a Cartesian horizontal field dimension with specified ij mask.
-  HorizontalFieldDimension(dawn::ast::cartesian_, std::array<bool, 2> mask)
-      : impl_(std::make_unique<CartesianFieldDimension>(mask)) {}
-
-  // Construct a Unstructured horizontal field sparse dimension with specified neighbor chain
-  // (sparse part). Dense part is the first element of the chain.
-  HorizontalFieldDimension(dawn::ast::unstructured_, ast::NeighborChain neighborChain,
-                           bool includeCenter = false)
-      : impl_(std::make_unique<UnstructuredFieldDimension>(neighborChain, includeCenter)) {}
-  // Construct a Unstructured horizontal field dense dimension with specified (dense) location type.
-  HorizontalFieldDimension(dawn::ast::unstructured_, ast::LocationType locationType,
-                           bool includeCenter = false)
-      : impl_(std::make_unique<UnstructuredFieldDimension>(ast::NeighborChain{locationType},
-                                                           includeCenter)) {}
-
-  HorizontalFieldDimension(const HorizontalFieldDimension& other) { *this = other; }
-  HorizontalFieldDimension(HorizontalFieldDimension&& other) { *this = other; };
-
-  HorizontalFieldDimension& operator=(const HorizontalFieldDimension& other) {
-    impl_ = other.impl_->clone();
-    return *this;
-  }
-  HorizontalFieldDimension& operator=(HorizontalFieldDimension&& other) {
-    impl_ = std::move(other.impl_);
-    return *this;
-  }
-
-  bool operator==(const HorizontalFieldDimension& other) const { return *impl_ == *other.impl_; }
-
-  ast::GridType getType() const;
-
-  template <typename T>
-  friend T dimension_cast(HorizontalFieldDimension const& dimension);
-  template <typename T>
-  friend bool dimension_isa(HorizontalFieldDimension const& dimension);
-};
-
-template <typename T>
-T dimension_cast(HorizontalFieldDimension const& dimension) {
-  using PlainT = std::remove_reference_t<T>;
-  static_assert(std::is_base_of_v<FieldDimensionImpl, PlainT>,
-                "Can only be casted to a valid field dimension implementation");
-  static_assert(std::is_const_v<PlainT>, "Can only be casted to const");
-  return *dynamic_cast<std::add_pointer_t<T>>(dimension.impl_.get());
-}
-
-template <typename T>
-bool dimension_isa(HorizontalFieldDimension const& dimension) {
-  using PlainT = std::remove_pointer_t<std::remove_reference_t<T>>;
-  static_assert(std::is_base_of_v<FieldDimensionImpl, PlainT>,
-                "Can only be casted to a valid field dimension implementation");
-  return static_cast<bool>(dynamic_cast<PlainT*>(dimension.impl_.get()));
-}
-
-class FieldDimensions {
-public:
-  FieldDimensions(HorizontalFieldDimension&& horizontalFieldDimension, bool maskK)
-      : horizontalFieldDimension_(horizontalFieldDimension), maskK_(maskK) {
-    if(!maskK && dimension_isa<CartesianFieldDimension>(*horizontalFieldDimension_)) {
-      auto cartDims = dimension_cast<const CartesianFieldDimension&>(*horizontalFieldDimension_);
-      DAWN_ASSERT_MSG(cartDims.I() || cartDims.J(),
-                      "a field cant' have all dimensions masked out!");
-    }
-  }
-  FieldDimensions(bool maskK) : maskK_(maskK) {
-    DAWN_ASSERT_MSG(
-        maskK_, "a field can't have null horizontal dimensions as well as masked out k dimension!");
-  }
-  FieldDimensions(const FieldDimensions&) = default;
-  FieldDimensions(FieldDimensions&&) = default;
-
-  FieldDimensions& operator=(const FieldDimensions&) = default;
-  FieldDimensions& operator=(FieldDimensions&&) = default;
-
-  bool operator==(const FieldDimensions& other) const {
-    return (maskK_ == other.maskK_ && horizontalFieldDimension_ == other.horizontalFieldDimension_);
-  }
-
-  bool K() const { return maskK_; }
-  const HorizontalFieldDimension& getHorizontalFieldDimension() const {
-    DAWN_ASSERT_MSG(!isVertical(), "attempted to get horizontal dimension of a vertical field!");
-    return horizontalFieldDimension_.value();
-  }
-  bool isVertical() const { return !horizontalFieldDimension_.has_value(); }
-  std::string toString() const;
-
-  // returns number of dimensions (1-3)
-  int numSpatialDimensions() const;
-
-  // returns the rank of the corresponding storage (multidimensional array)
-  int rank() const;
-
-private:
-  std::optional<HorizontalFieldDimension> horizontalFieldDimension_;
-  bool maskK_;
-};
-
 /// @brief Representation of a field
 /// @ingroup sir
 struct Field : public StencilFunctionArg {
-  Field(const std::string& name, FieldDimensions&& fieldDimensions,
+  Field(const std::string& name, ast::FieldDimensions&& fieldDimensions,
         SourceLocation loc = SourceLocation())
       : StencilFunctionArg{name, ArgumentKind::Field, loc}, IsTemporary(false),
         Dimensions(fieldDimensions) {}
 
   bool IsTemporary;
-  FieldDimensions Dimensions;
+  ast::FieldDimensions Dimensions;
 
   static bool classof(const StencilFunctionArg* arg) { return arg->Kind == ArgumentKind::Field; }
   bool operator==(const Field& rhs) const { return comparison(rhs); }

--- a/dawn/src/dawn/SIR/proto/DawnSIR.cmake
+++ b/dawn/src/dawn/SIR/proto/DawnSIR.cmake
@@ -1,1 +1,1 @@
-set(dawn_sir_proto_files SIR/SIR.proto SIR/statements.proto SIR/enums.proto)
+set(dawn_sir_proto_files SIR/SIR.proto)

--- a/dawn/src/dawn/SIR/proto/SIR/SIR.proto
+++ b/dawn/src/dawn/SIR/proto/SIR/SIR.proto
@@ -81,40 +81,6 @@ message StencilFunction {
 }
 
 /*===------------------------------------------------------------------------------------------===*\
- *     GlobalVariableMap
-\*===------------------------------------------------------------------------------------------===*/
-
-// TODO this needs to be changed to accept a type independent of a value if we
-// want it to be 1-to-1 with the SIR structures.
-// @brief Value of a global variable
-message GlobalVariableValue {
-  // Type and value of the variable
-  oneof Value {
-    bool boolean_value = 1;
-    int32 integer_value = 2;
-    double double_value = 3;
-    string string_value = 4;
-    float float_value = 5;
-  }
-
-  // Is the value a a compile time constant?
-  bool is_constexpr = 6;
-}
-
-// @brief Map of global variables
-//
-// The support of global variables is essential for scientific models to store switches to
-// control the flow of the execution, like the order of the horizontal advection, or simulation
-// parameters such as the time step of the model. A global variable is identified by a unique
-// name and a value which can either be set statically at compile time or dynamically at run
-// time.
-//
-// @ingroup sir_proto
-message GlobalVariableMap {
-  map<string, GlobalVariableValue> map = 1; // Mape of global variables (name to value)
-}
-
-/*===------------------------------------------------------------------------------------------===*\
  *     SIR
 \*===------------------------------------------------------------------------------------------===*/
 
@@ -138,5 +104,5 @@ message SIR {
   repeated StencilFunction stencil_functions = 4;
 
   // Map of global variables
-  GlobalVariableMap global_variables = 5;
+  dawn.proto.ast.GlobalVariableMap global_variables = 5;
 }

--- a/dawn/src/dawn/SIR/proto/SIR/SIR.proto
+++ b/dawn/src/dawn/SIR/proto/SIR/SIR.proto
@@ -19,8 +19,8 @@
 syntax = "proto3";
 
 package dawn.sir.proto;
-import "SIR/statements.proto";
-import "SIR/enums.proto";
+import "AST/statements.proto";
+import "AST/enums.proto";
 
 option java_package = "dawn.sir";
 option java_outer_classname = "SIR_pb2";
@@ -31,8 +31,8 @@ option java_outer_classname = "SIR_pb2";
 
 // @brief Stencil description of the SIR
 //
-// A stencil represents the executation of a series of statements on a finite number of input fields
-// producing a finite number of output fields, hence a stencilcan have multiple output fields.
+// A stencil represents the execution of a series of statements on a finite number of input fields
+// producing a finite number of output fields, hence a stencil can have multiple output fields.
 // Hence, a stencil is described by an AST and a list of participating Field(s).
 //
 // @ingroup sir_proto
@@ -57,7 +57,7 @@ message Stencil {
 // @brief Stencil function description of the SIR
 //
 // Stencil functions are represented, like stencils, by a unique identifier, a list of arguments
-// and a list vertical intervals and coressponding AST(s). The latter allows to *specialize* the
+// and a list vertical intervals and corresponding AST(s). The latter allows to *specialize* the
 // stencil function for a specific vertical interval enabling straight-forward incorporation of
 // vertical boundary conditions. Next to simple field and scalar arguments, stencil functions can be
 // parametrized on Direction `(i, j or k)` and Offset `(i+1) arguments.

--- a/dawn/src/dawn/SIR/proto/SIR/SIR.proto
+++ b/dawn/src/dawn/SIR/proto/SIR/SIR.proto
@@ -18,7 +18,7 @@
 
 syntax = "proto3";
 
-package dawn.sir.proto;
+package dawn.proto.sir;
 import "AST/statements.proto";
 import "AST/enums.proto";
 
@@ -41,13 +41,13 @@ message Stencil {
   string name = 3;
 
   // Source location of the stencil
-  dawn.proto.statements.SourceLocation loc = 4;
+  dawn.proto.ast.SourceLocation loc = 4;
 
   // Stencil description AST
-  dawn.proto.statements.AST ast = 1;
+  dawn.proto.ast.AST ast = 1;
 
   // Fields referenced by this stencil
-  repeated dawn.proto.statements.Field fields = 2;
+  repeated dawn.proto.ast.Field fields = 2;
 }
 
 /*===------------------------------------------------------------------------------------------===*\
@@ -68,16 +68,16 @@ message StencilFunction {
   string name = 5;
 
   // Source location of the stencil function
-  dawn.proto.statements.SourceLocation loc = 4;
+  dawn.proto.ast.SourceLocation loc = 4;
 
   // Stencil body ASTs
-  repeated dawn.proto.statements.AST asts = 1;
+  repeated dawn.proto.ast.AST asts = 1;
 
   // Associated intervals of the AST
-  repeated dawn.proto.statements.Interval intervals = 2;
+  repeated dawn.proto.ast.Interval intervals = 2;
 
   // Fields referenced by this stencil
-  repeated dawn.proto.statements.StencilFunctionArg arguments = 3;
+  repeated dawn.proto.ast.StencilFunctionArg arguments = 3;
 }
 
 /*===------------------------------------------------------------------------------------------===*\
@@ -126,7 +126,7 @@ message GlobalVariableMap {
 // @ingroup sir_proto
 message SIR {
 
-  dawn.proto.enums.GridType gridType = 1;
+  dawn.proto.ast.GridType gridType = 1;
 
   // Name of the file the SIR was parsed from (can be empty)
   string filename = 2;

--- a/dawn/src/dawn/Serialization/ASTSerializer.cpp
+++ b/dawn/src/dawn/Serialization/ASTSerializer.cpp
@@ -273,13 +273,13 @@ void setOffset(dawn::proto::ast::Offset* offsetProto, const sir::Offset* offset)
 }
 
 void setFieldDimensions(dawn::proto::ast::FieldDimensions* protoFieldDimensions,
-                        const sir::FieldDimensions& fieldDimensions) {
+                        const ast::FieldDimensions& fieldDimensions) {
   protoFieldDimensions->set_mask_k(fieldDimensions.K());
   if(!fieldDimensions.isVertical()) {
-    if(dawn::sir::dimension_isa<sir::CartesianFieldDimension const&>(
+    if(dawn::ast::dimension_isa<ast::CartesianFieldDimension const&>(
            fieldDimensions.getHorizontalFieldDimension())) {
       auto const& cartesianDimension =
-          dawn::sir::dimension_cast<dawn::sir::CartesianFieldDimension const&>(
+          dawn::ast::dimension_cast<dawn::ast::CartesianFieldDimension const&>(
               fieldDimensions.getHorizontalFieldDimension());
 
       dawn::proto::ast::CartesianDimension* protoCartesianDimension =
@@ -290,7 +290,7 @@ void setFieldDimensions(dawn::proto::ast::FieldDimensions* protoFieldDimensions,
 
     } else {
       auto const& unstructuredDimension =
-          dawn::sir::dimension_cast<dawn::sir::UnstructuredFieldDimension const&>(
+          dawn::ast::dimension_cast<dawn::ast::UnstructuredFieldDimension const&>(
               fieldDimensions.getHorizontalFieldDimension());
 
       auto protoIterSpace =
@@ -754,13 +754,13 @@ void setAST(proto::ast::AST* astProto, const AST* ast) {
 // Deserialization
 //===------------------------------------------------------------------------------------------===//
 
-sir::FieldDimensions
+ast::FieldDimensions
 makeFieldDimensions(const proto::ast::FieldDimensions& protoFieldDimensions) {
 
   if(protoFieldDimensions.has_cartesian_horizontal_dimension()) {
     const auto& protoCartesianDimension = protoFieldDimensions.cartesian_horizontal_dimension();
-    return sir::FieldDimensions(
-        sir::HorizontalFieldDimension(
+    return ast::FieldDimensions(
+        ast::HorizontalFieldDimension(
             dawn::ast::cartesian,
             std::array<bool, 2>({(bool)protoCartesianDimension.mask_cart_i(),
                                  (bool)protoCartesianDimension.mask_cart_j()})),
@@ -776,13 +776,13 @@ makeFieldDimensions(const proto::ast::FieldDimensions& protoFieldDimensions) {
           getLocationTypeFromProtoLocationType(protoUnstructuredDimension.iter_space().chain(i)));
     }
 
-    return sir::FieldDimensions(
-        sir::HorizontalFieldDimension(dawn::ast::unstructured, neighborChain,
+    return ast::FieldDimensions(
+        ast::HorizontalFieldDimension(dawn::ast::unstructured, neighborChain,
                                       protoUnstructuredDimension.iter_space().include_center()),
         protoFieldDimensions.mask_k());
 
   } else {
-    return sir::FieldDimensions(protoFieldDimensions.mask_k());
+    return ast::FieldDimensions(protoFieldDimensions.mask_k());
   }
 }
 

--- a/dawn/src/dawn/Serialization/ASTSerializer.cpp
+++ b/dawn/src/dawn/Serialization/ASTSerializer.cpp
@@ -35,7 +35,7 @@ using namespace ast;
 
 namespace {
 
-void fillData(iir::IIRStmtData& data, dawn::proto::statements::StmtData const& dataProto) {
+void fillData(iir::IIRStmtData& data, dawn::proto::ast::StmtData const& dataProto) {
   if(dataProto.has_accesses()) {
     iir::Accesses callerAccesses;
     for(auto writeAccess : dataProto.accesses().writeaccess()) {
@@ -49,7 +49,7 @@ void fillData(iir::IIRStmtData& data, dawn::proto::statements::StmtData const& d
 }
 
 std::unique_ptr<ast::StmtData> makeData(ast::StmtData::DataType dataType,
-                                        dawn::proto::statements::StmtData const& dataProto) {
+                                        dawn::proto::ast::StmtData const& dataProto) {
   if(dataType == ast::StmtData::SIR_DATA_TYPE)
     return std::make_unique<sir::SIRStmtData>();
   else {
@@ -61,8 +61,8 @@ std::unique_ptr<ast::StmtData> makeData(ast::StmtData::DataType dataType,
 
 std::unique_ptr<ast::StmtData>
 makeVarDeclStmtData(ast::StmtData::DataType dataType,
-                    dawn::proto::statements::StmtData const& dataProto,
-                    const dawn::proto::statements::VarDeclStmtData& varDeclStmtDataProto) {
+                    dawn::proto::ast::StmtData const& dataProto,
+                    const dawn::proto::ast::VarDeclStmtData& varDeclStmtDataProto) {
   if(dataType == ast::StmtData::SIR_DATA_TYPE) {
     return std::make_unique<sir::SIRStmtData>();
   } else {
@@ -74,30 +74,30 @@ makeVarDeclStmtData(ast::StmtData::DataType dataType,
   }
 }
 void fillAccessExprDataFromProto(ast::Offsets& offset,
-                                 const dawn::proto::statements::AccessExprData& dataProto) {
+                                 const dawn::proto::ast::AccessExprData& dataProto) {
   if(dataProto.has_accessid())
     offset.setVerticalIndirectionAccessID(dataProto.accessid().value());
 }
 void fillAccessExprDataFromProto(iir::IIRAccessExprData& data,
-                                 const dawn::proto::statements::AccessExprData& dataProto) {
+                                 const dawn::proto::ast::AccessExprData& dataProto) {
   if(dataProto.has_accessid())
     data.AccessID = std::make_optional(dataProto.accessid().value());
 }
-void setAccessExprData(dawn::proto::statements::AccessExprData* dataProto,
+void setAccessExprData(dawn::proto::ast::AccessExprData* dataProto,
                        const iir::IIRAccessExprData& data) {
   if(data.AccessID) {
     auto accessID = dataProto->mutable_accessid();
     accessID->set_value(*data.AccessID);
   }
 }
-void setAccessExprData(dawn::proto::statements::AccessExprData* dataProto,
+void setAccessExprData(dawn::proto::ast::AccessExprData* dataProto,
                        std::optional<int> dataAccessID) {
   if(dataAccessID.has_value()) {
     auto accessID = dataProto->mutable_accessid();
     accessID->set_value(dataAccessID.value());
   }
 }
-void setStmtData(proto::statements::StmtData* protoStmtData, ast::Stmt& stmt) {
+void setStmtData(proto::ast::StmtData* protoStmtData, ast::Stmt& stmt) {
   if(stmt.getDataType() == ast::StmtData::IIR_DATA_TYPE) {
     if(stmt.getData<iir::IIRStmtData>().CallerAccesses.has_value()) {
       setAccesses(protoStmtData->mutable_accesses(),
@@ -108,7 +108,7 @@ void setStmtData(proto::statements::StmtData* protoStmtData, ast::Stmt& stmt) {
   }
 }
 
-void setVarDeclStmtData(dawn::proto::statements::VarDeclStmtData* dataProto,
+void setVarDeclStmtData(dawn::proto::ast::VarDeclStmtData* dataProto,
                         const ast::VarDeclStmt& stmt) {
   if(stmt.getDataType() == ast::StmtData::IIR_DATA_TYPE) {
     if(stmt.getData<iir::VarDeclStmtData>().AccessID) {
@@ -120,17 +120,17 @@ void setVarDeclStmtData(dawn::proto::statements::VarDeclStmtData* dataProto,
 
 } // namespace
 
-proto::enums::LocationType getProtoLocationTypeFromLocationType(ast::LocationType locationType) {
-  proto::enums::LocationType protoLocationType;
+proto::ast::LocationType getProtoLocationTypeFromLocationType(ast::LocationType locationType) {
+  proto::ast::LocationType protoLocationType;
   switch(locationType) {
   case ast::LocationType::Cells:
-    protoLocationType = proto::enums::LocationType::Cell;
+    protoLocationType = proto::ast::LocationType::Cell;
     break;
   case ast::LocationType::Edges:
-    protoLocationType = proto::enums::LocationType::Edge;
+    protoLocationType = proto::ast::LocationType::Edge;
     break;
   case ast::LocationType::Vertices:
-    protoLocationType = proto::enums::LocationType::Vertex;
+    protoLocationType = proto::ast::LocationType::Vertex;
     break;
   default:
     dawn_unreachable("unknown location type");
@@ -139,16 +139,16 @@ proto::enums::LocationType getProtoLocationTypeFromLocationType(ast::LocationTyp
 }
 
 ast::LocationType
-getLocationTypeFromProtoLocationType(proto::enums::LocationType protoLocationType) {
+getLocationTypeFromProtoLocationType(proto::ast::LocationType protoLocationType) {
   ast::LocationType loc;
   switch(protoLocationType) {
-  case proto::enums::LocationType::Cell:
+  case proto::ast::LocationType::Cell:
     loc = ast::LocationType::Cells;
     break;
-  case proto::enums::LocationType::Edge:
+  case proto::ast::LocationType::Edge:
     loc = ast::LocationType::Edges;
     break;
-  case proto::enums::LocationType::Vertex:
+  case proto::ast::LocationType::Vertex:
     loc = ast::LocationType::Vertices;
     break;
   default:
@@ -157,8 +157,8 @@ getLocationTypeFromProtoLocationType(proto::enums::LocationType protoLocationTyp
   return loc;
 }
 
-dawn::proto::statements::Extents makeProtoExtents(dawn::iir::Extents const& extents) {
-  dawn::proto::statements::Extents protoExtents;
+dawn::proto::ast::Extents makeProtoExtents(dawn::iir::Extents const& extents) {
+  dawn::proto::ast::Extents protoExtents;
   extent_dispatch(
       extents.horizontalExtent(),
       [&](iir::CartesianExtent const& hExtent) {
@@ -189,7 +189,7 @@ dawn::proto::statements::Extents makeProtoExtents(dawn::iir::Extents const& exte
   return protoExtents;
 }
 
-void setAccesses(dawn::proto::statements::Accesses* protoAccesses,
+void setAccesses(dawn::proto::ast::Accesses* protoAccesses,
                  const std::optional<iir::Accesses>& accesses) {
   auto protoReadAccesses = protoAccesses->mutable_readaccess();
   for(auto IDExtentsPair : accesses->getReadAccesses())
@@ -200,8 +200,8 @@ void setAccesses(dawn::proto::statements::Accesses* protoAccesses,
     protoWriteAccesses->insert({IDExtentsPair.first, makeProtoExtents(IDExtentsPair.second)});
 }
 
-iir::Extents makeExtents(const dawn::proto::statements::Extents* protoExtents) {
-  using ProtoExtents = dawn::proto::statements::Extents;
+iir::Extents makeExtents(const dawn::proto::ast::Extents* protoExtents) {
+  using ProtoExtents = dawn::proto::ast::Extents;
   iir::Extent vExtent;
   if(protoExtents->vertical_extent().undefined()) {
     vExtent = iir::Extent(iir::UndefinedExtent{});
@@ -229,31 +229,31 @@ iir::Extents makeExtents(const dawn::proto::statements::Extents* protoExtents) {
   }
 }
 
-void setAST(dawn::proto::statements::AST* astProto, const AST* ast);
+void setAST(dawn::proto::ast::AST* astProto, const AST* ast);
 
-void setLocation(dawn::proto::statements::SourceLocation* locProto, const SourceLocation& loc) {
+void setLocation(dawn::proto::ast::SourceLocation* locProto, const SourceLocation& loc) {
   locProto->set_column(loc.Column);
   locProto->set_line(loc.Line);
 }
 
-void setBuiltinType(dawn::proto::statements::BuiltinType* builtinTypeProto,
+void setBuiltinType(dawn::proto::ast::BuiltinType* builtinTypeProto,
                     const BuiltinTypeID& builtinType) {
   builtinTypeProto->set_type_id(
-      static_cast<dawn::proto::statements::BuiltinType_TypeID>(builtinType));
+      static_cast<dawn::proto::ast::BuiltinType_TypeID>(builtinType));
 }
 
-void setInterval(dawn::proto::statements::Interval* intervalProto, const Interval* interval) {
+void setInterval(dawn::proto::ast::Interval* intervalProto, const Interval* interval) {
   if(interval->LowerLevel == Interval::Start)
-    intervalProto->set_special_lower_level(dawn::proto::statements::Interval::Start);
+    intervalProto->set_special_lower_level(dawn::proto::ast::Interval::Start);
   else if(interval->LowerLevel == Interval::End)
-    intervalProto->set_special_lower_level(dawn::proto::statements::Interval::End);
+    intervalProto->set_special_lower_level(dawn::proto::ast::Interval::End);
   else
     intervalProto->set_lower_level(interval->LowerLevel);
 
   if(interval->UpperLevel == Interval::Start)
-    intervalProto->set_special_upper_level(dawn::proto::statements::Interval::Start);
+    intervalProto->set_special_upper_level(dawn::proto::ast::Interval::Start);
   else if(interval->UpperLevel == Interval::End)
-    intervalProto->set_special_upper_level(dawn::proto::statements::Interval::End);
+    intervalProto->set_special_upper_level(dawn::proto::ast::Interval::End);
   else
     intervalProto->set_upper_level(interval->UpperLevel);
 
@@ -261,18 +261,18 @@ void setInterval(dawn::proto::statements::Interval* intervalProto, const Interva
   intervalProto->set_upper_offset(interval->UpperOffset);
 }
 
-void setDirection(dawn::proto::statements::Direction* directionProto,
+void setDirection(dawn::proto::ast::Direction* directionProto,
                   const sir::Direction* direction) {
   directionProto->set_name(direction->Name);
   setLocation(directionProto->mutable_loc(), direction->Loc);
 }
 
-void setOffset(dawn::proto::statements::Offset* offsetProto, const sir::Offset* offset) {
+void setOffset(dawn::proto::ast::Offset* offsetProto, const sir::Offset* offset) {
   offsetProto->set_name(offset->Name);
   setLocation(offsetProto->mutable_loc(), offset->Loc);
 }
 
-void setFieldDimensions(dawn::proto::statements::FieldDimensions* protoFieldDimensions,
+void setFieldDimensions(dawn::proto::ast::FieldDimensions* protoFieldDimensions,
                         const sir::FieldDimensions& fieldDimensions) {
   protoFieldDimensions->set_mask_k(fieldDimensions.K());
   if(!fieldDimensions.isVertical()) {
@@ -282,7 +282,7 @@ void setFieldDimensions(dawn::proto::statements::FieldDimensions* protoFieldDime
           dawn::sir::dimension_cast<dawn::sir::CartesianFieldDimension const&>(
               fieldDimensions.getHorizontalFieldDimension());
 
-      dawn::proto::statements::CartesianDimension* protoCartesianDimension =
+      dawn::proto::ast::CartesianDimension* protoCartesianDimension =
           protoFieldDimensions->mutable_cartesian_horizontal_dimension();
 
       protoCartesianDimension->set_mask_cart_i(cartesianDimension.I());
@@ -309,7 +309,7 @@ void setFieldDimensions(dawn::proto::statements::FieldDimensions* protoFieldDime
   }
 }
 
-void setField(dawn::proto::statements::Field* fieldProto, const sir::Field* field) {
+void setField(dawn::proto::ast::Field* fieldProto, const sir::Field* field) {
   fieldProto->set_name(field->Name);
   fieldProto->set_is_temporary(field->IsTemporary);
   setLocation(fieldProto->mutable_loc(), field->Loc);
@@ -317,24 +317,24 @@ void setField(dawn::proto::statements::Field* fieldProto, const sir::Field* fiel
   setFieldDimensions(fieldProto->mutable_field_dimensions(), field->Dimensions);
 }
 
-ProtoStmtBuilder::ProtoStmtBuilder(dawn::proto::statements::Stmt* stmtProto,
+ProtoStmtBuilder::ProtoStmtBuilder(dawn::proto::ast::Stmt* stmtProto,
                                    dawn::ast::StmtData::DataType dataType)
     : dataType_(dataType) {
   currentStmtProto_.push(stmtProto);
 }
 
-ProtoStmtBuilder::ProtoStmtBuilder(dawn::proto::statements::Expr* exprProto,
+ProtoStmtBuilder::ProtoStmtBuilder(dawn::proto::ast::Expr* exprProto,
                                    dawn::ast::StmtData::DataType dataType)
     : dataType_(dataType) {
   currentExprProto_.push(exprProto);
 }
 
-dawn::proto::statements::Stmt* ProtoStmtBuilder::getCurrentStmtProto() {
+dawn::proto::ast::Stmt* ProtoStmtBuilder::getCurrentStmtProto() {
   DAWN_ASSERT(!currentStmtProto_.empty());
   return currentStmtProto_.top();
 }
 
-dawn::proto::statements::Expr* ProtoStmtBuilder::getCurrentExprProto() {
+dawn::proto::ast::Expr* ProtoStmtBuilder::getCurrentExprProto() {
   DAWN_ASSERT(!currentExprProto_.empty());
   return currentExprProto_.top();
 }
@@ -440,7 +440,7 @@ void ProtoStmtBuilder::visit(const std::shared_ptr<VerticalRegionDeclStmt>& stmt
   auto protoStmt = getCurrentStmtProto()->mutable_vertical_region_decl_stmt();
 
   dawn::sir::VerticalRegion* verticalRegion = stmt->getVerticalRegion().get();
-  dawn::proto::statements::VerticalRegion* verticalRegionProto =
+  dawn::proto::ast::VerticalRegion* verticalRegionProto =
       protoStmt->mutable_vertical_region();
 
   // VerticalRegion.Loc
@@ -455,8 +455,8 @@ void ProtoStmtBuilder::visit(const std::shared_ptr<VerticalRegionDeclStmt>& stmt
   // VerticalRegion.LoopOrder
   verticalRegionProto->set_loop_order(verticalRegion->LoopOrder ==
                                               dawn::sir::VerticalRegion::LoopOrderKind::Backward
-                                          ? dawn::proto::statements::VerticalRegion::Backward
-                                          : dawn::proto::statements::VerticalRegion::Forward);
+                                          ? dawn::proto::ast::VerticalRegion::Backward
+                                          : dawn::proto::ast::VerticalRegion::Forward);
 
   setLocation(protoStmt->mutable_loc(), stmt->getSourceLocation());
 
@@ -477,7 +477,7 @@ void ProtoStmtBuilder::visit(const std::shared_ptr<StencilCallDeclStmt>& stmt) {
   auto protoStmt = getCurrentStmtProto()->mutable_stencil_call_decl_stmt();
 
   dawn::ast::StencilCall* stencilCall = stmt->getStencilCall().get();
-  dawn::proto::statements::StencilCall* stencilCallProto = protoStmt->mutable_stencil_call();
+  dawn::proto::ast::StencilCall* stencilCallProto = protoStmt->mutable_stencil_call();
 
   // StencilCall.Loc
   setLocation(stencilCallProto->mutable_loc(), stencilCall->Loc);
@@ -631,8 +631,8 @@ void ProtoStmtBuilder::visit(const std::shared_ptr<StencilFunArgExpr>& expr) {
 
   protoExpr->mutable_dimension()->set_direction(
       expr->getDimension() == -1
-          ? dawn::proto::statements::Dimension::Invalid
-          : static_cast<dawn::proto::statements::Dimension_Direction>(expr->getDimension()));
+          ? dawn::proto::ast::Dimension::Invalid
+          : static_cast<dawn::proto::ast::Dimension_Direction>(expr->getDimension()));
   protoExpr->set_offset(expr->getOffset());
   protoExpr->set_argument_index(expr->getArgumentIndex());
 
@@ -743,7 +743,7 @@ void ProtoStmtBuilder::visit(const std::shared_ptr<ReductionOverNeighborExpr>& e
   }
 }
 
-void setAST(proto::statements::AST* astProto, const AST* ast) {
+void setAST(proto::ast::AST* astProto, const AST* ast) {
   // Dynamically determine data type
   auto dataType = ast->getRoot()->getDataType();
   ProtoStmtBuilder builder(astProto->mutable_root(), dataType);
@@ -755,7 +755,7 @@ void setAST(proto::statements::AST* astProto, const AST* ast) {
 //===------------------------------------------------------------------------------------------===//
 
 sir::FieldDimensions
-makeFieldDimensions(const proto::statements::FieldDimensions& protoFieldDimensions) {
+makeFieldDimensions(const proto::ast::FieldDimensions& protoFieldDimensions) {
 
   if(protoFieldDimensions.has_cartesian_horizontal_dimension()) {
     const auto& protoCartesianDimension = protoFieldDimensions.cartesian_horizontal_dimension();
@@ -786,19 +786,19 @@ makeFieldDimensions(const proto::statements::FieldDimensions& protoFieldDimensio
   }
 }
 
-BuiltinTypeID makeBuiltinTypeID(const proto::statements::BuiltinType& builtinTypeProto) {
+BuiltinTypeID makeBuiltinTypeID(const proto::ast::BuiltinType& builtinTypeProto) {
   switch(builtinTypeProto.type_id()) {
-  case proto::statements::BuiltinType_TypeID_Invalid:
+  case proto::ast::BuiltinType_TypeID_Invalid:
     return BuiltinTypeID::Invalid;
-  case proto::statements::BuiltinType_TypeID_Auto:
+  case proto::ast::BuiltinType_TypeID_Auto:
     return BuiltinTypeID::Auto;
-  case proto::statements::BuiltinType_TypeID_Boolean:
+  case proto::ast::BuiltinType_TypeID_Boolean:
     return BuiltinTypeID::Boolean;
-  case proto::statements::BuiltinType_TypeID_Integer:
+  case proto::ast::BuiltinType_TypeID_Integer:
     return BuiltinTypeID::Integer;
-  case proto::statements::BuiltinType_TypeID_Float:
+  case proto::ast::BuiltinType_TypeID_Float:
     return BuiltinTypeID::Float;
-  case proto::statements::BuiltinType_TypeID_Double:
+  case proto::ast::BuiltinType_TypeID_Double:
     return BuiltinTypeID::Double;
   default:
     return BuiltinTypeID::Invalid;
@@ -806,28 +806,28 @@ BuiltinTypeID makeBuiltinTypeID(const proto::statements::BuiltinType& builtinTyp
   return BuiltinTypeID::Invalid;
 }
 
-std::shared_ptr<sir::Direction> makeDirection(const proto::statements::Direction& directionProto) {
+std::shared_ptr<sir::Direction> makeDirection(const proto::ast::Direction& directionProto) {
   return std::make_shared<sir::Direction>(directionProto.name(), makeLocation(directionProto));
 }
 
-std::shared_ptr<sir::Offset> makeOffset(const proto::statements::Offset& offsetProto) {
+std::shared_ptr<sir::Offset> makeOffset(const proto::ast::Offset& offsetProto) {
   return std::make_shared<sir::Offset>(offsetProto.name(), makeLocation(offsetProto));
 }
 
-std::shared_ptr<ast::Interval> makeInterval(const proto::statements::Interval& intervalProto) {
+std::shared_ptr<ast::Interval> makeInterval(const proto::ast::Interval& intervalProto) {
   int lowerLevel = -1, upperLevel = -1, lowerOffset = -1, upperOffset = -1;
 
-  if(intervalProto.LowerLevel_case() == proto::statements::Interval::kSpecialLowerLevel)
+  if(intervalProto.LowerLevel_case() == proto::ast::Interval::kSpecialLowerLevel)
     lowerLevel = intervalProto.special_lower_level() ==
-                         proto::statements::Interval_SpecialLevel::Interval_SpecialLevel_Start
+                         proto::ast::Interval_SpecialLevel::Interval_SpecialLevel_Start
                      ? ast::Interval::Start
                      : ast::Interval::End;
   else
     lowerLevel = intervalProto.lower_level();
 
-  if(intervalProto.UpperLevel_case() == proto::statements::Interval::kSpecialUpperLevel)
+  if(intervalProto.UpperLevel_case() == proto::ast::Interval::kSpecialUpperLevel)
     upperLevel = intervalProto.special_upper_level() ==
-                         proto::statements::Interval_SpecialLevel::Interval_SpecialLevel_Start
+                         proto::ast::Interval_SpecialLevel::Interval_SpecialLevel_Start
                      ? ast::Interval::Start
                      : ast::Interval::End;
   else
@@ -838,10 +838,10 @@ std::shared_ptr<ast::Interval> makeInterval(const proto::statements::Interval& i
   return std::make_shared<ast::Interval>(lowerLevel, upperLevel, lowerOffset, upperOffset);
 }
 
-std::shared_ptr<Expr> makeExpr(const proto::statements::Expr& expressionProto,
+std::shared_ptr<Expr> makeExpr(const proto::ast::Expr& expressionProto,
                                ast::StmtData::DataType dataType, int& maxID) {
   switch(expressionProto.expr_case()) {
-  case proto::statements::Expr::kUnaryOperator: {
+  case proto::ast::Expr::kUnaryOperator: {
     const auto& exprProto = expressionProto.unary_operator();
     auto expr = std::make_shared<UnaryOperator>(makeExpr(exprProto.operand(), dataType, maxID),
                                                 exprProto.op(), makeLocation(exprProto));
@@ -849,7 +849,7 @@ std::shared_ptr<Expr> makeExpr(const proto::statements::Expr& expressionProto,
     maxID = std::max(std::abs(exprProto.id()), maxID);
     return expr;
   }
-  case proto::statements::Expr::kBinaryOperator: {
+  case proto::ast::Expr::kBinaryOperator: {
     const auto& exprProto = expressionProto.binary_operator();
     auto expr = std::make_shared<BinaryOperator>(
         makeExpr(exprProto.left(), dataType, maxID), exprProto.op(),
@@ -858,7 +858,7 @@ std::shared_ptr<Expr> makeExpr(const proto::statements::Expr& expressionProto,
     maxID = std::max(std::abs(exprProto.id()), maxID);
     return expr;
   }
-  case proto::statements::Expr::kAssignmentExpr: {
+  case proto::ast::Expr::kAssignmentExpr: {
     const auto& exprProto = expressionProto.assignment_expr();
     auto expr = std::make_shared<AssignmentExpr>(makeExpr(exprProto.left(), dataType, maxID),
                                                  makeExpr(exprProto.right(), dataType, maxID),
@@ -867,7 +867,7 @@ std::shared_ptr<Expr> makeExpr(const proto::statements::Expr& expressionProto,
     maxID = std::max(std::abs(exprProto.id()), maxID);
     return expr;
   }
-  case proto::statements::Expr::kTernaryOperator: {
+  case proto::ast::Expr::kTernaryOperator: {
     const auto& exprProto = expressionProto.ternary_operator();
     auto expr = std::make_shared<TernaryOperator>(
         makeExpr(exprProto.cond(), dataType, maxID), makeExpr(exprProto.left(), dataType, maxID),
@@ -876,7 +876,7 @@ std::shared_ptr<Expr> makeExpr(const proto::statements::Expr& expressionProto,
     maxID = std::max(std::abs(exprProto.id()), maxID);
     return expr;
   }
-  case proto::statements::Expr::kFunCallExpr: {
+  case proto::ast::Expr::kFunCallExpr: {
     const auto& exprProto = expressionProto.fun_call_expr();
     auto expr = std::make_shared<FunCallExpr>(exprProto.callee(), makeLocation(exprProto));
     for(const auto& argProto : exprProto.arguments())
@@ -885,7 +885,7 @@ std::shared_ptr<Expr> makeExpr(const proto::statements::Expr& expressionProto,
     maxID = std::max(std::abs(exprProto.id()), maxID);
     return expr;
   }
-  case proto::statements::Expr::kStencilFunCallExpr: {
+  case proto::ast::Expr::kStencilFunCallExpr: {
     const auto& exprProto = expressionProto.stencil_fun_call_expr();
     auto expr = std::make_shared<StencilFunCallExpr>(exprProto.callee(), makeLocation(exprProto));
     for(const auto& argProto : exprProto.arguments())
@@ -894,22 +894,22 @@ std::shared_ptr<Expr> makeExpr(const proto::statements::Expr& expressionProto,
     maxID = std::max(std::abs(exprProto.id()), maxID);
     return expr;
   }
-  case proto::statements::Expr::kStencilFunArgExpr: {
+  case proto::ast::Expr::kStencilFunArgExpr: {
     const auto& exprProto = expressionProto.stencil_fun_arg_expr();
     int direction = -1, offset = 0, argumentIndex = -1; // default values
 
     if(exprProto.has_dimension()) {
       switch(exprProto.dimension().direction()) {
-      case proto::statements::Dimension_Direction_I:
+      case proto::ast::Dimension_Direction_I:
         direction = 0;
         break;
-      case proto::statements::Dimension_Direction_J:
+      case proto::ast::Dimension_Direction_J:
         direction = 1;
         break;
-      case proto::statements::Dimension_Direction_K:
+      case proto::ast::Dimension_Direction_K:
         direction = 2;
         break;
-      case proto::statements::Dimension_Direction_Invalid:
+      case proto::ast::Dimension_Direction_Invalid:
       default:
         direction = -1;
         break;
@@ -923,7 +923,7 @@ std::shared_ptr<Expr> makeExpr(const proto::statements::Expr& expressionProto,
     maxID = std::max(std::abs(exprProto.id()), maxID);
     return expr;
   }
-  case proto::statements::Expr::kVarAccessExpr: {
+  case proto::ast::Expr::kVarAccessExpr: {
     const auto& exprProto = expressionProto.var_access_expr();
     auto expr = std::make_shared<VarAccessExpr>(
         exprProto.name(),
@@ -936,9 +936,9 @@ std::shared_ptr<Expr> makeExpr(const proto::statements::Expr& expressionProto,
     maxID = std::max(std::abs(exprProto.id()), maxID);
     return expr;
   }
-  case proto::statements::Expr::kFieldAccessExpr: {
+  case proto::ast::Expr::kFieldAccessExpr: {
 
-    using ProtoFieldAccessExpr = dawn::proto::statements::FieldAccessExpr;
+    using ProtoFieldAccessExpr = dawn::proto::ast::FieldAccessExpr;
     const auto& exprProto = expressionProto.field_access_expr();
     auto name = exprProto.name();
     auto negateOffset = exprProto.negate_offset();
@@ -1015,7 +1015,7 @@ std::shared_ptr<Expr> makeExpr(const proto::statements::Expr& expressionProto,
     maxID = std::max(std::abs(exprProto.id()), maxID);
     return expr;
   }
-  case proto::statements::Expr::kLiteralAccessExpr: {
+  case proto::ast::Expr::kLiteralAccessExpr: {
     const auto& exprProto = expressionProto.literal_access_expr();
     auto expr = std::make_shared<LiteralAccessExpr>(
         exprProto.value(), makeBuiltinTypeID(exprProto.type()), makeLocation(exprProto));
@@ -1025,7 +1025,7 @@ std::shared_ptr<Expr> makeExpr(const proto::statements::Expr& expressionProto,
     maxID = std::max(std::abs(exprProto.id()), maxID);
     return expr;
   }
-  case proto::statements::Expr::kReductionOverNeighborExpr: {
+  case proto::ast::Expr::kReductionOverNeighborExpr: {
     const auto& exprProto = expressionProto.reduction_over_neighbor_expr();
     auto weights = exprProto.weights();
 
@@ -1052,17 +1052,17 @@ std::shared_ptr<Expr> makeExpr(const proto::statements::Expr& expressionProto,
       return expr;
     }
   }
-  case proto::statements::Expr::EXPR_NOT_SET:
+  case proto::ast::Expr::EXPR_NOT_SET:
   default:
     dawn_unreachable("expr not set");
   }
   return nullptr;
 }
 
-std::shared_ptr<Stmt> makeStmt(const proto::statements::Stmt& statementProto,
+std::shared_ptr<Stmt> makeStmt(const proto::ast::Stmt& statementProto,
                                ast::StmtData::DataType dataType, int& maxID) {
   switch(statementProto.stmt_case()) {
-  case proto::statements::Stmt::kBlockStmt: {
+  case proto::ast::Stmt::kBlockStmt: {
     const auto& stmtProto = statementProto.block_stmt();
     auto stmt =
         std::make_shared<BlockStmt>(makeData(dataType, stmtProto.data()), makeLocation(stmtProto));
@@ -1073,13 +1073,13 @@ std::shared_ptr<Stmt> makeStmt(const proto::statements::Stmt& statementProto,
     maxID = std::max(std::abs(stmtProto.id()), maxID);
     return stmt;
   }
-  case proto::statements::Stmt::kLoopStmt: {
+  case proto::ast::Stmt::kLoopStmt: {
     const auto& stmtProto = statementProto.loop_stmt();
     const auto& blockStmt = makeStmt(stmtProto.statements(), dataType, maxID);
     DAWN_ASSERT_MSG(blockStmt->getKind() == Stmt::Kind::BlockStmt, "Expected a BlockStmt.");
 
     switch(stmtProto.loop_descriptor().desc_case()) {
-    case dawn::proto::statements::LoopDescriptor::kLoopDescriptorChain: {
+    case dawn::proto::ast::LoopDescriptor::kLoopDescriptorChain: {
 
       ast::NeighborChain chain;
       for(int i = 0;
@@ -1095,7 +1095,7 @@ std::shared_ptr<Stmt> makeStmt(const proto::statements::Stmt& statementProto,
       maxID = std::max(std::abs(stmtProto.id()), maxID);
       return stmt;
     }
-    case dawn::proto::statements::LoopDescriptor::kLoopDescriptorGeneral: {
+    case dawn::proto::ast::LoopDescriptor::kLoopDescriptorGeneral: {
       dawn_unreachable("general loop bounds not implemented!\n");
       break;
     }
@@ -1103,7 +1103,7 @@ std::shared_ptr<Stmt> makeStmt(const proto::statements::Stmt& statementProto,
       dawn_unreachable("descriptor not set!\n");
     }
   }
-  case proto::statements::Stmt::kExprStmt: {
+  case proto::ast::Stmt::kExprStmt: {
     const auto& stmtProto = statementProto.expr_stmt();
     auto stmt = std::make_shared<ExprStmt>(makeData(dataType, stmtProto.data()),
                                            makeExpr(stmtProto.expr(), dataType, maxID),
@@ -1112,7 +1112,7 @@ std::shared_ptr<Stmt> makeStmt(const proto::statements::Stmt& statementProto,
     maxID = std::max(std::abs(stmtProto.id()), maxID);
     return stmt;
   }
-  case proto::statements::Stmt::kReturnStmt: {
+  case proto::ast::Stmt::kReturnStmt: {
     const auto& stmtProto = statementProto.return_stmt();
     auto stmt = std::make_shared<ReturnStmt>(makeData(dataType, stmtProto.data()),
                                              makeExpr(stmtProto.expr(), dataType, maxID),
@@ -1121,14 +1121,14 @@ std::shared_ptr<Stmt> makeStmt(const proto::statements::Stmt& statementProto,
     maxID = std::max(std::abs(stmtProto.id()), maxID);
     return stmt;
   }
-  case proto::statements::Stmt::kVarDeclStmt: {
+  case proto::ast::Stmt::kVarDeclStmt: {
     const auto& stmtProto = statementProto.var_decl_stmt();
 
     std::vector<std::shared_ptr<Expr>> initList;
     for(const auto& e : stmtProto.init_list())
       initList.emplace_back(makeExpr(e, dataType, maxID));
 
-    const proto::statements::Type& typeProto = stmtProto.type();
+    const proto::ast::Type& typeProto = stmtProto.type();
     CVQualifier cvQual = CVQualifier::Invalid;
     if(typeProto.is_const())
       cvQual |= CVQualifier::Const;
@@ -1145,7 +1145,7 @@ std::shared_ptr<Stmt> makeStmt(const proto::statements::Stmt& statementProto,
     maxID = std::max(std::abs(stmtProto.id()), maxID);
     return stmt;
   }
-  case proto::statements::Stmt::kStencilCallDeclStmt: {
+  case proto::ast::Stmt::kStencilCallDeclStmt: {
     auto metaloc = makeLocation(statementProto.stencil_call_decl_stmt());
     const auto& stmtProto = statementProto.stencil_call_decl_stmt();
     auto loc = makeLocation(stmtProto.stencil_call());
@@ -1160,16 +1160,16 @@ std::shared_ptr<Stmt> makeStmt(const proto::statements::Stmt& statementProto,
     maxID = std::max(std::abs(stmtProto.id()), maxID);
     return stmt;
   }
-  case proto::statements::Stmt::kVerticalRegionDeclStmt: {
+  case proto::ast::Stmt::kVerticalRegionDeclStmt: {
     const auto& stmtProto = statementProto.vertical_region_decl_stmt();
     auto loc = makeLocation(stmtProto.vertical_region());
     std::shared_ptr<ast::Interval> interval = makeInterval(stmtProto.vertical_region().interval());
     sir::VerticalRegion::LoopOrderKind looporder;
     switch(stmtProto.vertical_region().loop_order()) {
-    case proto::statements::VerticalRegion_LoopOrder_Forward:
+    case proto::ast::VerticalRegion_LoopOrder_Forward:
       looporder = sir::VerticalRegion::LoopOrderKind::Forward;
       break;
-    case proto::statements::VerticalRegion_LoopOrder_Backward:
+    case proto::ast::VerticalRegion_LoopOrder_Backward:
       looporder = sir::VerticalRegion::LoopOrderKind::Backward;
       break;
     default:
@@ -1193,7 +1193,7 @@ std::shared_ptr<Stmt> makeStmt(const proto::statements::Stmt& statementProto,
     }
     return stmt;
   }
-  case proto::statements::Stmt::kBoundaryConditionDeclStmt: {
+  case proto::ast::Stmt::kBoundaryConditionDeclStmt: {
     const auto& stmtProto = statementProto.boundary_condition_decl_stmt();
     auto stmt = std::make_shared<BoundaryConditionDeclStmt>(
         makeData(dataType, stmtProto.data()), stmtProto.functor(), makeLocation(stmtProto));
@@ -1203,7 +1203,7 @@ std::shared_ptr<Stmt> makeStmt(const proto::statements::Stmt& statementProto,
     maxID = std::max(std::abs(stmtProto.id()), maxID);
     return stmt;
   }
-  case proto::statements::Stmt::kIfStmt: {
+  case proto::ast::Stmt::kIfStmt: {
     const auto& stmtProto = statementProto.if_stmt();
     auto stmt = std::make_shared<IfStmt>(
         makeData(dataType, stmtProto.data()), makeStmt(stmtProto.cond_part(), dataType, maxID),
@@ -1214,14 +1214,14 @@ std::shared_ptr<Stmt> makeStmt(const proto::statements::Stmt& statementProto,
     maxID = std::max(std::abs(stmtProto.id()), maxID);
     return stmt;
   }
-  case proto::statements::Stmt::STMT_NOT_SET:
+  case proto::ast::Stmt::STMT_NOT_SET:
   default:
     dawn_unreachable("stmt not set");
   }
   return nullptr;
 }
 
-std::shared_ptr<AST> makeAST(const dawn::proto::statements::AST& astProto,
+std::shared_ptr<AST> makeAST(const dawn::proto::ast::AST& astProto,
                              ast::StmtData::DataType dataType, int& maxID) {
   auto root = dyn_pointer_cast<BlockStmt>(makeStmt(astProto.root(), dataType, maxID));
   if(!root)

--- a/dawn/src/dawn/Serialization/ASTSerializer.h
+++ b/dawn/src/dawn/Serialization/ASTSerializer.h
@@ -18,7 +18,7 @@
 #include "dawn/IIR/StencilInstantiation.h"
 #include "dawn/AST/ASTVisitor.h"
 #include "dawn/SIR/SIR.h"
-#include "dawn/SIR/SIR/statements.pb.h"
+#include "dawn/AST/AST/statements.pb.h"
 #include <stack>
 
 using namespace dawn;

--- a/dawn/src/dawn/Serialization/ASTSerializer.h
+++ b/dawn/src/dawn/Serialization/ASTSerializer.h
@@ -23,52 +23,52 @@
 
 using namespace dawn;
 
-proto::enums::LocationType getProtoLocationTypeFromLocationType(ast::LocationType locationType);
+proto::ast::LocationType getProtoLocationTypeFromLocationType(ast::LocationType locationType);
 
 ast::LocationType
-getLocationTypeFromProtoLocationType(proto::enums::LocationType protoLocationType);
+getLocationTypeFromProtoLocationType(proto::ast::LocationType protoLocationType);
 
-void setAST(dawn::proto::statements::AST* astProto, const ast::AST* ast);
+void setAST(dawn::proto::ast::AST* astProto, const ast::AST* ast);
 
-void setLocation(dawn::proto::statements::SourceLocation* locProto, const SourceLocation& loc);
+void setLocation(dawn::proto::ast::SourceLocation* locProto, const SourceLocation& loc);
 
-void setBuiltinType(dawn::proto::statements::BuiltinType* builtinTypeProto,
+void setBuiltinType(dawn::proto::ast::BuiltinType* builtinTypeProto,
                     const BuiltinTypeID& builtinType);
 
-void setInterval(dawn::proto::statements::Interval* intervalProto, const ast::Interval* interval);
+void setInterval(dawn::proto::ast::Interval* intervalProto, const ast::Interval* interval);
 
-void setDirection(dawn::proto::statements::Direction* directionProto,
+void setDirection(dawn::proto::ast::Direction* directionProto,
                   const sir::Direction* direction);
 
-void setOffset(dawn::proto::statements::Offset* offsetProto, const sir::Offset* offset);
+void setOffset(dawn::proto::ast::Offset* offsetProto, const sir::Offset* offset);
 
-void setFieldDimensions(dawn::proto::statements::FieldDimensions* protoFieldDimensions,
+void setFieldDimensions(dawn::proto::ast::FieldDimensions* protoFieldDimensions,
                         const sir::FieldDimensions& fieldDimensions);
 
-void setField(dawn::proto::statements::Field* fieldProto, const sir::Field* field);
+void setField(dawn::proto::ast::Field* fieldProto, const sir::Field* field);
 
-dawn::proto::statements::Extents makeProtoExtents(dawn::iir::Extents const& extents);
+dawn::proto::ast::Extents makeProtoExtents(dawn::iir::Extents const& extents);
 
-void setAccesses(dawn::proto::statements::Accesses* protoAccesses,
+void setAccesses(dawn::proto::ast::Accesses* protoAccesses,
                  const std::optional<iir::Accesses>& accesses);
 
-iir::Extents makeExtents(const dawn::proto::statements::Extents* protoExtents);
+iir::Extents makeExtents(const dawn::proto::ast::Extents* protoExtents);
 
 class ProtoStmtBuilder : public ast::ASTVisitorNonConst {
-  std::stack<dawn::proto::statements::Stmt*> currentStmtProto_;
-  std::stack<dawn::proto::statements::Expr*> currentExprProto_;
+  std::stack<dawn::proto::ast::Stmt*> currentStmtProto_;
+  std::stack<dawn::proto::ast::Expr*> currentExprProto_;
   const dawn::ast::StmtData::DataType dataType_;
 
 public:
-  ProtoStmtBuilder(dawn::proto::statements::Stmt* stmtProto,
+  ProtoStmtBuilder(dawn::proto::ast::Stmt* stmtProto,
                    dawn::ast::StmtData::DataType dataType);
 
-  ProtoStmtBuilder(dawn::proto::statements::Expr* exprProto,
+  ProtoStmtBuilder(dawn::proto::ast::Expr* exprProto,
                    dawn::ast::StmtData::DataType dataType);
 
-  dawn::proto::statements::Stmt* getCurrentStmtProto();
+  dawn::proto::ast::Stmt* getCurrentStmtProto();
 
-  dawn::proto::statements::Expr* getCurrentExprProto();
+  dawn::proto::ast::Expr* getCurrentExprProto();
 
   void visit(const std::shared_ptr<ast::BlockStmt>& stmt) override;
 
@@ -110,7 +110,7 @@ public:
   void visit(const std::shared_ptr<ast::ReductionOverNeighborExpr>& expr) override;
 };
 
-void setAST(proto::statements::AST* astProto, const ast::AST* ast);
+void setAST(proto::ast::AST* astProto, const ast::AST* ast);
 
 //===------------------------------------------------------------------------------------------===//
 // Deserialization
@@ -123,23 +123,23 @@ SourceLocation makeLocation(const T& proto) {
 }
 
 sir::FieldDimensions
-makeFieldDimensions(const proto::statements::FieldDimensions& protoFieldDimensions);
+makeFieldDimensions(const proto::ast::FieldDimensions& protoFieldDimensions);
 
-std::shared_ptr<sir::Field> makeField(const proto::statements::Field& fieldProto);
+std::shared_ptr<sir::Field> makeField(const proto::ast::Field& fieldProto);
 
-BuiltinTypeID makeBuiltinTypeID(const proto::statements::BuiltinType& builtinTypeProto);
+BuiltinTypeID makeBuiltinTypeID(const proto::ast::BuiltinType& builtinTypeProto);
 
-std::shared_ptr<sir::Direction> makeDirection(const proto::statements::Direction& directionProto);
+std::shared_ptr<sir::Direction> makeDirection(const proto::ast::Direction& directionProto);
 
-std::shared_ptr<sir::Offset> makeOffset(const proto::statements::Offset& offsetProto);
+std::shared_ptr<sir::Offset> makeOffset(const proto::ast::Offset& offsetProto);
 
-std::shared_ptr<ast::Interval> makeInterval(const proto::statements::Interval& intervalProto);
+std::shared_ptr<ast::Interval> makeInterval(const proto::ast::Interval& intervalProto);
 
-std::shared_ptr<ast::Expr> makeExpr(const proto::statements::Expr& expressionProto,
+std::shared_ptr<ast::Expr> makeExpr(const proto::ast::Expr& expressionProto,
                                     ast::StmtData::DataType dataType, int& maxID);
 
-std::shared_ptr<ast::Stmt> makeStmt(const proto::statements::Stmt& statementProto,
+std::shared_ptr<ast::Stmt> makeStmt(const proto::ast::Stmt& statementProto,
                                     ast::StmtData::DataType dataType, int& maxID);
 
-std::shared_ptr<ast::AST> makeAST(const dawn::proto::statements::AST& astProto,
+std::shared_ptr<ast::AST> makeAST(const dawn::proto::ast::AST& astProto,
                                   ast::StmtData::DataType dataType, int& maxID);

--- a/dawn/src/dawn/Serialization/ASTSerializer.h
+++ b/dawn/src/dawn/Serialization/ASTSerializer.h
@@ -43,7 +43,7 @@ void setDirection(dawn::proto::ast::Direction* directionProto,
 void setOffset(dawn::proto::ast::Offset* offsetProto, const sir::Offset* offset);
 
 void setFieldDimensions(dawn::proto::ast::FieldDimensions* protoFieldDimensions,
-                        const sir::FieldDimensions& fieldDimensions);
+                        const ast::FieldDimensions& fieldDimensions);
 
 void setField(dawn::proto::ast::Field* fieldProto, const sir::Field* field);
 
@@ -122,7 +122,7 @@ SourceLocation makeLocation(const T& proto) {
                          : SourceLocation{};
 }
 
-sir::FieldDimensions
+ast::FieldDimensions
 makeFieldDimensions(const proto::ast::FieldDimensions& protoFieldDimensions);
 
 std::shared_ptr<sir::Field> makeField(const proto::ast::Field& fieldProto);

--- a/dawn/src/dawn/Serialization/IIRSerializer.cpp
+++ b/dawn/src/dawn/Serialization/IIRSerializer.cpp
@@ -41,18 +41,18 @@ IIRSerializer::Format IIRSerializer::parseFormatString(const std::string& format
     throw std::invalid_argument(std::string("SIRSerializer::Format parse failed: ") + format);
 }
 
-proto::enums::LocationType
+proto::ast::LocationType
 optionalLocationTypeToProto(std::optional<ast::LocationType> locationType) {
   if(locationType.has_value()) {
     return getProtoLocationTypeFromLocationType(*locationType);
   } else {
-    return proto::enums::LocationTypeUnknown;
+    return proto::ast::LocationTypeUnknown;
   }
 }
 
 std::optional<ast::LocationType>
-protoLocationTypeToOptional(proto::enums::LocationType protoLocationType) {
-  if(protoLocationType == proto::enums::LocationTypeUnknown) {
+protoLocationTypeToOptional(proto::ast::LocationType protoLocationType) {
+  if(protoLocationType == proto::ast::LocationTypeUnknown) {
     return std::nullopt;
   } else {
     return getLocationTypeFromProtoLocationType(protoLocationType);
@@ -226,7 +226,7 @@ void IIRSerializer::serializeMetaData(proto::iir::StencilInstantiation& target,
   // map<string, dawn.proto.statements.BoundaryConditionDeclStmt> FieldnameToBoundaryCondition = 9;
   auto& protoFieldNameToBC = *protoMetaData->mutable_fieldnametoboundarycondition();
   for(auto fieldNameToBC : metaData.fieldnameToBoundaryConditionMap_) {
-    proto::statements::Stmt protoStencilCall;
+    proto::ast::Stmt protoStencilCall;
     ProtoStmtBuilder builder(&protoStencilCall, ast::StmtData::IIR_DATA_TYPE);
     fieldNameToBC.second->accept(builder);
     protoFieldNameToBC.insert({fieldNameToBC.first, protoStencilCall});
@@ -235,7 +235,7 @@ void IIRSerializer::serializeMetaData(proto::iir::StencilInstantiation& target,
   // Filling Field: map<int32, Array3i> fieldIDtoLegalDimensions = 10;
   auto& protoInitializedDimensionsMap = *protoMetaData->mutable_fieldidtodimensions();
   for(auto IDToLegalDimension : metaData.fieldIDToInitializedDimensionsMap_) {
-    dawn::proto::statements::FieldDimensions protoFieldDimensions;
+    dawn::proto::ast::FieldDimensions protoFieldDimensions;
     setFieldDimensions(&protoFieldDimensions, IDToLegalDimension.second);
     protoInitializedDimensionsMap.insert({IDToLegalDimension.first, protoFieldDimensions});
   }
@@ -243,7 +243,7 @@ void IIRSerializer::serializeMetaData(proto::iir::StencilInstantiation& target,
   // Filling Field: map<int32, dawn.proto.statements.StencilCallDeclStmt> IDToStencilCall = 11;
   auto& protoIDToStencilCallMap = *protoMetaData->mutable_idtostencilcall();
   for(auto IDToStencilCall : metaData.getStencilIDToStencilCallMap().getDirectMap()) {
-    proto::statements::Stmt protoStencilCall;
+    proto::ast::Stmt protoStencilCall;
     ProtoStmtBuilder builder(&protoStencilCall, ast::StmtData::IIR_DATA_TYPE);
     IDToStencilCall.second->accept(builder);
     protoIDToStencilCallMap.insert({IDToStencilCall.first, protoStencilCall});
@@ -276,10 +276,10 @@ void IIRSerializer::serializeIIR(proto::iir::StencilInstantiation& target,
 
   switch(iir->getGridType()) {
   case ast::GridType::Cartesian:
-    protoIIR->set_gridtype(proto::enums::GridType::Cartesian);
+    protoIIR->set_gridtype(proto::ast::GridType::Cartesian);
     break;
   case ast::GridType::Unstructured:
-    protoIIR->set_gridtype(proto::enums::GridType::Unstructured);
+    protoIIR->set_gridtype(proto::ast::GridType::Unstructured);
     break;
   }
 
@@ -783,10 +783,10 @@ IIRSerializer::deserializeImpl(const std::string& str, IIRSerializer::Format kin
   std::shared_ptr<iir::StencilInstantiation> target;
 
   switch(protoStencilInstantiation.internalir().gridtype()) {
-  case dawn::proto::enums::GridType::Cartesian:
+  case dawn::proto::ast::GridType::Cartesian:
     target = std::make_shared<iir::StencilInstantiation>(ast::GridType::Cartesian);
     break;
-  case dawn::proto::enums::GridType::Unstructured:
+  case dawn::proto::ast::GridType::Unstructured:
     target = std::make_shared<iir::StencilInstantiation>(ast::GridType::Unstructured);
     break;
   default:

--- a/dawn/src/dawn/Serialization/IIRSerializer.cpp
+++ b/dawn/src/dawn/Serialization/IIRSerializer.cpp
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------TypeKind--------------------------------------------------===//
 #include "dawn/Serialization/IIRSerializer.h"
-#include "SIR/enums.pb.h"
+#include "dawn/AST/AST/enums.pb.h"
 #include "dawn/AST/ASTStmt.h"
 #include "dawn/AST/LocationType.h"
 #include "dawn/IIR/ASTStmt.h"

--- a/dawn/src/dawn/Serialization/SIRSerializer.cpp
+++ b/dawn/src/dawn/Serialization/SIRSerializer.cpp
@@ -190,7 +190,7 @@ static std::string serializeImpl(const SIR* sir, SIRSerializer::Format kind) {
   for(const auto& [name, value] : *sir->GlobalVariableMap) {
 
     // is_constexpr
-    proto::sir::GlobalVariableValue valueProto;
+    proto::ast::GlobalVariableValue valueProto;
     valueProto.set_is_constexpr(value.isConstexpr());
 
     // Value
@@ -758,28 +758,28 @@ static std::shared_ptr<SIR> deserializeImpl(const std::string& str, SIRSerialize
     // AST.GlobalVariableMap
     for(const auto& nameValuePair : sirProto.global_variables().map()) {
       const std::string& sirName = nameValuePair.first;
-      const proto::sir::GlobalVariableValue& sirValue = nameValuePair.second;
+      const proto::ast::GlobalVariableValue& sirValue = nameValuePair.second;
       std::shared_ptr<ast::Global> value = nullptr;
       bool isConstExpr = sirValue.is_constexpr();
 
       switch(sirValue.Value_case()) {
-      case proto::sir::GlobalVariableValue::kBooleanValue:
+      case proto::ast::GlobalVariableValue::kBooleanValue:
         value = std::make_shared<ast::Global>(static_cast<bool>(sirValue.boolean_value()), isConstExpr);
         break;
-      case proto::sir::GlobalVariableValue::kIntegerValue:
+      case proto::ast::GlobalVariableValue::kIntegerValue:
         value = std::make_shared<ast::Global>(static_cast<int>(sirValue.integer_value()), isConstExpr);
         break;
-      case proto::sir::GlobalVariableValue::kFloatValue:
+      case proto::ast::GlobalVariableValue::kFloatValue:
         value = std::make_shared<ast::Global>(static_cast<float>(sirValue.float_value()), isConstExpr);
         break;
-      case proto::sir::GlobalVariableValue::kDoubleValue:
+      case proto::ast::GlobalVariableValue::kDoubleValue:
         value = std::make_shared<ast::Global>(static_cast<double>(sirValue.double_value()), isConstExpr);
         break;
-      case proto::sir::GlobalVariableValue::kStringValue:
+      case proto::ast::GlobalVariableValue::kStringValue:
         value = std::make_shared<ast::Global>(static_cast<std::string>(sirValue.string_value()),
                                          isConstExpr);
         break;
-      case proto::sir::GlobalVariableValue::VALUE_NOT_SET:
+      case proto::ast::GlobalVariableValue::VALUE_NOT_SET:
       default:
         throw std::out_of_range("value not set");
       }

--- a/dawn/src/dawn/Serialization/SIRSerializer.cpp
+++ b/dawn/src/dawn/Serialization/SIRSerializer.cpp
@@ -113,15 +113,15 @@ static std::string serializeImpl(const SIR* sir, SIRSerializer::Format kind) {
   ProtobufLogger::init();
 
   // Convert SIR to protobuf SIR
-  sir::proto::SIR sirProto;
+  proto::sir::SIR sirProto;
 
   // SIR.GridType
   switch(sir->GridType) {
   case ast::GridType::Cartesian:
-    sirProto.set_gridtype(proto::enums::GridType::Cartesian);
+    sirProto.set_gridtype(proto::ast::GridType::Cartesian);
     break;
   case ast::GridType::Unstructured:
-    sirProto.set_gridtype(proto::enums::GridType::Unstructured);
+    sirProto.set_gridtype(proto::ast::GridType::Unstructured);
     break;
   }
 
@@ -190,7 +190,7 @@ static std::string serializeImpl(const SIR* sir, SIRSerializer::Format kind) {
   for(const auto& [name, value] : *sir->GlobalVariableMap) {
 
     // is_constexpr
-    sir::proto::GlobalVariableValue valueProto;
+    proto::sir::GlobalVariableValue valueProto;
     valueProto.set_is_constexpr(value.isConstexpr());
 
     // Value
@@ -259,7 +259,7 @@ std::string SIRSerializer::serializeToString(const SIR* sir, SIRSerializer::Form
 
 namespace {
 
-static std::shared_ptr<ast::AST> makeAST(const dawn::proto::statements::AST& astProto);
+static std::shared_ptr<ast::AST> makeAST(const dawn::proto::ast::AST& astProto);
 
 template <class T>
 static SourceLocation makeLocation(const T& proto) {
@@ -267,7 +267,7 @@ static SourceLocation makeLocation(const T& proto) {
                          : SourceLocation{};
 }
 
-static std::shared_ptr<sir::Field> makeField(const dawn::proto::statements::Field& fieldProto) {
+static std::shared_ptr<sir::Field> makeField(const dawn::proto::ast::Field& fieldProto) {
   auto field = std::make_shared<sir::Field>(fieldProto.name(),
                                             makeFieldDimensions(fieldProto.field_dimensions()),
                                             makeLocation(fieldProto));
@@ -277,19 +277,19 @@ static std::shared_ptr<sir::Field> makeField(const dawn::proto::statements::Fiel
 }
 
 static BuiltinTypeID
-makeBuiltinTypeID(const dawn::proto::statements::BuiltinType& builtinTypeProto) {
+makeBuiltinTypeID(const dawn::proto::ast::BuiltinType& builtinTypeProto) {
   switch(builtinTypeProto.type_id()) {
-  case dawn::proto::statements::BuiltinType_TypeID_Invalid:
+  case dawn::proto::ast::BuiltinType_TypeID_Invalid:
     return BuiltinTypeID::Invalid;
-  case dawn::proto::statements::BuiltinType_TypeID_Auto:
+  case dawn::proto::ast::BuiltinType_TypeID_Auto:
     return BuiltinTypeID::Auto;
-  case dawn::proto::statements::BuiltinType_TypeID_Boolean:
+  case dawn::proto::ast::BuiltinType_TypeID_Boolean:
     return BuiltinTypeID::Boolean;
-  case dawn::proto::statements::BuiltinType_TypeID_Integer:
+  case dawn::proto::ast::BuiltinType_TypeID_Integer:
     return BuiltinTypeID::Integer;
-  case dawn::proto::statements::BuiltinType_TypeID_Float:
+  case dawn::proto::ast::BuiltinType_TypeID_Float:
     return BuiltinTypeID::Float;
-  case dawn::proto::statements::BuiltinType_TypeID_Double:
+  case dawn::proto::ast::BuiltinType_TypeID_Double:
     return BuiltinTypeID::Double;
   default:
     return BuiltinTypeID::Invalid;
@@ -298,29 +298,29 @@ makeBuiltinTypeID(const dawn::proto::statements::BuiltinType& builtinTypeProto) 
 }
 
 static std::shared_ptr<sir::Direction>
-makeDirection(const dawn::proto::statements::Direction& directionProto) {
+makeDirection(const dawn::proto::ast::Direction& directionProto) {
   return std::make_shared<sir::Direction>(directionProto.name(), makeLocation(directionProto));
 }
 
-static std::shared_ptr<sir::Offset> makeOffset(const dawn::proto::statements::Offset& offsetProto) {
+static std::shared_ptr<sir::Offset> makeOffset(const dawn::proto::ast::Offset& offsetProto) {
   return std::make_shared<sir::Offset>(offsetProto.name(), makeLocation(offsetProto));
 }
 
 static std::shared_ptr<ast::Interval>
-makeInterval(const dawn::proto::statements::Interval& intervalProto) {
+makeInterval(const dawn::proto::ast::Interval& intervalProto) {
   int lowerLevel = -1, upperLevel = -1, lowerOffset = -1, upperOffset = -1;
 
-  if(intervalProto.LowerLevel_case() == dawn::proto::statements::Interval::kSpecialLowerLevel)
+  if(intervalProto.LowerLevel_case() == dawn::proto::ast::Interval::kSpecialLowerLevel)
     lowerLevel = intervalProto.special_lower_level() ==
-                         dawn::proto::statements::Interval_SpecialLevel::Interval_SpecialLevel_Start
+                         dawn::proto::ast::Interval_SpecialLevel::Interval_SpecialLevel_Start
                      ? ast::Interval::Start
                      : ast::Interval::End;
   else
     lowerLevel = intervalProto.lower_level();
 
-  if(intervalProto.UpperLevel_case() == dawn::proto::statements::Interval::kSpecialUpperLevel)
+  if(intervalProto.UpperLevel_case() == dawn::proto::ast::Interval::kSpecialUpperLevel)
     upperLevel = intervalProto.special_upper_level() ==
-                         dawn::proto::statements::Interval_SpecialLevel::Interval_SpecialLevel_Start
+                         dawn::proto::ast::Interval_SpecialLevel::Interval_SpecialLevel_Start
                      ? ast::Interval::Start
                      : ast::Interval::End;
   else
@@ -332,7 +332,7 @@ makeInterval(const dawn::proto::statements::Interval& intervalProto) {
 }
 
 static std::shared_ptr<sir::VerticalRegion>
-makeVerticalRegion(const dawn::proto::statements::VerticalRegion& verticalRegionProto) {
+makeVerticalRegion(const dawn::proto::ast::VerticalRegion& verticalRegionProto) {
   // VerticalRegion.Loc
   auto loc = makeLocation(verticalRegionProto);
 
@@ -344,7 +344,7 @@ makeVerticalRegion(const dawn::proto::statements::VerticalRegion& verticalRegion
 
   // VerticalRegion.LoopOrder
   auto loopOrder =
-      verticalRegionProto.loop_order() == dawn::proto::statements::VerticalRegion::Backward
+      verticalRegionProto.loop_order() == dawn::proto::ast::VerticalRegion::Backward
           ? sir::VerticalRegion::LoopOrderKind::Backward
           : sir::VerticalRegion::LoopOrderKind::Forward;
 
@@ -361,7 +361,7 @@ makeVerticalRegion(const dawn::proto::statements::VerticalRegion& verticalRegion
 }
 
 static std::shared_ptr<ast::StencilCall>
-makeStencilCall(const dawn::proto::statements::StencilCall& stencilCallProto) {
+makeStencilCall(const dawn::proto::ast::StencilCall& stencilCallProto) {
   auto stencilCall =
       std::make_shared<ast::StencilCall>(stencilCallProto.callee(), makeLocation(stencilCallProto));
 
@@ -371,39 +371,39 @@ makeStencilCall(const dawn::proto::statements::StencilCall& stencilCallProto) {
   return stencilCall;
 }
 
-static std::shared_ptr<ast::Expr> makeExpr(const dawn::proto::statements::Expr& expressionProto) {
+static std::shared_ptr<ast::Expr> makeExpr(const dawn::proto::ast::Expr& expressionProto) {
   switch(expressionProto.expr_case()) {
-  case dawn::proto::statements::Expr::kUnaryOperator: {
+  case dawn::proto::ast::Expr::kUnaryOperator: {
     const auto& exprProto = expressionProto.unary_operator();
     return std::make_shared<ast::UnaryOperator>(makeExpr(exprProto.operand()), exprProto.op(),
                                                 makeLocation(exprProto));
   }
-  case dawn::proto::statements::Expr::kBinaryOperator: {
+  case dawn::proto::ast::Expr::kBinaryOperator: {
     const auto& exprProto = expressionProto.binary_operator();
     return std::make_shared<ast::BinaryOperator>(makeExpr(exprProto.left()), exprProto.op(),
                                                  makeExpr(exprProto.right()),
                                                  makeLocation(exprProto));
   }
-  case dawn::proto::statements::Expr::kAssignmentExpr: {
+  case dawn::proto::ast::Expr::kAssignmentExpr: {
     const auto& exprProto = expressionProto.assignment_expr();
     return std::make_shared<ast::AssignmentExpr>(makeExpr(exprProto.left()),
                                                  makeExpr(exprProto.right()), exprProto.op(),
                                                  makeLocation(exprProto));
   }
-  case dawn::proto::statements::Expr::kTernaryOperator: {
+  case dawn::proto::ast::Expr::kTernaryOperator: {
     const auto& exprProto = expressionProto.ternary_operator();
     return std::make_shared<ast::TernaryOperator>(
         makeExpr(exprProto.cond()), makeExpr(exprProto.left()), makeExpr(exprProto.right()),
         makeLocation(exprProto));
   }
-  case dawn::proto::statements::Expr::kFunCallExpr: {
+  case dawn::proto::ast::Expr::kFunCallExpr: {
     const auto& exprProto = expressionProto.fun_call_expr();
     auto expr = std::make_shared<ast::FunCallExpr>(exprProto.callee(), makeLocation(exprProto));
     for(const auto& argProto : exprProto.arguments())
       expr->getArguments().emplace_back(makeExpr(argProto));
     return expr;
   }
-  case dawn::proto::statements::Expr::kStencilFunCallExpr: {
+  case dawn::proto::ast::Expr::kStencilFunCallExpr: {
     const auto& exprProto = expressionProto.stencil_fun_call_expr();
     auto expr =
         std::make_shared<ast::StencilFunCallExpr>(exprProto.callee(), makeLocation(exprProto));
@@ -411,22 +411,22 @@ static std::shared_ptr<ast::Expr> makeExpr(const dawn::proto::statements::Expr& 
       expr->getArguments().emplace_back(makeExpr(argProto));
     return expr;
   }
-  case dawn::proto::statements::Expr::kStencilFunArgExpr: {
+  case dawn::proto::ast::Expr::kStencilFunArgExpr: {
     const auto& exprProto = expressionProto.stencil_fun_arg_expr();
     int direction = -1, offset = 0, argumentIndex = -1; // default values
 
     if(exprProto.has_dimension()) {
       switch(exprProto.dimension().direction()) {
-      case dawn::proto::statements::Dimension_Direction_I:
+      case dawn::proto::ast::Dimension_Direction_I:
         direction = 0;
         break;
-      case dawn::proto::statements::Dimension_Direction_J:
+      case dawn::proto::ast::Dimension_Direction_J:
         direction = 1;
         break;
-      case dawn::proto::statements::Dimension_Direction_K:
+      case dawn::proto::ast::Dimension_Direction_K:
         direction = 2;
         break;
-      case dawn::proto::statements::Dimension_Direction_Invalid:
+      case dawn::proto::ast::Dimension_Direction_Invalid:
       default:
         direction = -1;
         break;
@@ -437,7 +437,7 @@ static std::shared_ptr<ast::Expr> makeExpr(const dawn::proto::statements::Expr& 
     return std::make_shared<ast::StencilFunArgExpr>(direction, offset, argumentIndex,
                                                     makeLocation(exprProto));
   }
-  case dawn::proto::statements::Expr::kVarAccessExpr: {
+  case dawn::proto::ast::Expr::kVarAccessExpr: {
     const auto& exprProto = expressionProto.var_access_expr();
     auto expr = std::make_shared<ast::VarAccessExpr>(
         exprProto.name(), exprProto.has_index() ? makeExpr(exprProto.index()) : nullptr,
@@ -445,8 +445,8 @@ static std::shared_ptr<ast::Expr> makeExpr(const dawn::proto::statements::Expr& 
     expr->setIsExternal(exprProto.is_external());
     return expr;
   }
-  case dawn::proto::statements::Expr::kFieldAccessExpr: {
-    using ProtoFieldAccessExpr = dawn::proto::statements::FieldAccessExpr;
+  case dawn::proto::ast::Expr::kFieldAccessExpr: {
+    using ProtoFieldAccessExpr = dawn::proto::ast::FieldAccessExpr;
 
     const auto& exprProto = expressionProto.field_access_expr();
     auto name = exprProto.name();
@@ -512,12 +512,12 @@ static std::shared_ptr<ast::Expr> makeExpr(const dawn::proto::statements::Expr& 
     return std::make_shared<ast::FieldAccessExpr>(name, offset, argumentMap, argumentOffset,
                                                   negateOffset, makeLocation(exprProto));
   }
-  case dawn::proto::statements::Expr::kLiteralAccessExpr: {
+  case dawn::proto::ast::Expr::kLiteralAccessExpr: {
     const auto& exprProto = expressionProto.literal_access_expr();
     return std::make_shared<ast::LiteralAccessExpr>(
         exprProto.value(), makeBuiltinTypeID(exprProto.type()), makeLocation(exprProto));
   }
-  case dawn::proto::statements::Expr::kReductionOverNeighborExpr: {
+  case dawn::proto::ast::Expr::kReductionOverNeighborExpr: {
     const auto& exprProto = expressionProto.reduction_over_neighbor_expr();
     std::vector<std::shared_ptr<ast::Expr>> weights;
 
@@ -540,16 +540,16 @@ static std::shared_ptr<ast::Expr> makeExpr(const dawn::proto::statements::Expr& 
           exprProto.iter_space().include_center(), makeLocation(exprProto));
     }
   }
-  case dawn::proto::statements::Expr::EXPR_NOT_SET:
+  case dawn::proto::ast::Expr::EXPR_NOT_SET:
   default:
     throw std::out_of_range("expr not set");
   }
   return nullptr;
 }
 
-static std::shared_ptr<ast::Stmt> makeStmt(const dawn::proto::statements::Stmt& statementProto) {
+static std::shared_ptr<ast::Stmt> makeStmt(const dawn::proto::ast::Stmt& statementProto) {
   switch(statementProto.stmt_case()) {
-  case dawn::proto::statements::Stmt::kBlockStmt: {
+  case dawn::proto::ast::Stmt::kBlockStmt: {
     const auto& stmtProto = statementProto.block_stmt();
     auto stmt = sir::makeBlockStmt(makeLocation(stmtProto));
 
@@ -558,13 +558,13 @@ static std::shared_ptr<ast::Stmt> makeStmt(const dawn::proto::statements::Stmt& 
 
     return stmt;
   }
-  case dawn::proto::statements::Stmt::kLoopStmt: {
+  case dawn::proto::ast::Stmt::kLoopStmt: {
     const auto& stmtProto = statementProto.loop_stmt();
     const auto& blockStmt = makeStmt(stmtProto.statements());
     DAWN_ASSERT_MSG(blockStmt->getKind() == ast::Stmt::Kind::BlockStmt, "Expected a BlockStmt.");
 
     switch(stmtProto.loop_descriptor().desc_case()) {
-    case dawn::proto::statements::LoopDescriptor::kLoopDescriptorChain: {
+    case dawn::proto::ast::LoopDescriptor::kLoopDescriptorChain: {
 
       ast::NeighborChain chain;
       for(int i = 0;
@@ -578,7 +578,7 @@ static std::shared_ptr<ast::Stmt> makeStmt(const dawn::proto::statements::Stmt& 
           std::dynamic_pointer_cast<ast::BlockStmt>(blockStmt), makeLocation(stmtProto));
       return stmt;
     }
-    case dawn::proto::statements::LoopDescriptor::kLoopDescriptorGeneral: {
+    case dawn::proto::ast::LoopDescriptor::kLoopDescriptorGeneral: {
       dawn_unreachable("general loop bounds not implemented!\n");
       break;
     }
@@ -586,22 +586,22 @@ static std::shared_ptr<ast::Stmt> makeStmt(const dawn::proto::statements::Stmt& 
       dawn_unreachable("descriptor not set!\n");
     }
   }
-  case dawn::proto::statements::Stmt::kExprStmt: {
+  case dawn::proto::ast::Stmt::kExprStmt: {
     const auto& stmtProto = statementProto.expr_stmt();
     return sir::makeExprStmt(makeExpr(stmtProto.expr()), makeLocation(stmtProto));
   }
-  case dawn::proto::statements::Stmt::kReturnStmt: {
+  case dawn::proto::ast::Stmt::kReturnStmt: {
     const auto& stmtProto = statementProto.return_stmt();
     return sir::makeReturnStmt(makeExpr(stmtProto.expr()), makeLocation(stmtProto));
   }
-  case dawn::proto::statements::Stmt::kVarDeclStmt: {
+  case dawn::proto::ast::Stmt::kVarDeclStmt: {
     const auto& stmtProto = statementProto.var_decl_stmt();
 
     std::vector<std::shared_ptr<ast::Expr>> initList;
     for(const auto& e : stmtProto.init_list())
       initList.emplace_back(makeExpr(e));
 
-    const dawn::proto::statements::Type& typeProto = stmtProto.type();
+    const dawn::proto::ast::Type& typeProto = stmtProto.type();
     CVQualifier cvQual = CVQualifier::Invalid;
     if(typeProto.is_const())
       cvQual |= CVQualifier::Const;
@@ -613,37 +613,37 @@ static std::shared_ptr<ast::Stmt> makeStmt(const dawn::proto::statements::Stmt& 
     return sir::makeVarDeclStmt(type, stmtProto.name(), stmtProto.dimension(),
                                 stmtProto.op().c_str(), initList, makeLocation(stmtProto));
   }
-  case dawn::proto::statements::Stmt::kStencilCallDeclStmt: {
+  case dawn::proto::ast::Stmt::kStencilCallDeclStmt: {
     const auto& stmtProto = statementProto.stencil_call_decl_stmt();
     return sir::makeStencilCallDeclStmt(makeStencilCall(stmtProto.stencil_call()),
                                         makeLocation(stmtProto));
   }
-  case dawn::proto::statements::Stmt::kVerticalRegionDeclStmt: {
+  case dawn::proto::ast::Stmt::kVerticalRegionDeclStmt: {
     const auto& stmtProto = statementProto.vertical_region_decl_stmt();
     return sir::makeVerticalRegionDeclStmt(makeVerticalRegion(stmtProto.vertical_region()),
                                            makeLocation(stmtProto));
   }
-  case dawn::proto::statements::Stmt::kBoundaryConditionDeclStmt: {
+  case dawn::proto::ast::Stmt::kBoundaryConditionDeclStmt: {
     const auto& stmtProto = statementProto.boundary_condition_decl_stmt();
     auto stmt = sir::makeBoundaryConditionDeclStmt(stmtProto.functor(), makeLocation(stmtProto));
     for(const auto& fieldName : stmtProto.fields())
       stmt->getFields().emplace_back(fieldName);
     return stmt;
   }
-  case dawn::proto::statements::Stmt::kIfStmt: {
+  case dawn::proto::ast::Stmt::kIfStmt: {
     const auto& stmtProto = statementProto.if_stmt();
     return sir::makeIfStmt(makeStmt(stmtProto.cond_part()), makeStmt(stmtProto.then_part()),
                            stmtProto.has_else_part() ? makeStmt(stmtProto.else_part()) : nullptr,
                            makeLocation(stmtProto));
   }
-  case dawn::proto::statements::Stmt::STMT_NOT_SET:
+  case dawn::proto::ast::Stmt::STMT_NOT_SET:
   default:
     throw std::out_of_range("stmt not set");
   }
   return nullptr;
 }
 
-static std::shared_ptr<ast::AST> makeAST(const dawn::proto::statements::AST& astProto) {
+static std::shared_ptr<ast::AST> makeAST(const dawn::proto::ast::AST& astProto) {
   auto root = dyn_pointer_cast<ast::BlockStmt>(makeStmt(astProto.root()));
   if(!root)
     throw std::runtime_error("root statement of AST is not a 'BlockStmt'");
@@ -657,7 +657,7 @@ static std::shared_ptr<SIR> deserializeImpl(const std::string& str, SIRSerialize
   ProtobufLogger::init();
 
   // Decode the string
-  sir::proto::SIR sirProto;
+  proto::sir::SIR sirProto;
   switch(kind) {
   case dawn::SIRSerializer::Format::Json: {
     auto status = google::protobuf::util::JsonStringToMessage(str, &sirProto);
@@ -682,10 +682,10 @@ static std::shared_ptr<SIR> deserializeImpl(const std::string& str, SIRSerialize
 
     // SIR.GridType
     switch(sirProto.gridtype()) {
-    case dawn::proto::enums::GridType::Cartesian:
+    case dawn::proto::ast::GridType::Cartesian:
       sir = std::make_shared<SIR>(ast::GridType::Cartesian);
       break;
-    case dawn::proto::enums::GridType::Unstructured:
+    case dawn::proto::ast::GridType::Unstructured:
       sir = std::make_shared<SIR>(ast::GridType::Unstructured);
       break;
     default:
@@ -696,7 +696,7 @@ static std::shared_ptr<SIR> deserializeImpl(const std::string& str, SIRSerialize
     sir->Filename = sirProto.filename();
 
     // SIR.Stencils
-    for(const sir::proto::Stencil& stencilProto : sirProto.stencils()) {
+    for(const proto::sir::Stencil& stencilProto : sirProto.stencils()) {
       std::shared_ptr<Stencil> stencil = std::make_shared<Stencil>();
 
       // Stencil.Name
@@ -709,14 +709,14 @@ static std::shared_ptr<SIR> deserializeImpl(const std::string& str, SIRSerialize
       stencil->StencilDescAst = makeAST(stencilProto.ast());
 
       // Stencil.Fields
-      for(const dawn::proto::statements::Field& fieldProto : stencilProto.fields())
+      for(const dawn::proto::ast::Field& fieldProto : stencilProto.fields())
         stencil->Fields.emplace_back(makeField(fieldProto));
 
       sir->Stencils.emplace_back(stencil);
     }
 
     // SIR.StencilFunctions
-    for(const sir::proto::StencilFunction& stencilFunctionProto : sirProto.stencil_functions()) {
+    for(const proto::sir::StencilFunction& stencilFunctionProto : sirProto.stencil_functions()) {
       std::shared_ptr<StencilFunction> stencilFunction = std::make_shared<StencilFunction>();
 
       // StencilFunction.Name
@@ -726,30 +726,30 @@ static std::shared_ptr<SIR> deserializeImpl(const std::string& str, SIRSerialize
       stencilFunction->Loc = makeLocation(stencilFunctionProto);
 
       // StencilFunction.Args
-      for(const dawn::proto::statements::StencilFunctionArg& sirArg :
+      for(const dawn::proto::ast::StencilFunctionArg& sirArg :
           stencilFunctionProto.arguments()) {
         switch(sirArg.Arg_case()) {
-        case dawn::proto::statements::StencilFunctionArg::kFieldValue:
+        case dawn::proto::ast::StencilFunctionArg::kFieldValue:
           stencilFunction->Args.emplace_back(makeField(sirArg.field_value()));
           break;
-        case dawn::proto::statements::StencilFunctionArg::kDirectionValue:
+        case dawn::proto::ast::StencilFunctionArg::kDirectionValue:
           stencilFunction->Args.emplace_back(makeDirection(sirArg.direction_value()));
           break;
-        case dawn::proto::statements::StencilFunctionArg::kOffsetValue:
+        case dawn::proto::ast::StencilFunctionArg::kOffsetValue:
           stencilFunction->Args.emplace_back(makeOffset(sirArg.offset_value()));
           break;
-        case dawn::proto::statements::StencilFunctionArg::ARG_NOT_SET:
+        case dawn::proto::ast::StencilFunctionArg::ARG_NOT_SET:
         default:
           throw std::out_of_range("argument not set");
         }
       }
 
       // StencilFunction.Intervals
-      for(const dawn::proto::statements::Interval& sirInterval : stencilFunctionProto.intervals())
+      for(const dawn::proto::ast::Interval& sirInterval : stencilFunctionProto.intervals())
         stencilFunction->Intervals.emplace_back(makeInterval(sirInterval));
 
       // StencilFunction.Asts
-      for(const dawn::proto::statements::AST& sirAst : stencilFunctionProto.asts())
+      for(const dawn::proto::ast::AST& sirAst : stencilFunctionProto.asts())
         stencilFunction->Asts.emplace_back(makeAST(sirAst));
 
       sir->StencilFunctions.emplace_back(stencilFunction);
@@ -758,28 +758,28 @@ static std::shared_ptr<SIR> deserializeImpl(const std::string& str, SIRSerialize
     // AST.GlobalVariableMap
     for(const auto& nameValuePair : sirProto.global_variables().map()) {
       const std::string& sirName = nameValuePair.first;
-      const sir::proto::GlobalVariableValue& sirValue = nameValuePair.second;
+      const proto::sir::GlobalVariableValue& sirValue = nameValuePair.second;
       std::shared_ptr<ast::Global> value = nullptr;
       bool isConstExpr = sirValue.is_constexpr();
 
       switch(sirValue.Value_case()) {
-      case sir::proto::GlobalVariableValue::kBooleanValue:
+      case proto::sir::GlobalVariableValue::kBooleanValue:
         value = std::make_shared<ast::Global>(static_cast<bool>(sirValue.boolean_value()), isConstExpr);
         break;
-      case sir::proto::GlobalVariableValue::kIntegerValue:
+      case proto::sir::GlobalVariableValue::kIntegerValue:
         value = std::make_shared<ast::Global>(static_cast<int>(sirValue.integer_value()), isConstExpr);
         break;
-      case sir::proto::GlobalVariableValue::kFloatValue:
+      case proto::sir::GlobalVariableValue::kFloatValue:
         value = std::make_shared<ast::Global>(static_cast<float>(sirValue.float_value()), isConstExpr);
         break;
-      case sir::proto::GlobalVariableValue::kDoubleValue:
+      case proto::sir::GlobalVariableValue::kDoubleValue:
         value = std::make_shared<ast::Global>(static_cast<double>(sirValue.double_value()), isConstExpr);
         break;
-      case sir::proto::GlobalVariableValue::kStringValue:
+      case proto::sir::GlobalVariableValue::kStringValue:
         value = std::make_shared<ast::Global>(static_cast<std::string>(sirValue.string_value()),
                                          isConstExpr);
         break;
-      case sir::proto::GlobalVariableValue::VALUE_NOT_SET:
+      case proto::sir::GlobalVariableValue::VALUE_NOT_SET:
       default:
         throw std::out_of_range("value not set");
       }

--- a/dawn/src/dawn/Serialization/SIRSerializer.cpp
+++ b/dawn/src/dawn/Serialization/SIRSerializer.cpp
@@ -16,7 +16,7 @@
 #include "dawn/SIR/AST.h"
 #include "dawn/SIR/SIR.h"
 #include "dawn/SIR/SIR/SIR.pb.h"
-#include "dawn/SIR/SIR/statements.pb.h"
+#include "dawn/AST/AST/statements.pb.h"
 #include "dawn/Serialization/ASTSerializer.h"
 #include "dawn/Support/Exception.h"
 #include "dawn/Support/Format.h"

--- a/dawn/src/dawn/Unittest/IIRBuilder.cpp
+++ b/dawn/src/dawn/Unittest/IIRBuilder.cpp
@@ -245,8 +245,8 @@ std::shared_ptr<ast::Stmt> IIRBuilder::declareVar(IIRBuilder::LocalVar& var) {
 IIRBuilder::Field CartesianIIRBuilder::field(const std::string& name, FieldType ft) {
   DAWN_ASSERT(si_);
   auto fieldMaskArray = asArray(ft);
-  sir::FieldDimensions dimensions(
-      sir::HorizontalFieldDimension{ast::cartesian,
+  ast::FieldDimensions dimensions(
+      ast::HorizontalFieldDimension{ast::cartesian,
                                     {fieldMaskArray[0] == 1, fieldMaskArray[1] == 1}},
       fieldMaskArray[2] == 1);
   int id = si_->getMetaData().addField(iir::FieldAccessType::APIField, name, std::move(dimensions));
@@ -256,8 +256,8 @@ IIRBuilder::Field CartesianIIRBuilder::field(const std::string& name, FieldType 
 IIRBuilder::Field CartesianIIRBuilder::tmpField(const std::string& name, FieldType ft) {
   DAWN_ASSERT(si_);
   auto fieldMaskArray = asArray(ft);
-  sir::FieldDimensions dimensions(
-      sir::HorizontalFieldDimension{ast::cartesian,
+  ast::FieldDimensions dimensions(
+      ast::HorizontalFieldDimension{ast::cartesian,
                                     {fieldMaskArray[0] == 1, fieldMaskArray[1] == 1}},
       fieldMaskArray[2] == 1);
   int id = si_->getMetaData().addTmpField(iir::FieldAccessType::StencilTemporary, name,
@@ -283,8 +283,8 @@ IIRBuilder::Field UnstructuredIIRBuilder::field(std::string const& name, ast::Lo
   DAWN_ASSERT(si_);
   int id = si_->getMetaData().addField(
       iir::FieldAccessType::APIField, name,
-      sir::FieldDimensions(
-          sir::HorizontalFieldDimension{ast::unstructured, location, includeCenter}, maskK));
+      ast::FieldDimensions(
+          ast::HorizontalFieldDimension{ast::unstructured, location, includeCenter}, maskK));
   return {id, name};
 }
 
@@ -294,8 +294,8 @@ IIRBuilder::Field UnstructuredIIRBuilder::field(std::string const& name,
   DAWN_ASSERT(si_);
   int id = si_->getMetaData().addField(
       iir::FieldAccessType::APIField, name,
-      sir::FieldDimensions(
-          sir::HorizontalFieldDimension{ast::unstructured, sparseChain, includeCenter}, maskK));
+      ast::FieldDimensions(
+          ast::HorizontalFieldDimension{ast::unstructured, sparseChain, includeCenter}, maskK));
   return {id, name};
 }
 
@@ -305,8 +305,8 @@ IIRBuilder::Field UnstructuredIIRBuilder::tmpField(std::string const& name,
   DAWN_ASSERT(si_);
   int id = si_->getMetaData().addField(
       iir::FieldAccessType::StencilTemporary, name,
-      sir::FieldDimensions(
-          sir::HorizontalFieldDimension{ast::unstructured, location, includeCenter}, maskK));
+      ast::FieldDimensions(
+          ast::HorizontalFieldDimension{ast::unstructured, location, includeCenter}, maskK));
   return {id, name};
 }
 
@@ -316,15 +316,15 @@ IIRBuilder::Field UnstructuredIIRBuilder::tmpField(std::string const& name,
   DAWN_ASSERT(si_);
   int id = si_->getMetaData().addField(
       iir::FieldAccessType::StencilTemporary, name,
-      sir::FieldDimensions(
-          sir::HorizontalFieldDimension{ast::unstructured, sparseChain, includeCenter}, maskK));
+      ast::FieldDimensions(
+          ast::HorizontalFieldDimension{ast::unstructured, sparseChain, includeCenter}, maskK));
   return {id, name};
 }
 
 IIRBuilder::Field UnstructuredIIRBuilder::vertical_field(std::string const& name) {
   DAWN_ASSERT(si_);
   int id =
-      si_->getMetaData().addField(iir::FieldAccessType::APIField, name, sir::FieldDimensions(true));
+      si_->getMetaData().addField(iir::FieldAccessType::APIField, name, ast::FieldDimensions(true));
   return {id, name};
 }
 

--- a/dawn/src/dawn/Validator/UnstructuredDimensionChecker.h
+++ b/dawn/src/dawn/Validator/UnstructuredDimensionChecker.h
@@ -38,8 +38,8 @@ private:
     };
 
   private:
-    std::optional<sir::FieldDimensions> curDimensions_;
-    const std::unordered_map<std::string, sir::FieldDimensions> nameToDimensions_;
+    std::optional<ast::FieldDimensions> curDimensions_;
+    const std::unordered_map<std::string, ast::FieldDimensions> nameToDimensions_;
     const std::unordered_map<int, std::string> idToNameMap_;
     const std::unordered_map<int, iir::LocalVariableData> idToLocalVariableData_;
     bool dimensionsConsistent_ = true;
@@ -47,8 +47,8 @@ private:
     UnstructuredDimensionCheckerConfig config_;
     checkType checkType_ = checkType::runOnIIR;
 
-    void checkBinaryOpUnstructured(const sir::FieldDimensions& left,
-                                   const sir::FieldDimensions& right);
+    void checkBinaryOpUnstructured(const ast::FieldDimensions& left,
+                                   const ast::FieldDimensions& right);
 
   public:
     void visit(const std::shared_ptr<ast::FieldAccessExpr>& stmt) override;
@@ -68,18 +68,18 @@ private:
     bool hasHorizontalDimensions() const {
       return hasDimensions() && !curDimensions_->isVertical();
     };
-    const sir::FieldDimensions& getDimensions() const;
+    const ast::FieldDimensions& getDimensions() const;
 
     // This constructor is used when the check is performed on the SIR. In this case, each
     // Field is uniquely identified by its name
     UnstructuredDimensionCheckerImpl(
-        const std::unordered_map<std::string, sir::FieldDimensions> nameToDimensionsMap,
+        const std::unordered_map<std::string, ast::FieldDimensions> nameToDimensionsMap,
         UnstructuredDimensionCheckerConfig = UnstructuredDimensionCheckerConfig());
     // This constructor is used when the check is performed from IIR. In this case, the fields may
     // have been renamed if stencils had to be merged. Hence, an additional map with key AccessID is
     // needed
     UnstructuredDimensionCheckerImpl(
-        const std::unordered_map<std::string, sir::FieldDimensions> nameToDimensionsMap,
+        const std::unordered_map<std::string, ast::FieldDimensions> nameToDimensionsMap,
         const std::unordered_map<int, std::string> idToNameMap,
         const std::unordered_map<int, iir::LocalVariableData> idToLocalVariableData,
         UnstructuredDimensionCheckerConfig = UnstructuredDimensionCheckerConfig());

--- a/dawn/src/dawn/Validator/WeightChecker.cpp
+++ b/dawn/src/dawn/Validator/WeightChecker.cpp
@@ -40,7 +40,7 @@ void WeightChecker::WeightCheckerImpl::visit(
     }
 
     DAWN_ASSERT(nameToDimensions_.count(fieldName));
-    weightsValid_ = sir::dimension_cast<const sir::UnstructuredFieldDimension&>(
+    weightsValid_ = ast::dimension_cast<const ast::UnstructuredFieldDimension&>(
                         nameToDimensions_.at(fieldName).getHorizontalFieldDimension())
                         .isDense();
   }
@@ -91,11 +91,11 @@ void WeightChecker::WeightCheckerImpl::visit(
 bool WeightChecker::WeightCheckerImpl::isValid() const { return weightsValid_; }
 
 WeightChecker::WeightCheckerImpl::WeightCheckerImpl(
-    const std::unordered_map<std::string, sir::FieldDimensions> nameToDimensionsMap)
+    const std::unordered_map<std::string, ast::FieldDimensions> nameToDimensionsMap)
     : nameToDimensions_(nameToDimensionsMap) {}
 
 WeightChecker::WeightCheckerImpl::WeightCheckerImpl(
-    const std::unordered_map<std::string, sir::FieldDimensions> nameToDimensionsMap,
+    const std::unordered_map<std::string, ast::FieldDimensions> nameToDimensionsMap,
     const std::unordered_map<int, std::string> idToNameMap,
     const std::unordered_map<std::shared_ptr<ast::StencilFunCallExpr>,
                              std::shared_ptr<iir::StencilFunctionInstantiation>>& exprToFunMap)
@@ -121,7 +121,7 @@ WeightChecker::CheckWeights(const iir::IIR& iir, const iir::StencilMetaInformati
 WeightChecker::ConsistencyResult WeightChecker::CheckWeights(const SIR& sir) {
   for(const auto& stencil : sir.Stencils) {
     DAWN_ASSERT(stencil);
-    std::unordered_map<std::string, sir::FieldDimensions> stencilFieldDims;
+    std::unordered_map<std::string, ast::FieldDimensions> stencilFieldDims;
     for(const auto& field : stencil->Fields) {
       stencilFieldDims.insert({field->Name, field->Dimensions});
     }

--- a/dawn/src/dawn/Validator/WeightChecker.h
+++ b/dawn/src/dawn/Validator/WeightChecker.h
@@ -42,7 +42,7 @@ private:
   private:
     bool weightsValid_ = true;
     bool parentIsWeight_ = false;
-    const std::unordered_map<std::string, sir::FieldDimensions> nameToDimensions_;
+    const std::unordered_map<std::string, ast::FieldDimensions> nameToDimensions_;
     const std::unordered_map<int, std::string> idToNameMap_;
     std::stack<std::shared_ptr<const iir::StencilFunctionInstantiation>>
         functionInstantiationStack_;
@@ -63,12 +63,12 @@ private:
     // This constructor is used when the check is performed on the SIR. In this case, each
     // Field is uniquely identified by its name
     WeightCheckerImpl(
-        const std::unordered_map<std::string, sir::FieldDimensions> nameToDimensionsMap);
+        const std::unordered_map<std::string, ast::FieldDimensions> nameToDimensionsMap);
     // This constructor is used when the check is performed from IIR. In this case, the fields may
     // have been renamed if stencils had to be merged. Hence, an additional map with key AccessID
     // is needed
     WeightCheckerImpl(
-        const std::unordered_map<std::string, sir::FieldDimensions> nameToDimensionsMap,
+        const std::unordered_map<std::string, ast::FieldDimensions> nameToDimensionsMap,
         const std::unordered_map<int, std::string> idToNameMap,
         const std::unordered_map<std::shared_ptr<ast::StencilFunCallExpr>,
                                  std::shared_ptr<iir::StencilFunctionInstantiation>>& exprToFunMap);

--- a/dawn/src/dawn4py/.gitignore
+++ b/dawn/src/dawn4py/.gitignore
@@ -35,6 +35,7 @@ pip-wheel-metadata/
 MANIFEST
 
 # Generated Protobuf files
+serialization/AST/*pb2.py
 serialization/SIR/*pb2.py
 serialization/IIR/*pb2.py
 

--- a/dawn/src/dawn4py/CMakeLists.txt
+++ b/dawn/src/dawn4py/CMakeLists.txt
@@ -15,13 +15,24 @@
 # Generate python proto files
 include(DawnProtobufGenerate)
 
-# Defines dawn_sir_proto_files and dawn_iir_proto_files
+# Defines dawn_ast_proto_files, dawn_sir_proto_files and dawn_iir_proto_files
+include(${PROJECT_SOURCE_DIR}/src/dawn/AST/proto/DawnAST.cmake)
 include(${PROJECT_SOURCE_DIR}/src/dawn/SIR/proto/DawnSIR.cmake)
 include(${PROJECT_SOURCE_DIR}/src/dawn/IIR/proto/DawnIIR.cmake)
 
 dawn_protobuf_generate(
+  OUT_FILES ast_proto_python_files
+  PROTOS ${dawn_ast_proto_files}
+  WDIR ${PROJECT_SOURCE_DIR}/src/dawn/AST/proto
+  OUTDIR ${DAWN4PY_MODULE_DIR}/dawn4py/serialization
+  PACKG AST
+  LANGUAGE python
+)
+
+dawn_protobuf_generate(
   OUT_FILES sir_proto_python_files
   PROTOS ${dawn_sir_proto_files}
+  INC_DIR ${PROJECT_SOURCE_DIR}/src/dawn/AST/proto
   WDIR ${PROJECT_SOURCE_DIR}/src/dawn/SIR/proto
   OUTDIR ${DAWN4PY_MODULE_DIR}/dawn4py/serialization
   PACKG SIR
@@ -31,14 +42,14 @@ dawn_protobuf_generate(
 dawn_protobuf_generate(
   OUT_FILES iir_proto_python_files
   PROTOS ${dawn_iir_proto_files}
-  INC_DIR ${PROJECT_SOURCE_DIR}/src/dawn/SIR/proto
+  INC_DIR ${PROJECT_SOURCE_DIR}/src/dawn/AST/proto
   WDIR ${PROJECT_SOURCE_DIR}/src/dawn/IIR/proto
   OUTDIR ${DAWN4PY_MODULE_DIR}/dawn4py/serialization
   PACKG IIR
   LANGUAGE python
 )
 
-add_custom_target(generate_python_proto DEPENDS ${sir_proto_python_files} ${iir_proto_python_files})
+add_custom_target(generate_python_proto DEPENDS ${ast_proto_python_files} ${sir_proto_python_files} ${iir_proto_python_files})
 
 # Build python module
 include(FetchContent)

--- a/dawn/src/dawn4py/serialization/AST/__init__.py
+++ b/dawn/src/dawn4py/serialization/AST/__init__.py
@@ -13,11 +13,9 @@
 ##
 ##===------------------------------------------------------------------------------------------===##
 
-"""
-Python serialization tools for SIR and IIR.
-"""
+import sys
 
-from . import AST, SIR, IIR
+sys.modules[__name__.split(".")[-1]] = sys.modules[__name__]
 
-from .utils import *
-from .error import *
+from .statements_pb2 import *
+from .enums_pb2 import *

--- a/dawn/src/dawn4py/serialization/SIR/__init__.py
+++ b/dawn/src/dawn4py/serialization/SIR/__init__.py
@@ -18,5 +18,3 @@ import sys
 sys.modules[__name__.split(".")[-1]] = sys.modules[__name__]
 
 from .SIR_pb2 import *
-from .statements_pb2 import *
-from .enums_pb2 import *

--- a/dawn/src/dawn4py/serialization/utils.py
+++ b/dawn/src/dawn4py/serialization/utils.py
@@ -29,8 +29,8 @@ from google.protobuf import json_format
 
 from .error import ParseError, SIRError
 from .SIR.SIR_pb2 import *
-from .SIR.statements_pb2 import *
-from .SIR.enums_pb2 import *
+from .AST.statements_pb2 import *
+from .AST.enums_pb2 import *
 from .. import utils
 
 __all__ = [

--- a/dawn/test/integration-test/dawn4py-tests/ICON_gradient.py
+++ b/dawn/test/integration-test/dawn4py-tests/ICON_gradient.py
@@ -25,7 +25,7 @@ import argparse
 import os
 
 import dawn4py
-from dawn4py.serialization import SIR
+from dawn4py.serialization import SIR, AST
 from dawn4py.serialization import utils as sir_utils
 from google.protobuf.json_format import MessageToJson, Parse
 
@@ -37,15 +37,15 @@ SIR_OUTPUT_FILE = f"{OUTPUT_NAME}.sir"
 
 def main(args: argparse.Namespace):
     interval = sir_utils.make_interval(
-        SIR.Interval.Start, SIR.Interval.End, 0, 0)
+        AST.Interval.Start, AST.Interval.End, 0, 0)
     
     body_ast = sir_utils.make_ast(
         [
             sir_utils.make_loop_stmt(
                 sir_utils.make_assignment_stmt(
                     sir_utils.make_field_access_expr("geofac_grg"), 
-                    sir_utils.make_literal_access_expr("2.", SIR.BuiltinType.Double)), 
-                    [SIR.LocationType.Value("Cell"), SIR.LocationType.Value("Edge"), SIR.LocationType.Value("Cell")],
+                    sir_utils.make_literal_access_expr("2.", AST.BuiltinType.Double)),
+                    [AST.LocationType.Value("Cell"), AST.LocationType.Value("Edge"), AST.LocationType.Value("Cell")],
                     include_center = True),
             sir_utils.make_assignment_stmt(
                 sir_utils.make_field_access_expr("p_grad"),
@@ -56,9 +56,9 @@ def main(args: argparse.Namespace):
                         "*", 
                         sir_utils.make_unstructured_field_access_expr("p_ccpr", horizontal_offset=sir_utils.make_unstructured_offset(True))),
                     init=sir_utils.make_literal_access_expr(
-                        "0.0", SIR.BuiltinType.Double),
-                    chain=[SIR.LocationType.Value(
-                        "Cell"), SIR.LocationType.Value("Edge"), SIR.LocationType.Value(
+                        "0.0", AST.BuiltinType.Double),
+                    chain=[AST.LocationType.Value(
+                        "Cell"), AST.LocationType.Value("Edge"), AST.LocationType.Value(
                         "Cell")],
                     include_center = True,
                 ),
@@ -68,12 +68,12 @@ def main(args: argparse.Namespace):
     )
 
     vertical_region_stmt = sir_utils.make_vertical_region_decl_stmt(
-        body_ast, interval, SIR.VerticalRegion.Forward
+        body_ast, interval, AST.VerticalRegion.Forward
     )
 
     sir = sir_utils.make_sir(
         OUTPUT_FILE,
-        SIR.GridType.Value("Unstructured"),
+        AST.GridType.Value("Unstructured"),
         [
             sir_utils.make_stencil(
                 OUTPUT_NAME,
@@ -82,19 +82,19 @@ def main(args: argparse.Namespace):
                     sir_utils.make_field(
                         "p_grad",
                         sir_utils.make_field_dimensions_unstructured(
-                            [SIR.LocationType.Value("Cell")], 1
+                            [AST.LocationType.Value("Cell")], 1
                         ),
                     ),
                     sir_utils.make_field(
                         "p_ccpr",
                         sir_utils.make_field_dimensions_unstructured(
-                            [SIR.LocationType.Value("Cell")], 1
+                            [AST.LocationType.Value("Cell")], 1
                         ),
                     ),
                     sir_utils.make_field(
                         "geofac_grg",
                         sir_utils.make_field_dimensions_unstructured(
-                            [SIR.LocationType.Value("Cell"), SIR.LocationType.Value("Edge"), SIR.LocationType.Value("Cell")], 1, include_center = True
+                            [AST.LocationType.Value("Cell"), AST.LocationType.Value("Edge"), AST.LocationType.Value("Cell")], 1, include_center = True
                         ),
                     ),
                 ],

--- a/dawn/test/integration-test/dawn4py-tests/ICON_gradient.py
+++ b/dawn/test/integration-test/dawn4py-tests/ICON_gradient.py
@@ -26,7 +26,7 @@ import os
 
 import dawn4py
 from dawn4py.serialization import SIR, AST
-from dawn4py.serialization import utils as sir_utils
+from dawn4py.serialization import utils as serial_utils
 from google.protobuf.json_format import MessageToJson, Parse
 
 OUTPUT_NAME = "ICON_gradient"
@@ -36,26 +36,26 @@ SIR_OUTPUT_FILE = f"{OUTPUT_NAME}.sir"
 
 
 def main(args: argparse.Namespace):
-    interval = sir_utils.make_interval(
+    interval = serial_utils.make_interval(
         AST.Interval.Start, AST.Interval.End, 0, 0)
     
-    body_ast = sir_utils.make_ast(
+    body_ast = serial_utils.make_ast(
         [
-            sir_utils.make_loop_stmt(
-                sir_utils.make_assignment_stmt(
-                    sir_utils.make_field_access_expr("geofac_grg"), 
-                    sir_utils.make_literal_access_expr("2.", AST.BuiltinType.Double)),
+            serial_utils.make_loop_stmt(
+                serial_utils.make_assignment_stmt(
+                    serial_utils.make_field_access_expr("geofac_grg"), 
+                    serial_utils.make_literal_access_expr("2.", AST.BuiltinType.Double)),
                     [AST.LocationType.Value("Cell"), AST.LocationType.Value("Edge"), AST.LocationType.Value("Cell")],
                     include_center = True),
-            sir_utils.make_assignment_stmt(
-                sir_utils.make_field_access_expr("p_grad"),
-                sir_utils.make_reduction_over_neighbor_expr(
+            serial_utils.make_assignment_stmt(
+                serial_utils.make_field_access_expr("p_grad"),
+                serial_utils.make_reduction_over_neighbor_expr(
                     "+",
-                    sir_utils.make_binary_operator( 
-                        sir_utils.make_unstructured_field_access_expr("geofac_grg"), 
+                    serial_utils.make_binary_operator( 
+                        serial_utils.make_unstructured_field_access_expr("geofac_grg"), 
                         "*", 
-                        sir_utils.make_unstructured_field_access_expr("p_ccpr", horizontal_offset=sir_utils.make_unstructured_offset(True))),
-                    init=sir_utils.make_literal_access_expr(
+                        serial_utils.make_unstructured_field_access_expr("p_ccpr", horizontal_offset=serial_utils.make_unstructured_offset(True))),
+                    init=serial_utils.make_literal_access_expr(
                         "0.0", AST.BuiltinType.Double),
                     chain=[AST.LocationType.Value(
                         "Cell"), AST.LocationType.Value("Edge"), AST.LocationType.Value(
@@ -67,33 +67,33 @@ def main(args: argparse.Namespace):
         ]
     )
 
-    vertical_region_stmt = sir_utils.make_vertical_region_decl_stmt(
+    vertical_region_stmt = serial_utils.make_vertical_region_decl_stmt(
         body_ast, interval, AST.VerticalRegion.Forward
     )
 
-    sir = sir_utils.make_sir(
+    sir = serial_utils.make_sir(
         OUTPUT_FILE,
         AST.GridType.Value("Unstructured"),
         [
-            sir_utils.make_stencil(
+            serial_utils.make_stencil(
                 OUTPUT_NAME,
-                sir_utils.make_ast([vertical_region_stmt]),
+                serial_utils.make_ast([vertical_region_stmt]),
                 [
-                    sir_utils.make_field(
+                    serial_utils.make_field(
                         "p_grad",
-                        sir_utils.make_field_dimensions_unstructured(
+                        serial_utils.make_field_dimensions_unstructured(
                             [AST.LocationType.Value("Cell")], 1
                         ),
                     ),
-                    sir_utils.make_field(
+                    serial_utils.make_field(
                         "p_ccpr",
-                        sir_utils.make_field_dimensions_unstructured(
+                        serial_utils.make_field_dimensions_unstructured(
                             [AST.LocationType.Value("Cell")], 1
                         ),
                     ),
-                    sir_utils.make_field(
+                    serial_utils.make_field(
                         "geofac_grg",
-                        sir_utils.make_field_dimensions_unstructured(
+                        serial_utils.make_field_dimensions_unstructured(
                             [AST.LocationType.Value("Cell"), AST.LocationType.Value("Edge"), AST.LocationType.Value("Cell")], 1, include_center = True
                         ),
                     ),

--- a/dawn/test/integration-test/dawn4py-tests/ICON_laplacian_diamond_stencil.py
+++ b/dawn/test/integration-test/dawn4py-tests/ICON_laplacian_diamond_stencil.py
@@ -24,7 +24,7 @@ import os
 
 import dawn4py
 from dawn4py.serialization import SIR, AST
-from dawn4py.serialization import utils as sir_utils
+from dawn4py.serialization import utils as serial_utils
 from google.protobuf.json_format import MessageToJson, Parse
 
 
@@ -33,343 +33,343 @@ def main(args: argparse.Namespace):
     gen_outputfile = f"{stencil_name}.cpp"
     sir_outputfile = f"{stencil_name}.sir"
 
-    interval = sir_utils.make_interval(
+    interval = serial_utils.make_interval(
         AST.Interval.Start, AST.Interval.End, 0, 0)
 
-    body_ast = sir_utils.make_ast(
+    body_ast = serial_utils.make_ast(
         [
             # fill sparse dimension vn vert using the loop concept
-            sir_utils.make_loop_stmt(
-                [sir_utils.make_assignment_stmt(
-                    sir_utils.make_field_access_expr("vn_vert"),
-                    sir_utils.make_binary_operator(
-                        sir_utils.make_binary_operator(sir_utils.make_field_access_expr(
-                            "u_vert", [True, 0]), "*", sir_utils.make_field_access_expr("primal_normal_x", [True, 0])),
-                        "+", sir_utils.make_binary_operator(sir_utils.make_field_access_expr(
-                            "v_vert", [True, 0]), "*", sir_utils.make_field_access_expr("primal_normal_y", [True, 0])),
+            serial_utils.make_loop_stmt(
+                [serial_utils.make_assignment_stmt(
+                    serial_utils.make_field_access_expr("vn_vert"),
+                    serial_utils.make_binary_operator(
+                        serial_utils.make_binary_operator(serial_utils.make_field_access_expr(
+                            "u_vert", [True, 0]), "*", serial_utils.make_field_access_expr("primal_normal_x", [True, 0])),
+                        "+", serial_utils.make_binary_operator(serial_utils.make_field_access_expr(
+                            "v_vert", [True, 0]), "*", serial_utils.make_field_access_expr("primal_normal_y", [True, 0])),
                     ),
                     "=")],
                 [AST.LocationType.Value(
                     "Edge"), AST.LocationType.Value("Cell"), AST.LocationType.Value("Vertex")]
             ),
             # dvt_tang for smagorinsky
-            sir_utils.make_assignment_stmt(
-                sir_utils.make_field_access_expr("dvt_tang"),
-                sir_utils.make_reduction_over_neighbor_expr(
+            serial_utils.make_assignment_stmt(
+                serial_utils.make_field_access_expr("dvt_tang"),
+                serial_utils.make_reduction_over_neighbor_expr(
                     op="+",
-                    init=sir_utils.make_literal_access_expr(
+                    init=serial_utils.make_literal_access_expr(
                         "0.0", AST.BuiltinType.Double),
-                    rhs=sir_utils.make_binary_operator(
-                        sir_utils.make_binary_operator(sir_utils.make_field_access_expr(
-                            "u_vert", [True, 0]), "*", sir_utils.make_field_access_expr("dual_normal_x", [True, 0])),
-                        "+", sir_utils.make_binary_operator(sir_utils.make_field_access_expr(
-                            "v_vert", [True, 0]), "*", sir_utils.make_field_access_expr("dual_normal_y", [True, 0])),
+                    rhs=serial_utils.make_binary_operator(
+                        serial_utils.make_binary_operator(serial_utils.make_field_access_expr(
+                            "u_vert", [True, 0]), "*", serial_utils.make_field_access_expr("dual_normal_x", [True, 0])),
+                        "+", serial_utils.make_binary_operator(serial_utils.make_field_access_expr(
+                            "v_vert", [True, 0]), "*", serial_utils.make_field_access_expr("dual_normal_y", [True, 0])),
                     ),
                     chain=[AST.LocationType.Value("Edge"), AST.LocationType.Value(
                         "Cell"), AST.LocationType.Value("Vertex")],
-                    weights=[sir_utils.make_literal_access_expr(
-                        "-1.0", AST.BuiltinType.Double), sir_utils.make_literal_access_expr(
-                        "1.0", AST.BuiltinType.Double), sir_utils.make_literal_access_expr(
-                        "0.0", AST.BuiltinType.Double), sir_utils.make_literal_access_expr(
+                    weights=[serial_utils.make_literal_access_expr(
+                        "-1.0", AST.BuiltinType.Double), serial_utils.make_literal_access_expr(
+                        "1.0", AST.BuiltinType.Double), serial_utils.make_literal_access_expr(
+                        "0.0", AST.BuiltinType.Double), serial_utils.make_literal_access_expr(
                         "0.0", AST.BuiltinType.Double)]
 
                 ),
                 "=",
             ),
-            sir_utils.make_assignment_stmt(
-                sir_utils.make_field_access_expr("dvt_tang"), sir_utils.make_binary_operator(
-                    sir_utils.make_field_access_expr("dvt_tang"), "*", sir_utils.make_field_access_expr("tangent_orientation")), "="),
+            serial_utils.make_assignment_stmt(
+                serial_utils.make_field_access_expr("dvt_tang"), serial_utils.make_binary_operator(
+                    serial_utils.make_field_access_expr("dvt_tang"), "*", serial_utils.make_field_access_expr("tangent_orientation")), "="),
             # dvt_norm for smagorinsky
-            sir_utils.make_assignment_stmt(
-                sir_utils.make_field_access_expr("dvt_norm"),
-                sir_utils.make_reduction_over_neighbor_expr(
+            serial_utils.make_assignment_stmt(
+                serial_utils.make_field_access_expr("dvt_norm"),
+                serial_utils.make_reduction_over_neighbor_expr(
                     op="+",
-                    init=sir_utils.make_literal_access_expr(
+                    init=serial_utils.make_literal_access_expr(
                         "0.0", AST.BuiltinType.Double),
-                    rhs=sir_utils.make_binary_operator(
-                        sir_utils.make_binary_operator(sir_utils.make_field_access_expr(
-                            "u_vert", [True, 0]), "*", sir_utils.make_field_access_expr("dual_normal_x", [True, 0])),
-                        "+", sir_utils.make_binary_operator(sir_utils.make_field_access_expr(
-                            "v_vert", [True, 0]), "*", sir_utils.make_field_access_expr("dual_normal_y", [True, 0])),
+                    rhs=serial_utils.make_binary_operator(
+                        serial_utils.make_binary_operator(serial_utils.make_field_access_expr(
+                            "u_vert", [True, 0]), "*", serial_utils.make_field_access_expr("dual_normal_x", [True, 0])),
+                        "+", serial_utils.make_binary_operator(serial_utils.make_field_access_expr(
+                            "v_vert", [True, 0]), "*", serial_utils.make_field_access_expr("dual_normal_y", [True, 0])),
                     ),
                     chain=[AST.LocationType.Value("Edge"), AST.LocationType.Value(
                         "Cell"), AST.LocationType.Value("Vertex")],
-                    weights=[sir_utils.make_literal_access_expr(
-                        "0.0", AST.BuiltinType.Double), sir_utils.make_literal_access_expr(
-                        "0.0", AST.BuiltinType.Double), sir_utils.make_literal_access_expr(
-                        "-1.0", AST.BuiltinType.Double), sir_utils.make_literal_access_expr(
+                    weights=[serial_utils.make_literal_access_expr(
+                        "0.0", AST.BuiltinType.Double), serial_utils.make_literal_access_expr(
+                        "0.0", AST.BuiltinType.Double), serial_utils.make_literal_access_expr(
+                        "-1.0", AST.BuiltinType.Double), serial_utils.make_literal_access_expr(
                         "1.0", AST.BuiltinType.Double)]
 
                 ),
                 "=",
             ),
             # compute smagorinsky
-            sir_utils.make_assignment_stmt(
-                sir_utils.make_field_access_expr("kh_smag_1"),
-                sir_utils.make_reduction_over_neighbor_expr(
+            serial_utils.make_assignment_stmt(
+                serial_utils.make_field_access_expr("kh_smag_1"),
+                serial_utils.make_reduction_over_neighbor_expr(
                     op="+",
-                    init=sir_utils.make_literal_access_expr(
+                    init=serial_utils.make_literal_access_expr(
                         "0.0", AST.BuiltinType.Double),
-                    rhs=sir_utils.make_field_access_expr("vn_vert"),
+                    rhs=serial_utils.make_field_access_expr("vn_vert"),
                     chain=[AST.LocationType.Value("Edge"), AST.LocationType.Value(
                         "Cell"), AST.LocationType.Value("Vertex")],
-                    weights=[sir_utils.make_literal_access_expr(
-                        "-1.0", AST.BuiltinType.Double), sir_utils.make_literal_access_expr(
-                        "1.0", AST.BuiltinType.Double), sir_utils.make_literal_access_expr(
-                        "0.0", AST.BuiltinType.Double), sir_utils.make_literal_access_expr(
+                    weights=[serial_utils.make_literal_access_expr(
+                        "-1.0", AST.BuiltinType.Double), serial_utils.make_literal_access_expr(
+                        "1.0", AST.BuiltinType.Double), serial_utils.make_literal_access_expr(
+                        "0.0", AST.BuiltinType.Double), serial_utils.make_literal_access_expr(
                         "0.0", AST.BuiltinType.Double)]
 
                 ),
                 "=",
             ),
-            sir_utils.make_assignment_stmt(
-                sir_utils.make_field_access_expr("kh_smag_1"),
-                sir_utils.make_binary_operator(
-                    sir_utils.make_binary_operator(
-                        sir_utils.make_binary_operator(
-                            sir_utils.make_field_access_expr("kh_smag_1"),
+            serial_utils.make_assignment_stmt(
+                serial_utils.make_field_access_expr("kh_smag_1"),
+                serial_utils.make_binary_operator(
+                    serial_utils.make_binary_operator(
+                        serial_utils.make_binary_operator(
+                            serial_utils.make_field_access_expr("kh_smag_1"),
                             "*",
-                            sir_utils.make_field_access_expr("tangent_orientation")),
+                            serial_utils.make_field_access_expr("tangent_orientation")),
                         "*",
-                        sir_utils.make_field_access_expr("inv_primal_edge_length")), "+",
-                    sir_utils.make_binary_operator(
-                        sir_utils.make_field_access_expr("dvt_norm"),
+                        serial_utils.make_field_access_expr("inv_primal_edge_length")), "+",
+                    serial_utils.make_binary_operator(
+                        serial_utils.make_field_access_expr("dvt_norm"),
                         "*",
-                        sir_utils.make_field_access_expr("inv_vert_vert_length"))), "="),
-            sir_utils.make_assignment_stmt(sir_utils.make_field_access_expr("kh_smag_1"),
-                                           sir_utils.make_binary_operator(sir_utils.make_field_access_expr(
-                                               "kh_smag_1"), "*", sir_utils.make_field_access_expr("kh_smag_1"))),
-            sir_utils.make_assignment_stmt(
-                sir_utils.make_field_access_expr("kh_smag_2"),
-                sir_utils.make_reduction_over_neighbor_expr(
+                        serial_utils.make_field_access_expr("inv_vert_vert_length"))), "="),
+            serial_utils.make_assignment_stmt(serial_utils.make_field_access_expr("kh_smag_1"),
+                                           serial_utils.make_binary_operator(serial_utils.make_field_access_expr(
+                                               "kh_smag_1"), "*", serial_utils.make_field_access_expr("kh_smag_1"))),
+            serial_utils.make_assignment_stmt(
+                serial_utils.make_field_access_expr("kh_smag_2"),
+                serial_utils.make_reduction_over_neighbor_expr(
                     op="+",
-                    init=sir_utils.make_literal_access_expr(
+                    init=serial_utils.make_literal_access_expr(
                         "0.0", AST.BuiltinType.Double),
-                    rhs=sir_utils.make_field_access_expr("vn_vert"),
+                    rhs=serial_utils.make_field_access_expr("vn_vert"),
                     chain=[AST.LocationType.Value("Edge"), AST.LocationType.Value(
                         "Cell"), AST.LocationType.Value("Vertex")],
-                    weights=[sir_utils.make_literal_access_expr(
-                        "0.0", AST.BuiltinType.Double), sir_utils.make_literal_access_expr(
-                        "0.0", AST.BuiltinType.Double), sir_utils.make_literal_access_expr(
-                        "-1.0", AST.BuiltinType.Double), sir_utils.make_literal_access_expr(
+                    weights=[serial_utils.make_literal_access_expr(
+                        "0.0", AST.BuiltinType.Double), serial_utils.make_literal_access_expr(
+                        "0.0", AST.BuiltinType.Double), serial_utils.make_literal_access_expr(
+                        "-1.0", AST.BuiltinType.Double), serial_utils.make_literal_access_expr(
                         " 1.0", AST.BuiltinType.Double)]
 
                 ),
                 "=",
             ),
-            sir_utils.make_assignment_stmt(
-                sir_utils.make_field_access_expr("kh_smag_2"),
-                sir_utils.make_binary_operator(
-                    sir_utils.make_binary_operator(
-                        sir_utils.make_field_access_expr("kh_smag_2"),
+            serial_utils.make_assignment_stmt(
+                serial_utils.make_field_access_expr("kh_smag_2"),
+                serial_utils.make_binary_operator(
+                    serial_utils.make_binary_operator(
+                        serial_utils.make_field_access_expr("kh_smag_2"),
                         "*",
-                        sir_utils.make_field_access_expr("inv_vert_vert_length")),
+                        serial_utils.make_field_access_expr("inv_vert_vert_length")),
                     "+",
-                    sir_utils.make_binary_operator(
-                        sir_utils.make_field_access_expr("dvt_tang"),
+                    serial_utils.make_binary_operator(
+                        serial_utils.make_field_access_expr("dvt_tang"),
                         "*",
-                        sir_utils.make_field_access_expr("inv_primal_edge_length"))), "="),
-            sir_utils.make_assignment_stmt(sir_utils.make_field_access_expr("kh_smag_2"),
-                                           sir_utils.make_binary_operator(sir_utils.make_field_access_expr(
-                                               "kh_smag_2"), "*", sir_utils.make_field_access_expr("kh_smag_2"))),
+                        serial_utils.make_field_access_expr("inv_primal_edge_length"))), "="),
+            serial_utils.make_assignment_stmt(serial_utils.make_field_access_expr("kh_smag_2"),
+                                           serial_utils.make_binary_operator(serial_utils.make_field_access_expr(
+                                               "kh_smag_2"), "*", serial_utils.make_field_access_expr("kh_smag_2"))),
             # currently not able to forward a sqrt, so this is technically kh_smag**2
-            sir_utils.make_assignment_stmt(
-                sir_utils.make_field_access_expr("kh_smag"),
-                sir_utils.make_binary_operator(sir_utils.make_field_access_expr("diff_multfac_smag"), "*",
-                                               sir_utils.make_fun_call_expr("math::sqrt",
-                                                                            [sir_utils.make_binary_operator(sir_utils.make_field_access_expr(
-                                                                                "kh_smag_1"), "+", sir_utils.make_field_access_expr("kh_smag_2"))])),
+            serial_utils.make_assignment_stmt(
+                serial_utils.make_field_access_expr("kh_smag"),
+                serial_utils.make_binary_operator(serial_utils.make_field_access_expr("diff_multfac_smag"), "*",
+                                               serial_utils.make_fun_call_expr("math::sqrt",
+                                                                            [serial_utils.make_binary_operator(serial_utils.make_field_access_expr(
+                                                                                "kh_smag_1"), "+", serial_utils.make_field_access_expr("kh_smag_2"))])),
                 "="),
             # compute nabla2 using the diamond reduction
-            sir_utils.make_assignment_stmt(
-                sir_utils.make_field_access_expr("nabla2"),
-                sir_utils.make_reduction_over_neighbor_expr(
+            serial_utils.make_assignment_stmt(
+                serial_utils.make_field_access_expr("nabla2"),
+                serial_utils.make_reduction_over_neighbor_expr(
                     op="+",
-                    init=sir_utils.make_literal_access_expr(
+                    init=serial_utils.make_literal_access_expr(
                         "0.0", AST.BuiltinType.Double),
-                    rhs=sir_utils.make_binary_operator(sir_utils.make_literal_access_expr(
-                        "4.0", AST.BuiltinType.Double), "*", sir_utils.make_field_access_expr("vn_vert")),
+                    rhs=serial_utils.make_binary_operator(serial_utils.make_literal_access_expr(
+                        "4.0", AST.BuiltinType.Double), "*", serial_utils.make_field_access_expr("vn_vert")),
                     chain=[AST.LocationType.Value("Edge"), AST.LocationType.Value(
                         "Cell"), AST.LocationType.Value("Vertex")],
                     weights=[
-                        sir_utils.make_binary_operator(
-                            sir_utils.make_field_access_expr(
+                        serial_utils.make_binary_operator(
+                            serial_utils.make_field_access_expr(
                                 "inv_primal_edge_length"),
                             '*',
-                            sir_utils.make_field_access_expr(
+                            serial_utils.make_field_access_expr(
                                 "inv_primal_edge_length")),
-                        sir_utils.make_binary_operator(
-                            sir_utils.make_field_access_expr(
+                        serial_utils.make_binary_operator(
+                            serial_utils.make_field_access_expr(
                                 "inv_primal_edge_length"),
                             '*',
-                            sir_utils.make_field_access_expr(
+                            serial_utils.make_field_access_expr(
                                 "inv_primal_edge_length")),
-                        sir_utils.make_binary_operator(
-                            sir_utils.make_field_access_expr(
+                        serial_utils.make_binary_operator(
+                            serial_utils.make_field_access_expr(
                                 "inv_vert_vert_length"),
                             '*',
-                            sir_utils.make_field_access_expr(
+                            serial_utils.make_field_access_expr(
                                 "inv_vert_vert_length")),
-                        sir_utils.make_binary_operator(
-                            sir_utils.make_field_access_expr(
+                        serial_utils.make_binary_operator(
+                            serial_utils.make_field_access_expr(
                                 "inv_vert_vert_length"),
                             '*',
-                            sir_utils.make_field_access_expr(
+                            serial_utils.make_field_access_expr(
                                 "inv_vert_vert_length")),
                     ]
                 ),
                 "=",
             ),
-            sir_utils.make_assignment_stmt(
-                sir_utils.make_field_access_expr("nabla2"),
-                sir_utils.make_binary_operator(
-                    sir_utils.make_field_access_expr("nabla2"),
+            serial_utils.make_assignment_stmt(
+                serial_utils.make_field_access_expr("nabla2"),
+                serial_utils.make_binary_operator(
+                    serial_utils.make_field_access_expr("nabla2"),
                     "-",
-                    sir_utils.make_binary_operator(
-                        sir_utils.make_binary_operator(sir_utils.make_binary_operator(sir_utils.make_literal_access_expr(
-                            "8.0", AST.BuiltinType.Double), "*", sir_utils.make_field_access_expr("vn")), "*",
-                            sir_utils.make_binary_operator(
-                                sir_utils.make_field_access_expr(
+                    serial_utils.make_binary_operator(
+                        serial_utils.make_binary_operator(serial_utils.make_binary_operator(serial_utils.make_literal_access_expr(
+                            "8.0", AST.BuiltinType.Double), "*", serial_utils.make_field_access_expr("vn")), "*",
+                            serial_utils.make_binary_operator(
+                                serial_utils.make_field_access_expr(
                                     "inv_primal_edge_length"),
                                 "*",
-                                sir_utils.make_field_access_expr(
+                                serial_utils.make_field_access_expr(
                                     "inv_primal_edge_length"))),
                         "+",
-                        sir_utils.make_binary_operator(sir_utils.make_binary_operator(sir_utils.make_literal_access_expr(
-                            "8.0", AST.BuiltinType.Double), "*", sir_utils.make_field_access_expr("vn")), "*",
-                            sir_utils.make_binary_operator(
-                                sir_utils.make_field_access_expr(
+                        serial_utils.make_binary_operator(serial_utils.make_binary_operator(serial_utils.make_literal_access_expr(
+                            "8.0", AST.BuiltinType.Double), "*", serial_utils.make_field_access_expr("vn")), "*",
+                            serial_utils.make_binary_operator(
+                                serial_utils.make_field_access_expr(
                                     "inv_vert_vert_length"),
                                 "*",
-                                sir_utils.make_field_access_expr(
+                                serial_utils.make_field_access_expr(
                                     "inv_vert_vert_length"))))),
                 "=")
         ]
     )
 
-    vertical_region_stmt = sir_utils.make_vertical_region_decl_stmt(
+    vertical_region_stmt = serial_utils.make_vertical_region_decl_stmt(
         body_ast, interval, AST.VerticalRegion.Forward
     )
 
-    sir = sir_utils.make_sir(
+    sir = serial_utils.make_sir(
         gen_outputfile,
         AST.GridType.Value("Unstructured"),
         [
-            sir_utils.make_stencil(
+            serial_utils.make_stencil(
                 stencil_name,
-                sir_utils.make_ast([vertical_region_stmt]),
+                serial_utils.make_ast([vertical_region_stmt]),
                 [
-                    sir_utils.make_field(
+                    serial_utils.make_field(
                         "diff_multfac_smag",
-                        sir_utils.make_field_dimensions_unstructured(
+                        serial_utils.make_field_dimensions_unstructured(
                             [AST.LocationType.Value(
                                 "Edge")], 1
                         ),
                     ),
-                    sir_utils.make_field(
+                    serial_utils.make_field(
                         "tangent_orientation",
-                        sir_utils.make_field_dimensions_unstructured(
+                        serial_utils.make_field_dimensions_unstructured(
                             [AST.LocationType.Value("Edge")], 1
                         ),
                     ),
-                    sir_utils.make_field(
+                    serial_utils.make_field(
                         "inv_primal_edge_length",
-                        sir_utils.make_field_dimensions_unstructured(
+                        serial_utils.make_field_dimensions_unstructured(
                             [AST.LocationType.Value("Edge")], 1
                         ),
                     ),
-                    sir_utils.make_field(
+                    serial_utils.make_field(
                         "inv_vert_vert_length",
-                        sir_utils.make_field_dimensions_unstructured(
+                        serial_utils.make_field_dimensions_unstructured(
                             [AST.LocationType.Value("Edge")], 1
                         ),
                     ),
-                    sir_utils.make_field(
+                    serial_utils.make_field(
                         "u_vert",
-                        sir_utils.make_field_dimensions_unstructured(
+                        serial_utils.make_field_dimensions_unstructured(
                             [AST.LocationType.Value("Vertex")], 1
                         ),
                     ),
-                    sir_utils.make_field(
+                    serial_utils.make_field(
                         "v_vert",
-                        sir_utils.make_field_dimensions_unstructured(
+                        serial_utils.make_field_dimensions_unstructured(
                             [AST.LocationType.Value("Vertex")], 1
                         ),
                     ),
-                    sir_utils.make_field(
+                    serial_utils.make_field(
                         "primal_normal_x",
-                        sir_utils.make_field_dimensions_unstructured(
+                        serial_utils.make_field_dimensions_unstructured(
                             [AST.LocationType.Value("Edge"), AST.LocationType.Value(
                                 "Cell"), AST.LocationType.Value("Vertex")], 1
                         ),
                     ),
-                    sir_utils.make_field(
+                    serial_utils.make_field(
                         "primal_normal_y",
-                        sir_utils.make_field_dimensions_unstructured(
+                        serial_utils.make_field_dimensions_unstructured(
                             [AST.LocationType.Value("Edge"), AST.LocationType.Value(
                                 "Cell"), AST.LocationType.Value("Vertex")], 1
                         ),
                     ),
-                    sir_utils.make_field(
+                    serial_utils.make_field(
                         "dual_normal_x",
-                        sir_utils.make_field_dimensions_unstructured(
+                        serial_utils.make_field_dimensions_unstructured(
                             [AST.LocationType.Value("Edge"), AST.LocationType.Value(
                                 "Cell"), AST.LocationType.Value("Vertex")], 1
                         ),
                     ),
-                    sir_utils.make_field(
+                    serial_utils.make_field(
                         "dual_normal_y",
-                        sir_utils.make_field_dimensions_unstructured(
+                        serial_utils.make_field_dimensions_unstructured(
                             [AST.LocationType.Value("Edge"), AST.LocationType.Value(
                                 "Cell"), AST.LocationType.Value("Vertex")], 1
                         ),
                     ),
-                    sir_utils.make_field(
+                    serial_utils.make_field(
                         "vn_vert",
-                        sir_utils.make_field_dimensions_unstructured(
+                        serial_utils.make_field_dimensions_unstructured(
                             [AST.LocationType.Value("Edge"), AST.LocationType.Value(
                                 "Cell"), AST.LocationType.Value("Vertex")], 1
                         ),
                     ),
-                    sir_utils.make_field(
+                    serial_utils.make_field(
                         "vn",
-                        sir_utils.make_field_dimensions_unstructured(
+                        serial_utils.make_field_dimensions_unstructured(
                             [AST.LocationType.Value("Edge")], 1
                         ),
                     ),
-                    sir_utils.make_field(
+                    serial_utils.make_field(
                         "dvt_tang",
-                        sir_utils.make_field_dimensions_unstructured(
+                        serial_utils.make_field_dimensions_unstructured(
                             [AST.LocationType.Value("Edge")], 1
                         ),
                     ),
-                    sir_utils.make_field(
+                    serial_utils.make_field(
                         "dvt_norm",
-                        sir_utils.make_field_dimensions_unstructured(
+                        serial_utils.make_field_dimensions_unstructured(
                             [AST.LocationType.Value("Edge")], 1
                         ),
                     ),
-                    sir_utils.make_field(
+                    serial_utils.make_field(
                         "kh_smag_1",
-                        sir_utils.make_field_dimensions_unstructured(
+                        serial_utils.make_field_dimensions_unstructured(
                             [AST.LocationType.Value("Edge")], 1
                         ),
                     ),
-                    sir_utils.make_field(
+                    serial_utils.make_field(
                         "kh_smag_2",
-                        sir_utils.make_field_dimensions_unstructured(
+                        serial_utils.make_field_dimensions_unstructured(
                             [AST.LocationType.Value("Edge")], 1
                         ),
                     ),
-                    sir_utils.make_field(
+                    serial_utils.make_field(
                         "kh_smag",
-                        sir_utils.make_field_dimensions_unstructured(
+                        serial_utils.make_field_dimensions_unstructured(
                             [AST.LocationType.Value("Edge")], 1
                         ),
                     ),
-                    sir_utils.make_field(
+                    serial_utils.make_field(
                         "nabla2",
-                        sir_utils.make_field_dimensions_unstructured(
+                        serial_utils.make_field_dimensions_unstructured(
                             [AST.LocationType.Value("Edge")], 1
                         ),
                     ),

--- a/dawn/test/integration-test/dawn4py-tests/ICON_laplacian_diamond_stencil.py
+++ b/dawn/test/integration-test/dawn4py-tests/ICON_laplacian_diamond_stencil.py
@@ -23,7 +23,7 @@ import argparse
 import os
 
 import dawn4py
-from dawn4py.serialization import SIR
+from dawn4py.serialization import SIR, AST
 from dawn4py.serialization import utils as sir_utils
 from google.protobuf.json_format import MessageToJson, Parse
 
@@ -34,7 +34,7 @@ def main(args: argparse.Namespace):
     sir_outputfile = f"{stencil_name}.sir"
 
     interval = sir_utils.make_interval(
-        SIR.Interval.Start, SIR.Interval.End, 0, 0)
+        AST.Interval.Start, AST.Interval.End, 0, 0)
 
     body_ast = sir_utils.make_ast(
         [
@@ -49,8 +49,8 @@ def main(args: argparse.Namespace):
                             "v_vert", [True, 0]), "*", sir_utils.make_field_access_expr("primal_normal_y", [True, 0])),
                     ),
                     "=")],
-                [SIR.LocationType.Value(
-                    "Edge"), SIR.LocationType.Value("Cell"), SIR.LocationType.Value("Vertex")]
+                [AST.LocationType.Value(
+                    "Edge"), AST.LocationType.Value("Cell"), AST.LocationType.Value("Vertex")]
             ),
             # dvt_tang for smagorinsky
             sir_utils.make_assignment_stmt(
@@ -58,20 +58,20 @@ def main(args: argparse.Namespace):
                 sir_utils.make_reduction_over_neighbor_expr(
                     op="+",
                     init=sir_utils.make_literal_access_expr(
-                        "0.0", SIR.BuiltinType.Double),
+                        "0.0", AST.BuiltinType.Double),
                     rhs=sir_utils.make_binary_operator(
                         sir_utils.make_binary_operator(sir_utils.make_field_access_expr(
                             "u_vert", [True, 0]), "*", sir_utils.make_field_access_expr("dual_normal_x", [True, 0])),
                         "+", sir_utils.make_binary_operator(sir_utils.make_field_access_expr(
                             "v_vert", [True, 0]), "*", sir_utils.make_field_access_expr("dual_normal_y", [True, 0])),
                     ),
-                    chain=[SIR.LocationType.Value("Edge"), SIR.LocationType.Value(
-                        "Cell"), SIR.LocationType.Value("Vertex")],
+                    chain=[AST.LocationType.Value("Edge"), AST.LocationType.Value(
+                        "Cell"), AST.LocationType.Value("Vertex")],
                     weights=[sir_utils.make_literal_access_expr(
-                        "-1.0", SIR.BuiltinType.Double), sir_utils.make_literal_access_expr(
-                        "1.0", SIR.BuiltinType.Double), sir_utils.make_literal_access_expr(
-                        "0.0", SIR.BuiltinType.Double), sir_utils.make_literal_access_expr(
-                        "0.0", SIR.BuiltinType.Double)]
+                        "-1.0", AST.BuiltinType.Double), sir_utils.make_literal_access_expr(
+                        "1.0", AST.BuiltinType.Double), sir_utils.make_literal_access_expr(
+                        "0.0", AST.BuiltinType.Double), sir_utils.make_literal_access_expr(
+                        "0.0", AST.BuiltinType.Double)]
 
                 ),
                 "=",
@@ -85,20 +85,20 @@ def main(args: argparse.Namespace):
                 sir_utils.make_reduction_over_neighbor_expr(
                     op="+",
                     init=sir_utils.make_literal_access_expr(
-                        "0.0", SIR.BuiltinType.Double),
+                        "0.0", AST.BuiltinType.Double),
                     rhs=sir_utils.make_binary_operator(
                         sir_utils.make_binary_operator(sir_utils.make_field_access_expr(
                             "u_vert", [True, 0]), "*", sir_utils.make_field_access_expr("dual_normal_x", [True, 0])),
                         "+", sir_utils.make_binary_operator(sir_utils.make_field_access_expr(
                             "v_vert", [True, 0]), "*", sir_utils.make_field_access_expr("dual_normal_y", [True, 0])),
                     ),
-                    chain=[SIR.LocationType.Value("Edge"), SIR.LocationType.Value(
-                        "Cell"), SIR.LocationType.Value("Vertex")],
+                    chain=[AST.LocationType.Value("Edge"), AST.LocationType.Value(
+                        "Cell"), AST.LocationType.Value("Vertex")],
                     weights=[sir_utils.make_literal_access_expr(
-                        "0.0", SIR.BuiltinType.Double), sir_utils.make_literal_access_expr(
-                        "0.0", SIR.BuiltinType.Double), sir_utils.make_literal_access_expr(
-                        "-1.0", SIR.BuiltinType.Double), sir_utils.make_literal_access_expr(
-                        "1.0", SIR.BuiltinType.Double)]
+                        "0.0", AST.BuiltinType.Double), sir_utils.make_literal_access_expr(
+                        "0.0", AST.BuiltinType.Double), sir_utils.make_literal_access_expr(
+                        "-1.0", AST.BuiltinType.Double), sir_utils.make_literal_access_expr(
+                        "1.0", AST.BuiltinType.Double)]
 
                 ),
                 "=",
@@ -109,15 +109,15 @@ def main(args: argparse.Namespace):
                 sir_utils.make_reduction_over_neighbor_expr(
                     op="+",
                     init=sir_utils.make_literal_access_expr(
-                        "0.0", SIR.BuiltinType.Double),
+                        "0.0", AST.BuiltinType.Double),
                     rhs=sir_utils.make_field_access_expr("vn_vert"),
-                    chain=[SIR.LocationType.Value("Edge"), SIR.LocationType.Value(
-                        "Cell"), SIR.LocationType.Value("Vertex")],
+                    chain=[AST.LocationType.Value("Edge"), AST.LocationType.Value(
+                        "Cell"), AST.LocationType.Value("Vertex")],
                     weights=[sir_utils.make_literal_access_expr(
-                        "-1.0", SIR.BuiltinType.Double), sir_utils.make_literal_access_expr(
-                        "1.0", SIR.BuiltinType.Double), sir_utils.make_literal_access_expr(
-                        "0.0", SIR.BuiltinType.Double), sir_utils.make_literal_access_expr(
-                        "0.0", SIR.BuiltinType.Double)]
+                        "-1.0", AST.BuiltinType.Double), sir_utils.make_literal_access_expr(
+                        "1.0", AST.BuiltinType.Double), sir_utils.make_literal_access_expr(
+                        "0.0", AST.BuiltinType.Double), sir_utils.make_literal_access_expr(
+                        "0.0", AST.BuiltinType.Double)]
 
                 ),
                 "=",
@@ -144,15 +144,15 @@ def main(args: argparse.Namespace):
                 sir_utils.make_reduction_over_neighbor_expr(
                     op="+",
                     init=sir_utils.make_literal_access_expr(
-                        "0.0", SIR.BuiltinType.Double),
+                        "0.0", AST.BuiltinType.Double),
                     rhs=sir_utils.make_field_access_expr("vn_vert"),
-                    chain=[SIR.LocationType.Value("Edge"), SIR.LocationType.Value(
-                        "Cell"), SIR.LocationType.Value("Vertex")],
+                    chain=[AST.LocationType.Value("Edge"), AST.LocationType.Value(
+                        "Cell"), AST.LocationType.Value("Vertex")],
                     weights=[sir_utils.make_literal_access_expr(
-                        "0.0", SIR.BuiltinType.Double), sir_utils.make_literal_access_expr(
-                        "0.0", SIR.BuiltinType.Double), sir_utils.make_literal_access_expr(
-                        "-1.0", SIR.BuiltinType.Double), sir_utils.make_literal_access_expr(
-                        " 1.0", SIR.BuiltinType.Double)]
+                        "0.0", AST.BuiltinType.Double), sir_utils.make_literal_access_expr(
+                        "0.0", AST.BuiltinType.Double), sir_utils.make_literal_access_expr(
+                        "-1.0", AST.BuiltinType.Double), sir_utils.make_literal_access_expr(
+                        " 1.0", AST.BuiltinType.Double)]
 
                 ),
                 "=",
@@ -186,11 +186,11 @@ def main(args: argparse.Namespace):
                 sir_utils.make_reduction_over_neighbor_expr(
                     op="+",
                     init=sir_utils.make_literal_access_expr(
-                        "0.0", SIR.BuiltinType.Double),
+                        "0.0", AST.BuiltinType.Double),
                     rhs=sir_utils.make_binary_operator(sir_utils.make_literal_access_expr(
-                        "4.0", SIR.BuiltinType.Double), "*", sir_utils.make_field_access_expr("vn_vert")),
-                    chain=[SIR.LocationType.Value("Edge"), SIR.LocationType.Value(
-                        "Cell"), SIR.LocationType.Value("Vertex")],
+                        "4.0", AST.BuiltinType.Double), "*", sir_utils.make_field_access_expr("vn_vert")),
+                    chain=[AST.LocationType.Value("Edge"), AST.LocationType.Value(
+                        "Cell"), AST.LocationType.Value("Vertex")],
                     weights=[
                         sir_utils.make_binary_operator(
                             sir_utils.make_field_access_expr(
@@ -227,7 +227,7 @@ def main(args: argparse.Namespace):
                     "-",
                     sir_utils.make_binary_operator(
                         sir_utils.make_binary_operator(sir_utils.make_binary_operator(sir_utils.make_literal_access_expr(
-                            "8.0", SIR.BuiltinType.Double), "*", sir_utils.make_field_access_expr("vn")), "*",
+                            "8.0", AST.BuiltinType.Double), "*", sir_utils.make_field_access_expr("vn")), "*",
                             sir_utils.make_binary_operator(
                                 sir_utils.make_field_access_expr(
                                     "inv_primal_edge_length"),
@@ -236,7 +236,7 @@ def main(args: argparse.Namespace):
                                     "inv_primal_edge_length"))),
                         "+",
                         sir_utils.make_binary_operator(sir_utils.make_binary_operator(sir_utils.make_literal_access_expr(
-                            "8.0", SIR.BuiltinType.Double), "*", sir_utils.make_field_access_expr("vn")), "*",
+                            "8.0", AST.BuiltinType.Double), "*", sir_utils.make_field_access_expr("vn")), "*",
                             sir_utils.make_binary_operator(
                                 sir_utils.make_field_access_expr(
                                     "inv_vert_vert_length"),
@@ -248,12 +248,12 @@ def main(args: argparse.Namespace):
     )
 
     vertical_region_stmt = sir_utils.make_vertical_region_decl_stmt(
-        body_ast, interval, SIR.VerticalRegion.Forward
+        body_ast, interval, AST.VerticalRegion.Forward
     )
 
     sir = sir_utils.make_sir(
         gen_outputfile,
-        SIR.GridType.Value("Unstructured"),
+        AST.GridType.Value("Unstructured"),
         [
             sir_utils.make_stencil(
                 stencil_name,
@@ -262,115 +262,115 @@ def main(args: argparse.Namespace):
                     sir_utils.make_field(
                         "diff_multfac_smag",
                         sir_utils.make_field_dimensions_unstructured(
-                            [SIR.LocationType.Value(
+                            [AST.LocationType.Value(
                                 "Edge")], 1
                         ),
                     ),
                     sir_utils.make_field(
                         "tangent_orientation",
                         sir_utils.make_field_dimensions_unstructured(
-                            [SIR.LocationType.Value("Edge")], 1
+                            [AST.LocationType.Value("Edge")], 1
                         ),
                     ),
                     sir_utils.make_field(
                         "inv_primal_edge_length",
                         sir_utils.make_field_dimensions_unstructured(
-                            [SIR.LocationType.Value("Edge")], 1
+                            [AST.LocationType.Value("Edge")], 1
                         ),
                     ),
                     sir_utils.make_field(
                         "inv_vert_vert_length",
                         sir_utils.make_field_dimensions_unstructured(
-                            [SIR.LocationType.Value("Edge")], 1
+                            [AST.LocationType.Value("Edge")], 1
                         ),
                     ),
                     sir_utils.make_field(
                         "u_vert",
                         sir_utils.make_field_dimensions_unstructured(
-                            [SIR.LocationType.Value("Vertex")], 1
+                            [AST.LocationType.Value("Vertex")], 1
                         ),
                     ),
                     sir_utils.make_field(
                         "v_vert",
                         sir_utils.make_field_dimensions_unstructured(
-                            [SIR.LocationType.Value("Vertex")], 1
+                            [AST.LocationType.Value("Vertex")], 1
                         ),
                     ),
                     sir_utils.make_field(
                         "primal_normal_x",
                         sir_utils.make_field_dimensions_unstructured(
-                            [SIR.LocationType.Value("Edge"), SIR.LocationType.Value(
-                                "Cell"), SIR.LocationType.Value("Vertex")], 1
+                            [AST.LocationType.Value("Edge"), AST.LocationType.Value(
+                                "Cell"), AST.LocationType.Value("Vertex")], 1
                         ),
                     ),
                     sir_utils.make_field(
                         "primal_normal_y",
                         sir_utils.make_field_dimensions_unstructured(
-                            [SIR.LocationType.Value("Edge"), SIR.LocationType.Value(
-                                "Cell"), SIR.LocationType.Value("Vertex")], 1
+                            [AST.LocationType.Value("Edge"), AST.LocationType.Value(
+                                "Cell"), AST.LocationType.Value("Vertex")], 1
                         ),
                     ),
                     sir_utils.make_field(
                         "dual_normal_x",
                         sir_utils.make_field_dimensions_unstructured(
-                            [SIR.LocationType.Value("Edge"), SIR.LocationType.Value(
-                                "Cell"), SIR.LocationType.Value("Vertex")], 1
+                            [AST.LocationType.Value("Edge"), AST.LocationType.Value(
+                                "Cell"), AST.LocationType.Value("Vertex")], 1
                         ),
                     ),
                     sir_utils.make_field(
                         "dual_normal_y",
                         sir_utils.make_field_dimensions_unstructured(
-                            [SIR.LocationType.Value("Edge"), SIR.LocationType.Value(
-                                "Cell"), SIR.LocationType.Value("Vertex")], 1
+                            [AST.LocationType.Value("Edge"), AST.LocationType.Value(
+                                "Cell"), AST.LocationType.Value("Vertex")], 1
                         ),
                     ),
                     sir_utils.make_field(
                         "vn_vert",
                         sir_utils.make_field_dimensions_unstructured(
-                            [SIR.LocationType.Value("Edge"), SIR.LocationType.Value(
-                                "Cell"), SIR.LocationType.Value("Vertex")], 1
+                            [AST.LocationType.Value("Edge"), AST.LocationType.Value(
+                                "Cell"), AST.LocationType.Value("Vertex")], 1
                         ),
                     ),
                     sir_utils.make_field(
                         "vn",
                         sir_utils.make_field_dimensions_unstructured(
-                            [SIR.LocationType.Value("Edge")], 1
+                            [AST.LocationType.Value("Edge")], 1
                         ),
                     ),
                     sir_utils.make_field(
                         "dvt_tang",
                         sir_utils.make_field_dimensions_unstructured(
-                            [SIR.LocationType.Value("Edge")], 1
+                            [AST.LocationType.Value("Edge")], 1
                         ),
                     ),
                     sir_utils.make_field(
                         "dvt_norm",
                         sir_utils.make_field_dimensions_unstructured(
-                            [SIR.LocationType.Value("Edge")], 1
+                            [AST.LocationType.Value("Edge")], 1
                         ),
                     ),
                     sir_utils.make_field(
                         "kh_smag_1",
                         sir_utils.make_field_dimensions_unstructured(
-                            [SIR.LocationType.Value("Edge")], 1
+                            [AST.LocationType.Value("Edge")], 1
                         ),
                     ),
                     sir_utils.make_field(
                         "kh_smag_2",
                         sir_utils.make_field_dimensions_unstructured(
-                            [SIR.LocationType.Value("Edge")], 1
+                            [AST.LocationType.Value("Edge")], 1
                         ),
                     ),
                     sir_utils.make_field(
                         "kh_smag",
                         sir_utils.make_field_dimensions_unstructured(
-                            [SIR.LocationType.Value("Edge")], 1
+                            [AST.LocationType.Value("Edge")], 1
                         ),
                     ),
                     sir_utils.make_field(
                         "nabla2",
                         sir_utils.make_field_dimensions_unstructured(
-                            [SIR.LocationType.Value("Edge")], 1
+                            [AST.LocationType.Value("Edge")], 1
                         ),
                     ),
                 ],

--- a/dawn/test/integration-test/dawn4py-tests/ICON_laplacian_stencil.py
+++ b/dawn/test/integration-test/dawn4py-tests/ICON_laplacian_stencil.py
@@ -21,7 +21,7 @@ import argparse
 import os
 
 import dawn4py
-from dawn4py.serialization import SIR
+from dawn4py.serialization import SIR, AST
 from dawn4py.serialization import utils as sir_utils
 from google.protobuf.json_format import MessageToJson, Parse
 
@@ -31,7 +31,7 @@ def main(args: argparse.Namespace):
     gen_outputfile = f"{stencil_name}.cpp"
     sir_outputfile = f"{stencil_name}.sir"
 
-    interval = sir_utils.make_interval(SIR.Interval.Start, SIR.Interval.End, 0, 0)
+    interval = sir_utils.make_interval(AST.Interval.Start, AST.Interval.End, 0, 0)
 
     body_ast = sir_utils.make_ast(
         [
@@ -39,13 +39,13 @@ def main(args: argparse.Namespace):
                 sir_utils.make_field_access_expr("rot_vec"),
                 sir_utils.make_reduction_over_neighbor_expr(
                     op="+",
-                    init=sir_utils.make_literal_access_expr("0.0", SIR.BuiltinType.Double),
+                    init=sir_utils.make_literal_access_expr("0.0", AST.BuiltinType.Double),
                     rhs=sir_utils.make_binary_operator(
                         sir_utils.make_field_access_expr("vec", [True, 0]),
                         "*",
                         sir_utils.make_field_access_expr("geofac_rot"),
                     ),
-                    chain=[SIR.LocationType.Value("Vertex"), SIR.LocationType.Value("Edge")],
+                    chain=[AST.LocationType.Value("Vertex"), AST.LocationType.Value("Edge")],
                 ),
                 "=",
             ),
@@ -53,13 +53,13 @@ def main(args: argparse.Namespace):
                 sir_utils.make_field_access_expr("div_vec"),
                 sir_utils.make_reduction_over_neighbor_expr(
                     op="+",
-                    init=sir_utils.make_literal_access_expr("0.0", SIR.BuiltinType.Double),
+                    init=sir_utils.make_literal_access_expr("0.0", AST.BuiltinType.Double),
                     rhs=sir_utils.make_binary_operator(
                         sir_utils.make_field_access_expr("vec", [True, 0]),
                         "*",
                         sir_utils.make_field_access_expr("geofac_div"),
                     ),
-                    chain=[SIR.LocationType.Value("Cell"), SIR.LocationType.Value("Edge")],
+                    chain=[AST.LocationType.Value("Cell"), AST.LocationType.Value("Edge")],
                 ),
                 "=",
             ),
@@ -68,13 +68,13 @@ def main(args: argparse.Namespace):
                 sir_utils.make_reduction_over_neighbor_expr(
                     op="+",
                     init=sir_utils.make_literal_access_expr(
-                        "0.0", SIR.BuiltinType.Double),
+                        "0.0", AST.BuiltinType.Double),
                     rhs=sir_utils.make_field_access_expr("rot_vec", [True, 0]),
-                    chain=[SIR.LocationType.Value(
-                        "Edge"), SIR.LocationType.Value("Vertex")],
+                    chain=[AST.LocationType.Value(
+                        "Edge"), AST.LocationType.Value("Vertex")],
                     weights=[sir_utils.make_literal_access_expr(
-                        "-1.0", SIR.BuiltinType.Double), sir_utils.make_literal_access_expr(
-                        "1.0", SIR.BuiltinType.Double)]
+                        "-1.0", AST.BuiltinType.Double), sir_utils.make_literal_access_expr(
+                        "1.0", AST.BuiltinType.Double)]
                 ),
                 "=",
             ),
@@ -96,13 +96,13 @@ def main(args: argparse.Namespace):
                 sir_utils.make_reduction_over_neighbor_expr(
                     op="+",
                     init=sir_utils.make_literal_access_expr(
-                        "0.0", SIR.BuiltinType.Double),
+                        "0.0", AST.BuiltinType.Double),
                     rhs=sir_utils.make_field_access_expr("div_vec", [True, 0]),
-                    chain=[SIR.LocationType.Value(
-                        "Edge"), SIR.LocationType.Value("Cell")],
+                    chain=[AST.LocationType.Value(
+                        "Edge"), AST.LocationType.Value("Cell")],
                     weights=[sir_utils.make_literal_access_expr(
-                        "-1.0", SIR.BuiltinType.Double), sir_utils.make_literal_access_expr(
-                        "1.0", SIR.BuiltinType.Double)]
+                        "-1.0", AST.BuiltinType.Double), sir_utils.make_literal_access_expr(
+                        "1.0", AST.BuiltinType.Double)]
                 ),
                 "=",
             ),
@@ -128,12 +128,12 @@ def main(args: argparse.Namespace):
     )
 
     vertical_region_stmt = sir_utils.make_vertical_region_decl_stmt(
-        body_ast, interval, SIR.VerticalRegion.Forward
+        body_ast, interval, AST.VerticalRegion.Forward
     )
 
     sir = sir_utils.make_sir(
         gen_outputfile,
-        SIR.GridType.Value("Unstructured"),
+        AST.GridType.Value("Unstructured"),
         [
             sir_utils.make_stencil(
                 stencil_name,
@@ -142,69 +142,69 @@ def main(args: argparse.Namespace):
                     sir_utils.make_field(
                         "vec",
                         sir_utils.make_field_dimensions_unstructured(
-                            [SIR.LocationType.Value("Edge")], 1
+                            [AST.LocationType.Value("Edge")], 1
                         ),
                     ),
                     sir_utils.make_field(
                         "div_vec",
                         sir_utils.make_field_dimensions_unstructured(
-                            [SIR.LocationType.Value("Cell")], 1
+                            [AST.LocationType.Value("Cell")], 1
                         ),
                     ),
                     sir_utils.make_field(
                         "rot_vec",
                         sir_utils.make_field_dimensions_unstructured(
-                            [SIR.LocationType.Value("Vertex")], 1
+                            [AST.LocationType.Value("Vertex")], 1
                         ),
                     ),
                     sir_utils.make_field(
                         "nabla2t1_vec",
                         sir_utils.make_field_dimensions_unstructured(
-                            [SIR.LocationType.Value("Edge")], 1
+                            [AST.LocationType.Value("Edge")], 1
                         ),
                         is_temporary = True
                     ),
                     sir_utils.make_field(
                         "nabla2t2_vec",
                         sir_utils.make_field_dimensions_unstructured(
-                            [SIR.LocationType.Value("Edge")], 1
+                            [AST.LocationType.Value("Edge")], 1
                         ),
                         is_temporary = True
                     ),
                     sir_utils.make_field(
                         "nabla2_vec",
                         sir_utils.make_field_dimensions_unstructured(
-                            [SIR.LocationType.Value("Edge")], 1
+                            [AST.LocationType.Value("Edge")], 1
                         ),
                     ),
                     sir_utils.make_field(
                         "primal_edge_length",
                         sir_utils.make_field_dimensions_unstructured(
-                            [SIR.LocationType.Value("Edge")], 1
+                            [AST.LocationType.Value("Edge")], 1
                         ),
                     ),
                     sir_utils.make_field(
                         "dual_edge_length",
                         sir_utils.make_field_dimensions_unstructured(
-                            [SIR.LocationType.Value("Edge")], 1
+                            [AST.LocationType.Value("Edge")], 1
                         ),
                     ),
                     sir_utils.make_field(
                         "tangent_orientation",
                         sir_utils.make_field_dimensions_unstructured(
-                            [SIR.LocationType.Value("Edge")], 1
+                            [AST.LocationType.Value("Edge")], 1
                         ),
                     ),
                     sir_utils.make_field(
                         "geofac_rot",
                         sir_utils.make_field_dimensions_unstructured(
-                            [SIR.LocationType.Value("Vertex"), SIR.LocationType.Value("Edge")], 1
+                            [AST.LocationType.Value("Vertex"), AST.LocationType.Value("Edge")], 1
                         ),
                     ),
                     sir_utils.make_field(
                         "geofac_div",
                         sir_utils.make_field_dimensions_unstructured(
-                            [SIR.LocationType.Value("Cell"), SIR.LocationType.Value("Edge")], 1
+                            [AST.LocationType.Value("Cell"), AST.LocationType.Value("Edge")], 1
                         ),
                     ),
                 ],

--- a/dawn/test/integration-test/dawn4py-tests/ICON_laplacian_stencil.py
+++ b/dawn/test/integration-test/dawn4py-tests/ICON_laplacian_stencil.py
@@ -22,7 +22,7 @@ import os
 
 import dawn4py
 from dawn4py.serialization import SIR, AST
-from dawn4py.serialization import utils as sir_utils
+from dawn4py.serialization import utils as serial_utils
 from google.protobuf.json_format import MessageToJson, Parse
 
 
@@ -31,179 +31,179 @@ def main(args: argparse.Namespace):
     gen_outputfile = f"{stencil_name}.cpp"
     sir_outputfile = f"{stencil_name}.sir"
 
-    interval = sir_utils.make_interval(AST.Interval.Start, AST.Interval.End, 0, 0)
+    interval = serial_utils.make_interval(AST.Interval.Start, AST.Interval.End, 0, 0)
 
-    body_ast = sir_utils.make_ast(
+    body_ast = serial_utils.make_ast(
         [
-            sir_utils.make_assignment_stmt(
-                sir_utils.make_field_access_expr("rot_vec"),
-                sir_utils.make_reduction_over_neighbor_expr(
+            serial_utils.make_assignment_stmt(
+                serial_utils.make_field_access_expr("rot_vec"),
+                serial_utils.make_reduction_over_neighbor_expr(
                     op="+",
-                    init=sir_utils.make_literal_access_expr("0.0", AST.BuiltinType.Double),
-                    rhs=sir_utils.make_binary_operator(
-                        sir_utils.make_field_access_expr("vec", [True, 0]),
+                    init=serial_utils.make_literal_access_expr("0.0", AST.BuiltinType.Double),
+                    rhs=serial_utils.make_binary_operator(
+                        serial_utils.make_field_access_expr("vec", [True, 0]),
                         "*",
-                        sir_utils.make_field_access_expr("geofac_rot"),
+                        serial_utils.make_field_access_expr("geofac_rot"),
                     ),
                     chain=[AST.LocationType.Value("Vertex"), AST.LocationType.Value("Edge")],
                 ),
                 "=",
             ),
-            sir_utils.make_assignment_stmt(
-                sir_utils.make_field_access_expr("div_vec"),
-                sir_utils.make_reduction_over_neighbor_expr(
+            serial_utils.make_assignment_stmt(
+                serial_utils.make_field_access_expr("div_vec"),
+                serial_utils.make_reduction_over_neighbor_expr(
                     op="+",
-                    init=sir_utils.make_literal_access_expr("0.0", AST.BuiltinType.Double),
-                    rhs=sir_utils.make_binary_operator(
-                        sir_utils.make_field_access_expr("vec", [True, 0]),
+                    init=serial_utils.make_literal_access_expr("0.0", AST.BuiltinType.Double),
+                    rhs=serial_utils.make_binary_operator(
+                        serial_utils.make_field_access_expr("vec", [True, 0]),
                         "*",
-                        sir_utils.make_field_access_expr("geofac_div"),
+                        serial_utils.make_field_access_expr("geofac_div"),
                     ),
                     chain=[AST.LocationType.Value("Cell"), AST.LocationType.Value("Edge")],
                 ),
                 "=",
             ),
-            sir_utils.make_assignment_stmt(
-                sir_utils.make_field_access_expr("nabla2t1_vec"),
-                sir_utils.make_reduction_over_neighbor_expr(
+            serial_utils.make_assignment_stmt(
+                serial_utils.make_field_access_expr("nabla2t1_vec"),
+                serial_utils.make_reduction_over_neighbor_expr(
                     op="+",
-                    init=sir_utils.make_literal_access_expr(
+                    init=serial_utils.make_literal_access_expr(
                         "0.0", AST.BuiltinType.Double),
-                    rhs=sir_utils.make_field_access_expr("rot_vec", [True, 0]),
+                    rhs=serial_utils.make_field_access_expr("rot_vec", [True, 0]),
                     chain=[AST.LocationType.Value(
                         "Edge"), AST.LocationType.Value("Vertex")],
-                    weights=[sir_utils.make_literal_access_expr(
-                        "-1.0", AST.BuiltinType.Double), sir_utils.make_literal_access_expr(
+                    weights=[serial_utils.make_literal_access_expr(
+                        "-1.0", AST.BuiltinType.Double), serial_utils.make_literal_access_expr(
                         "1.0", AST.BuiltinType.Double)]
                 ),
                 "=",
             ),
-            sir_utils.make_assignment_stmt(
-                sir_utils.make_field_access_expr("nabla2t1_vec"),
-                sir_utils.make_binary_operator(
-                    sir_utils.make_binary_operator(
-                        sir_utils.make_field_access_expr("tangent_orientation"),
+            serial_utils.make_assignment_stmt(
+                serial_utils.make_field_access_expr("nabla2t1_vec"),
+                serial_utils.make_binary_operator(
+                    serial_utils.make_binary_operator(
+                        serial_utils.make_field_access_expr("tangent_orientation"),
                         "*",
-                        sir_utils.make_field_access_expr("nabla2t1_vec"),
+                        serial_utils.make_field_access_expr("nabla2t1_vec"),
                     ),
                     "/",
-                    sir_utils.make_field_access_expr("primal_edge_length"),
+                    serial_utils.make_field_access_expr("primal_edge_length"),
                 ),
                 "=",
             ),
-            sir_utils.make_assignment_stmt(
-                sir_utils.make_field_access_expr("nabla2t2_vec"),
-                sir_utils.make_reduction_over_neighbor_expr(
+            serial_utils.make_assignment_stmt(
+                serial_utils.make_field_access_expr("nabla2t2_vec"),
+                serial_utils.make_reduction_over_neighbor_expr(
                     op="+",
-                    init=sir_utils.make_literal_access_expr(
+                    init=serial_utils.make_literal_access_expr(
                         "0.0", AST.BuiltinType.Double),
-                    rhs=sir_utils.make_field_access_expr("div_vec", [True, 0]),
+                    rhs=serial_utils.make_field_access_expr("div_vec", [True, 0]),
                     chain=[AST.LocationType.Value(
                         "Edge"), AST.LocationType.Value("Cell")],
-                    weights=[sir_utils.make_literal_access_expr(
-                        "-1.0", AST.BuiltinType.Double), sir_utils.make_literal_access_expr(
+                    weights=[serial_utils.make_literal_access_expr(
+                        "-1.0", AST.BuiltinType.Double), serial_utils.make_literal_access_expr(
                         "1.0", AST.BuiltinType.Double)]
                 ),
                 "=",
             ),
-            sir_utils.make_assignment_stmt(
-                sir_utils.make_field_access_expr("nabla2t2_vec"),
-                sir_utils.make_binary_operator(
-                    sir_utils.make_field_access_expr("nabla2t2_vec"),
+            serial_utils.make_assignment_stmt(
+                serial_utils.make_field_access_expr("nabla2t2_vec"),
+                serial_utils.make_binary_operator(
+                    serial_utils.make_field_access_expr("nabla2t2_vec"),
                     "/",
-                    sir_utils.make_field_access_expr("dual_edge_length"),
+                    serial_utils.make_field_access_expr("dual_edge_length"),
                 ),
                 "=",
             ),
-            sir_utils.make_assignment_stmt(
-                sir_utils.make_field_access_expr("nabla2_vec"),
-                sir_utils.make_binary_operator(
-                    sir_utils.make_field_access_expr("nabla2t2_vec"),
+            serial_utils.make_assignment_stmt(
+                serial_utils.make_field_access_expr("nabla2_vec"),
+                serial_utils.make_binary_operator(
+                    serial_utils.make_field_access_expr("nabla2t2_vec"),
                     "-",
-                    sir_utils.make_field_access_expr("nabla2t1_vec"),
+                    serial_utils.make_field_access_expr("nabla2t1_vec"),
                 ),
                 "=",
             ),
         ]
     )
 
-    vertical_region_stmt = sir_utils.make_vertical_region_decl_stmt(
+    vertical_region_stmt = serial_utils.make_vertical_region_decl_stmt(
         body_ast, interval, AST.VerticalRegion.Forward
     )
 
-    sir = sir_utils.make_sir(
+    sir = serial_utils.make_sir(
         gen_outputfile,
         AST.GridType.Value("Unstructured"),
         [
-            sir_utils.make_stencil(
+            serial_utils.make_stencil(
                 stencil_name,
-                sir_utils.make_ast([vertical_region_stmt]),
+                serial_utils.make_ast([vertical_region_stmt]),
                 [
-                    sir_utils.make_field(
+                    serial_utils.make_field(
                         "vec",
-                        sir_utils.make_field_dimensions_unstructured(
+                        serial_utils.make_field_dimensions_unstructured(
                             [AST.LocationType.Value("Edge")], 1
                         ),
                     ),
-                    sir_utils.make_field(
+                    serial_utils.make_field(
                         "div_vec",
-                        sir_utils.make_field_dimensions_unstructured(
+                        serial_utils.make_field_dimensions_unstructured(
                             [AST.LocationType.Value("Cell")], 1
                         ),
                     ),
-                    sir_utils.make_field(
+                    serial_utils.make_field(
                         "rot_vec",
-                        sir_utils.make_field_dimensions_unstructured(
+                        serial_utils.make_field_dimensions_unstructured(
                             [AST.LocationType.Value("Vertex")], 1
                         ),
                     ),
-                    sir_utils.make_field(
+                    serial_utils.make_field(
                         "nabla2t1_vec",
-                        sir_utils.make_field_dimensions_unstructured(
+                        serial_utils.make_field_dimensions_unstructured(
                             [AST.LocationType.Value("Edge")], 1
                         ),
                         is_temporary = True
                     ),
-                    sir_utils.make_field(
+                    serial_utils.make_field(
                         "nabla2t2_vec",
-                        sir_utils.make_field_dimensions_unstructured(
+                        serial_utils.make_field_dimensions_unstructured(
                             [AST.LocationType.Value("Edge")], 1
                         ),
                         is_temporary = True
                     ),
-                    sir_utils.make_field(
+                    serial_utils.make_field(
                         "nabla2_vec",
-                        sir_utils.make_field_dimensions_unstructured(
+                        serial_utils.make_field_dimensions_unstructured(
                             [AST.LocationType.Value("Edge")], 1
                         ),
                     ),
-                    sir_utils.make_field(
+                    serial_utils.make_field(
                         "primal_edge_length",
-                        sir_utils.make_field_dimensions_unstructured(
+                        serial_utils.make_field_dimensions_unstructured(
                             [AST.LocationType.Value("Edge")], 1
                         ),
                     ),
-                    sir_utils.make_field(
+                    serial_utils.make_field(
                         "dual_edge_length",
-                        sir_utils.make_field_dimensions_unstructured(
+                        serial_utils.make_field_dimensions_unstructured(
                             [AST.LocationType.Value("Edge")], 1
                         ),
                     ),
-                    sir_utils.make_field(
+                    serial_utils.make_field(
                         "tangent_orientation",
-                        sir_utils.make_field_dimensions_unstructured(
+                        serial_utils.make_field_dimensions_unstructured(
                             [AST.LocationType.Value("Edge")], 1
                         ),
                     ),
-                    sir_utils.make_field(
+                    serial_utils.make_field(
                         "geofac_rot",
-                        sir_utils.make_field_dimensions_unstructured(
+                        serial_utils.make_field_dimensions_unstructured(
                             [AST.LocationType.Value("Vertex"), AST.LocationType.Value("Edge")], 1
                         ),
                     ),
-                    sir_utils.make_field(
+                    serial_utils.make_field(
                         "geofac_div",
-                        sir_utils.make_field_dimensions_unstructured(
+                        serial_utils.make_field_dimensions_unstructured(
                             [AST.LocationType.Value("Cell"), AST.LocationType.Value("Edge")], 1
                         ),
                     ),

--- a/dawn/test/integration-test/dawn4py-tests/copy_stencil.py
+++ b/dawn/test/integration-test/dawn4py-tests/copy_stencil.py
@@ -33,7 +33,7 @@ import os
 
 import dawn4py
 from dawn4py.serialization import SIR, AST
-from dawn4py.serialization import utils as sir_utils
+from dawn4py.serialization import utils as serial_utils
 from google.protobuf.json_format import MessageToJson, Parse
 
 OUTPUT_NAME = "copy_stencil"
@@ -42,33 +42,33 @@ OUTPUT_PATH = f"{OUTPUT_NAME}.cpp"
 
 
 def main(args: argparse.Namespace):
-    interval = sir_utils.make_interval(AST.Interval.Start, AST.Interval.End, 0, 0)
+    interval = serial_utils.make_interval(AST.Interval.Start, AST.Interval.End, 0, 0)
 
     # create the out = in[i+1] statement
-    body_ast = sir_utils.make_ast(
+    body_ast = serial_utils.make_ast(
         [
-            sir_utils.make_assignment_stmt(
-                sir_utils.make_field_access_expr("out", [0, 0, 0]),
-                sir_utils.make_field_access_expr("in", [1, 0, 0]),
+            serial_utils.make_assignment_stmt(
+                serial_utils.make_field_access_expr("out", [0, 0, 0]),
+                serial_utils.make_field_access_expr("in", [1, 0, 0]),
                 "=",
             )
         ]
     )
 
-    vertical_region_stmt = sir_utils.make_vertical_region_decl_stmt(
+    vertical_region_stmt = serial_utils.make_vertical_region_decl_stmt(
         body_ast, interval, AST.VerticalRegion.Forward
     )
 
-    sir = sir_utils.make_sir(
+    sir = serial_utils.make_sir(
         OUTPUT_FILE,
         AST.GridType.Value("Cartesian"),
         [
-            sir_utils.make_stencil(
+            serial_utils.make_stencil(
                 OUTPUT_NAME,
-                sir_utils.make_ast([vertical_region_stmt]),
+                serial_utils.make_ast([vertical_region_stmt]),
                 [
-                    sir_utils.make_field("in", sir_utils.make_field_dimensions_cartesian()),
-                    sir_utils.make_field("out", sir_utils.make_field_dimensions_cartesian()),
+                    serial_utils.make_field("in", serial_utils.make_field_dimensions_cartesian()),
+                    serial_utils.make_field("out", serial_utils.make_field_dimensions_cartesian()),
                 ],
             )
         ],

--- a/dawn/test/integration-test/dawn4py-tests/copy_stencil.py
+++ b/dawn/test/integration-test/dawn4py-tests/copy_stencil.py
@@ -32,7 +32,7 @@ import argparse
 import os
 
 import dawn4py
-from dawn4py.serialization import SIR
+from dawn4py.serialization import SIR, AST
 from dawn4py.serialization import utils as sir_utils
 from google.protobuf.json_format import MessageToJson, Parse
 
@@ -42,7 +42,7 @@ OUTPUT_PATH = f"{OUTPUT_NAME}.cpp"
 
 
 def main(args: argparse.Namespace):
-    interval = sir_utils.make_interval(SIR.Interval.Start, SIR.Interval.End, 0, 0)
+    interval = sir_utils.make_interval(AST.Interval.Start, AST.Interval.End, 0, 0)
 
     # create the out = in[i+1] statement
     body_ast = sir_utils.make_ast(
@@ -56,12 +56,12 @@ def main(args: argparse.Namespace):
     )
 
     vertical_region_stmt = sir_utils.make_vertical_region_decl_stmt(
-        body_ast, interval, SIR.VerticalRegion.Forward
+        body_ast, interval, AST.VerticalRegion.Forward
     )
 
     sir = sir_utils.make_sir(
         OUTPUT_FILE,
-        SIR.GridType.Value("Cartesian"),
+        AST.GridType.Value("Cartesian"),
         [
             sir_utils.make_stencil(
                 OUTPUT_NAME,

--- a/dawn/test/integration-test/dawn4py-tests/general_weights.py
+++ b/dawn/test/integration-test/dawn4py-tests/general_weights.py
@@ -23,7 +23,7 @@ import argparse
 import os
 
 import dawn4py
-from dawn4py.serialization import SIR
+from dawn4py.serialization import SIR, AST
 from dawn4py.serialization import utils as sir_utils
 from google.protobuf.json_format import MessageToJson, Parse
 
@@ -32,7 +32,7 @@ def main(args: argparse.Namespace):
     gen_outputfile = f"{stencil_name}.cpp"   
 
     interval = sir_utils.make_interval(
-        SIR.Interval.Start, SIR.Interval.End, 0, 0)
+        AST.Interval.Start, AST.Interval.End, 0, 0)
 
     body_ast = sir_utils.make_ast(
         [
@@ -42,10 +42,10 @@ def main(args: argparse.Namespace):
                 sir_utils.make_reduction_over_neighbor_expr(
                     op="+",
                     init=sir_utils.make_literal_access_expr(
-                        "0.0", SIR.BuiltinType.Double),
+                        "0.0", AST.BuiltinType.Double),
                     rhs=sir_utils.make_field_access_expr("vn_vert"),
-                    chain=[SIR.LocationType.Value("Edge"), SIR.LocationType.Value(
-                        "Cell"), SIR.LocationType.Value("Vertex")],
+                    chain=[AST.LocationType.Value("Edge"), AST.LocationType.Value(
+                        "Cell"), AST.LocationType.Value("Vertex")],
                     weights=[sir_utils.make_field_access_expr(
                         "inv_primal_edge_length"), sir_utils.make_field_access_expr(
                         "inv_primal_edge_length"), sir_utils.make_field_access_expr(
@@ -58,12 +58,12 @@ def main(args: argparse.Namespace):
     )
 
     vertical_region_stmt = sir_utils.make_vertical_region_decl_stmt(
-        body_ast, interval, SIR.VerticalRegion.Forward
+        body_ast, interval, AST.VerticalRegion.Forward
     )
 
     sir = sir_utils.make_sir(
         gen_outputfile,
-        SIR.GridType.Value("Unstructured"),
+        AST.GridType.Value("Unstructured"),
         [
             sir_utils.make_stencil(
                 stencil_name,
@@ -72,20 +72,20 @@ def main(args: argparse.Namespace):
                     sir_utils.make_field(
                         "inv_primal_edge_length",
                         sir_utils.make_field_dimensions_unstructured(
-                            [SIR.LocationType.Value("Edge")], 1
+                            [AST.LocationType.Value("Edge")], 1
                         ),
                     ),
                     sir_utils.make_field(
                         "vn_vert",
                         sir_utils.make_field_dimensions_unstructured(
-                            [SIR.LocationType.Value("Edge"), SIR.LocationType.Value(
-                                "Cell"), SIR.LocationType.Value("Vertex")], 1
+                            [AST.LocationType.Value("Edge"), AST.LocationType.Value(
+                                "Cell"), AST.LocationType.Value("Vertex")], 1
                         ),
                     ),
                     sir_utils.make_field(
                         "nabla2",
                         sir_utils.make_field_dimensions_unstructured(
-                            [SIR.LocationType.Value("Edge")], 1
+                            [AST.LocationType.Value("Edge")], 1
                         ),
                     ),
                 ],

--- a/dawn/test/integration-test/dawn4py-tests/general_weights.py
+++ b/dawn/test/integration-test/dawn4py-tests/general_weights.py
@@ -24,32 +24,32 @@ import os
 
 import dawn4py
 from dawn4py.serialization import SIR, AST
-from dawn4py.serialization import utils as sir_utils
+from dawn4py.serialization import utils as serial_utils
 from google.protobuf.json_format import MessageToJson, Parse
 
 def main(args: argparse.Namespace):
     stencil_name = "general_weights"
     gen_outputfile = f"{stencil_name}.cpp"   
 
-    interval = sir_utils.make_interval(
+    interval = serial_utils.make_interval(
         AST.Interval.Start, AST.Interval.End, 0, 0)
 
-    body_ast = sir_utils.make_ast(
+    body_ast = serial_utils.make_ast(
         [
             # compute nabla2 using the diamond reduction
-            sir_utils.make_assignment_stmt(
-                sir_utils.make_field_access_expr("nabla2"),
-                sir_utils.make_reduction_over_neighbor_expr(
+            serial_utils.make_assignment_stmt(
+                serial_utils.make_field_access_expr("nabla2"),
+                serial_utils.make_reduction_over_neighbor_expr(
                     op="+",
-                    init=sir_utils.make_literal_access_expr(
+                    init=serial_utils.make_literal_access_expr(
                         "0.0", AST.BuiltinType.Double),
-                    rhs=sir_utils.make_field_access_expr("vn_vert"),
+                    rhs=serial_utils.make_field_access_expr("vn_vert"),
                     chain=[AST.LocationType.Value("Edge"), AST.LocationType.Value(
                         "Cell"), AST.LocationType.Value("Vertex")],
-                    weights=[sir_utils.make_field_access_expr(
-                        "inv_primal_edge_length"), sir_utils.make_field_access_expr(
-                        "inv_primal_edge_length"), sir_utils.make_field_access_expr(
-                        "inv_primal_edge_length"), sir_utils.make_field_access_expr(
+                    weights=[serial_utils.make_field_access_expr(
+                        "inv_primal_edge_length"), serial_utils.make_field_access_expr(
+                        "inv_primal_edge_length"), serial_utils.make_field_access_expr(
+                        "inv_primal_edge_length"), serial_utils.make_field_access_expr(
                         "inv_primal_edge_length")]
                 ),
                 "=",
@@ -57,34 +57,34 @@ def main(args: argparse.Namespace):
         ]
     )
 
-    vertical_region_stmt = sir_utils.make_vertical_region_decl_stmt(
+    vertical_region_stmt = serial_utils.make_vertical_region_decl_stmt(
         body_ast, interval, AST.VerticalRegion.Forward
     )
 
-    sir = sir_utils.make_sir(
+    sir = serial_utils.make_sir(
         gen_outputfile,
         AST.GridType.Value("Unstructured"),
         [
-            sir_utils.make_stencil(
+            serial_utils.make_stencil(
                 stencil_name,
-                sir_utils.make_ast([vertical_region_stmt]),
+                serial_utils.make_ast([vertical_region_stmt]),
                 [
-                    sir_utils.make_field(
+                    serial_utils.make_field(
                         "inv_primal_edge_length",
-                        sir_utils.make_field_dimensions_unstructured(
+                        serial_utils.make_field_dimensions_unstructured(
                             [AST.LocationType.Value("Edge")], 1
                         ),
                     ),
-                    sir_utils.make_field(
+                    serial_utils.make_field(
                         "vn_vert",
-                        sir_utils.make_field_dimensions_unstructured(
+                        serial_utils.make_field_dimensions_unstructured(
                             [AST.LocationType.Value("Edge"), AST.LocationType.Value(
                                 "Cell"), AST.LocationType.Value("Vertex")], 1
                         ),
                     ),
-                    sir_utils.make_field(
+                    serial_utils.make_field(
                         "nabla2",
-                        sir_utils.make_field_dimensions_unstructured(
+                        serial_utils.make_field_dimensions_unstructured(
                             [AST.LocationType.Value("Edge")], 1
                         ),
                     ),

--- a/dawn/test/integration-test/dawn4py-tests/generate_empty_stage.py
+++ b/dawn/test/integration-test/dawn4py-tests/generate_empty_stage.py
@@ -23,7 +23,7 @@ import argparse
 import os
 
 import dawn4py
-from dawn4py.serialization import SIR
+from dawn4py.serialization import SIR, AST
 from dawn4py.serialization import utils as sir_utils
 from google.protobuf.json_format import MessageToJson, Parse
 
@@ -34,26 +34,26 @@ OUTPUT_PATH = f"{OUTPUT_NAME}.cpp"
 
 def main(args: argparse.Namespace):
     interval = sir_utils.make_interval(
-        SIR.Interval.Start, SIR.Interval.End, 0, 0)
+        AST.Interval.Start, AST.Interval.End, 0, 0)
 
     body_ast = sir_utils.make_ast(
         [
             sir_utils.make_assignment_stmt(
                 sir_utils.make_field_access_expr("x"),
                 sir_utils.make_literal_access_expr(
-                    "1",  SIR.BuiltinType.Double),
+                    "1",  AST.BuiltinType.Double),
                 "=",
             )
         ]
     )
 
     vertical_region_stmt = sir_utils.make_vertical_region_decl_stmt(
-        body_ast, interval, SIR.VerticalRegion.Forward
+        body_ast, interval, AST.VerticalRegion.Forward
     )
 
     sir = sir_utils.make_sir(
         OUTPUT_FILE,
-        SIR.GridType.Value("Unstructured"),
+        AST.GridType.Value("Unstructured"),
         [
             sir_utils.make_stencil(
                 OUTPUT_NAME,
@@ -62,19 +62,19 @@ def main(args: argparse.Namespace):
                     sir_utils.make_field(
                         "in",
                         sir_utils.make_field_dimensions_unstructured(
-                            [SIR.LocationType.Value("Edge")], 1
+                            [AST.LocationType.Value("Edge")], 1
                         ),
                     ),
                     sir_utils.make_field(
                         "out",
                         sir_utils.make_field_dimensions_unstructured(
-                            [SIR.LocationType.Value("Edge")], 1
+                            [AST.LocationType.Value("Edge")], 1
                         ),
                     ),
                     sir_utils.make_field(
                         "x",
                         sir_utils.make_field_dimensions_unstructured(
-                            [SIR.LocationType.Value("Edge")], 1
+                            [AST.LocationType.Value("Edge")], 1
                         ),
                         True
                     ),

--- a/dawn/test/integration-test/dawn4py-tests/generate_empty_stage.py
+++ b/dawn/test/integration-test/dawn4py-tests/generate_empty_stage.py
@@ -24,7 +24,7 @@ import os
 
 import dawn4py
 from dawn4py.serialization import SIR, AST
-from dawn4py.serialization import utils as sir_utils
+from dawn4py.serialization import utils as serial_utils
 from google.protobuf.json_format import MessageToJson, Parse
 
 OUTPUT_NAME = "empty_stage_stencil"
@@ -33,47 +33,47 @@ OUTPUT_PATH = f"{OUTPUT_NAME}.cpp"
 
 
 def main(args: argparse.Namespace):
-    interval = sir_utils.make_interval(
+    interval = serial_utils.make_interval(
         AST.Interval.Start, AST.Interval.End, 0, 0)
 
-    body_ast = sir_utils.make_ast(
+    body_ast = serial_utils.make_ast(
         [
-            sir_utils.make_assignment_stmt(
-                sir_utils.make_field_access_expr("x"),
-                sir_utils.make_literal_access_expr(
+            serial_utils.make_assignment_stmt(
+                serial_utils.make_field_access_expr("x"),
+                serial_utils.make_literal_access_expr(
                     "1",  AST.BuiltinType.Double),
                 "=",
             )
         ]
     )
 
-    vertical_region_stmt = sir_utils.make_vertical_region_decl_stmt(
+    vertical_region_stmt = serial_utils.make_vertical_region_decl_stmt(
         body_ast, interval, AST.VerticalRegion.Forward
     )
 
-    sir = sir_utils.make_sir(
+    sir = serial_utils.make_sir(
         OUTPUT_FILE,
         AST.GridType.Value("Unstructured"),
         [
-            sir_utils.make_stencil(
+            serial_utils.make_stencil(
                 OUTPUT_NAME,
-                sir_utils.make_ast([vertical_region_stmt]),
+                serial_utils.make_ast([vertical_region_stmt]),
                 [
-                    sir_utils.make_field(
+                    serial_utils.make_field(
                         "in",
-                        sir_utils.make_field_dimensions_unstructured(
+                        serial_utils.make_field_dimensions_unstructured(
                             [AST.LocationType.Value("Edge")], 1
                         ),
                     ),
-                    sir_utils.make_field(
+                    serial_utils.make_field(
                         "out",
-                        sir_utils.make_field_dimensions_unstructured(
+                        serial_utils.make_field_dimensions_unstructured(
                             [AST.LocationType.Value("Edge")], 1
                         ),
                     ),
-                    sir_utils.make_field(
+                    serial_utils.make_field(
                         "x",
-                        sir_utils.make_field_dimensions_unstructured(
+                        serial_utils.make_field_dimensions_unstructured(
                             [AST.LocationType.Value("Edge")], 1
                         ),
                         True

--- a/dawn/test/integration-test/dawn4py-tests/generate_versioned_field.py
+++ b/dawn/test/integration-test/dawn4py-tests/generate_versioned_field.py
@@ -23,7 +23,7 @@ import argparse
 import os
 
 import dawn4py
-from dawn4py.serialization import SIR
+from dawn4py.serialization import SIR, AST
 from dawn4py.serialization import utils as sir_utils
 from google.protobuf.json_format import MessageToJson, Parse
 
@@ -34,14 +34,14 @@ OUTPUT_PATH = f"{OUTPUT_NAME}.cpp"
 
 def main(args: argparse.Namespace):
     interval = sir_utils.make_interval(
-        SIR.Interval.Start, SIR.Interval.End, 0, 0)
+        AST.Interval.Start, AST.Interval.End, 0, 0)
 
     line_1 = sir_utils.make_assignment_stmt(
         sir_utils.make_field_access_expr("a"), sir_utils.make_binary_operator(sir_utils.make_binary_operator(
             sir_utils.make_field_access_expr("b"),
             "/",
             sir_utils.make_field_access_expr("c"),
-        ), "+", sir_utils.make_literal_access_expr("5", SIR.BuiltinType.Float)), "=")
+        ), "+", sir_utils.make_literal_access_expr("5", AST.BuiltinType.Float)), "=")
 
     line_2 = sir_utils.make_block_stmt(sir_utils.make_assignment_stmt(
         sir_utils.make_field_access_expr("a"), sir_utils.make_field_access_expr("b"), "="))
@@ -49,7 +49,7 @@ def main(args: argparse.Namespace):
     line_3 = sir_utils.make_block_stmt(sir_utils.make_assignment_stmt(
         sir_utils.make_field_access_expr("c"),
         sir_utils.make_binary_operator(
-            sir_utils.make_field_access_expr("a"), "+", sir_utils.make_literal_access_expr("1", SIR.BuiltinType.Float)),
+            sir_utils.make_field_access_expr("a"), "+", sir_utils.make_literal_access_expr("1", AST.BuiltinType.Float)),
         "="))
 
     body_ast = sir_utils.make_ast(
@@ -66,12 +66,12 @@ def main(args: argparse.Namespace):
     )
 
     vertical_region_stmt = sir_utils.make_vertical_region_decl_stmt(
-        body_ast, interval, SIR.VerticalRegion.Forward
+        body_ast, interval, AST.VerticalRegion.Forward
     )
 
     sir = sir_utils.make_sir(
         OUTPUT_FILE,
-        SIR.GridType.Value("Unstructured"),
+        AST.GridType.Value("Unstructured"),
         [
             sir_utils.make_stencil(
                 OUTPUT_NAME,
@@ -80,31 +80,31 @@ def main(args: argparse.Namespace):
                     sir_utils.make_field(
                         "a",
                         sir_utils.make_field_dimensions_unstructured(
-                            [SIR.LocationType.Value("Edge")], 1
+                            [AST.LocationType.Value("Edge")], 1
                         ),
                     ),
                     sir_utils.make_field(
                         "b",
                         sir_utils.make_field_dimensions_unstructured(
-                            [SIR.LocationType.Value("Edge")], 1
+                            [AST.LocationType.Value("Edge")], 1
                         ),
                     ),
                     sir_utils.make_field(
                         "c",
                         sir_utils.make_field_dimensions_unstructured(
-                            [SIR.LocationType.Value("Edge")], 1
+                            [AST.LocationType.Value("Edge")], 1
                         ),
                     ),
                     sir_utils.make_field(
                         "d",
                         sir_utils.make_field_dimensions_unstructured(
-                            [SIR.LocationType.Value("Edge")], 1
+                            [AST.LocationType.Value("Edge")], 1
                         ),
                     ),
                     sir_utils.make_field(
                         "e",
                         sir_utils.make_field_dimensions_unstructured(
-                            [SIR.LocationType.Value("Edge")], 1
+                            [AST.LocationType.Value("Edge")], 1
                         ),
                     ),
                 ],

--- a/dawn/test/integration-test/dawn4py-tests/generate_versioned_field.py
+++ b/dawn/test/integration-test/dawn4py-tests/generate_versioned_field.py
@@ -24,7 +24,7 @@ import os
 
 import dawn4py
 from dawn4py.serialization import SIR, AST
-from dawn4py.serialization import utils as sir_utils
+from dawn4py.serialization import utils as serial_utils
 from google.protobuf.json_format import MessageToJson, Parse
 
 OUTPUT_NAME = "generate_versioned_field"
@@ -33,77 +33,77 @@ OUTPUT_PATH = f"{OUTPUT_NAME}.cpp"
 
 
 def main(args: argparse.Namespace):
-    interval = sir_utils.make_interval(
+    interval = serial_utils.make_interval(
         AST.Interval.Start, AST.Interval.End, 0, 0)
 
-    line_1 = sir_utils.make_assignment_stmt(
-        sir_utils.make_field_access_expr("a"), sir_utils.make_binary_operator(sir_utils.make_binary_operator(
-            sir_utils.make_field_access_expr("b"),
+    line_1 = serial_utils.make_assignment_stmt(
+        serial_utils.make_field_access_expr("a"), serial_utils.make_binary_operator(serial_utils.make_binary_operator(
+            serial_utils.make_field_access_expr("b"),
             "/",
-            sir_utils.make_field_access_expr("c"),
-        ), "+", sir_utils.make_literal_access_expr("5", AST.BuiltinType.Float)), "=")
+            serial_utils.make_field_access_expr("c"),
+        ), "+", serial_utils.make_literal_access_expr("5", AST.BuiltinType.Float)), "=")
 
-    line_2 = sir_utils.make_block_stmt(sir_utils.make_assignment_stmt(
-        sir_utils.make_field_access_expr("a"), sir_utils.make_field_access_expr("b"), "="))
+    line_2 = serial_utils.make_block_stmt(serial_utils.make_assignment_stmt(
+        serial_utils.make_field_access_expr("a"), serial_utils.make_field_access_expr("b"), "="))
 
-    line_3 = sir_utils.make_block_stmt(sir_utils.make_assignment_stmt(
-        sir_utils.make_field_access_expr("c"),
-        sir_utils.make_binary_operator(
-            sir_utils.make_field_access_expr("a"), "+", sir_utils.make_literal_access_expr("1", AST.BuiltinType.Float)),
+    line_3 = serial_utils.make_block_stmt(serial_utils.make_assignment_stmt(
+        serial_utils.make_field_access_expr("c"),
+        serial_utils.make_binary_operator(
+            serial_utils.make_field_access_expr("a"), "+", serial_utils.make_literal_access_expr("1", AST.BuiltinType.Float)),
         "="))
 
-    body_ast = sir_utils.make_ast(
+    body_ast = serial_utils.make_ast(
         [
             line_1,
-            sir_utils.make_if_stmt(sir_utils.make_expr_stmt(sir_utils.make_field_access_expr("d")), line_2,
-                                   sir_utils.make_block_stmt(sir_utils.make_if_stmt(
-                                       sir_utils.make_expr_stmt(
-                                           sir_utils.make_field_access_expr("e")),
+            serial_utils.make_if_stmt(serial_utils.make_expr_stmt(serial_utils.make_field_access_expr("d")), line_2,
+                                   serial_utils.make_block_stmt(serial_utils.make_if_stmt(
+                                       serial_utils.make_expr_stmt(
+                                           serial_utils.make_field_access_expr("e")),
                                        line_3
                                    ))
                                    )
         ]
     )
 
-    vertical_region_stmt = sir_utils.make_vertical_region_decl_stmt(
+    vertical_region_stmt = serial_utils.make_vertical_region_decl_stmt(
         body_ast, interval, AST.VerticalRegion.Forward
     )
 
-    sir = sir_utils.make_sir(
+    sir = serial_utils.make_sir(
         OUTPUT_FILE,
         AST.GridType.Value("Unstructured"),
         [
-            sir_utils.make_stencil(
+            serial_utils.make_stencil(
                 OUTPUT_NAME,
-                sir_utils.make_ast([vertical_region_stmt]),
+                serial_utils.make_ast([vertical_region_stmt]),
                 [
-                    sir_utils.make_field(
+                    serial_utils.make_field(
                         "a",
-                        sir_utils.make_field_dimensions_unstructured(
+                        serial_utils.make_field_dimensions_unstructured(
                             [AST.LocationType.Value("Edge")], 1
                         ),
                     ),
-                    sir_utils.make_field(
+                    serial_utils.make_field(
                         "b",
-                        sir_utils.make_field_dimensions_unstructured(
+                        serial_utils.make_field_dimensions_unstructured(
                             [AST.LocationType.Value("Edge")], 1
                         ),
                     ),
-                    sir_utils.make_field(
+                    serial_utils.make_field(
                         "c",
-                        sir_utils.make_field_dimensions_unstructured(
+                        serial_utils.make_field_dimensions_unstructured(
                             [AST.LocationType.Value("Edge")], 1
                         ),
                     ),
-                    sir_utils.make_field(
+                    serial_utils.make_field(
                         "d",
-                        sir_utils.make_field_dimensions_unstructured(
+                        serial_utils.make_field_dimensions_unstructured(
                             [AST.LocationType.Value("Edge")], 1
                         ),
                     ),
-                    sir_utils.make_field(
+                    serial_utils.make_field(
                         "e",
-                        sir_utils.make_field_dimensions_unstructured(
+                        serial_utils.make_field_dimensions_unstructured(
                             [AST.LocationType.Value("Edge")], 1
                         ),
                     ),

--- a/dawn/test/integration-test/dawn4py-tests/global_index_stencil.py
+++ b/dawn/test/integration-test/dawn4py-tests/global_index_stencil.py
@@ -32,7 +32,7 @@ import os.path
 
 import dawn4py
 from dawn4py.serialization import SIR, AST
-from dawn4py.serialization import utils as sir_utils
+from dawn4py.serialization import utils as serial_utils
 from google.protobuf.json_format import MessageToJson, Parse
 
 OUTPUT_NAME = "global_index_stencil"
@@ -44,20 +44,20 @@ def create_vertical_region_stmt() -> AST.VerticalRegionDeclStmt:
     """ create a vertical region statement for the stencil
     """
 
-    interval = sir_utils.make_interval(AST.Interval.Start, AST.Interval.End, 0, 0)
+    interval = serial_utils.make_interval(AST.Interval.Start, AST.Interval.End, 0, 0)
 
     # create the out = in[i+1] statement
-    body_ast = sir_utils.make_ast(
+    body_ast = serial_utils.make_ast(
         [
-            sir_utils.make_assignment_stmt(
-                sir_utils.make_field_access_expr("out", [0, 0, 0]),
-                sir_utils.make_field_access_expr("in", [0, 0, 0]),
+            serial_utils.make_assignment_stmt(
+                serial_utils.make_field_access_expr("out", [0, 0, 0]),
+                serial_utils.make_field_access_expr("in", [0, 0, 0]),
                 "=",
             )
         ]
     )
 
-    vertical_region_stmt = sir_utils.make_vertical_region_decl_stmt(
+    vertical_region_stmt = serial_utils.make_vertical_region_decl_stmt(
         body_ast, interval, AST.VerticalRegion.Forward
     )
     return vertical_region_stmt
@@ -66,97 +66,97 @@ def create_vertical_region_stmt() -> AST.VerticalRegionDeclStmt:
 def create_boundary_correction_region(
     value="0", i_interval=None, j_interval=None
 ) -> AST.VerticalRegionDeclStmt:
-    interval = sir_utils.make_interval(AST.Interval.Start, AST.Interval.End, 0, 0)
-    boundary_body = sir_utils.make_ast(
+    interval = serial_utils.make_interval(AST.Interval.Start, AST.Interval.End, 0, 0)
+    boundary_body = serial_utils.make_ast(
         [
-            sir_utils.make_assignment_stmt(
-                sir_utils.make_field_access_expr("out", [0, 0, 0]),
-                sir_utils.make_literal_access_expr(value, AST.BuiltinType.Float),
+            serial_utils.make_assignment_stmt(
+                serial_utils.make_field_access_expr("out", [0, 0, 0]),
+                serial_utils.make_literal_access_expr(value, AST.BuiltinType.Float),
                 "=",
             )
         ]
     )
-    vertical_region_stmt = sir_utils.make_vertical_region_decl_stmt(
+    vertical_region_stmt = serial_utils.make_vertical_region_decl_stmt(
         boundary_body, interval, AST.VerticalRegion.Forward, IRange=i_interval, JRange=j_interval
     )
     return vertical_region_stmt
 
 
 def main(args: argparse.Namespace):
-    sir = sir_utils.make_sir(
+    sir = serial_utils.make_sir(
         OUTPUT_FILE,
         AST.GridType.Value("Cartesian"),
         [
-            sir_utils.make_stencil(
+            serial_utils.make_stencil(
                 "global_indexing",
-                sir_utils.make_ast(
+                serial_utils.make_ast(
                     [
                         create_vertical_region_stmt(),
                         create_boundary_correction_region(
                             value="4",
-                            i_interval=sir_utils.make_interval(
+                            i_interval=serial_utils.make_interval(
                                 AST.Interval.End, AST.Interval.End, -1, 0
                             ),
                         ),
                         create_boundary_correction_region(
                             value="8",
-                            i_interval=sir_utils.make_interval(
+                            i_interval=serial_utils.make_interval(
                                 AST.Interval.Start, AST.Interval.Start, 0, 1
                             ),
                         ),
                         create_boundary_correction_region(
                             value="6",
-                            j_interval=sir_utils.make_interval(
+                            j_interval=serial_utils.make_interval(
                                 AST.Interval.End, AST.Interval.End, -1, 0
                             ),
                         ),
                         create_boundary_correction_region(
                             value="2",
-                            j_interval=sir_utils.make_interval(
+                            j_interval=serial_utils.make_interval(
                                 AST.Interval.Start, AST.Interval.Start, 0, 1
                             ),
                         ),
                         create_boundary_correction_region(
                             value="1",
-                            j_interval=sir_utils.make_interval(
+                            j_interval=serial_utils.make_interval(
                                 AST.Interval.Start, AST.Interval.Start, 0, 1
                             ),
-                            i_interval=sir_utils.make_interval(
+                            i_interval=serial_utils.make_interval(
                                 AST.Interval.Start, AST.Interval.Start, 0, 1
                             ),
                         ),
                         create_boundary_correction_region(
                             value="3",
-                            j_interval=sir_utils.make_interval(
+                            j_interval=serial_utils.make_interval(
                                 AST.Interval.Start, AST.Interval.Start, 0, 1
                             ),
-                            i_interval=sir_utils.make_interval(
+                            i_interval=serial_utils.make_interval(
                                 AST.Interval.End, AST.Interval.End, -1, 0
                             ),
                         ),
                         create_boundary_correction_region(
                             value="7",
-                            j_interval=sir_utils.make_interval(
+                            j_interval=serial_utils.make_interval(
                                 AST.Interval.End, AST.Interval.End, -1, 0
                             ),
-                            i_interval=sir_utils.make_interval(
+                            i_interval=serial_utils.make_interval(
                                 AST.Interval.Start, AST.Interval.Start, 0, 1
                             ),
                         ),
                         create_boundary_correction_region(
                             value="5",
-                            j_interval=sir_utils.make_interval(
+                            j_interval=serial_utils.make_interval(
                                 AST.Interval.End, AST.Interval.End, -1, 0
                             ),
-                            i_interval=sir_utils.make_interval(
+                            i_interval=serial_utils.make_interval(
                                 AST.Interval.End, AST.Interval.End, -1, 0
                             ),
                         ),
                     ]
                 ),
                 [
-                    sir_utils.make_field("in", sir_utils.make_field_dimensions_cartesian()),
-                    sir_utils.make_field("out", sir_utils.make_field_dimensions_cartesian()),
+                    serial_utils.make_field("in", serial_utils.make_field_dimensions_cartesian()),
+                    serial_utils.make_field("out", serial_utils.make_field_dimensions_cartesian()),
                 ],
             )
         ],

--- a/dawn/test/integration-test/dawn4py-tests/global_index_stencil.py
+++ b/dawn/test/integration-test/dawn4py-tests/global_index_stencil.py
@@ -31,7 +31,7 @@ import argparse
 import os.path
 
 import dawn4py
-from dawn4py.serialization import SIR
+from dawn4py.serialization import SIR, AST
 from dawn4py.serialization import utils as sir_utils
 from google.protobuf.json_format import MessageToJson, Parse
 
@@ -40,11 +40,11 @@ OUTPUT_FILE = f"{OUTPUT_NAME}.cpp"
 OUTPUT_PATH = f"{OUTPUT_NAME}.cpp"
 
 
-def create_vertical_region_stmt() -> SIR.VerticalRegionDeclStmt:
+def create_vertical_region_stmt() -> AST.VerticalRegionDeclStmt:
     """ create a vertical region statement for the stencil
     """
 
-    interval = sir_utils.make_interval(SIR.Interval.Start, SIR.Interval.End, 0, 0)
+    interval = sir_utils.make_interval(AST.Interval.Start, AST.Interval.End, 0, 0)
 
     # create the out = in[i+1] statement
     body_ast = sir_utils.make_ast(
@@ -58,26 +58,26 @@ def create_vertical_region_stmt() -> SIR.VerticalRegionDeclStmt:
     )
 
     vertical_region_stmt = sir_utils.make_vertical_region_decl_stmt(
-        body_ast, interval, SIR.VerticalRegion.Forward
+        body_ast, interval, AST.VerticalRegion.Forward
     )
     return vertical_region_stmt
 
 
 def create_boundary_correction_region(
     value="0", i_interval=None, j_interval=None
-) -> SIR.VerticalRegionDeclStmt:
-    interval = sir_utils.make_interval(SIR.Interval.Start, SIR.Interval.End, 0, 0)
+) -> AST.VerticalRegionDeclStmt:
+    interval = sir_utils.make_interval(AST.Interval.Start, AST.Interval.End, 0, 0)
     boundary_body = sir_utils.make_ast(
         [
             sir_utils.make_assignment_stmt(
                 sir_utils.make_field_access_expr("out", [0, 0, 0]),
-                sir_utils.make_literal_access_expr(value, SIR.BuiltinType.Float),
+                sir_utils.make_literal_access_expr(value, AST.BuiltinType.Float),
                 "=",
             )
         ]
     )
     vertical_region_stmt = sir_utils.make_vertical_region_decl_stmt(
-        boundary_body, interval, SIR.VerticalRegion.Forward, IRange=i_interval, JRange=j_interval
+        boundary_body, interval, AST.VerticalRegion.Forward, IRange=i_interval, JRange=j_interval
     )
     return vertical_region_stmt
 
@@ -85,7 +85,7 @@ def create_boundary_correction_region(
 def main(args: argparse.Namespace):
     sir = sir_utils.make_sir(
         OUTPUT_FILE,
-        SIR.GridType.Value("Cartesian"),
+        AST.GridType.Value("Cartesian"),
         [
             sir_utils.make_stencil(
                 "global_indexing",
@@ -95,61 +95,61 @@ def main(args: argparse.Namespace):
                         create_boundary_correction_region(
                             value="4",
                             i_interval=sir_utils.make_interval(
-                                SIR.Interval.End, SIR.Interval.End, -1, 0
+                                AST.Interval.End, AST.Interval.End, -1, 0
                             ),
                         ),
                         create_boundary_correction_region(
                             value="8",
                             i_interval=sir_utils.make_interval(
-                                SIR.Interval.Start, SIR.Interval.Start, 0, 1
+                                AST.Interval.Start, AST.Interval.Start, 0, 1
                             ),
                         ),
                         create_boundary_correction_region(
                             value="6",
                             j_interval=sir_utils.make_interval(
-                                SIR.Interval.End, SIR.Interval.End, -1, 0
+                                AST.Interval.End, AST.Interval.End, -1, 0
                             ),
                         ),
                         create_boundary_correction_region(
                             value="2",
                             j_interval=sir_utils.make_interval(
-                                SIR.Interval.Start, SIR.Interval.Start, 0, 1
+                                AST.Interval.Start, AST.Interval.Start, 0, 1
                             ),
                         ),
                         create_boundary_correction_region(
                             value="1",
                             j_interval=sir_utils.make_interval(
-                                SIR.Interval.Start, SIR.Interval.Start, 0, 1
+                                AST.Interval.Start, AST.Interval.Start, 0, 1
                             ),
                             i_interval=sir_utils.make_interval(
-                                SIR.Interval.Start, SIR.Interval.Start, 0, 1
+                                AST.Interval.Start, AST.Interval.Start, 0, 1
                             ),
                         ),
                         create_boundary_correction_region(
                             value="3",
                             j_interval=sir_utils.make_interval(
-                                SIR.Interval.Start, SIR.Interval.Start, 0, 1
+                                AST.Interval.Start, AST.Interval.Start, 0, 1
                             ),
                             i_interval=sir_utils.make_interval(
-                                SIR.Interval.End, SIR.Interval.End, -1, 0
+                                AST.Interval.End, AST.Interval.End, -1, 0
                             ),
                         ),
                         create_boundary_correction_region(
                             value="7",
                             j_interval=sir_utils.make_interval(
-                                SIR.Interval.End, SIR.Interval.End, -1, 0
+                                AST.Interval.End, AST.Interval.End, -1, 0
                             ),
                             i_interval=sir_utils.make_interval(
-                                SIR.Interval.Start, SIR.Interval.Start, 0, 1
+                                AST.Interval.Start, AST.Interval.Start, 0, 1
                             ),
                         ),
                         create_boundary_correction_region(
                             value="5",
                             j_interval=sir_utils.make_interval(
-                                SIR.Interval.End, SIR.Interval.End, -1, 0
+                                AST.Interval.End, AST.Interval.End, -1, 0
                             ),
                             i_interval=sir_utils.make_interval(
-                                SIR.Interval.End, SIR.Interval.End, -1, 0
+                                AST.Interval.End, AST.Interval.End, -1, 0
                             ),
                         ),
                     ]

--- a/dawn/test/integration-test/dawn4py-tests/global_index_stencil_unstr.py
+++ b/dawn/test/integration-test/dawn4py-tests/global_index_stencil_unstr.py
@@ -25,7 +25,7 @@ import os
 
 import dawn4py
 from dawn4py.serialization import SIR, AST
-from dawn4py.serialization import utils as sir_utils
+from dawn4py.serialization import utils as serial_utils
 from google.protobuf.json_format import MessageToJson, Parse
 
 OUTPUT_NAME = "global_index_stencil_unstr"
@@ -39,90 +39,90 @@ OUTPUT_PATH = f"{OUTPUT_NAME}.cpp"
 
 
 def main(args: argparse.Namespace):
-    interval = sir_utils.make_interval(
+    interval = serial_utils.make_interval(
         AST.Interval.Start, AST.Interval.End, 0, 0)
 
     # out = in_1 on inner cells
-    body_ast_1 = sir_utils.make_ast(
+    body_ast_1 = serial_utils.make_ast(
         [
-            sir_utils.make_assignment_stmt(
-                sir_utils.make_field_access_expr("out"),
-                sir_utils.make_field_access_expr("in_1"),
+            serial_utils.make_assignment_stmt(
+                serial_utils.make_field_access_expr("out"),
+                serial_utils.make_field_access_expr("in_1"),
                 "=",
             )
         ]
     )
-    vertical_region_stmt_1 = sir_utils.make_vertical_region_decl_stmt(
-        body_ast_1, interval, AST.VerticalRegion.Forward, sir_utils.make_magic_num_interval(
+    vertical_region_stmt_1 = serial_utils.make_vertical_region_decl_stmt(
+        body_ast_1, interval, AST.VerticalRegion.Forward, serial_utils.make_magic_num_interval(
             0, 1, 0, 0)
     )
 
     # out = out + in_2 on inner cells
     #   should be merge-able to last stage
-    body_ast_2 = sir_utils.make_ast(
+    body_ast_2 = serial_utils.make_ast(
         [
-            sir_utils.make_assignment_stmt(
-                sir_utils.make_field_access_expr("out"),
-                sir_utils.make_binary_operator(
-                    sir_utils.make_field_access_expr("out"),
+            serial_utils.make_assignment_stmt(
+                serial_utils.make_field_access_expr("out"),
+                serial_utils.make_binary_operator(
+                    serial_utils.make_field_access_expr("out"),
                     "+",
-                    sir_utils.make_field_access_expr("in_2"),
+                    serial_utils.make_field_access_expr("in_2"),
                 ),
                 "="
             )
         ]
     )
-    vertical_region_stmt_2 = sir_utils.make_vertical_region_decl_stmt(
-        body_ast_2, interval, AST.VerticalRegion.Forward, sir_utils.make_interval(
+    vertical_region_stmt_2 = serial_utils.make_vertical_region_decl_stmt(
+        body_ast_2, interval, AST.VerticalRegion.Forward, serial_utils.make_interval(
             2, 3, 0, 0)
     )
 
     # out = out + in_3 on lateral boundary cells
     # out = in_1 on inner cells
-    body_ast_3 = sir_utils.make_ast(
+    body_ast_3 = serial_utils.make_ast(
         [
-            sir_utils.make_assignment_stmt(
-                sir_utils.make_field_access_expr("out"),
-                sir_utils.make_field_access_expr("in_3"),
+            serial_utils.make_assignment_stmt(
+                serial_utils.make_field_access_expr("out"),
+                serial_utils.make_field_access_expr("in_3"),
                 "=",
             )
         ]
     )
-    vertical_region_stmt_3 = sir_utils.make_vertical_region_decl_stmt(
-        body_ast_3, interval, AST.VerticalRegion.Forward, sir_utils.make_interval(
+    vertical_region_stmt_3 = serial_utils.make_vertical_region_decl_stmt(
+        body_ast_3, interval, AST.VerticalRegion.Forward, serial_utils.make_interval(
             3, 4, 0, 0)
     )
 
-    sir = sir_utils.make_sir(
+    sir = serial_utils.make_sir(
         OUTPUT_FILE,
         AST.GridType.Value("Unstructured"),
         [
-            sir_utils.make_stencil(
+            serial_utils.make_stencil(
                 OUTPUT_NAME,
-                sir_utils.make_ast(
+                serial_utils.make_ast(
                     [vertical_region_stmt_1, vertical_region_stmt_2, vertical_region_stmt_3]),
                 [
-                    sir_utils.make_field(
+                    serial_utils.make_field(
                         "in_1",
-                        sir_utils.make_field_dimensions_unstructured(
+                        serial_utils.make_field_dimensions_unstructured(
                             [AST.LocationType.Value("Cell")], 1
                         ),
                     ),
-                    sir_utils.make_field(
+                    serial_utils.make_field(
                         "in_2",
-                        sir_utils.make_field_dimensions_unstructured(
+                        serial_utils.make_field_dimensions_unstructured(
                             [AST.LocationType.Value("Cell")], 1
                         ),
                     ),
-                    sir_utils.make_field(
+                    serial_utils.make_field(
                         "in_3",
-                        sir_utils.make_field_dimensions_unstructured(
+                        serial_utils.make_field_dimensions_unstructured(
                             [AST.LocationType.Value("Cell")], 1
                         ),
                     ),
-                    sir_utils.make_field(
+                    serial_utils.make_field(
                         "out",
-                        sir_utils.make_field_dimensions_unstructured(
+                        serial_utils.make_field_dimensions_unstructured(
                             [AST.LocationType.Value("Cell")], 1
                         ),
                     ),

--- a/dawn/test/integration-test/dawn4py-tests/global_index_stencil_unstr.py
+++ b/dawn/test/integration-test/dawn4py-tests/global_index_stencil_unstr.py
@@ -24,7 +24,7 @@ import argparse
 import os
 
 import dawn4py
-from dawn4py.serialization import SIR
+from dawn4py.serialization import SIR, AST
 from dawn4py.serialization import utils as sir_utils
 from google.protobuf.json_format import MessageToJson, Parse
 
@@ -40,7 +40,7 @@ OUTPUT_PATH = f"{OUTPUT_NAME}.cpp"
 
 def main(args: argparse.Namespace):
     interval = sir_utils.make_interval(
-        SIR.Interval.Start, SIR.Interval.End, 0, 0)
+        AST.Interval.Start, AST.Interval.End, 0, 0)
 
     # out = in_1 on inner cells
     body_ast_1 = sir_utils.make_ast(
@@ -53,7 +53,7 @@ def main(args: argparse.Namespace):
         ]
     )
     vertical_region_stmt_1 = sir_utils.make_vertical_region_decl_stmt(
-        body_ast_1, interval, SIR.VerticalRegion.Forward, sir_utils.make_magic_num_interval(
+        body_ast_1, interval, AST.VerticalRegion.Forward, sir_utils.make_magic_num_interval(
             0, 1, 0, 0)
     )
 
@@ -73,7 +73,7 @@ def main(args: argparse.Namespace):
         ]
     )
     vertical_region_stmt_2 = sir_utils.make_vertical_region_decl_stmt(
-        body_ast_2, interval, SIR.VerticalRegion.Forward, sir_utils.make_interval(
+        body_ast_2, interval, AST.VerticalRegion.Forward, sir_utils.make_interval(
             2, 3, 0, 0)
     )
 
@@ -89,13 +89,13 @@ def main(args: argparse.Namespace):
         ]
     )
     vertical_region_stmt_3 = sir_utils.make_vertical_region_decl_stmt(
-        body_ast_3, interval, SIR.VerticalRegion.Forward, sir_utils.make_interval(
+        body_ast_3, interval, AST.VerticalRegion.Forward, sir_utils.make_interval(
             3, 4, 0, 0)
     )
 
     sir = sir_utils.make_sir(
         OUTPUT_FILE,
-        SIR.GridType.Value("Unstructured"),
+        AST.GridType.Value("Unstructured"),
         [
             sir_utils.make_stencil(
                 OUTPUT_NAME,
@@ -105,25 +105,25 @@ def main(args: argparse.Namespace):
                     sir_utils.make_field(
                         "in_1",
                         sir_utils.make_field_dimensions_unstructured(
-                            [SIR.LocationType.Value("Cell")], 1
+                            [AST.LocationType.Value("Cell")], 1
                         ),
                     ),
                     sir_utils.make_field(
                         "in_2",
                         sir_utils.make_field_dimensions_unstructured(
-                            [SIR.LocationType.Value("Cell")], 1
+                            [AST.LocationType.Value("Cell")], 1
                         ),
                     ),
                     sir_utils.make_field(
                         "in_3",
                         sir_utils.make_field_dimensions_unstructured(
-                            [SIR.LocationType.Value("Cell")], 1
+                            [AST.LocationType.Value("Cell")], 1
                         ),
                     ),
                     sir_utils.make_field(
                         "out",
                         sir_utils.make_field_dimensions_unstructured(
-                            [SIR.LocationType.Value("Cell")], 1
+                            [AST.LocationType.Value("Cell")], 1
                         ),
                     ),
                 ],

--- a/dawn/test/integration-test/dawn4py-tests/global_var.py
+++ b/dawn/test/integration-test/dawn4py-tests/global_var.py
@@ -19,7 +19,7 @@ import os
 
 import dawn4py
 from dawn4py.serialization import SIR, AST
-from dawn4py.serialization import utils as sir_utils
+from dawn4py.serialization import utils as serial_utils
 from google.protobuf.json_format import MessageToJson, Parse
 
 OUTPUT_NAME = "global_var_stencil"
@@ -28,38 +28,38 @@ OUTPUT_PATH = f"{OUTPUT_NAME}.cpp"
 
 
 def main(args: argparse.Namespace):
-    interval = sir_utils.make_interval(
+    interval = serial_utils.make_interval(
         AST.Interval.Start, AST.Interval.End, 0, 0)
     
-    body_ast = sir_utils.make_ast(
+    body_ast = serial_utils.make_ast(
         [
-            sir_utils.make_assignment_stmt(
-                sir_utils.make_field_access_expr("out", [0, 0, 0]),
-                sir_utils.make_binary_operator(sir_utils.make_var_access_expr(
-                    "dt", is_external=True), "*", sir_utils.make_field_access_expr("in", [1, 0, 0])),
+            serial_utils.make_assignment_stmt(
+                serial_utils.make_field_access_expr("out", [0, 0, 0]),
+                serial_utils.make_binary_operator(serial_utils.make_var_access_expr(
+                    "dt", is_external=True), "*", serial_utils.make_field_access_expr("in", [1, 0, 0])),
                 "="),
         ]
     )
 
-    vertical_region_stmt = sir_utils.make_vertical_region_decl_stmt(
+    vertical_region_stmt = serial_utils.make_vertical_region_decl_stmt(
         body_ast, interval, AST.VerticalRegion.Forward
     )
 
     globals = SIR.GlobalVariableMap()
     globals.map["dt"].double_value = 0.5
 
-    sir = sir_utils.make_sir(
+    sir = serial_utils.make_sir(
         OUTPUT_FILE,
         AST.GridType.Value("Cartesian"),
         [
-            sir_utils.make_stencil(
+            serial_utils.make_stencil(
                 OUTPUT_NAME,
-                sir_utils.make_ast([vertical_region_stmt]),
+                serial_utils.make_ast([vertical_region_stmt]),
                 [
-                    sir_utils.make_field(
-                        "in", sir_utils.make_field_dimensions_cartesian()),
-                    sir_utils.make_field(
-                        "out", sir_utils.make_field_dimensions_cartesian()),
+                    serial_utils.make_field(
+                        "in", serial_utils.make_field_dimensions_cartesian()),
+                    serial_utils.make_field(
+                        "out", serial_utils.make_field_dimensions_cartesian()),
                 ],
             )
         ],

--- a/dawn/test/integration-test/dawn4py-tests/global_var.py
+++ b/dawn/test/integration-test/dawn4py-tests/global_var.py
@@ -45,7 +45,7 @@ def main(args: argparse.Namespace):
         body_ast, interval, AST.VerticalRegion.Forward
     )
 
-    globals = SIR.GlobalVariableMap()
+    globals = AST.GlobalVariableMap()
     globals.map["dt"].double_value = 0.5
 
     sir = serial_utils.make_sir(

--- a/dawn/test/integration-test/dawn4py-tests/global_var.py
+++ b/dawn/test/integration-test/dawn4py-tests/global_var.py
@@ -18,7 +18,7 @@ import argparse
 import os
 
 import dawn4py
-from dawn4py.serialization import SIR
+from dawn4py.serialization import SIR, AST
 from dawn4py.serialization import utils as sir_utils
 from google.protobuf.json_format import MessageToJson, Parse
 
@@ -29,7 +29,7 @@ OUTPUT_PATH = f"{OUTPUT_NAME}.cpp"
 
 def main(args: argparse.Namespace):
     interval = sir_utils.make_interval(
-        SIR.Interval.Start, SIR.Interval.End, 0, 0)
+        AST.Interval.Start, AST.Interval.End, 0, 0)
     
     body_ast = sir_utils.make_ast(
         [
@@ -42,7 +42,7 @@ def main(args: argparse.Namespace):
     )
 
     vertical_region_stmt = sir_utils.make_vertical_region_decl_stmt(
-        body_ast, interval, SIR.VerticalRegion.Forward
+        body_ast, interval, AST.VerticalRegion.Forward
     )
 
     globals = SIR.GlobalVariableMap()
@@ -50,7 +50,7 @@ def main(args: argparse.Namespace):
 
     sir = sir_utils.make_sir(
         OUTPUT_FILE,
-        SIR.GridType.Value("Cartesian"),
+        AST.GridType.Value("Cartesian"),
         [
             sir_utils.make_stencil(
                 OUTPUT_NAME,

--- a/dawn/test/integration-test/dawn4py-tests/global_var_unstructured.py
+++ b/dawn/test/integration-test/dawn4py-tests/global_var_unstructured.py
@@ -18,7 +18,7 @@ import argparse
 import os
 
 import dawn4py
-from dawn4py.serialization import SIR
+from dawn4py.serialization import SIR, AST
 from dawn4py.serialization import utils as sir_utils
 from google.protobuf.json_format import MessageToJson, Parse
 
@@ -29,7 +29,7 @@ OUTPUT_PATH = f"{OUTPUT_NAME}.cpp"
 
 def main(args: argparse.Namespace):
     interval = sir_utils.make_interval(
-        SIR.Interval.Start, SIR.Interval.End, 0, 0)
+        AST.Interval.Start, AST.Interval.End, 0, 0)
 
     body_ast = sir_utils.make_ast(
         [
@@ -42,7 +42,7 @@ def main(args: argparse.Namespace):
     )
 
     vertical_region_stmt = sir_utils.make_vertical_region_decl_stmt(
-        body_ast, interval, SIR.VerticalRegion.Forward
+        body_ast, interval, AST.VerticalRegion.Forward
     )
 
     globals = SIR.GlobalVariableMap()
@@ -50,7 +50,7 @@ def main(args: argparse.Namespace):
 
     sir = sir_utils.make_sir(
         OUTPUT_FILE,
-        SIR.GridType.Value("Unstructured"),
+        AST.GridType.Value("Unstructured"),
         [
             sir_utils.make_stencil(
                 OUTPUT_NAME,
@@ -59,13 +59,13 @@ def main(args: argparse.Namespace):
                     sir_utils.make_field(
                         "in",
                         sir_utils.make_field_dimensions_unstructured(
-                            [SIR.LocationType.Value("Edge")], 1
+                            [AST.LocationType.Value("Edge")], 1
                         ),
                     ),
                     sir_utils.make_field(
                         "out",
                         sir_utils.make_field_dimensions_unstructured(
-                            [SIR.LocationType.Value("Edge")], 1
+                            [AST.LocationType.Value("Edge")], 1
                         ),
                     ),
                 ],

--- a/dawn/test/integration-test/dawn4py-tests/global_var_unstructured.py
+++ b/dawn/test/integration-test/dawn4py-tests/global_var_unstructured.py
@@ -45,7 +45,7 @@ def main(args: argparse.Namespace):
         body_ast, interval, AST.VerticalRegion.Forward
     )
 
-    globals = SIR.GlobalVariableMap()
+    globals = AST.GlobalVariableMap()
     globals.map["dt"].double_value = 0.5
 
     sir = serial_utils.make_sir(

--- a/dawn/test/integration-test/dawn4py-tests/global_var_unstructured.py
+++ b/dawn/test/integration-test/dawn4py-tests/global_var_unstructured.py
@@ -19,7 +19,7 @@ import os
 
 import dawn4py
 from dawn4py.serialization import SIR, AST
-from dawn4py.serialization import utils as sir_utils
+from dawn4py.serialization import utils as serial_utils
 from google.protobuf.json_format import MessageToJson, Parse
 
 OUTPUT_NAME = "global_var_stencil_unstructured"
@@ -28,43 +28,43 @@ OUTPUT_PATH = f"{OUTPUT_NAME}.cpp"
 
 
 def main(args: argparse.Namespace):
-    interval = sir_utils.make_interval(
+    interval = serial_utils.make_interval(
         AST.Interval.Start, AST.Interval.End, 0, 0)
 
-    body_ast = sir_utils.make_ast(
+    body_ast = serial_utils.make_ast(
         [
-            sir_utils.make_assignment_stmt(
-                sir_utils.make_field_access_expr("out"),
-                sir_utils.make_binary_operator(sir_utils.make_var_access_expr(
-                    "dt", is_external=True), "*", sir_utils.make_field_access_expr("in")),
+            serial_utils.make_assignment_stmt(
+                serial_utils.make_field_access_expr("out"),
+                serial_utils.make_binary_operator(serial_utils.make_var_access_expr(
+                    "dt", is_external=True), "*", serial_utils.make_field_access_expr("in")),
                 "="),
         ]
     )
 
-    vertical_region_stmt = sir_utils.make_vertical_region_decl_stmt(
+    vertical_region_stmt = serial_utils.make_vertical_region_decl_stmt(
         body_ast, interval, AST.VerticalRegion.Forward
     )
 
     globals = SIR.GlobalVariableMap()
     globals.map["dt"].double_value = 0.5
 
-    sir = sir_utils.make_sir(
+    sir = serial_utils.make_sir(
         OUTPUT_FILE,
         AST.GridType.Value("Unstructured"),
         [
-            sir_utils.make_stencil(
+            serial_utils.make_stencil(
                 OUTPUT_NAME,
-                sir_utils.make_ast([vertical_region_stmt]),
+                serial_utils.make_ast([vertical_region_stmt]),
                 [
-                    sir_utils.make_field(
+                    serial_utils.make_field(
                         "in",
-                        sir_utils.make_field_dimensions_unstructured(
+                        serial_utils.make_field_dimensions_unstructured(
                             [AST.LocationType.Value("Edge")], 1
                         ),
                     ),
-                    sir_utils.make_field(
+                    serial_utils.make_field(
                         "out",
-                        sir_utils.make_field_dimensions_unstructured(
+                        serial_utils.make_field_dimensions_unstructured(
                             [AST.LocationType.Value("Edge")], 1
                         ),
                     ),

--- a/dawn/test/integration-test/dawn4py-tests/hori_diff_stencil.py
+++ b/dawn/test/integration-test/dawn4py-tests/hori_diff_stencil.py
@@ -34,7 +34,7 @@ import os
 
 import dawn4py
 from dawn4py.serialization import SIR, AST
-from dawn4py.serialization import utils as sir_utils
+from dawn4py.serialization import utils as serial_utils
 from google.protobuf.json_format import MessageToJson, Parse
 
 OUTPUT_NAME = "hori_diff_stencil"
@@ -43,33 +43,33 @@ OUTPUT_PATH = f"{OUTPUT_NAME}.cpp"
 
 
 def main(args: argparse.Namespace):
-    interval = sir_utils.make_interval(AST.Interval.Start, AST.Interval.End, 0, 0)
+    interval = serial_utils.make_interval(AST.Interval.Start, AST.Interval.End, 0, 0)
 
     # create the stencil body AST
-    body_ast = sir_utils.make_ast(
+    body_ast = serial_utils.make_ast(
         [
-            sir_utils.make_assignment_stmt(
-                sir_utils.make_field_access_expr("lap"),
-                sir_utils.make_binary_operator(
-                    sir_utils.make_binary_operator(
-                        sir_utils.make_literal_access_expr("-4.0", AST.BuiltinType.Float),
+            serial_utils.make_assignment_stmt(
+                serial_utils.make_field_access_expr("lap"),
+                serial_utils.make_binary_operator(
+                    serial_utils.make_binary_operator(
+                        serial_utils.make_literal_access_expr("-4.0", AST.BuiltinType.Float),
                         "*",
-                        sir_utils.make_field_access_expr("in"),
+                        serial_utils.make_field_access_expr("in"),
                     ),
                     "+",
-                    sir_utils.make_binary_operator(
-                        sir_utils.make_field_access_expr("coeff"),
+                    serial_utils.make_binary_operator(
+                        serial_utils.make_field_access_expr("coeff"),
                         "*",
-                        sir_utils.make_binary_operator(
-                            sir_utils.make_field_access_expr("in", [1, 0, 0]),
+                        serial_utils.make_binary_operator(
+                            serial_utils.make_field_access_expr("in", [1, 0, 0]),
                             "+",
-                            sir_utils.make_binary_operator(
-                                sir_utils.make_field_access_expr("in", [-1, 0, 0]),
+                            serial_utils.make_binary_operator(
+                                serial_utils.make_field_access_expr("in", [-1, 0, 0]),
                                 "+",
-                                sir_utils.make_binary_operator(
-                                    sir_utils.make_field_access_expr("in", [0, 1, 0]),
+                                serial_utils.make_binary_operator(
+                                    serial_utils.make_field_access_expr("in", [0, 1, 0]),
                                     "+",
-                                    sir_utils.make_field_access_expr("in", [0, -1, 0]),
+                                    serial_utils.make_field_access_expr("in", [0, -1, 0]),
                                 ),
                             ),
                         ),
@@ -77,28 +77,28 @@ def main(args: argparse.Namespace):
                 ),
                 "=",
             ),
-            sir_utils.make_assignment_stmt(
-                sir_utils.make_field_access_expr("out"),
-                sir_utils.make_binary_operator(
-                    sir_utils.make_binary_operator(
-                        sir_utils.make_literal_access_expr("-4.0", AST.BuiltinType.Float),
+            serial_utils.make_assignment_stmt(
+                serial_utils.make_field_access_expr("out"),
+                serial_utils.make_binary_operator(
+                    serial_utils.make_binary_operator(
+                        serial_utils.make_literal_access_expr("-4.0", AST.BuiltinType.Float),
                         "*",
-                        sir_utils.make_field_access_expr("lap"),
+                        serial_utils.make_field_access_expr("lap"),
                     ),
                     "+",
-                    sir_utils.make_binary_operator(
-                        sir_utils.make_field_access_expr("coeff"),
+                    serial_utils.make_binary_operator(
+                        serial_utils.make_field_access_expr("coeff"),
                         "*",
-                        sir_utils.make_binary_operator(
-                            sir_utils.make_field_access_expr("lap", [1, 0, 0]),
+                        serial_utils.make_binary_operator(
+                            serial_utils.make_field_access_expr("lap", [1, 0, 0]),
                             "+",
-                            sir_utils.make_binary_operator(
-                                sir_utils.make_field_access_expr("lap", [-1, 0, 0]),
+                            serial_utils.make_binary_operator(
+                                serial_utils.make_field_access_expr("lap", [-1, 0, 0]),
                                 "+",
-                                sir_utils.make_binary_operator(
-                                    sir_utils.make_field_access_expr("lap", [0, 1, 0]),
+                                serial_utils.make_binary_operator(
+                                    serial_utils.make_field_access_expr("lap", [0, 1, 0]),
                                     "+",
-                                    sir_utils.make_field_access_expr("lap", [0, -1, 0]),
+                                    serial_utils.make_field_access_expr("lap", [0, -1, 0]),
                                 ),
                             ),
                         ),
@@ -109,23 +109,23 @@ def main(args: argparse.Namespace):
         ]
     )
 
-    vertical_region_stmt = sir_utils.make_vertical_region_decl_stmt(
+    vertical_region_stmt = serial_utils.make_vertical_region_decl_stmt(
         body_ast, interval, AST.VerticalRegion.Forward
     )
 
-    sir = sir_utils.make_sir(
+    sir = serial_utils.make_sir(
         OUTPUT_FILE,
         AST.GridType.Value("Cartesian"),
         [
-            sir_utils.make_stencil(
+            serial_utils.make_stencil(
                 OUTPUT_NAME,
-                sir_utils.make_ast([vertical_region_stmt]),
+                serial_utils.make_ast([vertical_region_stmt]),
                 [
-                    sir_utils.make_field("in", sir_utils.make_field_dimensions_cartesian()),
-                    sir_utils.make_field("out", sir_utils.make_field_dimensions_cartesian()),
-                    sir_utils.make_field("coeff", sir_utils.make_field_dimensions_cartesian()),
-                    sir_utils.make_field(
-                        "lap", sir_utils.make_field_dimensions_cartesian(), is_temporary=True
+                    serial_utils.make_field("in", serial_utils.make_field_dimensions_cartesian()),
+                    serial_utils.make_field("out", serial_utils.make_field_dimensions_cartesian()),
+                    serial_utils.make_field("coeff", serial_utils.make_field_dimensions_cartesian()),
+                    serial_utils.make_field(
+                        "lap", serial_utils.make_field_dimensions_cartesian(), is_temporary=True
                     ),
                 ],
             )

--- a/dawn/test/integration-test/dawn4py-tests/hori_diff_stencil.py
+++ b/dawn/test/integration-test/dawn4py-tests/hori_diff_stencil.py
@@ -33,7 +33,7 @@ import argparse
 import os
 
 import dawn4py
-from dawn4py.serialization import SIR
+from dawn4py.serialization import SIR, AST
 from dawn4py.serialization import utils as sir_utils
 from google.protobuf.json_format import MessageToJson, Parse
 
@@ -43,7 +43,7 @@ OUTPUT_PATH = f"{OUTPUT_NAME}.cpp"
 
 
 def main(args: argparse.Namespace):
-    interval = sir_utils.make_interval(SIR.Interval.Start, SIR.Interval.End, 0, 0)
+    interval = sir_utils.make_interval(AST.Interval.Start, AST.Interval.End, 0, 0)
 
     # create the stencil body AST
     body_ast = sir_utils.make_ast(
@@ -52,7 +52,7 @@ def main(args: argparse.Namespace):
                 sir_utils.make_field_access_expr("lap"),
                 sir_utils.make_binary_operator(
                     sir_utils.make_binary_operator(
-                        sir_utils.make_literal_access_expr("-4.0", SIR.BuiltinType.Float),
+                        sir_utils.make_literal_access_expr("-4.0", AST.BuiltinType.Float),
                         "*",
                         sir_utils.make_field_access_expr("in"),
                     ),
@@ -81,7 +81,7 @@ def main(args: argparse.Namespace):
                 sir_utils.make_field_access_expr("out"),
                 sir_utils.make_binary_operator(
                     sir_utils.make_binary_operator(
-                        sir_utils.make_literal_access_expr("-4.0", SIR.BuiltinType.Float),
+                        sir_utils.make_literal_access_expr("-4.0", AST.BuiltinType.Float),
                         "*",
                         sir_utils.make_field_access_expr("lap"),
                     ),
@@ -110,12 +110,12 @@ def main(args: argparse.Namespace):
     )
 
     vertical_region_stmt = sir_utils.make_vertical_region_decl_stmt(
-        body_ast, interval, SIR.VerticalRegion.Forward
+        body_ast, interval, AST.VerticalRegion.Forward
     )
 
     sir = sir_utils.make_sir(
         OUTPUT_FILE,
-        SIR.GridType.Value("Cartesian"),
+        AST.GridType.Value("Cartesian"),
         [
             sir_utils.make_stencil(
                 OUTPUT_NAME,

--- a/dawn/test/integration-test/dawn4py-tests/loop_copy_stencil.py
+++ b/dawn/test/integration-test/dawn4py-tests/loop_copy_stencil.py
@@ -18,7 +18,7 @@ import argparse
 import os
 
 import dawn4py
-from dawn4py.serialization import SIR
+from dawn4py.serialization import SIR, AST
 from dawn4py.serialization import utils as sir_utils
 from google.protobuf.json_format import MessageToJson
 
@@ -29,7 +29,7 @@ OUTPUT_PATH = f"{OUTPUT_NAME}.cpp"
 
 def main(args: argparse.Namespace):
     interval = sir_utils.make_interval(
-        SIR.Interval.Start, SIR.Interval.End, 0, 0)
+        AST.Interval.Start, AST.Interval.End, 0, 0)
 
     body_ast = sir_utils.make_ast(
         [
@@ -39,18 +39,18 @@ def main(args: argparse.Namespace):
                     sir_utils.make_field_access_expr("in"),
                     "=",
                 )],
-                [SIR.LocationType.Value("Cell"),
-                 SIR.LocationType.Value("Edge")]
+                [AST.LocationType.Value("Cell"),
+                 AST.LocationType.Value("Edge")]
             )
         ]
     )
 
     vertical_region_stmt = sir_utils.make_vertical_region_decl_stmt(
-        body_ast, interval, SIR.VerticalRegion.Forward)
+        body_ast, interval, AST.VerticalRegion.Forward)
 
     sir = sir_utils.make_sir(
         OUTPUT_FILE,
-        SIR.GridType.Value("Unstructured"),
+        AST.GridType.Value("Unstructured"),
         [
             sir_utils.make_stencil(
                 OUTPUT_NAME,
@@ -59,14 +59,14 @@ def main(args: argparse.Namespace):
                     sir_utils.make_field(
                         "out",
                         sir_utils.make_field_dimensions_unstructured(
-                            [SIR.LocationType.Value("Cell"),
-                             SIR.LocationType.Value("Edge")], 1
+                            [AST.LocationType.Value("Cell"),
+                             AST.LocationType.Value("Edge")], 1
                         ),
                     ),
                     sir_utils.make_field(
                         "in",
                         sir_utils.make_field_dimensions_unstructured(
-                            [SIR.LocationType.Value("Edge")], 1
+                            [AST.LocationType.Value("Edge")], 1
                         ),
                     ),
                 ],

--- a/dawn/test/integration-test/dawn4py-tests/loop_copy_stencil.py
+++ b/dawn/test/integration-test/dawn4py-tests/loop_copy_stencil.py
@@ -19,7 +19,7 @@ import os
 
 import dawn4py
 from dawn4py.serialization import SIR, AST
-from dawn4py.serialization import utils as sir_utils
+from dawn4py.serialization import utils as serial_utils
 from google.protobuf.json_format import MessageToJson
 
 OUTPUT_NAME = "loop_copy_stencil"
@@ -28,15 +28,15 @@ OUTPUT_PATH = f"{OUTPUT_NAME}.cpp"
 
 
 def main(args: argparse.Namespace):
-    interval = sir_utils.make_interval(
+    interval = serial_utils.make_interval(
         AST.Interval.Start, AST.Interval.End, 0, 0)
 
-    body_ast = sir_utils.make_ast(
+    body_ast = serial_utils.make_ast(
         [
-            sir_utils.make_loop_stmt(
-                [sir_utils.make_assignment_stmt(
-                    sir_utils.make_field_access_expr("out"),
-                    sir_utils.make_field_access_expr("in"),
+            serial_utils.make_loop_stmt(
+                [serial_utils.make_assignment_stmt(
+                    serial_utils.make_field_access_expr("out"),
+                    serial_utils.make_field_access_expr("in"),
                     "=",
                 )],
                 [AST.LocationType.Value("Cell"),
@@ -45,27 +45,27 @@ def main(args: argparse.Namespace):
         ]
     )
 
-    vertical_region_stmt = sir_utils.make_vertical_region_decl_stmt(
+    vertical_region_stmt = serial_utils.make_vertical_region_decl_stmt(
         body_ast, interval, AST.VerticalRegion.Forward)
 
-    sir = sir_utils.make_sir(
+    sir = serial_utils.make_sir(
         OUTPUT_FILE,
         AST.GridType.Value("Unstructured"),
         [
-            sir_utils.make_stencil(
+            serial_utils.make_stencil(
                 OUTPUT_NAME,
-                sir_utils.make_ast([vertical_region_stmt]),
+                serial_utils.make_ast([vertical_region_stmt]),
                 [
-                    sir_utils.make_field(
+                    serial_utils.make_field(
                         "out",
-                        sir_utils.make_field_dimensions_unstructured(
+                        serial_utils.make_field_dimensions_unstructured(
                             [AST.LocationType.Value("Cell"),
                              AST.LocationType.Value("Edge")], 1
                         ),
                     ),
-                    sir_utils.make_field(
+                    serial_utils.make_field(
                         "in",
-                        sir_utils.make_field_dimensions_unstructured(
+                        serial_utils.make_field_dimensions_unstructured(
                             [AST.LocationType.Value("Edge")], 1
                         ),
                     ),

--- a/dawn/test/integration-test/dawn4py-tests/sparse_dimensions.py
+++ b/dawn/test/integration-test/dawn4py-tests/sparse_dimensions.py
@@ -24,7 +24,7 @@ import os
 
 import dawn4py
 from dawn4py.serialization import SIR, AST
-from dawn4py.serialization import utils as sir_utils
+from dawn4py.serialization import utils as serial_utils
 from google.protobuf.json_format import MessageToJson, Parse
 
 OUTPUT_NAME = "sparse_dimensions"
@@ -33,21 +33,21 @@ OUTPUT_PATH = os.path.join(os.path.dirname(__file__), "data", f"{OUTPUT_NAME}.cp
 
 
 def main(args: argparse.Namespace):
-    interval = sir_utils.make_interval(AST.Interval.Start, AST.Interval.End, 0, 0)
+    interval = serial_utils.make_interval(AST.Interval.Start, AST.Interval.End, 0, 0)
 
     # create the out = reduce(sparse_CE * in) statement
-    body_ast = sir_utils.make_ast(
+    body_ast = serial_utils.make_ast(
         [
-            sir_utils.make_assignment_stmt(
-                sir_utils.make_field_access_expr("out"),
-                sir_utils.make_reduction_over_neighbor_expr(
+            serial_utils.make_assignment_stmt(
+                serial_utils.make_field_access_expr("out"),
+                serial_utils.make_reduction_over_neighbor_expr(
                     "+",
-                    sir_utils.make_binary_operator(
-                        sir_utils.make_field_access_expr("sparse_CE"),
+                    serial_utils.make_binary_operator(
+                        serial_utils.make_field_access_expr("sparse_CE"),
                         "*",
-                        sir_utils.make_field_access_expr("in"),
+                        serial_utils.make_field_access_expr("in"),
                     ),
-                    sir_utils.make_literal_access_expr("1.0", AST.BuiltinType.Float),
+                    serial_utils.make_literal_access_expr("1.0", AST.BuiltinType.Float),
                     chain=[AST.LocationType.Value("Cell"), AST.LocationType.Value("Edge")],
                 ),
                 "=",
@@ -55,33 +55,33 @@ def main(args: argparse.Namespace):
         ]
     )
 
-    vertical_region_stmt = sir_utils.make_vertical_region_decl_stmt(
+    vertical_region_stmt = serial_utils.make_vertical_region_decl_stmt(
         body_ast, interval, AST.VerticalRegion.Forward
     )
 
-    sir = sir_utils.make_sir(
+    sir = serial_utils.make_sir(
         OUTPUT_FILE,
         AST.GridType.Value("Unstructured"),
         [
-            sir_utils.make_stencil(
+            serial_utils.make_stencil(
                 OUTPUT_NAME,
-                sir_utils.make_ast([vertical_region_stmt]),
+                serial_utils.make_ast([vertical_region_stmt]),
                 [
-                    sir_utils.make_field(
+                    serial_utils.make_field(
                         "in",
-                        sir_utils.make_field_dimensions_unstructured(
+                        serial_utils.make_field_dimensions_unstructured(
                             [AST.LocationType.Value("Edge")], 1
                         ),
                     ),
-                    sir_utils.make_field(
+                    serial_utils.make_field(
                         "sparse_CE",
-                        sir_utils.make_field_dimensions_unstructured(
+                        serial_utils.make_field_dimensions_unstructured(
                             [AST.LocationType.Value("Cell"), AST.LocationType.Value("Edge")], 1
                         ),
                     ),
-                    sir_utils.make_field(
+                    serial_utils.make_field(
                         "out",
-                        sir_utils.make_field_dimensions_unstructured(
+                        serial_utils.make_field_dimensions_unstructured(
                             [AST.LocationType.Value("Cell")], 1
                         ),
                     ),

--- a/dawn/test/integration-test/dawn4py-tests/sparse_dimensions.py
+++ b/dawn/test/integration-test/dawn4py-tests/sparse_dimensions.py
@@ -23,7 +23,7 @@ import argparse
 import os
 
 import dawn4py
-from dawn4py.serialization import SIR
+from dawn4py.serialization import SIR, AST
 from dawn4py.serialization import utils as sir_utils
 from google.protobuf.json_format import MessageToJson, Parse
 
@@ -33,7 +33,7 @@ OUTPUT_PATH = os.path.join(os.path.dirname(__file__), "data", f"{OUTPUT_NAME}.cp
 
 
 def main(args: argparse.Namespace):
-    interval = sir_utils.make_interval(SIR.Interval.Start, SIR.Interval.End, 0, 0)
+    interval = sir_utils.make_interval(AST.Interval.Start, AST.Interval.End, 0, 0)
 
     # create the out = reduce(sparse_CE * in) statement
     body_ast = sir_utils.make_ast(
@@ -47,8 +47,8 @@ def main(args: argparse.Namespace):
                         "*",
                         sir_utils.make_field_access_expr("in"),
                     ),
-                    sir_utils.make_literal_access_expr("1.0", SIR.BuiltinType.Float),
-                    chain=[SIR.LocationType.Value("Cell"), SIR.LocationType.Value("Edge")],
+                    sir_utils.make_literal_access_expr("1.0", AST.BuiltinType.Float),
+                    chain=[AST.LocationType.Value("Cell"), AST.LocationType.Value("Edge")],
                 ),
                 "=",
             )
@@ -56,12 +56,12 @@ def main(args: argparse.Namespace):
     )
 
     vertical_region_stmt = sir_utils.make_vertical_region_decl_stmt(
-        body_ast, interval, SIR.VerticalRegion.Forward
+        body_ast, interval, AST.VerticalRegion.Forward
     )
 
     sir = sir_utils.make_sir(
         OUTPUT_FILE,
-        SIR.GridType.Value("Unstructured"),
+        AST.GridType.Value("Unstructured"),
         [
             sir_utils.make_stencil(
                 OUTPUT_NAME,
@@ -70,19 +70,19 @@ def main(args: argparse.Namespace):
                     sir_utils.make_field(
                         "in",
                         sir_utils.make_field_dimensions_unstructured(
-                            [SIR.LocationType.Value("Edge")], 1
+                            [AST.LocationType.Value("Edge")], 1
                         ),
                     ),
                     sir_utils.make_field(
                         "sparse_CE",
                         sir_utils.make_field_dimensions_unstructured(
-                            [SIR.LocationType.Value("Cell"), SIR.LocationType.Value("Edge")], 1
+                            [AST.LocationType.Value("Cell"), AST.LocationType.Value("Edge")], 1
                         ),
                     ),
                     sir_utils.make_field(
                         "out",
                         sir_utils.make_field_dimensions_unstructured(
-                            [SIR.LocationType.Value("Cell")], 1
+                            [AST.LocationType.Value("Cell")], 1
                         ),
                     ),
                 ],

--- a/dawn/test/integration-test/dawn4py-tests/tridiagonal_solve_stencil.py
+++ b/dawn/test/integration-test/dawn4py-tests/tridiagonal_solve_stencil.py
@@ -35,7 +35,7 @@ import os
 
 import dawn4py
 from dawn4py.serialization import SIR, AST
-from dawn4py.serialization import utils as sir_utils
+from dawn4py.serialization import utils as serial_utils
 from google.protobuf.json_format import MessageToJson, Parse
 
 OUTPUT_NAME = "tridiagonal_solve_stencil"
@@ -46,115 +46,115 @@ OUTPUT_PATH = f"{OUTPUT_NAME}.cpp"
 def main(args: argparse.Namespace):
 
     # ---- First vertical region statement ----
-    interval_1 = sir_utils.make_interval(AST.Interval.Start, AST.Interval.End, 0, 0)
-    body_ast_1 = sir_utils.make_ast(
+    interval_1 = serial_utils.make_interval(AST.Interval.Start, AST.Interval.End, 0, 0)
+    body_ast_1 = serial_utils.make_ast(
         [
-            sir_utils.make_assignment_stmt(
-                sir_utils.make_field_access_expr("c"),
-                sir_utils.make_binary_operator(
-                    sir_utils.make_field_access_expr("c"),
+            serial_utils.make_assignment_stmt(
+                serial_utils.make_field_access_expr("c"),
+                serial_utils.make_binary_operator(
+                    serial_utils.make_field_access_expr("c"),
                     "/",
-                    sir_utils.make_field_access_expr("b"),
+                    serial_utils.make_field_access_expr("b"),
                 ),
                 "=",
             )
         ]
     )
 
-    vertical_region_stmt_1 = sir_utils.make_vertical_region_decl_stmt(
+    vertical_region_stmt_1 = serial_utils.make_vertical_region_decl_stmt(
         body_ast_1, interval_1, AST.VerticalRegion.Forward
     )
 
     # ---- Second vertical region statement ----
-    interval_2 = sir_utils.make_interval(AST.Interval.Start, AST.Interval.End, 1, 0)
+    interval_2 = serial_utils.make_interval(AST.Interval.Start, AST.Interval.End, 1, 0)
 
-    body_ast_2 = sir_utils.make_ast(
+    body_ast_2 = serial_utils.make_ast(
         [
-            sir_utils.make_var_decl_stmt(
-                sir_utils.make_type(AST.BuiltinType.Integer),
+            serial_utils.make_var_decl_stmt(
+                serial_utils.make_type(AST.BuiltinType.Integer),
                 "m",
                 0,
                 "=",
-                sir_utils.make_expr(
-                    sir_utils.make_binary_operator(
-                        sir_utils.make_literal_access_expr("1.0", AST.BuiltinType.Float),
+                serial_utils.make_expr(
+                    serial_utils.make_binary_operator(
+                        serial_utils.make_literal_access_expr("1.0", AST.BuiltinType.Float),
                         "/",
-                        sir_utils.make_binary_operator(
-                            sir_utils.make_field_access_expr("b"),
+                        serial_utils.make_binary_operator(
+                            serial_utils.make_field_access_expr("b"),
                             "-",
-                            sir_utils.make_binary_operator(
-                                sir_utils.make_field_access_expr("a"),
+                            serial_utils.make_binary_operator(
+                                serial_utils.make_field_access_expr("a"),
                                 "*",
-                                sir_utils.make_field_access_expr("c", [0, 0, -1]),
+                                serial_utils.make_field_access_expr("c", [0, 0, -1]),
                             ),
                         ),
                     )
                 ),
             ),
-            sir_utils.make_assignment_stmt(
-                sir_utils.make_field_access_expr("c"),
-                sir_utils.make_binary_operator(
-                    sir_utils.make_field_access_expr("c"), "*", sir_utils.make_var_access_expr("m")
+            serial_utils.make_assignment_stmt(
+                serial_utils.make_field_access_expr("c"),
+                serial_utils.make_binary_operator(
+                    serial_utils.make_field_access_expr("c"), "*", serial_utils.make_var_access_expr("m")
                 ),
                 "=",
             ),
-            sir_utils.make_assignment_stmt(
-                sir_utils.make_field_access_expr("d"),
-                sir_utils.make_binary_operator(
-                    sir_utils.make_binary_operator(
-                        sir_utils.make_field_access_expr("d"),
+            serial_utils.make_assignment_stmt(
+                serial_utils.make_field_access_expr("d"),
+                serial_utils.make_binary_operator(
+                    serial_utils.make_binary_operator(
+                        serial_utils.make_field_access_expr("d"),
                         "-",
-                        sir_utils.make_binary_operator(
-                            sir_utils.make_field_access_expr("a"),
+                        serial_utils.make_binary_operator(
+                            serial_utils.make_field_access_expr("a"),
                             "*",
-                            sir_utils.make_field_access_expr("d", [0, 0, -1]),
+                            serial_utils.make_field_access_expr("d", [0, 0, -1]),
                         ),
                     ),
                     "*",
-                    sir_utils.make_var_access_expr("m"),
+                    serial_utils.make_var_access_expr("m"),
                 ),
                 "=",
             ),
         ]
     )
-    vertical_region_stmt_2 = sir_utils.make_vertical_region_decl_stmt(
+    vertical_region_stmt_2 = serial_utils.make_vertical_region_decl_stmt(
         body_ast_2, interval_2, AST.VerticalRegion.Forward
     )
 
     # ---- Third vertical region statement ----
-    interval_3 = sir_utils.make_interval(AST.Interval.Start, AST.Interval.End, 0, -1)
-    body_ast_3 = sir_utils.make_ast(
+    interval_3 = serial_utils.make_interval(AST.Interval.Start, AST.Interval.End, 0, -1)
+    body_ast_3 = serial_utils.make_ast(
         [
-            sir_utils.make_assignment_stmt(
-                sir_utils.make_field_access_expr("d"),
-                sir_utils.make_binary_operator(
-                    sir_utils.make_field_access_expr("c"),
+            serial_utils.make_assignment_stmt(
+                serial_utils.make_field_access_expr("d"),
+                serial_utils.make_binary_operator(
+                    serial_utils.make_field_access_expr("c"),
                     "*",
-                    sir_utils.make_field_access_expr("d", [0, 0, 1]),
+                    serial_utils.make_field_access_expr("d", [0, 0, 1]),
                 ),
                 "-=",
             )
         ]
     )
 
-    vertical_region_stmt_3 = sir_utils.make_vertical_region_decl_stmt(
+    vertical_region_stmt_3 = serial_utils.make_vertical_region_decl_stmt(
         body_ast_3, interval_3, AST.VerticalRegion.Backward
     )
 
-    sir = sir_utils.make_sir(
+    sir = serial_utils.make_sir(
         OUTPUT_FILE,
         AST.GridType.Value("Cartesian"),
         [
-            sir_utils.make_stencil(
+            serial_utils.make_stencil(
                 OUTPUT_NAME,
-                sir_utils.make_ast(
+                serial_utils.make_ast(
                     [vertical_region_stmt_1, vertical_region_stmt_2, vertical_region_stmt_3]
                 ),
                 [
-                    sir_utils.make_field("a", sir_utils.make_field_dimensions_cartesian()),
-                    sir_utils.make_field("b", sir_utils.make_field_dimensions_cartesian()),
-                    sir_utils.make_field("c", sir_utils.make_field_dimensions_cartesian()),
-                    sir_utils.make_field("d", sir_utils.make_field_dimensions_cartesian()),
+                    serial_utils.make_field("a", serial_utils.make_field_dimensions_cartesian()),
+                    serial_utils.make_field("b", serial_utils.make_field_dimensions_cartesian()),
+                    serial_utils.make_field("c", serial_utils.make_field_dimensions_cartesian()),
+                    serial_utils.make_field("d", serial_utils.make_field_dimensions_cartesian()),
                 ],
             )
         ],

--- a/dawn/test/integration-test/dawn4py-tests/tridiagonal_solve_stencil.py
+++ b/dawn/test/integration-test/dawn4py-tests/tridiagonal_solve_stencil.py
@@ -34,7 +34,7 @@ import argparse
 import os
 
 import dawn4py
-from dawn4py.serialization import SIR
+from dawn4py.serialization import SIR, AST
 from dawn4py.serialization import utils as sir_utils
 from google.protobuf.json_format import MessageToJson, Parse
 
@@ -46,7 +46,7 @@ OUTPUT_PATH = f"{OUTPUT_NAME}.cpp"
 def main(args: argparse.Namespace):
 
     # ---- First vertical region statement ----
-    interval_1 = sir_utils.make_interval(SIR.Interval.Start, SIR.Interval.End, 0, 0)
+    interval_1 = sir_utils.make_interval(AST.Interval.Start, AST.Interval.End, 0, 0)
     body_ast_1 = sir_utils.make_ast(
         [
             sir_utils.make_assignment_stmt(
@@ -62,22 +62,22 @@ def main(args: argparse.Namespace):
     )
 
     vertical_region_stmt_1 = sir_utils.make_vertical_region_decl_stmt(
-        body_ast_1, interval_1, SIR.VerticalRegion.Forward
+        body_ast_1, interval_1, AST.VerticalRegion.Forward
     )
 
     # ---- Second vertical region statement ----
-    interval_2 = sir_utils.make_interval(SIR.Interval.Start, SIR.Interval.End, 1, 0)
+    interval_2 = sir_utils.make_interval(AST.Interval.Start, AST.Interval.End, 1, 0)
 
     body_ast_2 = sir_utils.make_ast(
         [
             sir_utils.make_var_decl_stmt(
-                sir_utils.make_type(SIR.BuiltinType.Integer),
+                sir_utils.make_type(AST.BuiltinType.Integer),
                 "m",
                 0,
                 "=",
                 sir_utils.make_expr(
                     sir_utils.make_binary_operator(
-                        sir_utils.make_literal_access_expr("1.0", SIR.BuiltinType.Float),
+                        sir_utils.make_literal_access_expr("1.0", AST.BuiltinType.Float),
                         "/",
                         sir_utils.make_binary_operator(
                             sir_utils.make_field_access_expr("b"),
@@ -118,11 +118,11 @@ def main(args: argparse.Namespace):
         ]
     )
     vertical_region_stmt_2 = sir_utils.make_vertical_region_decl_stmt(
-        body_ast_2, interval_2, SIR.VerticalRegion.Forward
+        body_ast_2, interval_2, AST.VerticalRegion.Forward
     )
 
     # ---- Third vertical region statement ----
-    interval_3 = sir_utils.make_interval(SIR.Interval.Start, SIR.Interval.End, 0, -1)
+    interval_3 = sir_utils.make_interval(AST.Interval.Start, AST.Interval.End, 0, -1)
     body_ast_3 = sir_utils.make_ast(
         [
             sir_utils.make_assignment_stmt(
@@ -138,12 +138,12 @@ def main(args: argparse.Namespace):
     )
 
     vertical_region_stmt_3 = sir_utils.make_vertical_region_decl_stmt(
-        body_ast_3, interval_3, SIR.VerticalRegion.Backward
+        body_ast_3, interval_3, AST.VerticalRegion.Backward
     )
 
     sir = sir_utils.make_sir(
         OUTPUT_FILE,
-        SIR.GridType.Value("Cartesian"),
+        AST.GridType.Value("Cartesian"),
         [
             sir_utils.make_stencil(
                 OUTPUT_NAME,

--- a/dawn/test/integration-test/dawn4py-tests/tridiagonal_solve_unstructured.py
+++ b/dawn/test/integration-test/dawn4py-tests/tridiagonal_solve_unstructured.py
@@ -30,7 +30,7 @@ import os
 
 import dawn4py
 from dawn4py.serialization import SIR, AST
-from dawn4py.serialization import utils as sir_utils
+from dawn4py.serialization import utils as serial_utils
 from google.protobuf.json_format import MessageToJson, Parse
 
 OUTPUT_NAME = "unstructured_vertical_solver"
@@ -42,32 +42,32 @@ def create_vertical_region_stmt1():
     """ create a vertical region statement for the stencil
     """
 
-    interval = sir_utils.make_interval(sir_utils.Interval.Start, sir_utils.Interval.Start, 0, 0)
+    interval = serial_utils.make_interval(serial_utils.Interval.Start, serial_utils.Interval.Start, 0, 0)
 
-    body_ast = sir_utils.make_ast(
+    body_ast = serial_utils.make_ast(
         [
-            sir_utils.make_assignment_stmt(
-                sir_utils.make_unstructured_field_access_expr("c"),
-                sir_utils.make_binary_operator(
-                    sir_utils.make_unstructured_field_access_expr("c"),
+            serial_utils.make_assignment_stmt(
+                serial_utils.make_unstructured_field_access_expr("c"),
+                serial_utils.make_binary_operator(
+                    serial_utils.make_unstructured_field_access_expr("c"),
                     "/",
-                    sir_utils.make_unstructured_field_access_expr("b"),
+                    serial_utils.make_unstructured_field_access_expr("b"),
                 ),
                 "=",
             ),
-            sir_utils.make_assignment_stmt(
-                sir_utils.make_unstructured_field_access_expr("d"),
-                sir_utils.make_binary_operator(
-                    sir_utils.make_unstructured_field_access_expr("d"),
+            serial_utils.make_assignment_stmt(
+                serial_utils.make_unstructured_field_access_expr("d"),
+                serial_utils.make_binary_operator(
+                    serial_utils.make_unstructured_field_access_expr("d"),
                     "/",
-                    sir_utils.make_unstructured_field_access_expr("b"),
+                    serial_utils.make_unstructured_field_access_expr("b"),
                 ),
                 "=",
             ),
         ]
     )
 
-    vertical_region_stmt = sir_utils.make_vertical_region_decl_stmt(
+    vertical_region_stmt = serial_utils.make_vertical_region_decl_stmt(
         body_ast, interval, AST.VerticalRegion.Forward
     )
     return vertical_region_stmt
@@ -77,65 +77,65 @@ def create_vertical_region_stmt2():
     """ create a vertical region statement for the stencil
     """
 
-    interval = sir_utils.make_interval(sir_utils.Interval.Start, sir_utils.Interval.End, 1, 0)
+    interval = serial_utils.make_interval(serial_utils.Interval.Start, serial_utils.Interval.End, 1, 0)
 
-    body_ast = sir_utils.make_ast(
+    body_ast = serial_utils.make_ast(
         [
-            sir_utils.make_var_decl_stmt(
-                sir_utils.make_type(sir_utils.BuiltinType.Float),
+            serial_utils.make_var_decl_stmt(
+                serial_utils.make_type(serial_utils.BuiltinType.Float),
                 "m",
                 0,
                 "=",
-                sir_utils.make_expr(
-                    sir_utils.make_binary_operator(
-                        sir_utils.make_literal_access_expr("1.0", sir_utils.BuiltinType.Float),
+                serial_utils.make_expr(
+                    serial_utils.make_binary_operator(
+                        serial_utils.make_literal_access_expr("1.0", serial_utils.BuiltinType.Float),
                         "/",
-                        sir_utils.make_binary_operator(
-                            sir_utils.make_unstructured_field_access_expr("b"),
+                        serial_utils.make_binary_operator(
+                            serial_utils.make_unstructured_field_access_expr("b"),
                             "-",
-                            sir_utils.make_binary_operator(
-                                sir_utils.make_unstructured_field_access_expr("a"),
+                            serial_utils.make_binary_operator(
+                                serial_utils.make_unstructured_field_access_expr("a"),
                                 "*",
-                                sir_utils.make_unstructured_field_access_expr(
-                                    "c", sir_utils.make_unstructured_offset(False), -1
+                                serial_utils.make_unstructured_field_access_expr(
+                                    "c", serial_utils.make_unstructured_offset(False), -1
                                 ),
                             ),
                         ),
                     )
                 ),
             ),
-            sir_utils.make_assignment_stmt(
-                sir_utils.make_unstructured_field_access_expr("c"),
-                sir_utils.make_binary_operator(
-                    sir_utils.make_unstructured_field_access_expr("c"),
+            serial_utils.make_assignment_stmt(
+                serial_utils.make_unstructured_field_access_expr("c"),
+                serial_utils.make_binary_operator(
+                    serial_utils.make_unstructured_field_access_expr("c"),
                     "*",
-                    sir_utils.make_var_access_expr("m"),
+                    serial_utils.make_var_access_expr("m"),
                 ),
                 "=",
             ),
-            sir_utils.make_assignment_stmt(
-                sir_utils.make_unstructured_field_access_expr("d"),
-                sir_utils.make_binary_operator(
-                    sir_utils.make_binary_operator(
-                        sir_utils.make_unstructured_field_access_expr("d"),
+            serial_utils.make_assignment_stmt(
+                serial_utils.make_unstructured_field_access_expr("d"),
+                serial_utils.make_binary_operator(
+                    serial_utils.make_binary_operator(
+                        serial_utils.make_unstructured_field_access_expr("d"),
                         "-",
-                        sir_utils.make_binary_operator(
-                            sir_utils.make_unstructured_field_access_expr("a"),
+                        serial_utils.make_binary_operator(
+                            serial_utils.make_unstructured_field_access_expr("a"),
                             "*",
-                            sir_utils.make_unstructured_field_access_expr(
-                                "d", sir_utils.make_unstructured_offset(False), -1
+                            serial_utils.make_unstructured_field_access_expr(
+                                "d", serial_utils.make_unstructured_offset(False), -1
                             ),
                         ),
                     ),
                     "*",
-                    sir_utils.make_var_access_expr("m"),
+                    serial_utils.make_var_access_expr("m"),
                 ),
                 "=",
             ),
         ]
     )
 
-    vertical_region_stmt = sir_utils.make_vertical_region_decl_stmt(
+    vertical_region_stmt = serial_utils.make_vertical_region_decl_stmt(
         body_ast, interval, AST.VerticalRegion.Forward
     )
     return vertical_region_stmt
@@ -145,17 +145,17 @@ def create_vertical_region_stmt3():
     """ create a vertical region statement for the stencil
     """
 
-    interval = sir_utils.make_interval(sir_utils.Interval.Start, sir_utils.Interval.End, 0, -1)
+    interval = serial_utils.make_interval(serial_utils.Interval.Start, serial_utils.Interval.End, 0, -1)
 
-    body_ast = sir_utils.make_ast(
+    body_ast = serial_utils.make_ast(
         [
-            sir_utils.make_assignment_stmt(
-                sir_utils.make_unstructured_field_access_expr("d"),
-                sir_utils.make_binary_operator(
-                    sir_utils.make_unstructured_field_access_expr("c"),
+            serial_utils.make_assignment_stmt(
+                serial_utils.make_unstructured_field_access_expr("d"),
+                serial_utils.make_binary_operator(
+                    serial_utils.make_unstructured_field_access_expr("c"),
                     "*",
-                    sir_utils.make_unstructured_field_access_expr(
-                        "d", sir_utils.make_unstructured_offset(False), 1
+                    serial_utils.make_unstructured_field_access_expr(
+                        "d", serial_utils.make_unstructured_offset(False), 1
                     ),
                 ),
                 "-=",
@@ -163,20 +163,20 @@ def create_vertical_region_stmt3():
         ]
     )
 
-    vertical_region_stmt = sir_utils.make_vertical_region_decl_stmt(
+    vertical_region_stmt = serial_utils.make_vertical_region_decl_stmt(
         body_ast, interval, AST.VerticalRegion.Backward
     )
     return vertical_region_stmt
 
 
 def main(args: argparse.Namespace):
-    sir = sir_utils.make_sir(
+    sir = serial_utils.make_sir(
         OUTPUT_FILE,
         AST.GridType.Value("Unstructured"),
         [
-            sir_utils.make_stencil(
+            serial_utils.make_stencil(
                 OUTPUT_NAME,
-                sir_utils.make_ast(
+                serial_utils.make_ast(
                     [
                         create_vertical_region_stmt1(),
                         create_vertical_region_stmt2(),
@@ -184,27 +184,27 @@ def main(args: argparse.Namespace):
                     ]
                 ),
                 [
-                    sir_utils.make_field(
+                    serial_utils.make_field(
                         "a",
-                        sir_utils.make_field_dimensions_unstructured(
+                        serial_utils.make_field_dimensions_unstructured(
                             [AST.LocationType.Value("Cell")], 1
                         ),
                     ),
-                    sir_utils.make_field(
+                    serial_utils.make_field(
                         "b",
-                        sir_utils.make_field_dimensions_unstructured(
+                        serial_utils.make_field_dimensions_unstructured(
                             [AST.LocationType.Value("Cell")], 1
                         ),
                     ),
-                    sir_utils.make_field(
+                    serial_utils.make_field(
                         "c",
-                        sir_utils.make_field_dimensions_unstructured(
+                        serial_utils.make_field_dimensions_unstructured(
                             [AST.LocationType.Value("Cell")], 1
                         ),
                     ),
-                    sir_utils.make_field(
+                    serial_utils.make_field(
                         "d",
-                        sir_utils.make_field_dimensions_unstructured(
+                        serial_utils.make_field_dimensions_unstructured(
                             [AST.LocationType.Value("Cell")], 1
                         ),
                     ),

--- a/dawn/test/integration-test/dawn4py-tests/tridiagonal_solve_unstructured.py
+++ b/dawn/test/integration-test/dawn4py-tests/tridiagonal_solve_unstructured.py
@@ -29,7 +29,7 @@ import argparse
 import os
 
 import dawn4py
-from dawn4py.serialization import SIR
+from dawn4py.serialization import SIR, AST
 from dawn4py.serialization import utils as sir_utils
 from google.protobuf.json_format import MessageToJson, Parse
 
@@ -68,7 +68,7 @@ def create_vertical_region_stmt1():
     )
 
     vertical_region_stmt = sir_utils.make_vertical_region_decl_stmt(
-        body_ast, interval, SIR.VerticalRegion.Forward
+        body_ast, interval, AST.VerticalRegion.Forward
     )
     return vertical_region_stmt
 
@@ -136,7 +136,7 @@ def create_vertical_region_stmt2():
     )
 
     vertical_region_stmt = sir_utils.make_vertical_region_decl_stmt(
-        body_ast, interval, SIR.VerticalRegion.Forward
+        body_ast, interval, AST.VerticalRegion.Forward
     )
     return vertical_region_stmt
 
@@ -164,7 +164,7 @@ def create_vertical_region_stmt3():
     )
 
     vertical_region_stmt = sir_utils.make_vertical_region_decl_stmt(
-        body_ast, interval, SIR.VerticalRegion.Backward
+        body_ast, interval, AST.VerticalRegion.Backward
     )
     return vertical_region_stmt
 
@@ -172,7 +172,7 @@ def create_vertical_region_stmt3():
 def main(args: argparse.Namespace):
     sir = sir_utils.make_sir(
         OUTPUT_FILE,
-        SIR.GridType.Value("Unstructured"),
+        AST.GridType.Value("Unstructured"),
         [
             sir_utils.make_stencil(
                 OUTPUT_NAME,
@@ -187,25 +187,25 @@ def main(args: argparse.Namespace):
                     sir_utils.make_field(
                         "a",
                         sir_utils.make_field_dimensions_unstructured(
-                            [SIR.LocationType.Value("Cell")], 1
+                            [AST.LocationType.Value("Cell")], 1
                         ),
                     ),
                     sir_utils.make_field(
                         "b",
                         sir_utils.make_field_dimensions_unstructured(
-                            [SIR.LocationType.Value("Cell")], 1
+                            [AST.LocationType.Value("Cell")], 1
                         ),
                     ),
                     sir_utils.make_field(
                         "c",
                         sir_utils.make_field_dimensions_unstructured(
-                            [SIR.LocationType.Value("Cell")], 1
+                            [AST.LocationType.Value("Cell")], 1
                         ),
                     ),
                     sir_utils.make_field(
                         "d",
                         sir_utils.make_field_dimensions_unstructured(
-                            [SIR.LocationType.Value("Cell")], 1
+                            [AST.LocationType.Value("Cell")], 1
                         ),
                     ),
                 ],

--- a/dawn/test/integration-test/dawn4py-tests/unstructured_masked_fields.py
+++ b/dawn/test/integration-test/dawn4py-tests/unstructured_masked_fields.py
@@ -25,7 +25,7 @@ import argparse
 import os
 
 import dawn4py
-from dawn4py.serialization import SIR
+from dawn4py.serialization import SIR, AST
 from dawn4py.serialization import utils as sir_utils
 from google.protobuf.json_format import MessageToJson, Parse
 
@@ -36,7 +36,7 @@ OUTPUT_PATH = f"{OUTPUT_NAME}.cpp"
 
 def main(args: argparse.Namespace):
     interval = sir_utils.make_interval(
-        SIR.Interval.Start, SIR.Interval.End, 0, 0)
+        AST.Interval.Start, AST.Interval.End, 0, 0)
 
     body_ast = sir_utils.make_ast(
         [
@@ -55,11 +55,11 @@ def main(args: argparse.Namespace):
                 sir_utils.make_reduction_over_neighbor_expr(
                     op="+",
                     init=sir_utils.make_literal_access_expr(
-                        "1.0", SIR.BuiltinType.Float),
+                        "1.0", AST.BuiltinType.Float),
                     rhs=sir_utils.make_field_access_expr(
                         "horizontal_sparse", [True, 0]),
-                    chain=[SIR.LocationType.Value(
-                        "Edge"), SIR.LocationType.Value("Cell")],
+                    chain=[AST.LocationType.Value(
+                        "Edge"), AST.LocationType.Value("Cell")],
                 ),
                 "=",
             )
@@ -67,12 +67,12 @@ def main(args: argparse.Namespace):
     )
 
     vertical_region_stmt = sir_utils.make_vertical_region_decl_stmt(
-        body_ast, interval, SIR.VerticalRegion.Forward
+        body_ast, interval, AST.VerticalRegion.Forward
     )
 
     sir = sir_utils.make_sir(
         OUTPUT_FILE,
-        SIR.GridType.Value("Unstructured"),
+        AST.GridType.Value("Unstructured"),
         [
             sir_utils.make_stencil(
                 OUTPUT_NAME,
@@ -81,26 +81,26 @@ def main(args: argparse.Namespace):
                     sir_utils.make_field(
                         "out",
                         sir_utils.make_field_dimensions_unstructured(
-                            [SIR.LocationType.Value("Edge")], 1
+                            [AST.LocationType.Value("Edge")], 1
                         ),
                     ),
                     sir_utils.make_field(
                         "full",
                         sir_utils.make_field_dimensions_unstructured(
-                            [SIR.LocationType.Value("Edge")], 1
+                            [AST.LocationType.Value("Edge")], 1
                         ),
                     ),
                     sir_utils.make_field(
                         "horizontal",
                         sir_utils.make_field_dimensions_unstructured(
-                            [SIR.LocationType.Value("Edge")], 0
+                            [AST.LocationType.Value("Edge")], 0
                         ),
                     ),
                     sir_utils.make_field(
                         "horizontal_sparse",
                         sir_utils.make_field_dimensions_unstructured(
-                            [SIR.LocationType.Value(
-                                "Edge"), SIR.LocationType.Value("Cell")], 0
+                            [AST.LocationType.Value(
+                                "Edge"), AST.LocationType.Value("Cell")], 0
                         ),
                     ),
                     sir_utils.make_vertical_field("vertical"),

--- a/dawn/test/integration-test/dawn4py-tests/unstructured_masked_fields.py
+++ b/dawn/test/integration-test/dawn4py-tests/unstructured_masked_fields.py
@@ -26,7 +26,7 @@ import os
 
 import dawn4py
 from dawn4py.serialization import SIR, AST
-from dawn4py.serialization import utils as sir_utils
+from dawn4py.serialization import utils as serial_utils
 from google.protobuf.json_format import MessageToJson, Parse
 
 OUTPUT_NAME = "unstructured_masked_fields"
@@ -35,28 +35,28 @@ OUTPUT_PATH = f"{OUTPUT_NAME}.cpp"
 
 
 def main(args: argparse.Namespace):
-    interval = sir_utils.make_interval(
+    interval = serial_utils.make_interval(
         AST.Interval.Start, AST.Interval.End, 0, 0)
 
-    body_ast = sir_utils.make_ast(
+    body_ast = serial_utils.make_ast(
         [
-            sir_utils.make_assignment_stmt(
-                sir_utils.make_field_access_expr("out"),
-                sir_utils.make_binary_operator(
-                    sir_utils.make_field_access_expr("full"),
+            serial_utils.make_assignment_stmt(
+                serial_utils.make_field_access_expr("out"),
+                serial_utils.make_binary_operator(
+                    serial_utils.make_field_access_expr("full"),
                     "+",
-                    sir_utils.make_binary_operator(
-                        sir_utils.make_field_access_expr("horizontal"),
+                    serial_utils.make_binary_operator(
+                        serial_utils.make_field_access_expr("horizontal"),
                         "+",
-                        sir_utils.make_field_access_expr("vertical"))),
+                        serial_utils.make_field_access_expr("vertical"))),
                 "="),
-            sir_utils.make_assignment_stmt(
-                sir_utils.make_field_access_expr("out"),
-                sir_utils.make_reduction_over_neighbor_expr(
+            serial_utils.make_assignment_stmt(
+                serial_utils.make_field_access_expr("out"),
+                serial_utils.make_reduction_over_neighbor_expr(
                     op="+",
-                    init=sir_utils.make_literal_access_expr(
+                    init=serial_utils.make_literal_access_expr(
                         "1.0", AST.BuiltinType.Float),
-                    rhs=sir_utils.make_field_access_expr(
+                    rhs=serial_utils.make_field_access_expr(
                         "horizontal_sparse", [True, 0]),
                     chain=[AST.LocationType.Value(
                         "Edge"), AST.LocationType.Value("Cell")],
@@ -66,44 +66,44 @@ def main(args: argparse.Namespace):
         ]
     )
 
-    vertical_region_stmt = sir_utils.make_vertical_region_decl_stmt(
+    vertical_region_stmt = serial_utils.make_vertical_region_decl_stmt(
         body_ast, interval, AST.VerticalRegion.Forward
     )
 
-    sir = sir_utils.make_sir(
+    sir = serial_utils.make_sir(
         OUTPUT_FILE,
         AST.GridType.Value("Unstructured"),
         [
-            sir_utils.make_stencil(
+            serial_utils.make_stencil(
                 OUTPUT_NAME,
-                sir_utils.make_ast([vertical_region_stmt]),
+                serial_utils.make_ast([vertical_region_stmt]),
                 [
-                    sir_utils.make_field(
+                    serial_utils.make_field(
                         "out",
-                        sir_utils.make_field_dimensions_unstructured(
+                        serial_utils.make_field_dimensions_unstructured(
                             [AST.LocationType.Value("Edge")], 1
                         ),
                     ),
-                    sir_utils.make_field(
+                    serial_utils.make_field(
                         "full",
-                        sir_utils.make_field_dimensions_unstructured(
+                        serial_utils.make_field_dimensions_unstructured(
                             [AST.LocationType.Value("Edge")], 1
                         ),
                     ),
-                    sir_utils.make_field(
+                    serial_utils.make_field(
                         "horizontal",
-                        sir_utils.make_field_dimensions_unstructured(
+                        serial_utils.make_field_dimensions_unstructured(
                             [AST.LocationType.Value("Edge")], 0
                         ),
                     ),
-                    sir_utils.make_field(
+                    serial_utils.make_field(
                         "horizontal_sparse",
-                        sir_utils.make_field_dimensions_unstructured(
+                        serial_utils.make_field_dimensions_unstructured(
                             [AST.LocationType.Value(
                                 "Edge"), AST.LocationType.Value("Cell")], 0
                         ),
                     ),
-                    sir_utils.make_vertical_field("vertical"),
+                    serial_utils.make_vertical_field("vertical"),
                 ],
             ),
         ],
@@ -114,7 +114,7 @@ def main(args: argparse.Namespace):
         print(MessageToJson(sir))
 
     with open("out.json", "w+") as f:
-        f.write(sir_utils.to_json(sir))
+        f.write(serial_utils.to_json(sir))
 
     # compile
     code = dawn4py.compile(sir, backend=dawn4py.CodeGenBackend.CUDAIco)

--- a/dawn/test/integration-test/dawn4py-tests/unstructured_stencil.py
+++ b/dawn/test/integration-test/dawn4py-tests/unstructured_stencil.py
@@ -26,7 +26,7 @@ import os
 
 import dawn4py
 from dawn4py.serialization import SIR, AST
-from dawn4py.serialization import utils as sir_utils
+from dawn4py.serialization import utils as serial_utils
 from google.protobuf.json_format import MessageToJson, Parse
 
 OUTPUT_NAME = "unstructured_stencil"
@@ -35,19 +35,19 @@ OUTPUT_PATH = f"{OUTPUT_NAME}.cpp"
 
 
 def main(args: argparse.Namespace):
-    interval = sir_utils.make_interval(
+    interval = serial_utils.make_interval(
         AST.Interval.Start, AST.Interval.End, 0, 0)
 
     # create the out = in[i+1] statement
-    body_ast = sir_utils.make_ast(
+    body_ast = serial_utils.make_ast(
         [
-            sir_utils.make_assignment_stmt(
-                sir_utils.make_unstructured_field_access_expr("out"),
-                sir_utils.make_reduction_over_neighbor_expr(
+            serial_utils.make_assignment_stmt(
+                serial_utils.make_unstructured_field_access_expr("out"),
+                serial_utils.make_reduction_over_neighbor_expr(
                     "+",
-                    sir_utils.make_unstructured_field_access_expr(
-                        "in", horizontal_offset=sir_utils.make_unstructured_offset(False)),
-                    sir_utils.make_literal_access_expr(
+                    serial_utils.make_unstructured_field_access_expr(
+                        "in", horizontal_offset=serial_utils.make_unstructured_offset(False)),
+                    serial_utils.make_literal_access_expr(
                         "1.0", AST.BuiltinType.Float),
                     chain=[AST.LocationType.Value(
                         "Cell"), AST.LocationType.Value("Edge"), AST.LocationType.Value("Cell")],
@@ -57,27 +57,27 @@ def main(args: argparse.Namespace):
         ]
     )
 
-    vertical_region_stmt = sir_utils.make_vertical_region_decl_stmt(
+    vertical_region_stmt = serial_utils.make_vertical_region_decl_stmt(
         body_ast, interval, AST.VerticalRegion.Forward
     )
 
-    sir = sir_utils.make_sir(
+    sir = serial_utils.make_sir(
         OUTPUT_FILE,
         AST.GridType.Value("Unstructured"),
         [
-            sir_utils.make_stencil(
+            serial_utils.make_stencil(
                 OUTPUT_NAME,
-                sir_utils.make_ast([vertical_region_stmt]),
+                serial_utils.make_ast([vertical_region_stmt]),
                 [
-                    sir_utils.make_field(
+                    serial_utils.make_field(
                         "in",
-                        sir_utils.make_field_dimensions_unstructured(
+                        serial_utils.make_field_dimensions_unstructured(
                             [AST.LocationType.Value("Cell")], 1
                         ),
                     ),
-                    sir_utils.make_field(
+                    serial_utils.make_field(
                         "out",
-                        sir_utils.make_field_dimensions_unstructured(
+                        serial_utils.make_field_dimensions_unstructured(
                             [AST.LocationType.Value("Cell")], 1
                         ),
                     ),

--- a/dawn/test/integration-test/dawn4py-tests/unstructured_stencil.py
+++ b/dawn/test/integration-test/dawn4py-tests/unstructured_stencil.py
@@ -25,7 +25,7 @@ import argparse
 import os
 
 import dawn4py
-from dawn4py.serialization import SIR
+from dawn4py.serialization import SIR, AST
 from dawn4py.serialization import utils as sir_utils
 from google.protobuf.json_format import MessageToJson, Parse
 
@@ -36,7 +36,7 @@ OUTPUT_PATH = f"{OUTPUT_NAME}.cpp"
 
 def main(args: argparse.Namespace):
     interval = sir_utils.make_interval(
-        SIR.Interval.Start, SIR.Interval.End, 0, 0)
+        AST.Interval.Start, AST.Interval.End, 0, 0)
 
     # create the out = in[i+1] statement
     body_ast = sir_utils.make_ast(
@@ -48,9 +48,9 @@ def main(args: argparse.Namespace):
                     sir_utils.make_unstructured_field_access_expr(
                         "in", horizontal_offset=sir_utils.make_unstructured_offset(False)),
                     sir_utils.make_literal_access_expr(
-                        "1.0", SIR.BuiltinType.Float),                    
-                    chain=[SIR.LocationType.Value(
-                        "Cell"), SIR.LocationType.Value("Edge"), SIR.LocationType.Value("Cell")],
+                        "1.0", AST.BuiltinType.Float),
+                    chain=[AST.LocationType.Value(
+                        "Cell"), AST.LocationType.Value("Edge"), AST.LocationType.Value("Cell")],
                 ),
                 "=",
             )
@@ -58,12 +58,12 @@ def main(args: argparse.Namespace):
     )
 
     vertical_region_stmt = sir_utils.make_vertical_region_decl_stmt(
-        body_ast, interval, SIR.VerticalRegion.Forward
+        body_ast, interval, AST.VerticalRegion.Forward
     )
 
     sir = sir_utils.make_sir(
         OUTPUT_FILE,
-        SIR.GridType.Value("Unstructured"),
+        AST.GridType.Value("Unstructured"),
         [
             sir_utils.make_stencil(
                 OUTPUT_NAME,
@@ -72,13 +72,13 @@ def main(args: argparse.Namespace):
                     sir_utils.make_field(
                         "in",
                         sir_utils.make_field_dimensions_unstructured(
-                            [SIR.LocationType.Value("Cell")], 1
+                            [AST.LocationType.Value("Cell")], 1
                         ),
                     ),
                     sir_utils.make_field(
                         "out",
                         sir_utils.make_field_dimensions_unstructured(
-                            [SIR.LocationType.Value("Cell")], 1
+                            [AST.LocationType.Value("Cell")], 1
                         ),
                     ),
                 ],

--- a/dawn/test/integration-test/dawn4py-tests/vertical_indirection.py
+++ b/dawn/test/integration-test/dawn4py-tests/vertical_indirection.py
@@ -25,7 +25,7 @@ import argparse
 import os
 
 import dawn4py
-from dawn4py.serialization import SIR
+from dawn4py.serialization import SIR, AST
 from dawn4py.serialization import utils as sir_utils
 from dawn4py.serialization import to_json as sir_to_json
 from google.protobuf.json_format import MessageToJson, Parse
@@ -37,7 +37,7 @@ OUTPUT_PATH = f"{OUTPUT_NAME}.cpp"
 
 def main(args: argparse.Namespace):
     interval = sir_utils.make_interval(
-        SIR.Interval.Start, SIR.Interval.End, 0, 0)
+        AST.Interval.Start, AST.Interval.End, 0, 0)
 
     # out[c,k] = in[c,vert_nbh[k]]
     body_ast_1 = sir_utils.make_ast(
@@ -134,32 +134,32 @@ def main(args: argparse.Namespace):
     )
 
     vertical_region_stmt_1 = sir_utils.make_vertical_region_decl_stmt(
-        body_ast_1, interval, SIR.VerticalRegion.Forward
+        body_ast_1, interval, AST.VerticalRegion.Forward
     )
 
     vertical_region_stmt_2 = sir_utils.make_vertical_region_decl_stmt(
-        body_ast_2, interval, SIR.VerticalRegion.Forward
+        body_ast_2, interval, AST.VerticalRegion.Forward
     )
 
     vertical_region_stmt_3 = sir_utils.make_vertical_region_decl_stmt(
-        body_ast_3, interval, SIR.VerticalRegion.Forward
+        body_ast_3, interval, AST.VerticalRegion.Forward
     )
 
     vertical_region_stmt_4 = sir_utils.make_vertical_region_decl_stmt(
-        body_ast_4, interval, SIR.VerticalRegion.Forward
+        body_ast_4, interval, AST.VerticalRegion.Forward
     )
 
     vertical_region_stmt_5 = sir_utils.make_vertical_region_decl_stmt(
-        body_ast_5, interval, SIR.VerticalRegion.Forward
+        body_ast_5, interval, AST.VerticalRegion.Forward
     )
 
     vertical_region_stmt_6 = sir_utils.make_vertical_region_decl_stmt(
-        body_ast_6, interval, SIR.VerticalRegion.Forward
+        body_ast_6, interval, AST.VerticalRegion.Forward
     )
 
     sir = sir_utils.make_sir(
         OUTPUT_FILE,
-        SIR.GridType.Value("Unstructured"),
+        AST.GridType.Value("Unstructured"),
         [
             sir_utils.make_stencil(
                 OUTPUT_NAME,
@@ -174,25 +174,25 @@ def main(args: argparse.Namespace):
                     sir_utils.make_field(
                         "in",
                         sir_utils.make_field_dimensions_unstructured(
-                            [SIR.LocationType.Value("Cell")], 1
+                            [AST.LocationType.Value("Cell")], 1
                         ),
                     ),
                     sir_utils.make_field(
                         "in_out",
                         sir_utils.make_field_dimensions_unstructured(
-                            [SIR.LocationType.Value("Cell")], 1
+                            [AST.LocationType.Value("Cell")], 1
                         ),
                     ),
                     sir_utils.make_field(
                         "out",
                         sir_utils.make_field_dimensions_unstructured(
-                            [SIR.LocationType.Value("Cell")], 1
+                            [AST.LocationType.Value("Cell")], 1
                         ),
                     ),
                     sir_utils.make_field(
                         "vert_nbh",
                         sir_utils.make_field_dimensions_unstructured(
-                            [SIR.LocationType.Value("Cell")], 1
+                            [AST.LocationType.Value("Cell")], 1
                         ),
                     ),
                 ],

--- a/dawn/test/integration-test/dawn4py-tests/vertical_indirection.py
+++ b/dawn/test/integration-test/dawn4py-tests/vertical_indirection.py
@@ -26,7 +26,7 @@ import os
 
 import dawn4py
 from dawn4py.serialization import SIR, AST
-from dawn4py.serialization import utils as sir_utils
+from dawn4py.serialization import utils as serial_utils
 from dawn4py.serialization import to_json as sir_to_json
 from google.protobuf.json_format import MessageToJson, Parse
 
@@ -36,15 +36,15 @@ OUTPUT_PATH = f"{OUTPUT_NAME}.cpp"
 
 
 def main(args: argparse.Namespace):
-    interval = sir_utils.make_interval(
+    interval = serial_utils.make_interval(
         AST.Interval.Start, AST.Interval.End, 0, 0)
 
     # out[c,k] = in[c,vert_nbh[k]]
-    body_ast_1 = sir_utils.make_ast(
+    body_ast_1 = serial_utils.make_ast(
         [
-            sir_utils.make_assignment_stmt(
-                sir_utils.make_field_access_expr("out"),
-                sir_utils.make_unstructured_field_access_expr(
+            serial_utils.make_assignment_stmt(
+                serial_utils.make_field_access_expr("out"),
+                serial_utils.make_unstructured_field_access_expr(
                     "in", vertical_shift=0, vertical_indirection="vert_nbh"),
 
                 "=")
@@ -53,11 +53,11 @@ def main(args: argparse.Namespace):
     )
 
     # out[c,k] = in[c,vert_nbh[k]+1]
-    body_ast_2 = sir_utils.make_ast(
+    body_ast_2 = serial_utils.make_ast(
         [
-            sir_utils.make_assignment_stmt(
-                sir_utils.make_field_access_expr("out"),
-                sir_utils.make_unstructured_field_access_expr(
+            serial_utils.make_assignment_stmt(
+                serial_utils.make_field_access_expr("out"),
+                serial_utils.make_unstructured_field_access_expr(
                     "in", vertical_shift=1, vertical_indirection="vert_nbh"),
 
                 "=")
@@ -66,11 +66,11 @@ def main(args: argparse.Namespace):
     )
 
     # in_out[c,k] = in_out[c,vert_nbh[k]+1]
-    body_ast_3 = sir_utils.make_ast(
+    body_ast_3 = serial_utils.make_ast(
         [
-            sir_utils.make_assignment_stmt(
-                sir_utils.make_field_access_expr("in_out"),
-                sir_utils.make_unstructured_field_access_expr(
+            serial_utils.make_assignment_stmt(
+                serial_utils.make_field_access_expr("in_out"),
+                serial_utils.make_unstructured_field_access_expr(
                     "in_out", vertical_shift=1, vertical_indirection="vert_nbh"),
 
                 "=")
@@ -80,17 +80,17 @@ def main(args: argparse.Namespace):
 
     # vert_nbh[c,k] = vert_nbh[c,k+1]
     # out[c,k] = in[c,vert_nbh[k]]
-    body_ast_4 = sir_utils.make_ast(
+    body_ast_4 = serial_utils.make_ast(
         [
-            sir_utils.make_assignment_stmt(
-                sir_utils.make_field_access_expr("vert_nbh"),
-                sir_utils.make_unstructured_field_access_expr(
+            serial_utils.make_assignment_stmt(
+                serial_utils.make_field_access_expr("vert_nbh"),
+                serial_utils.make_unstructured_field_access_expr(
                     "vert_nbh", vertical_shift=1),
 
                 "="),
-            sir_utils.make_assignment_stmt(
-                sir_utils.make_field_access_expr("out"),
-                sir_utils.make_unstructured_field_access_expr(
+            serial_utils.make_assignment_stmt(
+                serial_utils.make_field_access_expr("out"),
+                serial_utils.make_unstructured_field_access_expr(
                     "in", vertical_shift=0, vertical_indirection="vert_nbh"),
 
                 "=")
@@ -100,17 +100,17 @@ def main(args: argparse.Namespace):
 
     # vert_nbh[c,k] = vert_nbh[c,k+1]
     # in_out[c,k] = in_out[c,vert_nbh[k]+1]
-    body_ast_5 = sir_utils.make_ast(
+    body_ast_5 = serial_utils.make_ast(
         [
-            sir_utils.make_assignment_stmt(
-                sir_utils.make_field_access_expr("vert_nbh"),
-                sir_utils.make_unstructured_field_access_expr(
+            serial_utils.make_assignment_stmt(
+                serial_utils.make_field_access_expr("vert_nbh"),
+                serial_utils.make_unstructured_field_access_expr(
                     "vert_nbh", vertical_shift=1),
 
                 "="),
-            sir_utils.make_assignment_stmt(
-                sir_utils.make_field_access_expr("in_out"),
-                sir_utils.make_unstructured_field_access_expr(
+            serial_utils.make_assignment_stmt(
+                serial_utils.make_field_access_expr("in_out"),
+                serial_utils.make_unstructured_field_access_expr(
                     "in_out", vertical_shift=1, vertical_indirection="vert_nbh"),
 
                 "=")
@@ -121,11 +121,11 @@ def main(args: argparse.Namespace):
     # in_out[c,k] = in_out[c,vert_nbh[k]-1]
     # technically a solver, but vert_nbh makes it a stencil
     #       => access expected to be treated like a stencil
-    body_ast_6 = sir_utils.make_ast(
+    body_ast_6 = serial_utils.make_ast(
         [
-            sir_utils.make_assignment_stmt(
-                sir_utils.make_field_access_expr("in"),
-                sir_utils.make_unstructured_field_access_expr(
+            serial_utils.make_assignment_stmt(
+                serial_utils.make_field_access_expr("in"),
+                serial_utils.make_unstructured_field_access_expr(
                     "in", vertical_shift=-1, vertical_indirection="vert_nbh"),
 
                 "="),
@@ -133,37 +133,37 @@ def main(args: argparse.Namespace):
         ]
     )
 
-    vertical_region_stmt_1 = sir_utils.make_vertical_region_decl_stmt(
+    vertical_region_stmt_1 = serial_utils.make_vertical_region_decl_stmt(
         body_ast_1, interval, AST.VerticalRegion.Forward
     )
 
-    vertical_region_stmt_2 = sir_utils.make_vertical_region_decl_stmt(
+    vertical_region_stmt_2 = serial_utils.make_vertical_region_decl_stmt(
         body_ast_2, interval, AST.VerticalRegion.Forward
     )
 
-    vertical_region_stmt_3 = sir_utils.make_vertical_region_decl_stmt(
+    vertical_region_stmt_3 = serial_utils.make_vertical_region_decl_stmt(
         body_ast_3, interval, AST.VerticalRegion.Forward
     )
 
-    vertical_region_stmt_4 = sir_utils.make_vertical_region_decl_stmt(
+    vertical_region_stmt_4 = serial_utils.make_vertical_region_decl_stmt(
         body_ast_4, interval, AST.VerticalRegion.Forward
     )
 
-    vertical_region_stmt_5 = sir_utils.make_vertical_region_decl_stmt(
+    vertical_region_stmt_5 = serial_utils.make_vertical_region_decl_stmt(
         body_ast_5, interval, AST.VerticalRegion.Forward
     )
 
-    vertical_region_stmt_6 = sir_utils.make_vertical_region_decl_stmt(
+    vertical_region_stmt_6 = serial_utils.make_vertical_region_decl_stmt(
         body_ast_6, interval, AST.VerticalRegion.Forward
     )
 
-    sir = sir_utils.make_sir(
+    sir = serial_utils.make_sir(
         OUTPUT_FILE,
         AST.GridType.Value("Unstructured"),
         [
-            sir_utils.make_stencil(
+            serial_utils.make_stencil(
                 OUTPUT_NAME,
-                sir_utils.make_ast(
+                serial_utils.make_ast(
                     [vertical_region_stmt_1,
                      vertical_region_stmt_2,
                      vertical_region_stmt_3,
@@ -171,27 +171,27 @@ def main(args: argparse.Namespace):
                      vertical_region_stmt_5,
                      vertical_region_stmt_6]),
                 [
-                    sir_utils.make_field(
+                    serial_utils.make_field(
                         "in",
-                        sir_utils.make_field_dimensions_unstructured(
+                        serial_utils.make_field_dimensions_unstructured(
                             [AST.LocationType.Value("Cell")], 1
                         ),
                     ),
-                    sir_utils.make_field(
+                    serial_utils.make_field(
                         "in_out",
-                        sir_utils.make_field_dimensions_unstructured(
+                        serial_utils.make_field_dimensions_unstructured(
                             [AST.LocationType.Value("Cell")], 1
                         ),
                     ),
-                    sir_utils.make_field(
+                    serial_utils.make_field(
                         "out",
-                        sir_utils.make_field_dimensions_unstructured(
+                        serial_utils.make_field_dimensions_unstructured(
                             [AST.LocationType.Value("Cell")], 1
                         ),
                     ),
-                    sir_utils.make_field(
+                    serial_utils.make_field(
                         "vert_nbh",
-                        sir_utils.make_field_dimensions_unstructured(
+                        serial_utils.make_field_dimensions_unstructured(
                             [AST.LocationType.Value("Cell")], 1
                         ),
                     ),

--- a/dawn/test/integration-test/serializer/GenerateInMemoryStencils.cpp
+++ b/dawn/test/integration-test/serializer/GenerateInMemoryStencils.cpp
@@ -59,8 +59,8 @@ std::shared_ptr<iir::StencilInstantiation> createCopyStencilIIRInMemory(ast::Gri
   IIRDoMethod->setID(target->nextUID());
 
   // create the statement
-  auto makeFieldDimensions = []() -> sir::FieldDimensions {
-    return sir::FieldDimensions(sir::HorizontalFieldDimension(ast::cartesian, {true, true}), true);
+  auto makeFieldDimensions = []() -> ast::FieldDimensions {
+    return ast::FieldDimensions(ast::HorizontalFieldDimension(ast::cartesian, {true, true}), true);
   };
 
   auto sirInField = std::make_shared<sir::Field>("in_field", makeFieldDimensions());
@@ -167,8 +167,8 @@ std::shared_ptr<iir::StencilInstantiation> createLapStencilIIRInMemory(ast::Grid
   IIRMSS->insertChild(std::move(IIRStage2));
 
   // create the statement
-  auto makeFieldDimensions = []() -> sir::FieldDimensions {
-    return sir::FieldDimensions(sir::HorizontalFieldDimension(ast::cartesian, {true, true}), true);
+  auto makeFieldDimensions = []() -> ast::FieldDimensions {
+    return ast::FieldDimensions(ast::HorizontalFieldDimension(ast::cartesian, {true, true}), true);
   };
 
   auto sirInField = std::make_shared<sir::Field>("in", makeFieldDimensions());

--- a/dawn/test/integration-test/unstructured/testMutator.cpp
+++ b/dawn/test/integration-test/unstructured/testMutator.cpp
@@ -32,7 +32,7 @@ void injectRedirectedReads(std::shared_ptr<dawn::iir::StencilInstantiation> sten
       if(field.second.field.getReadExtents().has_value()) {
         int accessID = stencilInstantiation->getMetaData().addField(
             dawn::iir::FieldAccessType::APIField, field.second.Name + "_indirection",
-            dawn::sir::FieldDimensions(field.second.field.getFieldDimensions()), std::nullopt);
+            dawn::ast::FieldDimensions(field.second.field.getFieldDimensions()), std::nullopt);
         mutatedFields.insert({field.second.Name, accessID});
       }
     }

--- a/dawn/test/unit-test/dawn/IIR/TestField.cpp
+++ b/dawn/test/unit-test/dawn/IIR/TestField.cpp
@@ -22,8 +22,8 @@ using namespace iir;
 
 namespace {
 
-auto fieldDimensions = []() -> sir::FieldDimensions {
-  return sir::FieldDimensions(sir::HorizontalFieldDimension(ast::cartesian, {true, true}), true);
+auto fieldDimensions = []() -> ast::FieldDimensions {
+  return ast::FieldDimensions(ast::HorizontalFieldDimension(ast::cartesian, {true, true}), true);
 };
 
 TEST(TestField, Construction) {
@@ -80,19 +80,19 @@ TEST(TestField, Equal) {
 
 TEST(TestField, CartesianDimensions) {
   auto c001 =
-      sir::FieldDimensions(sir::HorizontalFieldDimension(ast::cartesian, {false, false}), true);
+      ast::FieldDimensions(ast::HorizontalFieldDimension(ast::cartesian, {false, false}), true);
   auto c010 =
-      sir::FieldDimensions(sir::HorizontalFieldDimension(ast::cartesian, {false, true}), false);
+      ast::FieldDimensions(ast::HorizontalFieldDimension(ast::cartesian, {false, true}), false);
   auto c100 =
-      sir::FieldDimensions(sir::HorizontalFieldDimension(ast::cartesian, {true, false}), false);
+      ast::FieldDimensions(ast::HorizontalFieldDimension(ast::cartesian, {true, false}), false);
   auto c110 =
-      sir::FieldDimensions(sir::HorizontalFieldDimension(ast::cartesian, {true, true}), false);
+      ast::FieldDimensions(ast::HorizontalFieldDimension(ast::cartesian, {true, true}), false);
   auto c101 =
-      sir::FieldDimensions(sir::HorizontalFieldDimension(ast::cartesian, {true, false}), true);
+      ast::FieldDimensions(ast::HorizontalFieldDimension(ast::cartesian, {true, false}), true);
   auto c011 =
-      sir::FieldDimensions(sir::HorizontalFieldDimension(ast::cartesian, {false, true}), true);
+      ast::FieldDimensions(ast::HorizontalFieldDimension(ast::cartesian, {false, true}), true);
   auto c111 =
-      sir::FieldDimensions(sir::HorizontalFieldDimension(ast::cartesian, {true, true}), true);
+      ast::FieldDimensions(ast::HorizontalFieldDimension(ast::cartesian, {true, true}), true);
   EXPECT_EQ(c001.numSpatialDimensions(), 1);
   EXPECT_EQ(c010.numSpatialDimensions(), 1);
   EXPECT_EQ(c100.numSpatialDimensions(), 1);
@@ -103,11 +103,11 @@ TEST(TestField, CartesianDimensions) {
 }
 
 TEST(TestField, UnstructuredDimension) {
-  auto f1d = sir::FieldDimensions(true);
-  auto f2d = sir::FieldDimensions(
-      sir::HorizontalFieldDimension(ast::unstructured, ast::LocationType::Cells), false);
-  auto f3d = sir::FieldDimensions(
-      sir::HorizontalFieldDimension(ast::unstructured, ast::LocationType::Cells), true);
+  auto f1d = ast::FieldDimensions(true);
+  auto f2d = ast::FieldDimensions(
+      ast::HorizontalFieldDimension(ast::unstructured, ast::LocationType::Cells), false);
+  auto f3d = ast::FieldDimensions(
+      ast::HorizontalFieldDimension(ast::unstructured, ast::LocationType::Cells), true);
   EXPECT_EQ(f1d.numSpatialDimensions(), 1);
   EXPECT_EQ(f2d.numSpatialDimensions(), 2);
   EXPECT_EQ(f3d.numSpatialDimensions(), 3);

--- a/dawn/test/unit-test/dawn/IIR/TestIIRSerializer.cpp
+++ b/dawn/test/unit-test/dawn/IIR/TestIIRSerializer.cpp
@@ -464,8 +464,8 @@ TEST_F(IIRSerializerTest, IIRTests) {
 
     referenceInstantiation->getMetaData().addField(
         iir::FieldAccessType::Field, fieldname,
-        sir::FieldDimensions(
-            sir::HorizontalFieldDimension(ast::cartesian, std::array<bool, 2>{true, true}), true),
+        ast::FieldDimensions(
+            ast::HorizontalFieldDimension(ast::cartesian, std::array<bool, 2>{true, true}), true),
         id);
   }
 

--- a/dawn/test/unit-test/dawn/Optimizer/samples/SetLocationType.py
+++ b/dawn/test/unit-test/dawn/Optimizer/samples/SetLocationType.py
@@ -19,80 +19,80 @@ import os
 
 import dawn4py
 from dawn4py.serialization import SIR
-from dawn4py.serialization import utils as sir_utils
+from dawn4py.serialization import utils as serial_utils
 from google.protobuf.json_format import MessageToJson, Parse
 
 
 def copy_fields():
     outputfile = "../input/test_set_stage_location_type_copy_fields.sir"
-    interval = sir_utils.make_interval(
+    interval = serial_utils.make_interval(
         SIR.Interval.Start, SIR.Interval.End, 0, 0)
 
-    body_ast = sir_utils.make_ast(
+    body_ast = serial_utils.make_ast(
         [
-            sir_utils.make_assignment_stmt(
-                sir_utils.make_field_access_expr("out_cell"),
-                sir_utils.make_field_access_expr("in_cell"),
+            serial_utils.make_assignment_stmt(
+                serial_utils.make_field_access_expr("out_cell"),
+                serial_utils.make_field_access_expr("in_cell"),
                 "=",
             ),
-            sir_utils.make_assignment_stmt(
-                sir_utils.make_field_access_expr("out_edge"),
-                sir_utils.make_field_access_expr("in_edge"),
+            serial_utils.make_assignment_stmt(
+                serial_utils.make_field_access_expr("out_edge"),
+                serial_utils.make_field_access_expr("in_edge"),
                 "=",
             ),
-            sir_utils.make_assignment_stmt(
-                sir_utils.make_field_access_expr("out_vertex"),
-                sir_utils.make_field_access_expr("in_vertex"),
+            serial_utils.make_assignment_stmt(
+                serial_utils.make_field_access_expr("out_vertex"),
+                serial_utils.make_field_access_expr("in_vertex"),
                 "=",
             )
         ]
     )
 
-    vertical_region_stmt = sir_utils.make_vertical_region_decl_stmt(
+    vertical_region_stmt = serial_utils.make_vertical_region_decl_stmt(
         body_ast, interval, SIR.VerticalRegion.Forward
     )
 
-    sir = sir_utils.make_sir(
+    sir = serial_utils.make_sir(
         outputfile,
         SIR.GridType.Value("Unstructured"),
         [
-            sir_utils.make_stencil(
+            serial_utils.make_stencil(
                 "generated",
-                sir_utils.make_ast([vertical_region_stmt]),
+                serial_utils.make_ast([vertical_region_stmt]),
                 [
-                    sir_utils.make_field(
+                    serial_utils.make_field(
                         "in_cell",
-                        sir_utils.make_field_dimensions_unstructured(
+                        serial_utils.make_field_dimensions_unstructured(
                             [SIR.LocationType.Value("Cell")], 1
                         ),
                     ),
-                    sir_utils.make_field(
+                    serial_utils.make_field(
                         "out_cell",
-                        sir_utils.make_field_dimensions_unstructured(
+                        serial_utils.make_field_dimensions_unstructured(
                             [SIR.LocationType.Value("Cell")], 1
                         ),
                     ),
-                    sir_utils.make_field(
+                    serial_utils.make_field(
                         "in_edge",
-                        sir_utils.make_field_dimensions_unstructured(
+                        serial_utils.make_field_dimensions_unstructured(
                             [SIR.LocationType.Value("Edge")], 1
                         ),
                     ),
-                    sir_utils.make_field(
+                    serial_utils.make_field(
                         "out_edge",
-                        sir_utils.make_field_dimensions_unstructured(
+                        serial_utils.make_field_dimensions_unstructured(
                             [SIR.LocationType.Value("Edge")], 1
                         ),
                     ),
-                    sir_utils.make_field(
+                    serial_utils.make_field(
                         "in_vertex",
-                        sir_utils.make_field_dimensions_unstructured(
+                        serial_utils.make_field_dimensions_unstructured(
                             [SIR.LocationType.Value("Vertex")], 1
                         ),
                     ),
-                    sir_utils.make_field(
+                    serial_utils.make_field(
                         "out_vertex",
-                        sir_utils.make_field_dimensions_unstructured(
+                        serial_utils.make_field_dimensions_unstructured(
                             [SIR.LocationType.Value("Vertex")], 1
                         ),
                     ),
@@ -108,65 +108,65 @@ def copy_fields():
 def copy_vars():
     outputfile = "../input/test_set_stage_location_type_copy_vars.sir"
 
-    interval = sir_utils.make_interval(
+    interval = serial_utils.make_interval(
         SIR.Interval.Start, SIR.Interval.End, 0, 0)
 
-    body_ast = sir_utils.make_ast(
+    body_ast = serial_utils.make_ast(
         [
-            sir_utils.make_var_decl_stmt(
-                sir_utils.make_type(sir_utils.BuiltinType.Float),
+            serial_utils.make_var_decl_stmt(
+                serial_utils.make_type(serial_utils.BuiltinType.Float),
                 "out_var_cell"),
-            sir_utils.make_var_decl_stmt(
-                sir_utils.make_type(sir_utils.BuiltinType.Float),
+            serial_utils.make_var_decl_stmt(
+                serial_utils.make_type(serial_utils.BuiltinType.Float),
                 "out_var_edge"),
-            sir_utils.make_var_decl_stmt(
-                sir_utils.make_type(sir_utils.BuiltinType.Float),
+            serial_utils.make_var_decl_stmt(
+                serial_utils.make_type(serial_utils.BuiltinType.Float),
                 "out_var_vertex"),
-            sir_utils.make_assignment_stmt(
-                sir_utils.make_var_access_expr("out_var_cell"),
-                sir_utils.make_field_access_expr("in_cell"),
+            serial_utils.make_assignment_stmt(
+                serial_utils.make_var_access_expr("out_var_cell"),
+                serial_utils.make_field_access_expr("in_cell"),
                 "=",
             ),
-            sir_utils.make_assignment_stmt(
-                sir_utils.make_var_access_expr("out_var_edge"),
-                sir_utils.make_field_access_expr("in_edge"),
+            serial_utils.make_assignment_stmt(
+                serial_utils.make_var_access_expr("out_var_edge"),
+                serial_utils.make_field_access_expr("in_edge"),
                 "=",
             ),
-            sir_utils.make_assignment_stmt(
-                sir_utils.make_var_access_expr("out_var_vertex"),
-                sir_utils.make_field_access_expr("in_vertex"),
+            serial_utils.make_assignment_stmt(
+                serial_utils.make_var_access_expr("out_var_vertex"),
+                serial_utils.make_field_access_expr("in_vertex"),
                 "=",
             )
         ]
     )
 
-    vertical_region_stmt = sir_utils.make_vertical_region_decl_stmt(
+    vertical_region_stmt = serial_utils.make_vertical_region_decl_stmt(
         body_ast, interval, SIR.VerticalRegion.Forward
     )
 
-    sir = sir_utils.make_sir(
+    sir = serial_utils.make_sir(
         outputfile,
         SIR.GridType.Value("Unstructured"),
         [
-            sir_utils.make_stencil(
+            serial_utils.make_stencil(
                 "generated",
-                sir_utils.make_ast([vertical_region_stmt]),
+                serial_utils.make_ast([vertical_region_stmt]),
                 [
-                    sir_utils.make_field(
+                    serial_utils.make_field(
                         "in_cell",
-                        sir_utils.make_field_dimensions_unstructured(
+                        serial_utils.make_field_dimensions_unstructured(
                             [SIR.LocationType.Value("Cell")], 1
                         ),
                     ),
-                    sir_utils.make_field(
+                    serial_utils.make_field(
                         "in_edge",
-                        sir_utils.make_field_dimensions_unstructured(
+                        serial_utils.make_field_dimensions_unstructured(
                             [SIR.LocationType.Value("Edge")], 1
                         ),
                     ),
-                    sir_utils.make_field(
+                    serial_utils.make_field(
                         "in_vertex",
-                        sir_utils.make_field_dimensions_unstructured(
+                        serial_utils.make_field_dimensions_unstructured(
                             [SIR.LocationType.Value("Vertex")], 1
                         ),
                     ),
@@ -183,37 +183,37 @@ def copy_vars():
 def if_stmt():
     outputfile = "../input/test_set_stage_location_type_if_stmt.sir"
 
-    interval = sir_utils.make_interval(
+    interval = serial_utils.make_interval(
         SIR.Interval.Start, SIR.Interval.End, 0, 0)
 
-    body_ast = sir_utils.make_ast(
+    body_ast = serial_utils.make_ast(
         [
-            sir_utils.make_var_decl_stmt(
-                sir_utils.make_type(sir_utils.BuiltinType.Float),
+            serial_utils.make_var_decl_stmt(
+                serial_utils.make_type(serial_utils.BuiltinType.Float),
                 "out_var_cell"),
-            sir_utils.make_if_stmt(sir_utils.make_expr_stmt(sir_utils.make_var_access_expr("out_var_cell")), sir_utils.make_block_stmt(sir_utils.make_assignment_stmt(
-                sir_utils.make_var_access_expr("out_var_cell"),
-                sir_utils.make_field_access_expr("in_cell"),
+            serial_utils.make_if_stmt(serial_utils.make_expr_stmt(serial_utils.make_var_access_expr("out_var_cell")), serial_utils.make_block_stmt(serial_utils.make_assignment_stmt(
+                serial_utils.make_var_access_expr("out_var_cell"),
+                serial_utils.make_field_access_expr("in_cell"),
                 "=",
             ))),
         ]
     )
 
-    vertical_region_stmt = sir_utils.make_vertical_region_decl_stmt(
+    vertical_region_stmt = serial_utils.make_vertical_region_decl_stmt(
         body_ast, interval, SIR.VerticalRegion.Forward
     )
 
-    sir = sir_utils.make_sir(
+    sir = serial_utils.make_sir(
         outputfile,
         SIR.GridType.Value("Unstructured"),
         [
-            sir_utils.make_stencil(
+            serial_utils.make_stencil(
                 "generated",
-                sir_utils.make_ast([vertical_region_stmt]),
+                serial_utils.make_ast([vertical_region_stmt]),
                 [
-                    sir_utils.make_field(
+                    serial_utils.make_field(
                         "in_cell",
-                        sir_utils.make_field_dimensions_unstructured(
+                        serial_utils.make_field_dimensions_unstructured(
                             [SIR.LocationType.Value("Cell")], 1
                         ),
                     ),
@@ -230,52 +230,52 @@ def if_stmt():
 def function_call():
     outputfile = "../input/test_set_stage_location_type_function_call.sir"
 
-    interval = sir_utils.make_interval(
+    interval = serial_utils.make_interval(
         SIR.Interval.Start, SIR.Interval.End, 0, 0)
 
-    fun_ast = sir_utils.make_ast(
+    fun_ast = serial_utils.make_ast(
         [
-            sir_utils.make_assignment_stmt(
-                sir_utils.make_field_access_expr("out"),
-                sir_utils.make_literal_access_expr(
-                    value="2.0", type=sir_utils.BuiltinType.Float),
+            serial_utils.make_assignment_stmt(
+                serial_utils.make_field_access_expr("out"),
+                serial_utils.make_literal_access_expr(
+                    value="2.0", type=serial_utils.BuiltinType.Float),
                 "=",
             ),
         ]
     )
 
-    arg_field = sir_utils.make_field(
+    arg_field = serial_utils.make_field(
         "out",
-        sir_utils.make_field_dimensions_unstructured(
+        serial_utils.make_field_dimensions_unstructured(
             [SIR.LocationType.Value("Cell")], 1
         )
     )
 
-    fun = sir_utils.make_stencil_function(
-        name='f', asts=[fun_ast], intervals=[interval], arguments=[sir_utils.make_stencil_function_arg(arg_field)])
+    fun = serial_utils.make_stencil_function(
+        name='f', asts=[fun_ast], intervals=[interval], arguments=[serial_utils.make_stencil_function_arg(arg_field)])
 
-    body_ast = sir_utils.make_ast(
+    body_ast = serial_utils.make_ast(
         [
-            sir_utils.make_expr_stmt(expr=sir_utils.make_stencil_fun_call_expr(
-                callee="f", arguments=[sir_utils.make_field_access_expr("out_cell")])),
+            serial_utils.make_expr_stmt(expr=serial_utils.make_stencil_fun_call_expr(
+                callee="f", arguments=[serial_utils.make_field_access_expr("out_cell")])),
         ]
     )
 
-    vertical_region_stmt = sir_utils.make_vertical_region_decl_stmt(
+    vertical_region_stmt = serial_utils.make_vertical_region_decl_stmt(
         body_ast, interval, SIR.VerticalRegion.Forward
     )
 
-    sir = sir_utils.make_sir(
+    sir = serial_utils.make_sir(
         outputfile,
         SIR.GridType.Value("Unstructured"),
         [
-            sir_utils.make_stencil(
+            serial_utils.make_stencil(
                 "generated",
-                sir_utils.make_ast([vertical_region_stmt]),
+                serial_utils.make_ast([vertical_region_stmt]),
                 [
-                    sir_utils.make_field(
+                    serial_utils.make_field(
                         "out_cell",
-                        sir_utils.make_field_dimensions_unstructured(
+                        serial_utils.make_field_dimensions_unstructured(
                             [SIR.LocationType.Value("Cell")], 1
                         ),
                     ),

--- a/dawn/test/unit-test/dawn/Optimizer/samples/StageMergerUnstructured.py
+++ b/dawn/test/unit-test/dawn/Optimizer/samples/StageMergerUnstructured.py
@@ -19,7 +19,7 @@ import os
 
 import dawn4py
 from dawn4py.serialization import SIR
-from dawn4py.serialization import utils as sir_utils
+from dawn4py.serialization import utils as serial_utils
 from google.protobuf.json_format import MessageToJson, Parse
 
 backend = "c++-naive-ico"
@@ -27,56 +27,56 @@ backend = "c++-naive-ico"
 
 def two_copies():
     outputfile = "StageMergerTestTwoCopies"
-    interval = sir_utils.make_interval(SIR.Interval.Start, SIR.Interval.End, 0, 0)
+    interval = serial_utils.make_interval(SIR.Interval.Start, SIR.Interval.End, 0, 0)
 
-    body_ast = sir_utils.make_ast(
+    body_ast = serial_utils.make_ast(
         [
-            sir_utils.make_assignment_stmt(
-                sir_utils.make_unstructured_field_access_expr("out_cell_1"),
-                sir_utils.make_unstructured_field_access_expr("in_cell_1"),
+            serial_utils.make_assignment_stmt(
+                serial_utils.make_unstructured_field_access_expr("out_cell_1"),
+                serial_utils.make_unstructured_field_access_expr("in_cell_1"),
                 "=",
             ),
-            sir_utils.make_assignment_stmt(
-                sir_utils.make_unstructured_field_access_expr("out_cell_2"),
-                sir_utils.make_unstructured_field_access_expr("in_cell_2"),
+            serial_utils.make_assignment_stmt(
+                serial_utils.make_unstructured_field_access_expr("out_cell_2"),
+                serial_utils.make_unstructured_field_access_expr("in_cell_2"),
                 "=",
             ),
         ]
     )
 
-    vertical_region_stmt = sir_utils.make_vertical_region_decl_stmt(
+    vertical_region_stmt = serial_utils.make_vertical_region_decl_stmt(
         body_ast, interval, SIR.VerticalRegion.Forward
     )
 
-    sir = sir_utils.make_sir(
+    sir = serial_utils.make_sir(
         outputfile,
         SIR.GridType.Value("Unstructured"),
         [
-            sir_utils.make_stencil(
+            serial_utils.make_stencil(
                 "generated",
-                sir_utils.make_ast([vertical_region_stmt]),
+                serial_utils.make_ast([vertical_region_stmt]),
                 [
-                    sir_utils.make_field(
+                    serial_utils.make_field(
                         "in_cell_1",
-                        sir_utils.make_field_dimensions_unstructured(
+                        serial_utils.make_field_dimensions_unstructured(
                             [SIR.LocationType.Value("Cell")], 1
                         ),
                     ),
-                    sir_utils.make_field(
+                    serial_utils.make_field(
                         "out_cell_1",
-                        sir_utils.make_field_dimensions_unstructured(
+                        serial_utils.make_field_dimensions_unstructured(
                             [SIR.LocationType.Value("Cell")], 1
                         ),
                     ),
-                    sir_utils.make_field(
+                    serial_utils.make_field(
                         "in_cell_2",
-                        sir_utils.make_field_dimensions_unstructured(
+                        serial_utils.make_field_dimensions_unstructured(
                             [SIR.LocationType.Value("Cell")], 1
                         ),
                     ),
-                    sir_utils.make_field(
+                    serial_utils.make_field(
                         "out_cell_2",
-                        sir_utils.make_field_dimensions_unstructured(
+                        serial_utils.make_field_dimensions_unstructured(
                             [SIR.LocationType.Value("Cell")], 1
                         ),
                     ),
@@ -92,56 +92,56 @@ def two_copies():
 
 def two_copies_mixed():
     outputfile = "StageMergerTestTwoCopiesMixed"
-    interval = sir_utils.make_interval(SIR.Interval.Start, SIR.Interval.End, 0, 0)
+    interval = serial_utils.make_interval(SIR.Interval.Start, SIR.Interval.End, 0, 0)
 
-    body_ast = sir_utils.make_ast(
+    body_ast = serial_utils.make_ast(
         [
-            sir_utils.make_assignment_stmt(
-                sir_utils.make_unstructured_field_access_expr("out_cell"),
-                sir_utils.make_unstructured_field_access_expr("in_cell"),
+            serial_utils.make_assignment_stmt(
+                serial_utils.make_unstructured_field_access_expr("out_cell"),
+                serial_utils.make_unstructured_field_access_expr("in_cell"),
                 "=",
             ),
-            sir_utils.make_assignment_stmt(
-                sir_utils.make_unstructured_field_access_expr("out_edge"),
-                sir_utils.make_unstructured_field_access_expr("in_edge"),
+            serial_utils.make_assignment_stmt(
+                serial_utils.make_unstructured_field_access_expr("out_edge"),
+                serial_utils.make_unstructured_field_access_expr("in_edge"),
                 "=",
             ),
         ]
     )
 
-    vertical_region_stmt = sir_utils.make_vertical_region_decl_stmt(
+    vertical_region_stmt = serial_utils.make_vertical_region_decl_stmt(
         body_ast, interval, SIR.VerticalRegion.Forward
     )
 
-    sir = sir_utils.make_sir(
+    sir = serial_utils.make_sir(
         outputfile,
         SIR.GridType.Value("Unstructured"),
         [
-            sir_utils.make_stencil(
+            serial_utils.make_stencil(
                 "generated",
-                sir_utils.make_ast([vertical_region_stmt]),
+                serial_utils.make_ast([vertical_region_stmt]),
                 [
-                    sir_utils.make_field(
+                    serial_utils.make_field(
                         "in_cell",
-                        sir_utils.make_field_dimensions_unstructured(
+                        serial_utils.make_field_dimensions_unstructured(
                             [SIR.LocationType.Value("Cell")], 1
                         ),
                     ),
-                    sir_utils.make_field(
+                    serial_utils.make_field(
                         "out_cell",
-                        sir_utils.make_field_dimensions_unstructured(
+                        serial_utils.make_field_dimensions_unstructured(
                             [SIR.LocationType.Value("Cell")], 1
                         ),
                     ),
-                    sir_utils.make_field(
+                    serial_utils.make_field(
                         "in_edge",
-                        sir_utils.make_field_dimensions_unstructured(
+                        serial_utils.make_field_dimensions_unstructured(
                             [SIR.LocationType.Value("Edge")], 1
                         ),
                     ),
-                    sir_utils.make_field(
+                    serial_utils.make_field(
                         "out_edge",
-                        sir_utils.make_field_dimensions_unstructured(
+                        serial_utils.make_field_dimensions_unstructured(
                             [SIR.LocationType.Value("Edge")], 1
                         ),
                     ),

--- a/dawn/test/unit-test/dawn/Optimizer/samples/StageSplitAllStatements.py
+++ b/dawn/test/unit-test/dawn/Optimizer/samples/StageSplitAllStatements.py
@@ -19,25 +19,25 @@ import os
 
 import dawn4py
 from dawn4py.serialization import SIR
-from dawn4py.serialization import utils as sir_utils
+from dawn4py.serialization import utils as serial_utils
 from google.protobuf.json_format import MessageToJson, Parse
 
 
 def make_stencil(outputfile, body_ast):
-    interval = sir_utils.make_interval(
+    interval = serial_utils.make_interval(
         SIR.Interval.Start, SIR.Interval.End, 0, 0)
 
-    vertical_region_stmt = sir_utils.make_vertical_region_decl_stmt(
+    vertical_region_stmt = serial_utils.make_vertical_region_decl_stmt(
         body_ast, interval, SIR.VerticalRegion.Forward
     )
 
-    sir = sir_utils.make_sir(
+    sir = serial_utils.make_sir(
         outputfile,
         SIR.GridType.Value("Unstructured"),
         [
-            sir_utils.make_stencil(
+            serial_utils.make_stencil(
                 "generated",
-                sir_utils.make_ast([vertical_region_stmt]),
+                serial_utils.make_ast([vertical_region_stmt]),
                 [
                 ],
             ),
@@ -52,23 +52,23 @@ if __name__ == "__main__":
     # for the "no stmt" test, use the "one stmt" output and delete the statement
     # (from SIR it is not possible to generate a stage without statements)
 
-    one_stmt = sir_utils.make_ast(
+    one_stmt = serial_utils.make_ast(
         [
-            sir_utils.make_var_decl_stmt(
-                sir_utils.make_type(SIR.BuiltinType.Integer),
+            serial_utils.make_var_decl_stmt(
+                serial_utils.make_type(SIR.BuiltinType.Integer),
                 "a")
         ]
     )
     make_stencil(
         "../input/test_stage_split_all_statements_one_stmt.sir", one_stmt)
 
-    two_stmts = sir_utils.make_ast(
+    two_stmts = serial_utils.make_ast(
         [
-            sir_utils.make_var_decl_stmt(
-                sir_utils.make_type(SIR.BuiltinType.Integer),
+            serial_utils.make_var_decl_stmt(
+                serial_utils.make_type(SIR.BuiltinType.Integer),
                 "a"),
-            sir_utils.make_var_decl_stmt(
-                sir_utils.make_type(SIR.BuiltinType.Integer),
+            serial_utils.make_var_decl_stmt(
+                serial_utils.make_type(SIR.BuiltinType.Integer),
                 "b")
         ]
     )

--- a/dawn/test/unit-test/dawn/Optimizer/samples/TemporaryTypeDontDemoteSparse.py
+++ b/dawn/test/unit-test/dawn/Optimizer/samples/TemporaryTypeDontDemoteSparse.py
@@ -19,64 +19,64 @@ import os
 
 import dawn4py
 from dawn4py.serialization import SIR
-from dawn4py.serialization import utils as sir_utils
+from dawn4py.serialization import utils as serial_utils
 from google.protobuf.json_format import MessageToJson, Parse
 
 backend = "c++-naive-ico"
 
 def sparse_temporary():
     outputfile = "DontDemoteSparse"
-    interval = sir_utils.make_interval(SIR.Interval.Start, SIR.Interval.End, 0, 0)
+    interval = serial_utils.make_interval(SIR.Interval.Start, SIR.Interval.End, 0, 0)
 
-    body_ast = sir_utils.make_ast(
+    body_ast = serial_utils.make_ast(
         [
-            sir_utils.make_loop_stmt(
-                sir_utils.make_assignment_stmt(    
-                sir_utils.make_field_access_expr("sparseF"),                
-                sir_utils.make_literal_access_expr("1.", SIR.BuiltinType.Double),
+            serial_utils.make_loop_stmt(
+                serial_utils.make_assignment_stmt(    
+                serial_utils.make_field_access_expr("sparseF"),                
+                serial_utils.make_literal_access_expr("1.", SIR.BuiltinType.Double),
                 "="),
                 [SIR.LocationType.Value("Edge"), SIR.LocationType.Value("Cell"), SIR.LocationType.Value("Edge")]),
-            sir_utils.make_assignment_stmt(
-                sir_utils.make_field_access_expr("outF"),
-                sir_utils.make_reduction_over_neighbor_expr(
+            serial_utils.make_assignment_stmt(
+                serial_utils.make_field_access_expr("outF"),
+                serial_utils.make_reduction_over_neighbor_expr(
                     "+", 
-                    sir_utils.make_binary_operator(
-                        sir_utils.make_unstructured_field_access_expr("inF", horizontal_offset=sir_utils.make_unstructured_offset(False)),
+                    serial_utils.make_binary_operator(
+                        serial_utils.make_unstructured_field_access_expr("inF", horizontal_offset=serial_utils.make_unstructured_offset(False)),
                         "*",
-                        sir_utils.make_unstructured_field_access_expr("sparseF", horizontal_offset=sir_utils.make_unstructured_offset(True))),
-                    sir_utils.make_literal_access_expr("0.", SIR.BuiltinType.Double),
+                        serial_utils.make_unstructured_field_access_expr("sparseF", horizontal_offset=serial_utils.make_unstructured_offset(True))),
+                    serial_utils.make_literal_access_expr("0.", SIR.BuiltinType.Double),
                     [SIR.LocationType.Value("Edge"), SIR.LocationType.Value("Cell"), SIR.LocationType.Value("Edge")]),
                 "="),           
         ]
     )
 
-    vertical_region_stmt = sir_utils.make_vertical_region_decl_stmt(
+    vertical_region_stmt = serial_utils.make_vertical_region_decl_stmt(
         body_ast, interval, SIR.VerticalRegion.Forward
     )
 
-    sir = sir_utils.make_sir(
+    sir = serial_utils.make_sir(
         outputfile,
         SIR.GridType.Value("Unstructured"),
         [
-            sir_utils.make_stencil(
+            serial_utils.make_stencil(
                 "generated",
-                sir_utils.make_ast([vertical_region_stmt]),
+                serial_utils.make_ast([vertical_region_stmt]),
                 [
-                    sir_utils.make_field(
+                    serial_utils.make_field(
                         "inF",
-                        sir_utils.make_field_dimensions_unstructured(
+                        serial_utils.make_field_dimensions_unstructured(
                             [SIR.LocationType.Value("Edge")], 1
                         ),
                     ),
-                    sir_utils.make_field(
+                    serial_utils.make_field(
                         "outF",
-                        sir_utils.make_field_dimensions_unstructured(
+                        serial_utils.make_field_dimensions_unstructured(
                             [SIR.LocationType.Value("Edge")], 1
                         ),
                     ),
-                    sir_utils.make_field(
+                    serial_utils.make_field(
                         "sparseF",
-                        sir_utils.make_field_dimensions_unstructured(
+                        serial_utils.make_field_dimensions_unstructured(
                             [SIR.LocationType.Value("Edge"), SIR.LocationType.Value("Cell"), SIR.LocationType.Value("Edge")], 1
                         ),
                         is_temporary=True

--- a/dawn/test/unit-test/dawn/SIR/TestSIR.cpp
+++ b/dawn/test/unit-test/dawn/SIR/TestSIR.cpp
@@ -73,8 +73,8 @@ TEST_F(SIRStencilTest, Location) {
 }
 
 TEST_F(SIRStencilTest, Fields) {
-  auto makeFieldDimensions = []() -> sir::FieldDimensions {
-    return sir::FieldDimensions(sir::HorizontalFieldDimension(ast::cartesian, {true, true}), true);
+  auto makeFieldDimensions = []() -> ast::FieldDimensions {
+    return ast::FieldDimensions(ast::HorizontalFieldDimension(ast::cartesian, {true, true}), true);
   };
 
   sir1->Stencils[0]->Fields.emplace_back(
@@ -139,8 +139,8 @@ TEST_F(SIRStencilFunctionTest, Location) {
 }
 
 TEST_F(SIRStencilFunctionTest, Arguments) {
-  auto makeFieldDimensions = []() -> sir::FieldDimensions {
-    return sir::FieldDimensions(sir::HorizontalFieldDimension(ast::cartesian, {true, true}), true);
+  auto makeFieldDimensions = []() -> ast::FieldDimensions {
+    return ast::FieldDimensions(ast::HorizontalFieldDimension(ast::cartesian, {true, true}), true);
   };
 
   sir1->StencilFunctions[0]->Args.emplace_back(

--- a/dawn/test/unit-test/dawn/SIR/TestSIRSerializer.cpp
+++ b/dawn/test/unit-test/dawn/SIR/TestSIRSerializer.cpp
@@ -65,8 +65,8 @@ TEST_P(StencilTest, SourceLocation) {
 }
 
 TEST_P(StencilTest, Fields) {
-  auto makeFieldDimensions = []() -> sir::FieldDimensions {
-    return sir::FieldDimensions(sir::HorizontalFieldDimension(ast::cartesian, {true, true}), true);
+  auto makeFieldDimensions = []() -> ast::FieldDimensions {
+    return ast::FieldDimensions(ast::HorizontalFieldDimension(ast::cartesian, {true, true}), true);
   };
 
   sirRef->Stencils[0]->Fields.emplace_back(
@@ -76,15 +76,15 @@ TEST_P(StencilTest, Fields) {
   SIR_EXCPECT_EQ(sirRef, serializeAndDeserializeRef());
 }
 TEST_P(StencilTest, UnstructuredFields) {
-  auto makeFieldDimensionsDense = []() -> sir::FieldDimensions {
-    return sir::FieldDimensions(sir::HorizontalFieldDimension(ast::unstructured,
+  auto makeFieldDimensionsDense = []() -> ast::FieldDimensions {
+    return ast::FieldDimensions(ast::HorizontalFieldDimension(ast::unstructured,
                                                               dawn::ast::LocationType::Cells,
                                                               /*includeCenter*/ true),
                                 true);
   };
 
-  auto makeFieldDimensionsSparse = []() -> sir::FieldDimensions {
-    return sir::FieldDimensions(sir::HorizontalFieldDimension(ast::unstructured,
+  auto makeFieldDimensionsSparse = []() -> ast::FieldDimensions {
+    return ast::FieldDimensions(ast::HorizontalFieldDimension(ast::unstructured,
                                                               {dawn::ast::LocationType::Cells,
                                                                dawn::ast::LocationType::Edges,
                                                                dawn::ast::LocationType::Cells},
@@ -101,11 +101,11 @@ TEST_P(StencilTest, UnstructuredFields) {
 
 TEST_P(StencilTest, FieldsWithAttributes) {
   sirRef->Stencils[0]->Fields.emplace_back(std::make_shared<sir::Field>(
-      "foo", sir::FieldDimensions(sir::HorizontalFieldDimension(dawn::ast::cartesian, {true, true}),
+      "foo", ast::FieldDimensions(ast::HorizontalFieldDimension(dawn::ast::cartesian, {true, true}),
                                   true)));
   sirRef->Stencils[0]->Fields[0]->IsTemporary = true;
-  sirRef->Stencils[0]->Fields[0]->Dimensions = sir::FieldDimensions(
-      sir::HorizontalFieldDimension(dawn::ast::cartesian, {true, true}), false);
+  sirRef->Stencils[0]->Fields[0]->Dimensions = ast::FieldDimensions(
+      ast::HorizontalFieldDimension(dawn::ast::cartesian, {true, true}), false);
   SIR_EXCPECT_EQ(sirRef, serializeAndDeserializeRef());
 }
 
@@ -204,8 +204,8 @@ TEST_P(StencilFunctionTest, SourceLocation) {
 }
 
 TEST_P(StencilFunctionTest, Arguments) {
-  auto makeFieldDimensions = []() -> sir::FieldDimensions {
-    return sir::FieldDimensions(sir::HorizontalFieldDimension(ast::cartesian, {true, true}), true);
+  auto makeFieldDimensions = []() -> ast::FieldDimensions {
+    return ast::FieldDimensions(ast::HorizontalFieldDimension(ast::cartesian, {true, true}), true);
   };
 
   sirRef->StencilFunctions[0]->Args.emplace_back(

--- a/dawn/test/unit-test/dawn/Validator/TestGridTypeChecker.cpp
+++ b/dawn/test/unit-test/dawn/Validator/TestGridTypeChecker.cpp
@@ -59,8 +59,8 @@ TEST(GridTypeCheckerTest, MixedGridTypesFieldDimensions) {
   auto sten = std::make_shared<sir::Stencil>();
   auto field = std::make_shared<dawn::sir::Field>(
       "unstrcturedField",
-      sir::FieldDimensions(
-          sir::HorizontalFieldDimension(dawn::ast::unstructured_{},
+      ast::FieldDimensions(
+          ast::HorizontalFieldDimension(dawn::ast::unstructured_{},
                                         {ast::LocationType::Cells, ast::LocationType::Edges}),
           true));
   sten->Fields.push_back(field);

--- a/dawn/test/unit-test/dawn4py-tests/test_structured.py
+++ b/dawn/test/unit-test/dawn4py-tests/test_structured.py
@@ -18,7 +18,7 @@ import pytest
 
 import dawn4py
 from dawn4py.serialization import SIR, AST
-from dawn4py.serialization import utils as sir_utils
+from dawn4py.serialization import utils as serial_utils
 
 import utils
 

--- a/dawn/test/unit-test/dawn4py-tests/test_structured.py
+++ b/dawn/test/unit-test/dawn4py-tests/test_structured.py
@@ -17,7 +17,7 @@ import io
 import pytest
 
 import dawn4py
-from dawn4py.serialization import SIR
+from dawn4py.serialization import SIR, AST
 from dawn4py.serialization import utils as sir_utils
 
 import utils

--- a/dawn/test/unit-test/dawn4py-tests/test_unstructured.py
+++ b/dawn/test/unit-test/dawn4py-tests/test_unstructured.py
@@ -18,7 +18,7 @@ import pytest
 
 import dawn4py
 from dawn4py.serialization import SIR, AST
-from dawn4py.serialization import utils as sir_utils
+from dawn4py.serialization import utils as serial_utils
 
 import utils
 

--- a/dawn/test/unit-test/dawn4py-tests/test_unstructured.py
+++ b/dawn/test/unit-test/dawn4py-tests/test_unstructured.py
@@ -17,7 +17,7 @@ import io
 import pytest
 
 import dawn4py
-from dawn4py.serialization import SIR
+from dawn4py.serialization import SIR, AST
 from dawn4py.serialization import utils as sir_utils
 
 import utils

--- a/dawn/test/unit-test/dawn4py-tests/utils.py
+++ b/dawn/test/unit-test/dawn4py-tests/utils.py
@@ -16,7 +16,7 @@
 
 """pytest definitions and utilities"""
 
-from dawn4py.serialization import SIR
+from dawn4py.serialization import SIR, AST
 from dawn4py.serialization import utils as sir_utils
 
 
@@ -32,7 +32,7 @@ def make_copy_stencil_sir(name=None):
     OUTPUT_FILE = f"{OUTPUT_NAME}.cpp"
 
     interval = sir_utils.make_interval(
-        SIR.Interval.Start, SIR.Interval.End, 0, 0)
+        AST.Interval.Start, AST.Interval.End, 0, 0)
 
     # create the out = in[i+1] statement
     body_ast = sir_utils.make_ast(
@@ -46,7 +46,7 @@ def make_copy_stencil_sir(name=None):
     )
 
     vertical_region_stmt = sir_utils.make_vertical_region_decl_stmt(
-        body_ast, interval, SIR.VerticalRegion.Forward)
+        body_ast, interval, AST.VerticalRegion.Forward)
 
     sir = sir_utils.make_sir(
         OUTPUT_FILE,
@@ -71,7 +71,7 @@ def make_hori_diff_stencil_sir(name=None):
     OUTPUT_FILE = f"{OUTPUT_NAME}.cpp"
 
     interval = sir_utils.make_interval(
-        SIR.Interval.Start, SIR.Interval.End, 0, 0)
+        AST.Interval.Start, AST.Interval.End, 0, 0)
 
     # create the stencil body AST
     body_ast = sir_utils.make_ast(
@@ -81,7 +81,7 @@ def make_hori_diff_stencil_sir(name=None):
                 sir_utils.make_binary_operator(
                     sir_utils.make_binary_operator(
                         sir_utils.make_literal_access_expr(
-                            "-4.0", SIR.BuiltinType.Float),
+                            "-4.0", AST.BuiltinType.Float),
                         "*",
                         sir_utils.make_field_access_expr("in"),
                     ),
@@ -114,7 +114,7 @@ def make_hori_diff_stencil_sir(name=None):
                 sir_utils.make_binary_operator(
                     sir_utils.make_binary_operator(
                         sir_utils.make_literal_access_expr(
-                            "-4.0", SIR.BuiltinType.Float),
+                            "-4.0", AST.BuiltinType.Float),
                         "*",
                         sir_utils.make_field_access_expr("lap"),
                     ),
@@ -146,7 +146,7 @@ def make_hori_diff_stencil_sir(name=None):
     )
 
     vertical_region_stmt = sir_utils.make_vertical_region_decl_stmt(
-        body_ast, interval, SIR.VerticalRegion.Forward)
+        body_ast, interval, AST.VerticalRegion.Forward)
 
     sir = sir_utils.make_sir(
         OUTPUT_FILE,
@@ -178,7 +178,7 @@ def make_tridiagonal_solve_stencil_sir(name=None):
 
     # ---- First vertical region statement ----
     interval_1 = sir_utils.make_interval(
-        SIR.Interval.Start, SIR.Interval.End, 0, 0)
+        AST.Interval.Start, AST.Interval.End, 0, 0)
     body_ast_1 = sir_utils.make_ast(
         [
             sir_utils.make_assignment_stmt(
@@ -193,24 +193,24 @@ def make_tridiagonal_solve_stencil_sir(name=None):
     )
 
     vertical_region_stmt_1 = sir_utils.make_vertical_region_decl_stmt(
-        body_ast_1, interval_1, SIR.VerticalRegion.Forward
+        body_ast_1, interval_1, AST.VerticalRegion.Forward
     )
 
     # ---- Second vertical region statement ----
     interval_2 = sir_utils.make_interval(
-        SIR.Interval.Start, SIR.Interval.End, 1, 0)
+        AST.Interval.Start, AST.Interval.End, 1, 0)
 
     body_ast_2 = sir_utils.make_ast(
         [
             sir_utils.make_var_decl_stmt(
-                sir_utils.make_type(SIR.BuiltinType.Integer),
+                sir_utils.make_type(AST.BuiltinType.Integer),
                 "m",
                 0,
                 "=",
                 sir_utils.make_expr(
                     sir_utils.make_binary_operator(
                         sir_utils.make_literal_access_expr(
-                            "1.0", SIR.BuiltinType.Float),
+                            "1.0", AST.BuiltinType.Float),
                         "/",
                         sir_utils.make_binary_operator(
                             sir_utils.make_field_access_expr("b"),
@@ -253,12 +253,12 @@ def make_tridiagonal_solve_stencil_sir(name=None):
         ]
     )
     vertical_region_stmt_2 = sir_utils.make_vertical_region_decl_stmt(
-        body_ast_2, interval_2, SIR.VerticalRegion.Forward
+        body_ast_2, interval_2, AST.VerticalRegion.Forward
     )
 
     # ---- Third vertical region statement ----
     interval_3 = sir_utils.make_interval(
-        SIR.Interval.Start, SIR.Interval.End, 0, -1)
+        AST.Interval.Start, AST.Interval.End, 0, -1)
     body_ast_3 = sir_utils.make_ast(
         [
             sir_utils.make_assignment_stmt(
@@ -273,7 +273,7 @@ def make_tridiagonal_solve_stencil_sir(name=None):
     )
 
     vertical_region_stmt_3 = sir_utils.make_vertical_region_decl_stmt(
-        body_ast_3, interval_3, SIR.VerticalRegion.Backward
+        body_ast_3, interval_3, AST.VerticalRegion.Backward
     )
 
     sir = sir_utils.make_sir(
@@ -306,7 +306,7 @@ def make_unstructured_stencil_sir(name=None):
     OUTPUT_NAME = name if name is not None else "unstructured_stencil"
     OUTPUT_FILE = f"{OUTPUT_NAME}.cpp"
     interval = sir_utils.make_interval(
-        SIR.Interval.Start, SIR.Interval.End, 0, 0)
+        AST.Interval.Start, AST.Interval.End, 0, 0)
 
     # create the out = in[i+1] statement
     body_ast = sir_utils.make_ast(
@@ -316,9 +316,9 @@ def make_unstructured_stencil_sir(name=None):
                 sir_utils.make_reduction_over_neighbor_expr(
                     "+",
                     sir_utils.make_literal_access_expr(
-                        "1.0", SIR.BuiltinType.Float),
+                        "1.0", AST.BuiltinType.Float),
                     sir_utils.make_unstructured_field_access_expr("in"),
-                    chain=[SIR.LocationType.Value('Edge'), SIR.LocationType.Value('Cell')]
+                    chain=[AST.LocationType.Value('Edge'), AST.LocationType.Value('Cell')]
                 ),
                 "=",
             )
@@ -326,7 +326,7 @@ def make_unstructured_stencil_sir(name=None):
     )
 
     vertical_region_stmt = sir_utils.make_vertical_region_decl_stmt(
-        body_ast, interval, SIR.VerticalRegion.Forward)
+        body_ast, interval, AST.VerticalRegion.Forward)
 
     sir = sir_utils.make_sir(
         OUTPUT_FILE,
@@ -337,9 +337,9 @@ def make_unstructured_stencil_sir(name=None):
                 sir_utils.make_ast([vertical_region_stmt]),
                 [
                     sir_utils.make_field("in", sir_utils.make_field_dimensions_unstructured(
-                        [SIR.LocationType.Value('Cell')], 1)),
+                        [AST.LocationType.Value('Cell')], 1)),
                     sir_utils.make_field("out", sir_utils.make_field_dimensions_unstructured(
-                        [SIR.LocationType.Value('Edge')], 1))
+                        [AST.LocationType.Value('Edge')], 1))
                 ],
             )
         ],

--- a/dawn/test/unit-test/dawn4py-tests/utils.py
+++ b/dawn/test/unit-test/dawn4py-tests/utils.py
@@ -17,7 +17,7 @@
 """pytest definitions and utilities"""
 
 from dawn4py.serialization import SIR, AST
-from dawn4py.serialization import utils as sir_utils
+from dawn4py.serialization import utils as serial_utils
 
 
 GRID_TEST_CASES = ["copy_stencil",
@@ -31,34 +31,34 @@ def make_copy_stencil_sir(name=None):
     OUTPUT_NAME = name if name is not None else "copy_stencil"
     OUTPUT_FILE = f"{OUTPUT_NAME}.cpp"
 
-    interval = sir_utils.make_interval(
+    interval = serial_utils.make_interval(
         AST.Interval.Start, AST.Interval.End, 0, 0)
 
     # create the out = in[i+1] statement
-    body_ast = sir_utils.make_ast(
+    body_ast = serial_utils.make_ast(
         [
-            sir_utils.make_assignment_stmt(
-                sir_utils.make_field_access_expr("out", [0, 0, 0]),
-                sir_utils.make_field_access_expr("in", [1, 0, 0]),
+            serial_utils.make_assignment_stmt(
+                serial_utils.make_field_access_expr("out", [0, 0, 0]),
+                serial_utils.make_field_access_expr("in", [1, 0, 0]),
                 "=",
             )
         ]
     )
 
-    vertical_region_stmt = sir_utils.make_vertical_region_decl_stmt(
+    vertical_region_stmt = serial_utils.make_vertical_region_decl_stmt(
         body_ast, interval, AST.VerticalRegion.Forward)
 
-    sir = sir_utils.make_sir(
+    sir = serial_utils.make_sir(
         OUTPUT_FILE,
-        sir_utils.GridType.Value("Cartesian"),
+        serial_utils.GridType.Value("Cartesian"),
         [
-            sir_utils.make_stencil(
+            serial_utils.make_stencil(
                 OUTPUT_NAME,
-                sir_utils.make_ast([vertical_region_stmt]),
+                serial_utils.make_ast([vertical_region_stmt]),
                 [
-                    sir_utils.make_field(
-                        "in", sir_utils.make_field_dimensions_cartesian()),
-                    sir_utils.make_field("out", sir_utils.make_field_dimensions_cartesian())],
+                    serial_utils.make_field(
+                        "in", serial_utils.make_field_dimensions_cartesian()),
+                    serial_utils.make_field("out", serial_utils.make_field_dimensions_cartesian())],
             )
         ],
     )
@@ -70,37 +70,37 @@ def make_hori_diff_stencil_sir(name=None):
     OUTPUT_NAME = name if name is not None else "hori_diff_stencil"
     OUTPUT_FILE = f"{OUTPUT_NAME}.cpp"
 
-    interval = sir_utils.make_interval(
+    interval = serial_utils.make_interval(
         AST.Interval.Start, AST.Interval.End, 0, 0)
 
     # create the stencil body AST
-    body_ast = sir_utils.make_ast(
+    body_ast = serial_utils.make_ast(
         [
-            sir_utils.make_assignment_stmt(
-                sir_utils.make_field_access_expr("lap"),
-                sir_utils.make_binary_operator(
-                    sir_utils.make_binary_operator(
-                        sir_utils.make_literal_access_expr(
+            serial_utils.make_assignment_stmt(
+                serial_utils.make_field_access_expr("lap"),
+                serial_utils.make_binary_operator(
+                    serial_utils.make_binary_operator(
+                        serial_utils.make_literal_access_expr(
                             "-4.0", AST.BuiltinType.Float),
                         "*",
-                        sir_utils.make_field_access_expr("in"),
+                        serial_utils.make_field_access_expr("in"),
                     ),
                     "+",
-                    sir_utils.make_binary_operator(
-                        sir_utils.make_field_access_expr("coeff"),
+                    serial_utils.make_binary_operator(
+                        serial_utils.make_field_access_expr("coeff"),
                         "*",
-                        sir_utils.make_binary_operator(
-                            sir_utils.make_field_access_expr("in", [1, 0, 0]),
+                        serial_utils.make_binary_operator(
+                            serial_utils.make_field_access_expr("in", [1, 0, 0]),
                             "+",
-                            sir_utils.make_binary_operator(
-                                sir_utils.make_field_access_expr(
+                            serial_utils.make_binary_operator(
+                                serial_utils.make_field_access_expr(
                                     "in", [-1, 0, 0]),
                                 "+",
-                                sir_utils.make_binary_operator(
-                                    sir_utils.make_field_access_expr(
+                                serial_utils.make_binary_operator(
+                                    serial_utils.make_field_access_expr(
                                         "in", [0, 1, 0]),
                                     "+",
-                                    sir_utils.make_field_access_expr(
+                                    serial_utils.make_field_access_expr(
                                         "in", [0, -1, 0]),
                                 ),
                             ),
@@ -109,31 +109,31 @@ def make_hori_diff_stencil_sir(name=None):
                 ),
                 "=",
             ),
-            sir_utils.make_assignment_stmt(
-                sir_utils.make_field_access_expr("out"),
-                sir_utils.make_binary_operator(
-                    sir_utils.make_binary_operator(
-                        sir_utils.make_literal_access_expr(
+            serial_utils.make_assignment_stmt(
+                serial_utils.make_field_access_expr("out"),
+                serial_utils.make_binary_operator(
+                    serial_utils.make_binary_operator(
+                        serial_utils.make_literal_access_expr(
                             "-4.0", AST.BuiltinType.Float),
                         "*",
-                        sir_utils.make_field_access_expr("lap"),
+                        serial_utils.make_field_access_expr("lap"),
                     ),
                     "+",
-                    sir_utils.make_binary_operator(
-                        sir_utils.make_field_access_expr("coeff"),
+                    serial_utils.make_binary_operator(
+                        serial_utils.make_field_access_expr("coeff"),
                         "*",
-                        sir_utils.make_binary_operator(
-                            sir_utils.make_field_access_expr("lap", [1, 0, 0]),
+                        serial_utils.make_binary_operator(
+                            serial_utils.make_field_access_expr("lap", [1, 0, 0]),
                             "+",
-                            sir_utils.make_binary_operator(
-                                sir_utils.make_field_access_expr(
+                            serial_utils.make_binary_operator(
+                                serial_utils.make_field_access_expr(
                                     "lap", [-1, 0, 0]),
                                 "+",
-                                sir_utils.make_binary_operator(
-                                    sir_utils.make_field_access_expr(
+                                serial_utils.make_binary_operator(
+                                    serial_utils.make_field_access_expr(
                                         "lap", [0, 1, 0]),
                                     "+",
-                                    sir_utils.make_field_access_expr(
+                                    serial_utils.make_field_access_expr(
                                         "lap", [0, -1, 0]),
                                 ),
                             ),
@@ -145,25 +145,25 @@ def make_hori_diff_stencil_sir(name=None):
         ]
     )
 
-    vertical_region_stmt = sir_utils.make_vertical_region_decl_stmt(
+    vertical_region_stmt = serial_utils.make_vertical_region_decl_stmt(
         body_ast, interval, AST.VerticalRegion.Forward)
 
-    sir = sir_utils.make_sir(
+    sir = serial_utils.make_sir(
         OUTPUT_FILE,
-        sir_utils.GridType.Value("Cartesian"),
+        serial_utils.GridType.Value("Cartesian"),
         [
-            sir_utils.make_stencil(
+            serial_utils.make_stencil(
                 OUTPUT_NAME,
-                sir_utils.make_ast([vertical_region_stmt]),
+                serial_utils.make_ast([vertical_region_stmt]),
                 [
-                    sir_utils.make_field(
-                        "in", sir_utils.make_field_dimensions_cartesian()),
-                    sir_utils.make_field(
-                        "out", sir_utils.make_field_dimensions_cartesian()),
-                    sir_utils.make_field(
-                        "coeff", sir_utils.make_field_dimensions_cartesian()),
-                    sir_utils.make_field(
-                        "lap", sir_utils.make_field_dimensions_cartesian(), is_temporary=True),
+                    serial_utils.make_field(
+                        "in", serial_utils.make_field_dimensions_cartesian()),
+                    serial_utils.make_field(
+                        "out", serial_utils.make_field_dimensions_cartesian()),
+                    serial_utils.make_field(
+                        "coeff", serial_utils.make_field_dimensions_cartesian()),
+                    serial_utils.make_field(
+                        "lap", serial_utils.make_field_dimensions_cartesian(), is_temporary=True),
                 ],
             )
         ],
@@ -177,122 +177,122 @@ def make_tridiagonal_solve_stencil_sir(name=None):
     OUTPUT_FILE = f"{OUTPUT_NAME}.cpp"
 
     # ---- First vertical region statement ----
-    interval_1 = sir_utils.make_interval(
+    interval_1 = serial_utils.make_interval(
         AST.Interval.Start, AST.Interval.End, 0, 0)
-    body_ast_1 = sir_utils.make_ast(
+    body_ast_1 = serial_utils.make_ast(
         [
-            sir_utils.make_assignment_stmt(
-                sir_utils.make_field_access_expr("c"),
-                sir_utils.make_binary_operator(
-                    sir_utils.make_field_access_expr(
-                        "c"), "/", sir_utils.make_field_access_expr("b"),
+            serial_utils.make_assignment_stmt(
+                serial_utils.make_field_access_expr("c"),
+                serial_utils.make_binary_operator(
+                    serial_utils.make_field_access_expr(
+                        "c"), "/", serial_utils.make_field_access_expr("b"),
                 ),
                 "=",
             )
         ]
     )
 
-    vertical_region_stmt_1 = sir_utils.make_vertical_region_decl_stmt(
+    vertical_region_stmt_1 = serial_utils.make_vertical_region_decl_stmt(
         body_ast_1, interval_1, AST.VerticalRegion.Forward
     )
 
     # ---- Second vertical region statement ----
-    interval_2 = sir_utils.make_interval(
+    interval_2 = serial_utils.make_interval(
         AST.Interval.Start, AST.Interval.End, 1, 0)
 
-    body_ast_2 = sir_utils.make_ast(
+    body_ast_2 = serial_utils.make_ast(
         [
-            sir_utils.make_var_decl_stmt(
-                sir_utils.make_type(AST.BuiltinType.Integer),
+            serial_utils.make_var_decl_stmt(
+                serial_utils.make_type(AST.BuiltinType.Integer),
                 "m",
                 0,
                 "=",
-                sir_utils.make_expr(
-                    sir_utils.make_binary_operator(
-                        sir_utils.make_literal_access_expr(
+                serial_utils.make_expr(
+                    serial_utils.make_binary_operator(
+                        serial_utils.make_literal_access_expr(
                             "1.0", AST.BuiltinType.Float),
                         "/",
-                        sir_utils.make_binary_operator(
-                            sir_utils.make_field_access_expr("b"),
+                        serial_utils.make_binary_operator(
+                            serial_utils.make_field_access_expr("b"),
                             "-",
-                            sir_utils.make_binary_operator(
-                                sir_utils.make_field_access_expr("a"),
+                            serial_utils.make_binary_operator(
+                                serial_utils.make_field_access_expr("a"),
                                 "*",
-                                sir_utils.make_field_access_expr(
+                                serial_utils.make_field_access_expr(
                                     "c", [0, 0, -1]),
                             ),
                         ),
                     )
                 ),
             ),
-            sir_utils.make_assignment_stmt(
-                sir_utils.make_field_access_expr("c"),
-                sir_utils.make_binary_operator(
-                    sir_utils.make_field_access_expr(
-                        "c"), "*", sir_utils.make_var_access_expr("m")
+            serial_utils.make_assignment_stmt(
+                serial_utils.make_field_access_expr("c"),
+                serial_utils.make_binary_operator(
+                    serial_utils.make_field_access_expr(
+                        "c"), "*", serial_utils.make_var_access_expr("m")
                 ),
                 "=",
             ),
-            sir_utils.make_assignment_stmt(
-                sir_utils.make_field_access_expr("d"),
-                sir_utils.make_binary_operator(
-                    sir_utils.make_binary_operator(
-                        sir_utils.make_field_access_expr("d"),
+            serial_utils.make_assignment_stmt(
+                serial_utils.make_field_access_expr("d"),
+                serial_utils.make_binary_operator(
+                    serial_utils.make_binary_operator(
+                        serial_utils.make_field_access_expr("d"),
                         "-",
-                        sir_utils.make_binary_operator(
-                            sir_utils.make_field_access_expr("a"),
+                        serial_utils.make_binary_operator(
+                            serial_utils.make_field_access_expr("a"),
                             "*",
-                            sir_utils.make_field_access_expr("d", [0, 0, -1]),
+                            serial_utils.make_field_access_expr("d", [0, 0, -1]),
                         ),
                     ),
                     "*",
-                    sir_utils.make_var_access_expr("m"),
+                    serial_utils.make_var_access_expr("m"),
                 ),
                 "=",
             ),
         ]
     )
-    vertical_region_stmt_2 = sir_utils.make_vertical_region_decl_stmt(
+    vertical_region_stmt_2 = serial_utils.make_vertical_region_decl_stmt(
         body_ast_2, interval_2, AST.VerticalRegion.Forward
     )
 
     # ---- Third vertical region statement ----
-    interval_3 = sir_utils.make_interval(
+    interval_3 = serial_utils.make_interval(
         AST.Interval.Start, AST.Interval.End, 0, -1)
-    body_ast_3 = sir_utils.make_ast(
+    body_ast_3 = serial_utils.make_ast(
         [
-            sir_utils.make_assignment_stmt(
-                sir_utils.make_field_access_expr("d"),
-                sir_utils.make_binary_operator(
-                    sir_utils.make_field_access_expr(
-                        "c"), "*", sir_utils.make_field_access_expr("d", [0, 0, 1]),
+            serial_utils.make_assignment_stmt(
+                serial_utils.make_field_access_expr("d"),
+                serial_utils.make_binary_operator(
+                    serial_utils.make_field_access_expr(
+                        "c"), "*", serial_utils.make_field_access_expr("d", [0, 0, 1]),
                 ),
                 "-=",
             )
         ]
     )
 
-    vertical_region_stmt_3 = sir_utils.make_vertical_region_decl_stmt(
+    vertical_region_stmt_3 = serial_utils.make_vertical_region_decl_stmt(
         body_ast_3, interval_3, AST.VerticalRegion.Backward
     )
 
-    sir = sir_utils.make_sir(
+    sir = serial_utils.make_sir(
         OUTPUT_FILE,
-        sir_utils.GridType.Value("Cartesian"),
+        serial_utils.GridType.Value("Cartesian"),
         [
-            sir_utils.make_stencil(
+            serial_utils.make_stencil(
                 OUTPUT_NAME,
-                sir_utils.make_ast(
+                serial_utils.make_ast(
                     [vertical_region_stmt_1, vertical_region_stmt_2, vertical_region_stmt_3]),
                 [
-                    sir_utils.make_field(
-                        "a", sir_utils.make_field_dimensions_cartesian()),
-                    sir_utils.make_field(
-                        "b", sir_utils.make_field_dimensions_cartesian()),
-                    sir_utils.make_field(
-                        "c", sir_utils.make_field_dimensions_cartesian()),
-                    sir_utils.make_field(
-                        "d", sir_utils.make_field_dimensions_cartesian()),
+                    serial_utils.make_field(
+                        "a", serial_utils.make_field_dimensions_cartesian()),
+                    serial_utils.make_field(
+                        "b", serial_utils.make_field_dimensions_cartesian()),
+                    serial_utils.make_field(
+                        "c", serial_utils.make_field_dimensions_cartesian()),
+                    serial_utils.make_field(
+                        "d", serial_utils.make_field_dimensions_cartesian()),
                 ],
             )
         ],
@@ -305,19 +305,19 @@ def make_tridiagonal_solve_stencil_sir(name=None):
 def make_unstructured_stencil_sir(name=None):
     OUTPUT_NAME = name if name is not None else "unstructured_stencil"
     OUTPUT_FILE = f"{OUTPUT_NAME}.cpp"
-    interval = sir_utils.make_interval(
+    interval = serial_utils.make_interval(
         AST.Interval.Start, AST.Interval.End, 0, 0)
 
     # create the out = in[i+1] statement
-    body_ast = sir_utils.make_ast(
+    body_ast = serial_utils.make_ast(
         [
-            sir_utils.make_assignment_stmt(
-                sir_utils.make_unstructured_field_access_expr("out"),
-                sir_utils.make_reduction_over_neighbor_expr(
+            serial_utils.make_assignment_stmt(
+                serial_utils.make_unstructured_field_access_expr("out"),
+                serial_utils.make_reduction_over_neighbor_expr(
                     "+",
-                    sir_utils.make_literal_access_expr(
+                    serial_utils.make_literal_access_expr(
                         "1.0", AST.BuiltinType.Float),
-                    sir_utils.make_unstructured_field_access_expr("in"),
+                    serial_utils.make_unstructured_field_access_expr("in"),
                     chain=[AST.LocationType.Value('Edge'), AST.LocationType.Value('Cell')]
                 ),
                 "=",
@@ -325,20 +325,20 @@ def make_unstructured_stencil_sir(name=None):
         ]
     )
 
-    vertical_region_stmt = sir_utils.make_vertical_region_decl_stmt(
+    vertical_region_stmt = serial_utils.make_vertical_region_decl_stmt(
         body_ast, interval, AST.VerticalRegion.Forward)
 
-    sir = sir_utils.make_sir(
+    sir = serial_utils.make_sir(
         OUTPUT_FILE,
-        sir_utils.GridType.Value("Unstructured"),
+        serial_utils.GridType.Value("Unstructured"),
         [
-            sir_utils.make_stencil(
+            serial_utils.make_stencil(
                 OUTPUT_NAME,
-                sir_utils.make_ast([vertical_region_stmt]),
+                serial_utils.make_ast([vertical_region_stmt]),
                 [
-                    sir_utils.make_field("in", sir_utils.make_field_dimensions_unstructured(
+                    serial_utils.make_field("in", serial_utils.make_field_dimensions_unstructured(
                         [AST.LocationType.Value('Cell')], 1)),
-                    sir_utils.make_field("out", sir_utils.make_field_dimensions_unstructured(
+                    serial_utils.make_field("out", serial_utils.make_field_dimensions_unstructured(
                         [AST.LocationType.Value('Edge')], 1))
                 ],
             )

--- a/gtclang/src/gtclang/Frontend/StencilParser.cpp
+++ b/gtclang/src/gtclang/Frontend/StencilParser.cpp
@@ -762,8 +762,8 @@ void StencilParser::parseStorage(clang::FieldDecl* field) {
                                .Default({{false, false, false}});
     auto SIRField = std::make_shared<Field>(
         name,
-        dawn::sir::FieldDimensions(
-            dawn::sir::HorizontalFieldDimension(dawn::ast::cartesian,
+        dawn::ast::FieldDimensions(
+            dawn::ast::HorizontalFieldDimension(dawn::ast::cartesian,
                                                 {fieldDimensions[0], fieldDimensions[1]}),
             fieldDimensions[2]),
         getLocation(field));
@@ -776,8 +776,8 @@ void StencilParser::parseStorage(clang::FieldDecl* field) {
     DAWN_LOG(INFO) << "Parsing temporary field: " << name;
     auto SIRField = std::make_shared<dawn::sir::Field>(
         name,
-        dawn::sir::FieldDimensions(
-            dawn::sir::HorizontalFieldDimension(dawn::ast::cartesian, {true, true}), true),
+        dawn::ast::FieldDimensions(
+            dawn::ast::HorizontalFieldDimension(dawn::ast::cartesian, {true, true}), true),
         getLocation(field));
     SIRField->IsTemporary = true;
     currentParserRecord_->CurrentStencil->Fields.emplace_back(SIRField);
@@ -820,8 +820,8 @@ void StencilParser::parseArgument(clang::FieldDecl* arg) {
 
     auto SIRField = std::make_shared<dawn::sir::Field>(
         name,
-        dawn::sir::FieldDimensions(
-            dawn::sir::HorizontalFieldDimension(dawn::ast::cartesian,
+        dawn::ast::FieldDimensions(
+            dawn::ast::HorizontalFieldDimension(dawn::ast::cartesian,
                                                 {fieldDimensions[0], fieldDimensions[1]}),
             fieldDimensions[2]),
         getLocation(arg));

--- a/gtclang/src/gtclang/Unittest/ParsingComparison.cpp
+++ b/gtclang/src/gtclang/Unittest/ParsingComparison.cpp
@@ -188,8 +188,8 @@ public:
   virtual void visit(const std::shared_ptr<dawn::ast::FieldAccessExpr>& expr) override {
     auto fieldFromExpression = dawn::sir::Field(
         expr->getName(),
-        dawn::sir::FieldDimensions(
-            dawn::sir::HorizontalFieldDimension(dawn::ast::cartesian, {true, true}), true));
+        dawn::ast::FieldDimensions(
+            dawn::ast::HorizontalFieldDimension(dawn::ast::cartesian, {true, true}), true));
 
     auto iter = std::find(allFields_.begin(), allFields_.end(), fieldFromExpression);
     if(iter == allFields_.end())


### PR DESCRIPTION
## Technical Description

Further disentangled `AST` and `SIR` by moving `statements.proto` and `enums.proto` to the `AST`. Furthermore the `Fielddimension` class was also moved from `SIR` to `AST`.

### Resolves / Enhances

https://github.com/MeteoSwiss-APN/dawn/issues/319
https://github.com/MeteoSwiss-APN/dawn/issues/438