### PR TITLE
Fixed two bugs in codegen, one related to intervals, one to max_over (#1097 and #1098)

### DIFF
--- a/dawn/src/dawn/AST/ASTExpr.cpp
+++ b/dawn/src/dawn/AST/ASTExpr.cpp
@@ -519,5 +519,10 @@ bool ReductionOverNeighborExpr::equals(const Expr* other, bool compareData) cons
          otherPtr->iterSpace_ == iterSpace_;
 }
 
+bool ReductionOverNeighborExpr::is_arithmetic() const {
+  return any_of(ast::ReductionOverNeighborExpr::arithmetic_ops,
+                 [&](std::string op) { return op_ == op; });
+}
+
 } // namespace ast
 } // namespace dawn

--- a/dawn/src/dawn/AST/ASTExpr.cpp
+++ b/dawn/src/dawn/AST/ASTExpr.cpp
@@ -519,8 +519,8 @@ bool ReductionOverNeighborExpr::equals(const Expr* other, bool compareData) cons
          otherPtr->iterSpace_ == iterSpace_;
 }
 
-bool ReductionOverNeighborExpr::is_arithmetic() const {
-  return any_of(ast::ReductionOverNeighborExpr::arithmetic_ops,
+bool ReductionOverNeighborExpr::isArithmetic() const {
+  return any_of(ast::ReductionOverNeighborExpr::arithmeticOps,
                  [&](std::string op) { return op_ == op; });
 }
 

--- a/dawn/src/dawn/AST/ASTExpr.h
+++ b/dawn/src/dawn/AST/ASTExpr.h
@@ -649,7 +649,7 @@ private:
   bool chainIsValid() const;
 
 public:
-  inline static const std::vector<std::string> arithmetic_ops{"+", "-", "*", "/", "%"};
+  inline static const std::vector<std::string> arithmeticOps{"+", "-", "*", "/", "%"};
   /// @name Constructor & Destructor
   /// @{
   ReductionOverNeighborExpr(std::string const& op, std::shared_ptr<Expr> const& rhs,
@@ -683,7 +683,7 @@ public:
 
   std::shared_ptr<Expr> clone() const override;
   bool equals(const Expr* other, bool compareData = true) const override;
-  bool is_arithmetic() const;
+  bool isArithmetic() const;
 
   ACCEPTVISITOR(Expr, ReductionOverNeighborExpr)
 };

--- a/dawn/src/dawn/AST/ASTExpr.h
+++ b/dawn/src/dawn/AST/ASTExpr.h
@@ -649,6 +649,7 @@ private:
   bool chainIsValid() const;
 
 public:
+  inline static const std::vector<std::string> arithmetic_ops{"+", "-", "*", "/", "%"};
   /// @name Constructor & Destructor
   /// @{
   ReductionOverNeighborExpr(std::string const& op, std::shared_ptr<Expr> const& rhs,
@@ -682,6 +683,7 @@ public:
 
   std::shared_ptr<Expr> clone() const override;
   bool equals(const Expr* other, bool compareData = true) const override;
+  bool is_arithmetic() const;
 
   ACCEPTVISITOR(Expr, ReductionOverNeighborExpr)
 };

--- a/dawn/src/dawn/CodeGen/CXXNaive-ico/ASTStencilBody.cpp
+++ b/dawn/src/dawn/CodeGen/CXXNaive-ico/ASTStencilBody.cpp
@@ -376,13 +376,20 @@ void ASTStencilBody::visit(const std::shared_ptr<ast::ReductionOverNeighborExpr>
                "lhs, auto "
         << ASTStencilBody::ReductionIndexVarName(reductionDepth_ + 1)
         << ", auto const& weight) mutable {\n";
-    ss_ << "lhs " << expr->getOp() << "= ";
-    ss_ << "weight * ";
   } else {
     ss_ << ", [&, " + ASTStencilBody::ReductionSparseIndexVarName(reductionDepth_) +
                " = int(0)](auto& lhs, auto "
         << ASTStencilBody::ReductionIndexVarName(reductionDepth_ + 1) << ") mutable { ";
+  }
+
+  if(expr->getOp() != "+") {
+    ss_ << "lhs = " << expr->getOp() << "(lhs, ";
+  } else {
     ss_ << "lhs " << expr->getOp() << "= ";
+  }
+
+  if(hasWeights) {
+    ss_ << "weight * ";
   }
 
   auto argName = denseArgName_;
@@ -407,6 +414,9 @@ void ASTStencilBody::visit(const std::shared_ptr<ast::ReductionOverNeighborExpr>
   }
   // "pop" argName
   denseArgName_ = argName;
+  if(expr->getOp() != "+") {
+    ss_ << ")";
+  }
   ss_ << ";\n";
   ss_ << ASTStencilBody::ReductionSparseIndexVarName(reductionDepth_) << "++;\n";
   ss_ << "return lhs;\n";

--- a/dawn/src/dawn/CodeGen/CXXNaive-ico/ASTStencilBody.cpp
+++ b/dawn/src/dawn/CodeGen/CXXNaive-ico/ASTStencilBody.cpp
@@ -382,8 +382,7 @@ void ASTStencilBody::visit(const std::shared_ptr<ast::ReductionOverNeighborExpr>
         << ASTStencilBody::ReductionIndexVarName(reductionDepth_ + 1) << ") mutable { ";
   }
 
-  std::vector<std::string> arithmetic_ops{"+", "-", "*", "/", "%"};
-  if(none_of(arithmetic_ops, [&](std::string op){ return expr->getOp() == op; })) {
+  if(!expr->is_arithmetic()) {
     ss_ << "lhs = " << expr->getOp() << "(lhs, ";
   } else {
     ss_ << "lhs " << expr->getOp() << "= ";
@@ -415,7 +414,7 @@ void ASTStencilBody::visit(const std::shared_ptr<ast::ReductionOverNeighborExpr>
   }
   // "pop" argName
   denseArgName_ = argName;
-  if(none_of(arithmetic_ops, [&](std::string op){ return expr->getOp() == op; })) {
+  if(!expr->is_arithmetic()) {
     ss_ << ")";
   }
   ss_ << ";\n";

--- a/dawn/src/dawn/CodeGen/CXXNaive-ico/ASTStencilBody.cpp
+++ b/dawn/src/dawn/CodeGen/CXXNaive-ico/ASTStencilBody.cpp
@@ -382,7 +382,8 @@ void ASTStencilBody::visit(const std::shared_ptr<ast::ReductionOverNeighborExpr>
         << ASTStencilBody::ReductionIndexVarName(reductionDepth_ + 1) << ") mutable { ";
   }
 
-  if(expr->getOp() != "+") {
+  std::vector<std::string> num_ops {"+", "-", "*", "/", "%"};
+  if(none_of(num_ops, [&](std::string op){ return expr->getOp() == op; })) {
     ss_ << "lhs = " << expr->getOp() << "(lhs, ";
   } else {
     ss_ << "lhs " << expr->getOp() << "= ";
@@ -414,7 +415,7 @@ void ASTStencilBody::visit(const std::shared_ptr<ast::ReductionOverNeighborExpr>
   }
   // "pop" argName
   denseArgName_ = argName;
-  if(expr->getOp() != "+") {
+  if(none_of(num_ops, [&](std::string op){ return expr->getOp() == op; })) {
     ss_ << ")";
   }
   ss_ << ";\n";

--- a/dawn/src/dawn/CodeGen/CXXNaive-ico/ASTStencilBody.cpp
+++ b/dawn/src/dawn/CodeGen/CXXNaive-ico/ASTStencilBody.cpp
@@ -382,8 +382,8 @@ void ASTStencilBody::visit(const std::shared_ptr<ast::ReductionOverNeighborExpr>
         << ASTStencilBody::ReductionIndexVarName(reductionDepth_ + 1) << ") mutable { ";
   }
 
-  std::vector<std::string> num_ops {"+", "-", "*", "/", "%"};
-  if(none_of(num_ops, [&](std::string op){ return expr->getOp() == op; })) {
+  std::vector<std::string> arithmetic_ops{"+", "-", "*", "/", "%"};
+  if(none_of(arithmetic_ops, [&](std::string op){ return expr->getOp() == op; })) {
     ss_ << "lhs = " << expr->getOp() << "(lhs, ";
   } else {
     ss_ << "lhs " << expr->getOp() << "= ";
@@ -415,7 +415,7 @@ void ASTStencilBody::visit(const std::shared_ptr<ast::ReductionOverNeighborExpr>
   }
   // "pop" argName
   denseArgName_ = argName;
-  if(none_of(num_ops, [&](std::string op){ return expr->getOp() == op; })) {
+  if(none_of(arithmetic_ops, [&](std::string op){ return expr->getOp() == op; })) {
     ss_ << ")";
   }
   ss_ << ";\n";

--- a/dawn/src/dawn/CodeGen/CXXNaive-ico/ASTStencilBody.cpp
+++ b/dawn/src/dawn/CodeGen/CXXNaive-ico/ASTStencilBody.cpp
@@ -382,7 +382,7 @@ void ASTStencilBody::visit(const std::shared_ptr<ast::ReductionOverNeighborExpr>
         << ASTStencilBody::ReductionIndexVarName(reductionDepth_ + 1) << ") mutable { ";
   }
 
-  if(!expr->is_arithmetic()) {
+  if(!expr->isArithmetic()) {
     ss_ << "lhs = " << expr->getOp() << "(lhs, ";
   } else {
     ss_ << "lhs " << expr->getOp() << "= ";
@@ -414,7 +414,7 @@ void ASTStencilBody::visit(const std::shared_ptr<ast::ReductionOverNeighborExpr>
   }
   // "pop" argName
   denseArgName_ = argName;
-  if(!expr->is_arithmetic()) {
+  if(!expr->isArithmetic()) {
     ss_ << ")";
   }
   ss_ << ";\n";

--- a/dawn/src/dawn/CodeGen/Cuda-ico/ASTStencilBody.cpp
+++ b/dawn/src/dawn/CodeGen/Cuda-ico/ASTStencilBody.cpp
@@ -240,7 +240,7 @@ void ASTStencilBody::visit(const std::shared_ptr<ast::ReductionOverNeighborExpr>
       << "pidx * " << chainToSparseSizeString(expr->getIterSpace()) << " + nbhIter"
       << "];\n";
   ss_ << "if (nbhIdx == DEVICE_MISSING_VALUE) { continue; }";
-  if(!expr->is_arithmetic()) {
+  if(!expr->isArithmetic()) {
     ss_ << lhs_name << " = " << expr->getOp() << "(" << lhs_name << ", ";
   } else {
     ss_ << lhs_name << " " << expr->getOp() << "= ";
@@ -249,7 +249,7 @@ void ASTStencilBody::visit(const std::shared_ptr<ast::ReductionOverNeighborExpr>
     ss_ << weights_name << "[nbhIter] * ";
   }
   expr->getRhs()->accept(*this);
-  if(!expr->is_arithmetic()) {
+  if(!expr->isArithmetic()) {
     ss_ << ")";
   }
   ss_ << ";}\n";

--- a/dawn/src/dawn/CodeGen/Cuda-ico/ASTStencilBody.cpp
+++ b/dawn/src/dawn/CodeGen/Cuda-ico/ASTStencilBody.cpp
@@ -240,8 +240,8 @@ void ASTStencilBody::visit(const std::shared_ptr<ast::ReductionOverNeighborExpr>
       << "pidx * " << chainToSparseSizeString(expr->getIterSpace()) << " + nbhIter"
       << "];\n";
   ss_ << "if (nbhIdx == DEVICE_MISSING_VALUE) { continue; }";
-  std::vector<std::string> num_ops {"+", "-", "*", "/", "%"};
-  if(none_of(num_ops, [&](std::string op){ return expr->getOp() == op; })) {
+  std::vector<std::string> arithmetic_ops{"+", "-", "*", "/", "%"};
+  if(none_of(arithmetic_ops, [&](std::string op){ return expr->getOp() == op; })) {
     ss_ << lhs_name << " = " << expr->getOp() << "(" << lhs_name << ", ";
   } else {
     ss_ << lhs_name << " " << expr->getOp() << "= ";
@@ -250,7 +250,7 @@ void ASTStencilBody::visit(const std::shared_ptr<ast::ReductionOverNeighborExpr>
     ss_  << weights_name << "[nbhIter] * ";
   }
   expr->getRhs()->accept(*this);
-  if(none_of(num_ops, [&](std::string op){ return expr->getOp() == op; })) {
+  if(none_of(arithmetic_ops, [&](std::string op){ return expr->getOp() == op; })) {
     ss_ << ")";
   }
   ss_ << ";}\n";

--- a/dawn/src/dawn/CodeGen/Cuda-ico/ASTStencilBody.cpp
+++ b/dawn/src/dawn/CodeGen/Cuda-ico/ASTStencilBody.cpp
@@ -240,17 +240,16 @@ void ASTStencilBody::visit(const std::shared_ptr<ast::ReductionOverNeighborExpr>
       << "pidx * " << chainToSparseSizeString(expr->getIterSpace()) << " + nbhIter"
       << "];\n";
   ss_ << "if (nbhIdx == DEVICE_MISSING_VALUE) { continue; }";
-  std::vector<std::string> arithmetic_ops{"+", "-", "*", "/", "%"};
-  if(none_of(arithmetic_ops, [&](std::string op){ return expr->getOp() == op; })) {
+  if(!expr->is_arithmetic()) {
     ss_ << lhs_name << " = " << expr->getOp() << "(" << lhs_name << ", ";
   } else {
     ss_ << lhs_name << " " << expr->getOp() << "= ";
   }
   if(weights.has_value()) {
-    ss_  << weights_name << "[nbhIter] * ";
+    ss_ << weights_name << "[nbhIter] * ";
   }
   expr->getRhs()->accept(*this);
-  if(none_of(arithmetic_ops, [&](std::string op){ return expr->getOp() == op; })) {
+  if(!expr->is_arithmetic()) {
     ss_ << ")";
   }
   ss_ << ";}\n";

--- a/dawn/src/dawn/CodeGen/Cuda-ico/ASTStencilBody.cpp
+++ b/dawn/src/dawn/CodeGen/Cuda-ico/ASTStencilBody.cpp
@@ -240,11 +240,18 @@ void ASTStencilBody::visit(const std::shared_ptr<ast::ReductionOverNeighborExpr>
       << "pidx * " << chainToSparseSizeString(expr->getIterSpace()) << " + nbhIter"
       << "];\n";
   ss_ << "if (nbhIdx == DEVICE_MISSING_VALUE) { continue; }";
-  ss_ << lhs_name << " " << expr->getOp() << "=";
+  if(expr->getOp() != "+") {
+    ss_ << lhs_name << " = " << expr->getOp() << "(" << lhs_name << ",";
+  } else {
+    ss_ << lhs_name << " " << expr->getOp() << "=";
+  }
   if(weights.has_value()) {
     ss_ << " " << weights_name << "[nbhIter] * ";
   }
   expr->getRhs()->accept(*this);
+  if(expr->getOp() != "+") {
+    ss_ << ")";
+  }
   ss_ << ";}\n";
   parentIsReduction_ = false;
 }

--- a/dawn/src/dawn/CodeGen/Cuda-ico/ASTStencilBody.cpp
+++ b/dawn/src/dawn/CodeGen/Cuda-ico/ASTStencilBody.cpp
@@ -240,16 +240,17 @@ void ASTStencilBody::visit(const std::shared_ptr<ast::ReductionOverNeighborExpr>
       << "pidx * " << chainToSparseSizeString(expr->getIterSpace()) << " + nbhIter"
       << "];\n";
   ss_ << "if (nbhIdx == DEVICE_MISSING_VALUE) { continue; }";
-  if(expr->getOp() != "+") {
-    ss_ << lhs_name << " = " << expr->getOp() << "(" << lhs_name << ",";
+  std::vector<std::string> num_ops {"+", "-", "*", "/", "%"};
+  if(none_of(num_ops, [&](std::string op){ return expr->getOp() == op; })) {
+    ss_ << lhs_name << " = " << expr->getOp() << "(" << lhs_name << ", ";
   } else {
-    ss_ << lhs_name << " " << expr->getOp() << "=";
+    ss_ << lhs_name << " " << expr->getOp() << "= ";
   }
   if(weights.has_value()) {
-    ss_ << " " << weights_name << "[nbhIter] * ";
+    ss_  << weights_name << "[nbhIter] * ";
   }
   expr->getRhs()->accept(*this);
-  if(expr->getOp() != "+") {
+  if(none_of(num_ops, [&](std::string op){ return expr->getOp() == op; })) {
     ss_ << ")";
   }
   ss_ << ";}\n";


### PR DESCRIPTION
## Technical Description

Fixes the bugs in the following two tasks:
Fixes #1097 : Now explicitly check if the `lowerLevel` and `upperLevel` of the interval are both `End`.
Fixes #1098 : Now branch with `sum_over` being the special case and `max_over`, `min_over` behaving the same way.





