### PR TITLE
Generated code now formatted with clang::libFormat

### DIFF
--- a/dawn/src/dawn/CodeGen/CMakeLists.txt
+++ b/dawn/src/dawn/CodeGen/CMakeLists.txt
@@ -79,4 +79,4 @@ add_library(DawnCodeGen
 )
 
 target_add_dawn_standard_props(DawnCodeGen)
-target_link_libraries(DawnCodeGen PUBLIC DawnSerialization DawnSupport DawnIIR)
+target_link_libraries(DawnCodeGen PUBLIC DawnSerialization DawnSupport DawnIIR Clang::Clang LLVM::LLVM)

--- a/dawn/src/dawn/Support/ClangCompat/CompilerInvocation.h
+++ b/dawn/src/dawn/Support/ClangCompat/CompilerInvocation.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include "clang/Basic/Version.h"
+#include "clang/Frontend/CompilerInvocation.h"
+#include "llvm/Option/Option.h"
+
+namespace dawn::clang_compat::CompilerInvocation {
+#if CLANG_VERSION_MAJOR < 10
+inline bool CreateFromArgs(clang::CompilerInvocation& Res, llvm::opt::ArgStringList& ccArgs,
+                           clang::DiagnosticsEngine& Diags) {
+  return clang::CompilerInvocation::CreateFromArgs(
+      Res, const_cast<const char**>(ccArgs.data()),
+      const_cast<const char**>(ccArgs.data()) + ccArgs.size(), Diags);
+}
+#else
+inline bool CreateFromArgs(clang::CompilerInvocation& Res, llvm::opt::ArgStringList& ccArgs,
+                           clang::DiagnosticsEngine& Diags) {
+  return clang::CompilerInvocation::CreateFromArgs(Res, ccArgs, Diags);
+}
+#endif
+} // namespace dawn::clang_compat::CompilerInvocation

--- a/dawn/src/dawn/Support/ClangCompat/EvalResult.h
+++ b/dawn/src/dawn/Support/ClangCompat/EvalResult.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include "clang/AST/Expr.h"
+#include "clang/Basic/Version.h"
+
+namespace dawn::clang_compat::Expr {
+#if CLANG_VERSION_MAJOR < 8
+using EvalResultInt = ::llvm::APSInt;
+inline int64_t getInt(EvalResultInt const& res) { return res.getExtValue(); }
+
+#else
+using EvalResultInt = ::clang::Expr::EvalResult;
+inline int64_t getInt(EvalResultInt const& res) { return res.Val.getInt().getExtValue(); }
+
+#endif
+} // namespace dawn::clang_compat::Expr

--- a/dawn/src/dawn/Support/ClangCompat/FileSystem.h
+++ b/dawn/src/dawn/Support/ClangCompat/FileSystem.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include "llvm/Config/llvm-config.h"
+#include "llvm/Support/FileSystem.h"
+
+namespace dawn::clang_compat {
+#if LLVM_VERSION_MAJOR < 7
+namespace llvm::sys::fs::OpenFlags {
+static constexpr ::llvm::sys::fs::OpenFlags OF_Text = ::llvm::sys::fs::OpenFlags::F_Text;
+}
+#else
+namespace llvm::sys::fs::OpenFlags {
+static constexpr ::llvm::sys::fs::OpenFlags OF_Text = ::llvm::sys::fs::OpenFlags::OF_Text;
+}
+#endif
+} // namespace dawn::clang_compat

--- a/dawn/src/dawn/Support/ClangCompat/FileUtil.h
+++ b/dawn/src/dawn/Support/ClangCompat/FileUtil.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include "clang/Basic/FileManager.h"
+#include "clang/Basic/Version.h"
+
+namespace dawn::clang_compat::FileUtil {
+#if CLANG_VERSION_MAJOR < 10
+inline const clang::FileEntry* getFile(clang::FileManager& files, ::llvm::StringRef filename) {
+  return files.getFile(filename);
+}
+#else
+inline const clang::FileEntry* getFile(clang::FileManager& files, ::llvm::StringRef filename) {
+  return files.getFile(filename).get(); // maybe check for error
+}
+#endif
+} // namespace dawn::clang_compat::FileUtil

--- a/dawn/src/dawn/Support/ClangCompat/ImplicitNodes.h
+++ b/dawn/src/dawn/Support/ClangCompat/ImplicitNodes.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include "clang/AST/Expr.h"
+#include "clang/Basic/Version.h"
+
+// TODO skipAllImplicitNodes should be refactored to be only called for Exprs (not Stmts)
+// to reflect the change in clang 9
+
+namespace dawn::clang_compat {
+
+#if CLANG_VERSION_MAJOR < 9
+template <typename StmtT>
+StmtT* skipAllImplicitNodes(StmtT* e) {
+  static_assert(std::is_base_of_v<clang::Stmt, std::decay_t<StmtT>>);
+  while(e != e->IgnoreImplicit())
+    e = e->IgnoreImplicit();
+  return e;
+}
+#else
+template <typename StmtT>
+StmtT* skipAllImplicitNodes(StmtT* s) {
+  static_assert(std::is_base_of_v<clang::Stmt, std::decay_t<StmtT>>);
+  if(auto* e = llvm::dyn_cast_or_null<clang::Expr>(s)) {
+    while(e != e->IgnoreImplicit())
+      e = e->IgnoreImplicit();
+    return e;
+  }
+  return s;
+}
+#endif
+} // namespace dawn::clang_compat

--- a/dawn/src/dawn/Support/ClangCompat/SourceLocation.h
+++ b/dawn/src/dawn/Support/ClangCompat/SourceLocation.h
@@ -1,0 +1,44 @@
+#pragma once
+
+#include "clang/AST/DeclBase.h"
+#include "clang/AST/DeclCXX.h"
+#include "clang/AST/Expr.h"
+#include "clang/AST/Stmt.h"
+#include "clang/Basic/SourceLocation.h"
+#include "clang/Basic/Version.h"
+
+namespace dawn::clang_compat {
+#if CLANG_VERSION_MAJOR < 8
+inline ::clang::SourceLocation getEndLoc(::clang::CXXBaseSpecifier const& base) {
+  return base.getLocStart();
+}
+inline ::clang::SourceLocation getBeginLoc(::clang::CXXBaseSpecifier const& base) {
+  return base.getLocEnd();
+}
+
+inline ::clang::SourceLocation getBeginLoc(::clang::Decl const& decl) { return decl.getLocStart(); }
+inline ::clang::SourceLocation getEndLoc(::clang::Decl const& decl) { return decl.getLocEnd(); }
+
+inline ::clang::SourceLocation getBeginLoc(::clang::Expr const& expr) { return expr.getLocStart(); }
+inline ::clang::SourceLocation getEndLoc(::clang::Expr const& expr) { return expr.getLocEnd(); }
+
+inline ::clang::SourceLocation getBeginLoc(::clang::Stmt const& stmt) { return stmt.getLocStart(); }
+inline ::clang::SourceLocation getEndLoc(::clang::Stmt const& stmt) { return stmt.getLocEnd(); }
+#else
+inline ::clang::SourceLocation getEndLoc(::clang::CXXBaseSpecifier const& base) {
+  return base.getEndLoc();
+}
+inline ::clang::SourceLocation getBeginLoc(::clang::CXXBaseSpecifier const& base) {
+  return base.getBeginLoc();
+}
+
+inline ::clang::SourceLocation getBeginLoc(::clang::Decl const& decl) { return decl.getBeginLoc(); }
+inline ::clang::SourceLocation getEndLoc(::clang::Decl const& decl) { return decl.getEndLoc(); }
+
+inline ::clang::SourceLocation getBeginLoc(::clang::Expr const& expr) { return expr.getBeginLoc(); }
+inline ::clang::SourceLocation getEndLoc(::clang::Expr const& expr) { return expr.getEndLoc(); }
+
+inline ::clang::SourceLocation getBeginLoc(::clang::Stmt const& stmt) { return stmt.getBeginLoc(); }
+inline ::clang::SourceLocation getEndLoc(::clang::Stmt const& stmt) { return stmt.getEndLoc(); }
+#endif
+} // namespace dawn::clang_compat

--- a/dawn/src/dawn/Support/ClangCompat/VirtualFileSystem.h
+++ b/dawn/src/dawn/Support/ClangCompat/VirtualFileSystem.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "clang/Basic/Version.h"
+
+#if CLANG_VERSION_MAJOR < 8
+#include "clang/Basic/VirtualFileSystem.h"
+#else
+#include "llvm/Support/VirtualFileSystem.h"
+#endif
+
+namespace dawn::clang_compat {
+#if CLANG_VERSION_MAJOR < 8
+
+namespace llvm::vfs {
+using InMemoryFileSystem = ::clang::vfs::InMemoryFileSystem;
+}
+#else
+namespace llvm::vfs {
+using InMemoryFileSystem = ::llvm::vfs::InMemoryFileSystem;
+} // namespace llvm::vfs
+#endif
+
+} // namespace dawn::clang_compat

--- a/dawn/test/integration-test/dawn4py-tests/data/ICON_laplacian_stencil_ref.cpp
+++ b/dawn/test/integration-test/dawn4py-tests/data/ICON_laplacian_stencil_ref.cpp
@@ -6,13 +6,11 @@
 #include <driver-includes/unstructured_domain.hpp>
 #include <driver-includes/math.hpp>
 
-
-namespace dawn_generated{
-namespace cxxnaiveico{
-template<typename LibTag>
+namespace dawn_generated {
+namespace cxxnaiveico {
+template <typename LibTag>
 class ICON_laplacian_stencil {
 private:
-
   struct stencil_68 {
     ::dawn::mesh_t<LibTag> const& m_mesh;
     int m_k_size;
@@ -27,80 +25,153 @@ private:
     ::dawn::edge_field_t<LibTag, ::dawn::float_type>& m_tangent_orientation;
     ::dawn::sparse_vertex_field_t<LibTag, ::dawn::float_type>& m_geofac_rot;
     ::dawn::sparse_cell_field_t<LibTag, ::dawn::float_type>& m_geofac_div;
-    ::dawn::unstructured_domain   m_unstructured_domain ;
+    ::dawn::unstructured_domain m_unstructured_domain;
+
   public:
+    stencil_68(::dawn::mesh_t<LibTag> const& mesh, int k_size,
+               ::dawn::edge_field_t<LibTag, ::dawn::float_type>& vec,
+               ::dawn::cell_field_t<LibTag, ::dawn::float_type>& div_vec,
+               ::dawn::vertex_field_t<LibTag, ::dawn::float_type>& rot_vec,
+               ::dawn::edge_field_t<LibTag, ::dawn::float_type>& __tmp_nab_60,
+               ::dawn::edge_field_t<LibTag, ::dawn::float_type>& __tmp_nab_61,
+               ::dawn::edge_field_t<LibTag, ::dawn::float_type>& nabla2_vec,
+               ::dawn::edge_field_t<LibTag, ::dawn::float_type>& primal_edge_length,
+               ::dawn::edge_field_t<LibTag, ::dawn::float_type>& dual_edge_length,
+               ::dawn::edge_field_t<LibTag, ::dawn::float_type>& tangent_orientation,
+               ::dawn::sparse_vertex_field_t<LibTag, ::dawn::float_type>& geofac_rot,
+               ::dawn::sparse_cell_field_t<LibTag, ::dawn::float_type>& geofac_div)
+        : m_mesh(mesh), m_k_size(k_size), m_vec(vec), m_div_vec(div_vec), m_rot_vec(rot_vec),
+          m___tmp_nab_60(__tmp_nab_60), m___tmp_nab_61(__tmp_nab_61), m_nabla2_vec(nabla2_vec),
+          m_primal_edge_length(primal_edge_length), m_dual_edge_length(dual_edge_length),
+          m_tangent_orientation(tangent_orientation), m_geofac_rot(geofac_rot),
+          m_geofac_div(geofac_div) {}
 
-    stencil_68(::dawn::mesh_t<LibTag> const &mesh, int k_size, ::dawn::edge_field_t<LibTag, ::dawn::float_type>&vec, ::dawn::cell_field_t<LibTag, ::dawn::float_type>&div_vec, ::dawn::vertex_field_t<LibTag, ::dawn::float_type>&rot_vec, ::dawn::edge_field_t<LibTag, ::dawn::float_type>&__tmp_nab_60, ::dawn::edge_field_t<LibTag, ::dawn::float_type>&__tmp_nab_61, ::dawn::edge_field_t<LibTag, ::dawn::float_type>&nabla2_vec, ::dawn::edge_field_t<LibTag, ::dawn::float_type>&primal_edge_length, ::dawn::edge_field_t<LibTag, ::dawn::float_type>&dual_edge_length, ::dawn::edge_field_t<LibTag, ::dawn::float_type>&tangent_orientation, ::dawn::sparse_vertex_field_t<LibTag, ::dawn::float_type>&geofac_rot, ::dawn::sparse_cell_field_t<LibTag, ::dawn::float_type>&geofac_div) : m_mesh(mesh), m_k_size(k_size), m_vec(vec), m_div_vec(div_vec), m_rot_vec(rot_vec), m___tmp_nab_60(__tmp_nab_60), m___tmp_nab_61(__tmp_nab_61), m_nabla2_vec(nabla2_vec), m_primal_edge_length(primal_edge_length), m_dual_edge_length(dual_edge_length), m_tangent_orientation(tangent_orientation), m_geofac_rot(geofac_rot), m_geofac_div(geofac_div){}
+    ~stencil_68() {}
 
-    ~stencil_68() {
-    }
-
-    void sync_storages() {
-    }
-    static constexpr ::dawn::driver::unstructured_extent vec_extent = {true, 0,0};
-    static constexpr ::dawn::driver::unstructured_extent div_vec_extent = {true, 0,0};
-    static constexpr ::dawn::driver::unstructured_extent rot_vec_extent = {true, 0,0};
-    static constexpr ::dawn::driver::unstructured_extent nabla2_vec_extent = {false, 0,0};
-    static constexpr ::dawn::driver::unstructured_extent primal_edge_length_extent = {false, 0,0};
-    static constexpr ::dawn::driver::unstructured_extent dual_edge_length_extent = {false, 0,0};
-    static constexpr ::dawn::driver::unstructured_extent tangent_orientation_extent = {false, 0,0};
-    static constexpr ::dawn::driver::unstructured_extent geofac_rot_extent = {true, 0,0};
-    static constexpr ::dawn::driver::unstructured_extent geofac_div_extent = {true, 0,0};
+    void sync_storages() {}
+    static constexpr ::dawn::driver::unstructured_extent vec_extent = {true, 0, 0};
+    static constexpr ::dawn::driver::unstructured_extent div_vec_extent = {true, 0, 0};
+    static constexpr ::dawn::driver::unstructured_extent rot_vec_extent = {true, 0, 0};
+    static constexpr ::dawn::driver::unstructured_extent nabla2_vec_extent = {false, 0, 0};
+    static constexpr ::dawn::driver::unstructured_extent primal_edge_length_extent = {false, 0, 0};
+    static constexpr ::dawn::driver::unstructured_extent dual_edge_length_extent = {false, 0, 0};
+    static constexpr ::dawn::driver::unstructured_extent tangent_orientation_extent = {false, 0, 0};
+    static constexpr ::dawn::driver::unstructured_extent geofac_rot_extent = {true, 0, 0};
+    static constexpr ::dawn::driver::unstructured_extent geofac_div_extent = {true, 0, 0};
 
     void run() {
       using ::dawn::deref;
-{
-    for(int k = 0+0; k <= ( m_k_size == 0 ? 0 : (m_k_size - 1)) + 0+0; ++k) {
-      for(auto const& loc : getVertices(LibTag{}, m_mesh)) {
-m_rot_vec(deref(LibTag{}, loc), (k + 0)) = reduce(LibTag{}, m_mesh,loc, (::dawn::float_type) 0.0, std::vector<::dawn::LocationType>{::dawn::LocationType::Vertices, ::dawn::LocationType::Edges}, [&, sparse_dimension_idx0 = int(0)](auto& lhs, auto red_loc1) mutable { lhs += (m_vec(deref(LibTag{}, red_loc1), (k + 0)) * m_geofac_rot(deref(LibTag{}, loc),sparse_dimension_idx0, (k + 0)));
-sparse_dimension_idx0++;
-return lhs;
-});
-      }      for(auto const& loc : getCells(LibTag{}, m_mesh)) {
-m_div_vec(deref(LibTag{}, loc), (k + 0)) = reduce(LibTag{}, m_mesh,loc, (::dawn::float_type) 0.0, std::vector<::dawn::LocationType>{::dawn::LocationType::Cells, ::dawn::LocationType::Edges}, [&, sparse_dimension_idx0 = int(0)](auto& lhs, auto red_loc1) mutable { lhs += (m_vec(deref(LibTag{}, red_loc1), (k + 0)) * m_geofac_div(deref(LibTag{}, loc),sparse_dimension_idx0, (k + 0)));
-sparse_dimension_idx0++;
-return lhs;
-});
-      }      for(auto const& loc : getEdges(LibTag{}, m_mesh)) {
-m___tmp_nab_60(deref(LibTag{}, loc), (k + 0)) = reduce(LibTag{}, m_mesh,loc, (::dawn::float_type) 0.0, std::vector<::dawn::LocationType>{::dawn::LocationType::Edges, ::dawn::LocationType::Vertices}, [&, sparse_dimension_idx0 = int(0)](auto& lhs, auto red_loc1, auto const& weight) mutable {
-lhs += weight * m_rot_vec(deref(LibTag{}, red_loc1), (k + 0));
-sparse_dimension_idx0++;
-return lhs;
-}, std::vector<::dawn::float_type>({(::dawn::float_type) -1.0, (::dawn::float_type) 1.0}));
-      }      for(auto const& loc : getEdges(LibTag{}, m_mesh)) {
-m___tmp_nab_60(deref(LibTag{}, loc), (k + 0)) = ((m_tangent_orientation(deref(LibTag{}, loc), (k + 0)) * m___tmp_nab_60(deref(LibTag{}, loc), (k + 0))) / m_primal_edge_length(deref(LibTag{}, loc), (k + 0)));
-      }      for(auto const& loc : getEdges(LibTag{}, m_mesh)) {
-m___tmp_nab_61(deref(LibTag{}, loc), (k + 0)) = reduce(LibTag{}, m_mesh,loc, (::dawn::float_type) 0.0, std::vector<::dawn::LocationType>{::dawn::LocationType::Edges, ::dawn::LocationType::Cells}, [&, sparse_dimension_idx0 = int(0)](auto& lhs, auto red_loc1, auto const& weight) mutable {
-lhs += weight * m_div_vec(deref(LibTag{}, red_loc1), (k + 0));
-sparse_dimension_idx0++;
-return lhs;
-}, std::vector<::dawn::float_type>({(::dawn::float_type) -1.0, (::dawn::float_type) 1.0}));
-      }      for(auto const& loc : getEdges(LibTag{}, m_mesh)) {
-m___tmp_nab_61(deref(LibTag{}, loc), (k + 0)) = (m___tmp_nab_61(deref(LibTag{}, loc), (k + 0)) / m_dual_edge_length(deref(LibTag{}, loc), (k + 0)));
-      }      for(auto const& loc : getEdges(LibTag{}, m_mesh)) {
-m_nabla2_vec(deref(LibTag{}, loc), (k + 0)) = (m___tmp_nab_61(deref(LibTag{}, loc), (k + 0)) - m___tmp_nab_60(deref(LibTag{}, loc), (k + 0)));
-      }    }}      sync_storages();
+      {
+        for(int k = 0 + 0; k <= (m_k_size == 0 ? 0 : (m_k_size - 1)) + 0 + 0; ++k) {
+          for(auto const& loc : getVertices(LibTag{}, m_mesh)) {
+            m_rot_vec(deref(LibTag{}, loc), (k + 0)) =
+                reduce(LibTag{}, m_mesh, loc, (::dawn::float_type)0.0,
+                       std::vector<::dawn::LocationType>{::dawn::LocationType::Vertices,
+                                                         ::dawn::LocationType::Edges},
+                       [&, sparse_dimension_idx0 = int(0)](auto& lhs, auto red_loc1) mutable {
+                         lhs +=
+                             (m_vec(deref(LibTag{}, red_loc1), (k + 0)) *
+                              m_geofac_rot(deref(LibTag{}, loc), sparse_dimension_idx0, (k + 0)));
+                         sparse_dimension_idx0++;
+                         return lhs;
+                       });
+          }
+          for(auto const& loc : getCells(LibTag{}, m_mesh)) {
+            m_div_vec(deref(LibTag{}, loc), (k + 0)) =
+                reduce(LibTag{}, m_mesh, loc, (::dawn::float_type)0.0,
+                       std::vector<::dawn::LocationType>{::dawn::LocationType::Cells,
+                                                         ::dawn::LocationType::Edges},
+                       [&, sparse_dimension_idx0 = int(0)](auto& lhs, auto red_loc1) mutable {
+                         lhs +=
+                             (m_vec(deref(LibTag{}, red_loc1), (k + 0)) *
+                              m_geofac_div(deref(LibTag{}, loc), sparse_dimension_idx0, (k + 0)));
+                         sparse_dimension_idx0++;
+                         return lhs;
+                       });
+          }
+          for(auto const& loc : getEdges(LibTag{}, m_mesh)) {
+            m___tmp_nab_60(deref(LibTag{}, loc), (k + 0)) = reduce(
+                LibTag{}, m_mesh, loc, (::dawn::float_type)0.0,
+                std::vector<::dawn::LocationType>{::dawn::LocationType::Edges,
+                                                  ::dawn::LocationType::Vertices},
+                [&, sparse_dimension_idx0 = int(0)](auto& lhs, auto red_loc1,
+                                                    auto const& weight) mutable {
+                  lhs += weight * m_rot_vec(deref(LibTag{}, red_loc1), (k + 0));
+                  sparse_dimension_idx0++;
+                  return lhs;
+                },
+                std::vector<::dawn::float_type>(
+                    {(::dawn::float_type)-1.0, (::dawn::float_type)1.0}));
+          }
+          for(auto const& loc : getEdges(LibTag{}, m_mesh)) {
+            m___tmp_nab_60(deref(LibTag{}, loc), (k + 0)) =
+                ((m_tangent_orientation(deref(LibTag{}, loc), (k + 0)) *
+                  m___tmp_nab_60(deref(LibTag{}, loc), (k + 0))) /
+                 m_primal_edge_length(deref(LibTag{}, loc), (k + 0)));
+          }
+          for(auto const& loc : getEdges(LibTag{}, m_mesh)) {
+            m___tmp_nab_61(deref(LibTag{}, loc), (k + 0)) = reduce(
+                LibTag{}, m_mesh, loc, (::dawn::float_type)0.0,
+                std::vector<::dawn::LocationType>{::dawn::LocationType::Edges,
+                                                  ::dawn::LocationType::Cells},
+                [&, sparse_dimension_idx0 = int(0)](auto& lhs, auto red_loc1,
+                                                    auto const& weight) mutable {
+                  lhs += weight * m_div_vec(deref(LibTag{}, red_loc1), (k + 0));
+                  sparse_dimension_idx0++;
+                  return lhs;
+                },
+                std::vector<::dawn::float_type>(
+                    {(::dawn::float_type)-1.0, (::dawn::float_type)1.0}));
+          }
+          for(auto const& loc : getEdges(LibTag{}, m_mesh)) {
+            m___tmp_nab_61(deref(LibTag{}, loc), (k + 0)) =
+                (m___tmp_nab_61(deref(LibTag{}, loc), (k + 0)) /
+                 m_dual_edge_length(deref(LibTag{}, loc), (k + 0)));
+          }
+          for(auto const& loc : getEdges(LibTag{}, m_mesh)) {
+            m_nabla2_vec(deref(LibTag{}, loc), (k + 0)) =
+                (m___tmp_nab_61(deref(LibTag{}, loc), (k + 0)) -
+                 m___tmp_nab_60(deref(LibTag{}, loc), (k + 0)));
+          }
+        }
+      }
+      sync_storages();
     }
   };
   static constexpr const char* s_name = "ICON_laplacian_stencil";
   stencil_68 m_stencil_68;
-public:
 
+public:
   ICON_laplacian_stencil(const ICON_laplacian_stencil&) = delete;
 
   // Members
   ::dawn::edge_field_t<LibTag, ::dawn::float_type> m___tmp_nab_60;
   ::dawn::edge_field_t<LibTag, ::dawn::float_type> m___tmp_nab_61;
 
-  void set_splitter_index(::dawn::LocationType loc, ::dawn::UnstructuredSubdomain subdomain, int offset, int index) {
+  void set_splitter_index(::dawn::LocationType loc, ::dawn::UnstructuredSubdomain subdomain,
+                          int offset, int index) {
     m_stencil_68.m_unstructured_domain.set_splitter_index({loc, subdomain, offset}, index);
   }
 
-  ICON_laplacian_stencil(const ::dawn::mesh_t<LibTag> &mesh, int k_size, ::dawn::edge_field_t<LibTag, ::dawn::float_type>& vec, ::dawn::cell_field_t<LibTag, ::dawn::float_type>& div_vec, ::dawn::vertex_field_t<LibTag, ::dawn::float_type>& rot_vec, ::dawn::edge_field_t<LibTag, ::dawn::float_type>& nabla2_vec, ::dawn::edge_field_t<LibTag, ::dawn::float_type>& primal_edge_length, ::dawn::edge_field_t<LibTag, ::dawn::float_type>& dual_edge_length, ::dawn::edge_field_t<LibTag, ::dawn::float_type>& tangent_orientation, ::dawn::sparse_vertex_field_t<LibTag, ::dawn::float_type>& geofac_rot, ::dawn::sparse_cell_field_t<LibTag, ::dawn::float_type>& geofac_div) : m_stencil_68(mesh, k_size,vec,div_vec,rot_vec,m___tmp_nab_60,m___tmp_nab_61,nabla2_vec,primal_edge_length,dual_edge_length,tangent_orientation,geofac_rot,geofac_div), m___tmp_nab_60(allocateField(LibTag{}, numEdges(LibTag{}, mesh) + 0, k_size)), m___tmp_nab_61(allocateField(LibTag{}, numEdges(LibTag{}, mesh) + 0, k_size)){}
+  ICON_laplacian_stencil(const ::dawn::mesh_t<LibTag>& mesh, int k_size,
+                         ::dawn::edge_field_t<LibTag, ::dawn::float_type>& vec,
+                         ::dawn::cell_field_t<LibTag, ::dawn::float_type>& div_vec,
+                         ::dawn::vertex_field_t<LibTag, ::dawn::float_type>& rot_vec,
+                         ::dawn::edge_field_t<LibTag, ::dawn::float_type>& nabla2_vec,
+                         ::dawn::edge_field_t<LibTag, ::dawn::float_type>& primal_edge_length,
+                         ::dawn::edge_field_t<LibTag, ::dawn::float_type>& dual_edge_length,
+                         ::dawn::edge_field_t<LibTag, ::dawn::float_type>& tangent_orientation,
+                         ::dawn::sparse_vertex_field_t<LibTag, ::dawn::float_type>& geofac_rot,
+                         ::dawn::sparse_cell_field_t<LibTag, ::dawn::float_type>& geofac_div)
+      : m_stencil_68(mesh, k_size, vec, div_vec, rot_vec, m___tmp_nab_60, m___tmp_nab_61,
+                     nabla2_vec, primal_edge_length, dual_edge_length, tangent_orientation,
+                     geofac_rot, geofac_div),
+        m___tmp_nab_60(allocateField(LibTag{}, numEdges(LibTag{}, mesh) + 0, k_size)),
+        m___tmp_nab_61(allocateField(LibTag{}, numEdges(LibTag{}, mesh) + 0, k_size)) {}
 
   void run() {
     m_stencil_68.run();
-;
+    ;
   }
 };
 } // namespace cxxnaiveico

--- a/dawn/test/integration-test/dawn4py-tests/data/copy_stencil_ref.cpp
+++ b/dawn/test/integration-test/dawn4py-tests/data/copy_stencil_ref.cpp
@@ -2,45 +2,48 @@
 #undef DAWN_BACKEND_T
 #define DAWN_BACKEND_T CUDA
 #ifndef BOOST_RESULT_OF_USE_TR1
- #define BOOST_RESULT_OF_USE_TR1 1
+#define BOOST_RESULT_OF_USE_TR1 1
 #endif
 #ifndef BOOST_NO_CXX11_DECLTYPE
- #define BOOST_NO_CXX11_DECLTYPE 1
+#define BOOST_NO_CXX11_DECLTYPE 1
 #endif
 #ifndef GRIDTOOLS_DAWN_HALO_EXTENT
- #define GRIDTOOLS_DAWN_HALO_EXTENT 3
+#define GRIDTOOLS_DAWN_HALO_EXTENT 3
 #endif
 #ifndef BOOST_PP_VARIADICS
- #define BOOST_PP_VARIADICS 1
+#define BOOST_PP_VARIADICS 1
 #endif
 #ifndef BOOST_FUSION_DONT_USE_PREPROCESSED_FILES
- #define BOOST_FUSION_DONT_USE_PREPROCESSED_FILES 1
+#define BOOST_FUSION_DONT_USE_PREPROCESSED_FILES 1
 #endif
 #ifndef BOOST_MPL_CFG_NO_PREPROCESSED_HEADERS
- #define BOOST_MPL_CFG_NO_PREPROCESSED_HEADERS 1
+#define BOOST_MPL_CFG_NO_PREPROCESSED_HEADERS 1
 #endif
 #ifndef GT_VECTOR_LIMIT_SIZE
- #define GT_VECTOR_LIMIT_SIZE 30
+#define GT_VECTOR_LIMIT_SIZE 30
 #endif
 #ifndef BOOST_FUSION_INVOKE_MAX_ARITY
- #define BOOST_FUSION_INVOKE_MAX_ARITY GT_VECTOR_LIMIT_SIZE
+#define BOOST_FUSION_INVOKE_MAX_ARITY GT_VECTOR_LIMIT_SIZE
 #endif
 #ifndef FUSION_MAX_VECTOR_SIZE
- #define FUSION_MAX_VECTOR_SIZE GT_VECTOR_LIMIT_SIZE
+#define FUSION_MAX_VECTOR_SIZE GT_VECTOR_LIMIT_SIZE
 #endif
 #ifndef FUSION_MAX_MAP_SIZE
- #define FUSION_MAX_MAP_SIZE GT_VECTOR_LIMIT_SIZE
+#define FUSION_MAX_MAP_SIZE GT_VECTOR_LIMIT_SIZE
 #endif
 #ifndef BOOST_MPL_LIMIT_VECTOR_SIZE
- #define BOOST_MPL_LIMIT_VECTOR_SIZE GT_VECTOR_LIMIT_SIZE
+#define BOOST_MPL_LIMIT_VECTOR_SIZE GT_VECTOR_LIMIT_SIZE
 #endif
 #include <driver-includes/gridtools_includes.hpp>
 using namespace gridtools::dawn;
 
-
-namespace dawn_generated{
-namespace cuda{
-__global__ void __launch_bounds__(32)  copy_stencil_stencil11_ms23_kernel(const int isize, const int jsize, const int ksize, const int stride_111_1, const int stride_111_2, ::dawn::float_type * const in, ::dawn::float_type * const out) {
+namespace dawn_generated {
+namespace cuda {
+__global__ void __launch_bounds__(32)
+    copy_stencil_stencil11_ms23_kernel(const int isize, const int jsize, const int ksize,
+                                       const int stride_111_1, const int stride_111_2,
+                                       ::dawn::float_type* const in,
+                                       ::dawn::float_type* const out) {
 
   // Start kernel
   const unsigned int nx = isize;
@@ -77,20 +80,21 @@ __global__ void __launch_bounds__(32)  copy_stencil_stencil11_ms23_kernel(const 
   // Regions (a,h,e) and (c,i,g) are executed by two specialized warp
   int iblock = 0 - 1;
   int jblock = 0 - 1;
-if(threadIdx.y < +1) {
+  if(threadIdx.y < +1) {
     iblock = threadIdx.x;
     jblock = (int)threadIdx.y + 0;
-}
+  }
   // initialized iterators
-  int idx111 = (blockIdx.x*32+iblock)*1+(blockIdx.y*1+jblock)*stride_111_1;
+  int idx111 = (blockIdx.x * 32 + iblock) * 1 + (blockIdx.y * 1 + jblock) * stride_111_1;
 
   // Pre-fill of kcaches
-for(int k = 0+0; k <=  ksize - 1 + 0+0; ++k) {
+  for(int k = 0 + 0; k <= ksize - 1 + 0 + 0; ++k) {
 
     // Head fill of kcaches
-  if(iblock >= 0 && iblock <= block_size_i -1 + 0 && jblock >= 0 && jblock <= block_size_j -1 + 0) {
-out[idx111] = __ldg(&(in[idx111+1*1]));
-  }
+    if(iblock >= 0 && iblock <= block_size_i - 1 + 0 && jblock >= 0 &&
+       jblock <= block_size_j - 1 + 0) {
+      out[idx111] = __ldg(&(in[idx111 + 1 * 1]));
+    }
     // Flush of kcaches
 
     // Flush of kcaches
@@ -98,8 +102,8 @@ out[idx111] = __ldg(&(in[idx111+1*1]));
     // Slide kcaches
 
     // increment iterators
-    idx111+=stride_111_2;
-}
+    idx111 += stride_111_2;
+  }
   // Final flush of kcaches
 
   // Final flush of kcaches
@@ -109,14 +113,11 @@ out[idx111] = __ldg(&(in[idx111+1*1]));
 
 class copy_stencil {
 public:
-
   struct sbase : public timer_cuda {
 
-    sbase(std::string name) : timer_cuda(name){}
+    sbase(std::string name) : timer_cuda(name) {}
 
-    double get_time() {
-      return total_time();
-    }
+    double get_time() { return total_time(); }
   };
 
   struct stencil_11 : public sbase {
@@ -124,32 +125,37 @@ public:
     // Members
 
     // Temporary storage typedefs
-    using tmp_halo_t = gridtools::halo< 0,0, 0, 0, 0>;
-    using tmp_meta_data_t = storage_traits_t::storage_info_t< 0, 5, tmp_halo_t >;
-    using tmp_storage_t = storage_traits_t::data_store_t< ::dawn::float_type, tmp_meta_data_t>;
+    using tmp_halo_t = gridtools::halo<0, 0, 0, 0, 0>;
+    using tmp_meta_data_t = storage_traits_t::storage_info_t<0, 5, tmp_halo_t>;
+    using tmp_storage_t = storage_traits_t::data_store_t<::dawn::float_type, tmp_meta_data_t>;
     const gridtools::dawn::domain m_dom;
-  public:
 
-    stencil_11(const gridtools::dawn::domain& dom_, int rank, int xcols, int ycols) : sbase("stencil_11"), m_dom(dom_){}
-    static constexpr ::dawn::driver::cartesian_extent in_extent = {1,1, 0,0, 0,0};
-    static constexpr ::dawn::driver::cartesian_extent out_extent = {0,0, 0,0, 0,0};
+  public:
+    stencil_11(const gridtools::dawn::domain& dom_, int rank, int xcols, int ycols)
+        : sbase("stencil_11"), m_dom(dom_) {}
+    static constexpr ::dawn::driver::cartesian_extent in_extent = {1, 1, 0, 0, 0, 0};
+    static constexpr ::dawn::driver::cartesian_extent out_extent = {0, 0, 0, 0, 0, 0};
 
     void run(storage_ijk_t in_ds, storage_ijk_t out_ds) {
 
       // starting timers
       start();
-      {;
-      gridtools::data_view<storage_ijk_t> in= gridtools::make_device_view(in_ds);
-      gridtools::data_view<storage_ijk_t> out= gridtools::make_device_view(out_ds);
-      const unsigned int nx = m_dom.isize() - m_dom.iminus() - m_dom.iplus();
-      const unsigned int ny = m_dom.jsize() - m_dom.jminus() - m_dom.jplus();
-      const unsigned int nz = m_dom.ksize() - m_dom.kminus() - m_dom.kplus();
-      dim3 threads(32,1+0,1);
-      const unsigned int nbx = (nx + 32 - 1) / 32;
-      const unsigned int nby = (ny + 1 - 1) / 1;
-      const unsigned int nbz = 1;
-      dim3 blocks(nbx, nby, nbz);
-      copy_stencil_stencil11_ms23_kernel<<<blocks, threads>>>(nx,ny,nz,in_ds.strides()[1],in_ds.strides()[2],(in.data()+in_ds.get_storage_info_ptr()->index(in.begin<0>(), in.begin<1>(),0 )),(out.data()+out_ds.get_storage_info_ptr()->index(out.begin<0>(), out.begin<1>(),0 )));
+      {
+        ;
+        gridtools::data_view<storage_ijk_t> in = gridtools::make_device_view(in_ds);
+        gridtools::data_view<storage_ijk_t> out = gridtools::make_device_view(out_ds);
+        const unsigned int nx = m_dom.isize() - m_dom.iminus() - m_dom.iplus();
+        const unsigned int ny = m_dom.jsize() - m_dom.jminus() - m_dom.jplus();
+        const unsigned int nz = m_dom.ksize() - m_dom.kminus() - m_dom.kplus();
+        dim3 threads(32, 1 + 0, 1);
+        const unsigned int nbx = (nx + 32 - 1) / 32;
+        const unsigned int nby = (ny + 1 - 1) / 1;
+        const unsigned int nbz = 1;
+        dim3 blocks(nbx, nby, nbz);
+        copy_stencil_stencil11_ms23_kernel<<<blocks, threads>>>(
+            nx, ny, nz, in_ds.strides()[1], in_ds.strides()[2],
+            (in.data() + in_ds.get_storage_info_ptr()->index(in.begin<0>(), in.begin<1>(), 0)),
+            (out.data() + out_ds.get_storage_info_ptr()->index(out.begin<0>(), out.begin<1>(), 0)));
       };
 
       // stopping timers
@@ -158,44 +164,42 @@ public:
   };
   static constexpr const char* s_name = "copy_stencil";
   stencil_11 m_stencil_11;
-public:
 
+public:
   copy_stencil(const copy_stencil&) = delete;
 
   // Members
 
   // Stencil-Data
 
-  copy_stencil(const gridtools::dawn::domain& dom, int rank = 1, int xcols = 1, int ycols = 1) : m_stencil_11(dom, rank, xcols, ycols){}
+  copy_stencil(const gridtools::dawn::domain& dom, int rank = 1, int xcols = 1, int ycols = 1)
+      : m_stencil_11(dom, rank, xcols, ycols) {}
 
-  template<typename S>
+  template <typename S>
   void sync_storages(S field) {
     field.sync();
   }
 
-  template<typename S0, typename ... S>
+  template <typename S0, typename... S>
   void sync_storages(S0 f0, S... fields) {
     f0.sync();
     sync_storages(fields...);
   }
 
   void run(storage_ijk_t in, storage_ijk_t out) {
-    sync_storages(in,out);
-    m_stencil_11.run(in,out);
-;
-    sync_storages(in,out);
+    sync_storages(in, out);
+    m_stencil_11.run(in, out);
+    ;
+    sync_storages(in, out);
   }
 
-  std::string get_name()  const {
-    return std::string(s_name);
-  }
+  std::string get_name() const { return std::string(s_name); }
 
-  void reset_meters() {
-m_stencil_11.reset();  }
+  void reset_meters() { m_stencil_11.reset(); }
 
   double get_total_time() {
     double res = 0;
-    res +=m_stencil_11.get_time();
+    res += m_stencil_11.get_time();
     return res;
   }
 };

--- a/dawn/test/integration-test/dawn4py-tests/data/generate_versioned_field_ref.cpp
+++ b/dawn/test/integration-test/dawn4py-tests/data/generate_versioned_field_ref.cpp
@@ -6,13 +6,11 @@
 #include <driver-includes/unstructured_domain.hpp>
 #include <driver-includes/math.hpp>
 
-
-namespace dawn_generated{
-namespace cxxnaiveico{
-template<typename LibTag>
+namespace dawn_generated {
+namespace cxxnaiveico {
+template <typename LibTag>
 class generate_versioned_field {
 private:
-
   struct stencil_37 {
     ::dawn::mesh_t<LibTag> const& m_mesh;
     int m_k_size;
@@ -22,65 +20,83 @@ private:
     ::dawn::edge_field_t<LibTag, ::dawn::float_type>& m_d;
     ::dawn::edge_field_t<LibTag, ::dawn::float_type>& m_e;
     ::dawn::edge_field_t<LibTag, ::dawn::float_type>& m_c_0;
-    ::dawn::unstructured_domain   m_unstructured_domain ;
+    ::dawn::unstructured_domain m_unstructured_domain;
+
   public:
+    stencil_37(::dawn::mesh_t<LibTag> const& mesh, int k_size,
+               ::dawn::edge_field_t<LibTag, ::dawn::float_type>& a,
+               ::dawn::edge_field_t<LibTag, ::dawn::float_type>& b,
+               ::dawn::edge_field_t<LibTag, ::dawn::float_type>& c,
+               ::dawn::edge_field_t<LibTag, ::dawn::float_type>& d,
+               ::dawn::edge_field_t<LibTag, ::dawn::float_type>& e,
+               ::dawn::edge_field_t<LibTag, ::dawn::float_type>& c_0)
+        : m_mesh(mesh), m_k_size(k_size), m_a(a), m_b(b), m_c(c), m_d(d), m_e(e), m_c_0(c_0) {}
 
-    stencil_37(::dawn::mesh_t<LibTag> const &mesh, int k_size, ::dawn::edge_field_t<LibTag, ::dawn::float_type>&a, ::dawn::edge_field_t<LibTag, ::dawn::float_type>&b, ::dawn::edge_field_t<LibTag, ::dawn::float_type>&c, ::dawn::edge_field_t<LibTag, ::dawn::float_type>&d, ::dawn::edge_field_t<LibTag, ::dawn::float_type>&e, ::dawn::edge_field_t<LibTag, ::dawn::float_type>&c_0) : m_mesh(mesh), m_k_size(k_size), m_a(a), m_b(b), m_c(c), m_d(d), m_e(e), m_c_0(c_0){}
+    ~stencil_37() {}
 
-    ~stencil_37() {
-    }
-
-    void sync_storages() {
-    }
-    static constexpr ::dawn::driver::unstructured_extent a_extent = {false, 0,0};
-    static constexpr ::dawn::driver::unstructured_extent b_extent = {false, 0,0};
-    static constexpr ::dawn::driver::unstructured_extent c_extent = {false, 0,0};
-    static constexpr ::dawn::driver::unstructured_extent d_extent = {false, 0,0};
-    static constexpr ::dawn::driver::unstructured_extent e_extent = {false, 0,0};
-    static constexpr ::dawn::driver::unstructured_extent c_0_extent = {false, 0,0};
+    void sync_storages() {}
+    static constexpr ::dawn::driver::unstructured_extent a_extent = {false, 0, 0};
+    static constexpr ::dawn::driver::unstructured_extent b_extent = {false, 0, 0};
+    static constexpr ::dawn::driver::unstructured_extent c_extent = {false, 0, 0};
+    static constexpr ::dawn::driver::unstructured_extent d_extent = {false, 0, 0};
+    static constexpr ::dawn::driver::unstructured_extent e_extent = {false, 0, 0};
+    static constexpr ::dawn::driver::unstructured_extent c_0_extent = {false, 0, 0};
 
     void run() {
       using ::dawn::deref;
-{
-    for(int k = 0+0; k <= ( m_k_size == 0 ? 0 : (m_k_size - 1)) + 0+0; ++k) {
-      for(auto const& loc : getEdges(LibTag{}, m_mesh)) {
-m_c_0(deref(LibTag{}, loc), (k + 0)) = m_c(deref(LibTag{}, loc), (k + 0));
-      }    }}{
-    for(int k = 0+0; k <= ( m_k_size == 0 ? 0 : (m_k_size - 1)) + 0+0; ++k) {
-      for(auto const& loc : getEdges(LibTag{}, m_mesh)) {
-m_a(deref(LibTag{}, loc), (k + 0)) = ((m_b(deref(LibTag{}, loc), (k + 0)) / m_c_0(deref(LibTag{}, loc), (k + 0))) + (::dawn::float_type) 5);
-if(m_d(deref(LibTag{}, loc), (k + 0)))
-{
-  m_a(deref(LibTag{}, loc), (k + 0)) = m_b(deref(LibTag{}, loc), (k + 0));
-}
-else
-{
-  if(m_e(deref(LibTag{}, loc), (k + 0)))
-  {
-    m_c(deref(LibTag{}, loc), (k + 0)) = (m_a(deref(LibTag{}, loc), (k + 0)) + (::dawn::float_type) 1);
-  }
-}
-      }    }}      sync_storages();
+      {
+        for(int k = 0 + 0; k <= (m_k_size == 0 ? 0 : (m_k_size - 1)) + 0 + 0; ++k) {
+          for(auto const& loc : getEdges(LibTag{}, m_mesh)) {
+            m_c_0(deref(LibTag{}, loc), (k + 0)) = m_c(deref(LibTag{}, loc), (k + 0));
+          }
+        }
+      }
+      {
+        for(int k = 0 + 0; k <= (m_k_size == 0 ? 0 : (m_k_size - 1)) + 0 + 0; ++k) {
+          for(auto const& loc : getEdges(LibTag{}, m_mesh)) {
+            m_a(deref(LibTag{}, loc), (k + 0)) =
+                ((m_b(deref(LibTag{}, loc), (k + 0)) / m_c_0(deref(LibTag{}, loc), (k + 0))) +
+                 (::dawn::float_type)5);
+            if(m_d(deref(LibTag{}, loc), (k + 0))) {
+              m_a(deref(LibTag{}, loc), (k + 0)) = m_b(deref(LibTag{}, loc), (k + 0));
+            } else {
+              if(m_e(deref(LibTag{}, loc), (k + 0))) {
+                m_c(deref(LibTag{}, loc), (k + 0)) =
+                    (m_a(deref(LibTag{}, loc), (k + 0)) + (::dawn::float_type)1);
+              }
+            }
+          }
+        }
+      }
+      sync_storages();
     }
   };
   static constexpr const char* s_name = "generate_versioned_field";
   stencil_37 m_stencil_37;
-public:
 
+public:
   generate_versioned_field(const generate_versioned_field&) = delete;
 
   // Members
   ::dawn::edge_field_t<LibTag, ::dawn::float_type> m_c_0;
 
-  void set_splitter_index(::dawn::LocationType loc, ::dawn::UnstructuredSubdomain subdomain, int offset, int index) {
+  void set_splitter_index(::dawn::LocationType loc, ::dawn::UnstructuredSubdomain subdomain,
+                          int offset, int index) {
     m_stencil_37.m_unstructured_domain.set_splitter_index({loc, subdomain, offset}, index);
   }
 
-  generate_versioned_field(const ::dawn::mesh_t<LibTag> &mesh, int k_size, ::dawn::edge_field_t<LibTag, ::dawn::float_type>& a, ::dawn::edge_field_t<LibTag, ::dawn::float_type>& b, ::dawn::edge_field_t<LibTag, ::dawn::float_type>& c, ::dawn::edge_field_t<LibTag, ::dawn::float_type>& d, ::dawn::edge_field_t<LibTag, ::dawn::float_type>& e) : m_stencil_37(mesh, k_size,a,b,c,d,e,m_c_0), m_c_0(allocateField(LibTag{}, numEdges(LibTag{}, mesh) + 0, k_size)){}
+  generate_versioned_field(const ::dawn::mesh_t<LibTag>& mesh, int k_size,
+                           ::dawn::edge_field_t<LibTag, ::dawn::float_type>& a,
+                           ::dawn::edge_field_t<LibTag, ::dawn::float_type>& b,
+                           ::dawn::edge_field_t<LibTag, ::dawn::float_type>& c,
+                           ::dawn::edge_field_t<LibTag, ::dawn::float_type>& d,
+                           ::dawn::edge_field_t<LibTag, ::dawn::float_type>& e)
+      : m_stencil_37(mesh, k_size, a, b, c, d, e, m_c_0),
+        m_c_0(allocateField(LibTag{}, numEdges(LibTag{}, mesh) + 0, k_size)) {}
 
   void run() {
     m_stencil_37.run();
-;
+    ;
   }
 };
 } // namespace cxxnaiveico

--- a/dawn/test/integration-test/dawn4py-tests/data/hori_diff_stencil_ref.cpp
+++ b/dawn/test/integration-test/dawn4py-tests/data/hori_diff_stencil_ref.cpp
@@ -2,48 +2,52 @@
 #undef DAWN_BACKEND_T
 #define DAWN_BACKEND_T CUDA
 #ifndef BOOST_RESULT_OF_USE_TR1
- #define BOOST_RESULT_OF_USE_TR1 1
+#define BOOST_RESULT_OF_USE_TR1 1
 #endif
 #ifndef BOOST_NO_CXX11_DECLTYPE
- #define BOOST_NO_CXX11_DECLTYPE 1
+#define BOOST_NO_CXX11_DECLTYPE 1
 #endif
 #ifndef GRIDTOOLS_DAWN_HALO_EXTENT
- #define GRIDTOOLS_DAWN_HALO_EXTENT 3
+#define GRIDTOOLS_DAWN_HALO_EXTENT 3
 #endif
 #ifndef BOOST_PP_VARIADICS
- #define BOOST_PP_VARIADICS 1
+#define BOOST_PP_VARIADICS 1
 #endif
 #ifndef BOOST_FUSION_DONT_USE_PREPROCESSED_FILES
- #define BOOST_FUSION_DONT_USE_PREPROCESSED_FILES 1
+#define BOOST_FUSION_DONT_USE_PREPROCESSED_FILES 1
 #endif
 #ifndef BOOST_MPL_CFG_NO_PREPROCESSED_HEADERS
- #define BOOST_MPL_CFG_NO_PREPROCESSED_HEADERS 1
+#define BOOST_MPL_CFG_NO_PREPROCESSED_HEADERS 1
 #endif
 #ifndef GT_VECTOR_LIMIT_SIZE
- #define GT_VECTOR_LIMIT_SIZE 30
+#define GT_VECTOR_LIMIT_SIZE 30
 #endif
 #ifndef BOOST_FUSION_INVOKE_MAX_ARITY
- #define BOOST_FUSION_INVOKE_MAX_ARITY GT_VECTOR_LIMIT_SIZE
+#define BOOST_FUSION_INVOKE_MAX_ARITY GT_VECTOR_LIMIT_SIZE
 #endif
 #ifndef FUSION_MAX_VECTOR_SIZE
- #define FUSION_MAX_VECTOR_SIZE GT_VECTOR_LIMIT_SIZE
+#define FUSION_MAX_VECTOR_SIZE GT_VECTOR_LIMIT_SIZE
 #endif
 #ifndef FUSION_MAX_MAP_SIZE
- #define FUSION_MAX_MAP_SIZE GT_VECTOR_LIMIT_SIZE
+#define FUSION_MAX_MAP_SIZE GT_VECTOR_LIMIT_SIZE
 #endif
 #ifndef BOOST_MPL_LIMIT_VECTOR_SIZE
- #define BOOST_MPL_LIMIT_VECTOR_SIZE GT_VECTOR_LIMIT_SIZE
+#define BOOST_MPL_LIMIT_VECTOR_SIZE GT_VECTOR_LIMIT_SIZE
 #endif
 #include <driver-includes/gridtools_includes.hpp>
 using namespace gridtools::dawn;
 
-
-namespace dawn_generated{
-namespace cuda{
-__global__ void __launch_bounds__(256)  hori_diff_stencil_stencil41_ms87_kernel(const int isize, const int jsize, const int ksize, const int stride_111_1, const int stride_111_2, ::dawn::float_type * const in, ::dawn::float_type * const out, ::dawn::float_type * const coeff) {
+namespace dawn_generated {
+namespace cuda {
+__global__ void __launch_bounds__(256)
+    hori_diff_stencil_stencil41_ms87_kernel(const int isize, const int jsize, const int ksize,
+                                            const int stride_111_1, const int stride_111_2,
+                                            ::dawn::float_type* const in,
+                                            ::dawn::float_type* const out,
+                                            ::dawn::float_type* const coeff) {
 
   // Start kernel
-  __shared__ ::dawn::float_type lap_ijcache[34*6];
+  __shared__ ::dawn::float_type lap_ijcache[34 * 6];
   const unsigned int nx = isize;
   const unsigned int ny = jsize;
   const int block_size_i = (blockIdx.x + 1) * 32 < nx ? 32 : nx - blockIdx.x * 32;
@@ -78,30 +82,43 @@ __global__ void __launch_bounds__(256)  hori_diff_stencil_stencil41_ms87_kernel(
   // Regions (a,h,e) and (c,i,g) are executed by two specialized warp
   int iblock = -1 - 1;
   int jblock = -1 - 1;
-if(threadIdx.y < +6) {
+  if(threadIdx.y < +6) {
     iblock = threadIdx.x;
     jblock = (int)threadIdx.y + -1;
-}else if(threadIdx.y < +7) {
+  } else if(threadIdx.y < +7) {
     iblock = -1 + (int)threadIdx.x % 1;
-    jblock = (int)threadIdx.x / 1+-1;
-}else if(threadIdx.y < 8) {
+    jblock = (int)threadIdx.x / 1 + -1;
+  } else if(threadIdx.y < 8) {
     iblock = threadIdx.x % 1 + 32;
-    jblock = (int)threadIdx.x / 1+-1;
-}
+    jblock = (int)threadIdx.x / 1 + -1;
+  }
   // initialized iterators
-  int idx111 = (blockIdx.x*32+iblock)*1+(blockIdx.y*4+jblock)*stride_111_1;
-  int ijcacheindex= iblock + 1 + (jblock + 1)*34;
+  int idx111 = (blockIdx.x * 32 + iblock) * 1 + (blockIdx.y * 4 + jblock) * stride_111_1;
+  int ijcacheindex = iblock + 1 + (jblock + 1) * 34;
 
   // Pre-fill of kcaches
-for(int k = 0+0; k <=  ksize - 1 + 0+0; ++k) {
+  for(int k = 0 + 0; k <= ksize - 1 + 0 + 0; ++k) {
 
     // Head fill of kcaches
-  if(iblock >= -1 && iblock <= block_size_i -1 + 1 && jblock >= -1 && jblock <= block_size_j -1 + 1) {
-lap_ijcache[ijcacheindex] = (((::dawn::float_type) -4.0 * __ldg(&(in[idx111]))) + (__ldg(&(coeff[idx111])) * (__ldg(&(in[idx111+1*1])) + (__ldg(&(in[idx111+1*-1])) + (__ldg(&(in[idx111+stride_111_1*1])) + __ldg(&(in[idx111+stride_111_1*-1])))))));
-  }    __syncthreads();
-  if(iblock >= 0 && iblock <= block_size_i -1 + 0 && jblock >= 0 && jblock <= block_size_j -1 + 0) {
-out[idx111] = (((::dawn::float_type) -4.0 * lap_ijcache[ijcacheindex]) + (__ldg(&(coeff[idx111])) * (lap_ijcache[ijcacheindex+1] + (lap_ijcache[ijcacheindex+-1] + (lap_ijcache[ijcacheindex+1*34] + lap_ijcache[ijcacheindex+-1*34])))));
-  }    __syncthreads();
+    if(iblock >= -1 && iblock <= block_size_i - 1 + 1 && jblock >= -1 &&
+       jblock <= block_size_j - 1 + 1) {
+      lap_ijcache[ijcacheindex] =
+          (((::dawn::float_type)-4.0 * __ldg(&(in[idx111]))) +
+           (__ldg(&(coeff[idx111])) *
+            (__ldg(&(in[idx111 + 1 * 1])) +
+             (__ldg(&(in[idx111 + 1 * -1])) + (__ldg(&(in[idx111 + stride_111_1 * 1])) +
+                                               __ldg(&(in[idx111 + stride_111_1 * -1])))))));
+    }
+    __syncthreads();
+    if(iblock >= 0 && iblock <= block_size_i - 1 + 0 && jblock >= 0 &&
+       jblock <= block_size_j - 1 + 0) {
+      out[idx111] = (((::dawn::float_type)-4.0 * lap_ijcache[ijcacheindex]) +
+                     (__ldg(&(coeff[idx111])) *
+                      (lap_ijcache[ijcacheindex + 1] +
+                       (lap_ijcache[ijcacheindex + -1] + (lap_ijcache[ijcacheindex + 1 * 34] +
+                                                          lap_ijcache[ijcacheindex + -1 * 34])))));
+    }
+    __syncthreads();
 
     // Flush of kcaches
 
@@ -110,8 +127,8 @@ out[idx111] = (((::dawn::float_type) -4.0 * lap_ijcache[ijcacheindex]) + (__ldg(
     // Slide kcaches
 
     // increment iterators
-    idx111+=stride_111_2;
-}
+    idx111 += stride_111_2;
+  }
   // Final flush of kcaches
 
   // Final flush of kcaches
@@ -121,14 +138,11 @@ out[idx111] = (((::dawn::float_type) -4.0 * lap_ijcache[ijcacheindex]) + (__ldg(
 
 class hori_diff_stencil {
 public:
-
   struct sbase : public timer_cuda {
 
-    sbase(std::string name) : timer_cuda(name){}
+    sbase(std::string name) : timer_cuda(name) {}
 
-    double get_time() {
-      return total_time();
-    }
+    double get_time() { return total_time(); }
   };
 
   struct stencil_41 : public sbase {
@@ -136,38 +150,48 @@ public:
     // Members
 
     // Temporary storage typedefs
-    using tmp_halo_t = gridtools::halo< 1,1, 0, 0, 0>;
-    using tmp_meta_data_t = storage_traits_t::storage_info_t< 0, 5, tmp_halo_t >;
-    using tmp_storage_t = storage_traits_t::data_store_t< ::dawn::float_type, tmp_meta_data_t>;
+    using tmp_halo_t = gridtools::halo<1, 1, 0, 0, 0>;
+    using tmp_meta_data_t = storage_traits_t::storage_info_t<0, 5, tmp_halo_t>;
+    using tmp_storage_t = storage_traits_t::data_store_t<::dawn::float_type, tmp_meta_data_t>;
     const gridtools::dawn::domain m_dom;
 
     // temporary storage declarations
     tmp_meta_data_t m_tmp_meta_data;
     tmp_storage_t m_lap;
-  public:
 
-    stencil_41(const gridtools::dawn::domain& dom_, int rank, int xcols, int ycols) : sbase("stencil_41"), m_dom(dom_), m_tmp_meta_data(32+2, 4+2, (dom_.isize()+ 32 - 1) / 32, (dom_.jsize()+ 4 - 1) / 4, dom_.ksize() + 2 * 0), m_lap(m_tmp_meta_data){}
-    static constexpr ::dawn::driver::cartesian_extent in_extent = {-2,2, -2,2, 0,0};
-    static constexpr ::dawn::driver::cartesian_extent out_extent = {0,0, 0,0, 0,0};
-    static constexpr ::dawn::driver::cartesian_extent coeff_extent = {-1,1, -1,1, 0,0};
+  public:
+    stencil_41(const gridtools::dawn::domain& dom_, int rank, int xcols, int ycols)
+        : sbase("stencil_41"), m_dom(dom_),
+          m_tmp_meta_data(32 + 2, 4 + 2, (dom_.isize() + 32 - 1) / 32, (dom_.jsize() + 4 - 1) / 4,
+                          dom_.ksize() + 2 * 0),
+          m_lap(m_tmp_meta_data) {}
+    static constexpr ::dawn::driver::cartesian_extent in_extent = {-2, 2, -2, 2, 0, 0};
+    static constexpr ::dawn::driver::cartesian_extent out_extent = {0, 0, 0, 0, 0, 0};
+    static constexpr ::dawn::driver::cartesian_extent coeff_extent = {-1, 1, -1, 1, 0, 0};
 
     void run(storage_ijk_t in_ds, storage_ijk_t out_ds, storage_ijk_t coeff_ds) {
 
       // starting timers
       start();
-      {;
-      gridtools::data_view<storage_ijk_t> in= gridtools::make_device_view(in_ds);
-      gridtools::data_view<storage_ijk_t> out= gridtools::make_device_view(out_ds);
-      gridtools::data_view<storage_ijk_t> coeff= gridtools::make_device_view(coeff_ds);
-      const unsigned int nx = m_dom.isize() - m_dom.iminus() - m_dom.iplus();
-      const unsigned int ny = m_dom.jsize() - m_dom.jminus() - m_dom.jplus();
-      const unsigned int nz = m_dom.ksize() - m_dom.kminus() - m_dom.kplus();
-      dim3 threads(32,4+4,1);
-      const unsigned int nbx = (nx + 32 - 1) / 32;
-      const unsigned int nby = (ny + 4 - 1) / 4;
-      const unsigned int nbz = 1;
-      dim3 blocks(nbx, nby, nbz);
-      hori_diff_stencil_stencil41_ms87_kernel<<<blocks, threads>>>(nx,ny,nz,in_ds.strides()[1],in_ds.strides()[2],(in.data()+in_ds.get_storage_info_ptr()->index(in.begin<0>(), in.begin<1>(),0 )),(out.data()+out_ds.get_storage_info_ptr()->index(out.begin<0>(), out.begin<1>(),0 )),(coeff.data()+coeff_ds.get_storage_info_ptr()->index(coeff.begin<0>(), coeff.begin<1>(),0 )));
+      {
+        ;
+        gridtools::data_view<storage_ijk_t> in = gridtools::make_device_view(in_ds);
+        gridtools::data_view<storage_ijk_t> out = gridtools::make_device_view(out_ds);
+        gridtools::data_view<storage_ijk_t> coeff = gridtools::make_device_view(coeff_ds);
+        const unsigned int nx = m_dom.isize() - m_dom.iminus() - m_dom.iplus();
+        const unsigned int ny = m_dom.jsize() - m_dom.jminus() - m_dom.jplus();
+        const unsigned int nz = m_dom.ksize() - m_dom.kminus() - m_dom.kplus();
+        dim3 threads(32, 4 + 4, 1);
+        const unsigned int nbx = (nx + 32 - 1) / 32;
+        const unsigned int nby = (ny + 4 - 1) / 4;
+        const unsigned int nbz = 1;
+        dim3 blocks(nbx, nby, nbz);
+        hori_diff_stencil_stencil41_ms87_kernel<<<blocks, threads>>>(
+            nx, ny, nz, in_ds.strides()[1], in_ds.strides()[2],
+            (in.data() + in_ds.get_storage_info_ptr()->index(in.begin<0>(), in.begin<1>(), 0)),
+            (out.data() + out_ds.get_storage_info_ptr()->index(out.begin<0>(), out.begin<1>(), 0)),
+            (coeff.data() +
+             coeff_ds.get_storage_info_ptr()->index(coeff.begin<0>(), coeff.begin<1>(), 0)));
       };
 
       // stopping timers
@@ -176,44 +200,42 @@ public:
   };
   static constexpr const char* s_name = "hori_diff_stencil";
   stencil_41 m_stencil_41;
-public:
 
+public:
   hori_diff_stencil(const hori_diff_stencil&) = delete;
 
   // Members
 
   // Stencil-Data
 
-  hori_diff_stencil(const gridtools::dawn::domain& dom, int rank = 1, int xcols = 1, int ycols = 1) : m_stencil_41(dom, rank, xcols, ycols){}
+  hori_diff_stencil(const gridtools::dawn::domain& dom, int rank = 1, int xcols = 1, int ycols = 1)
+      : m_stencil_41(dom, rank, xcols, ycols) {}
 
-  template<typename S>
+  template <typename S>
   void sync_storages(S field) {
     field.sync();
   }
 
-  template<typename S0, typename ... S>
+  template <typename S0, typename... S>
   void sync_storages(S0 f0, S... fields) {
     f0.sync();
     sync_storages(fields...);
   }
 
   void run(storage_ijk_t in, storage_ijk_t out, storage_ijk_t coeff) {
-    sync_storages(in,out,coeff);
-    m_stencil_41.run(in,out,coeff);
-;
-    sync_storages(in,out,coeff);
+    sync_storages(in, out, coeff);
+    m_stencil_41.run(in, out, coeff);
+    ;
+    sync_storages(in, out, coeff);
   }
 
-  std::string get_name()  const {
-    return std::string(s_name);
-  }
+  std::string get_name() const { return std::string(s_name); }
 
-  void reset_meters() {
-m_stencil_41.reset();  }
+  void reset_meters() { m_stencil_41.reset(); }
 
   double get_total_time() {
     double res = 0;
-    res +=m_stencil_41.get_time();
+    res += m_stencil_41.get_time();
     return res;
   }
 };

--- a/dawn/test/integration-test/dawn4py-tests/data/tridiagonal_solve_stencil_ref.cpp
+++ b/dawn/test/integration-test/dawn4py-tests/data/tridiagonal_solve_stencil_ref.cpp
@@ -2,45 +2,47 @@
 #undef DAWN_BACKEND_T
 #define DAWN_BACKEND_T CUDA
 #ifndef BOOST_RESULT_OF_USE_TR1
- #define BOOST_RESULT_OF_USE_TR1 1
+#define BOOST_RESULT_OF_USE_TR1 1
 #endif
 #ifndef BOOST_NO_CXX11_DECLTYPE
- #define BOOST_NO_CXX11_DECLTYPE 1
+#define BOOST_NO_CXX11_DECLTYPE 1
 #endif
 #ifndef GRIDTOOLS_DAWN_HALO_EXTENT
- #define GRIDTOOLS_DAWN_HALO_EXTENT 3
+#define GRIDTOOLS_DAWN_HALO_EXTENT 3
 #endif
 #ifndef BOOST_PP_VARIADICS
- #define BOOST_PP_VARIADICS 1
+#define BOOST_PP_VARIADICS 1
 #endif
 #ifndef BOOST_FUSION_DONT_USE_PREPROCESSED_FILES
- #define BOOST_FUSION_DONT_USE_PREPROCESSED_FILES 1
+#define BOOST_FUSION_DONT_USE_PREPROCESSED_FILES 1
 #endif
 #ifndef BOOST_MPL_CFG_NO_PREPROCESSED_HEADERS
- #define BOOST_MPL_CFG_NO_PREPROCESSED_HEADERS 1
+#define BOOST_MPL_CFG_NO_PREPROCESSED_HEADERS 1
 #endif
 #ifndef GT_VECTOR_LIMIT_SIZE
- #define GT_VECTOR_LIMIT_SIZE 30
+#define GT_VECTOR_LIMIT_SIZE 30
 #endif
 #ifndef BOOST_FUSION_INVOKE_MAX_ARITY
- #define BOOST_FUSION_INVOKE_MAX_ARITY GT_VECTOR_LIMIT_SIZE
+#define BOOST_FUSION_INVOKE_MAX_ARITY GT_VECTOR_LIMIT_SIZE
 #endif
 #ifndef FUSION_MAX_VECTOR_SIZE
- #define FUSION_MAX_VECTOR_SIZE GT_VECTOR_LIMIT_SIZE
+#define FUSION_MAX_VECTOR_SIZE GT_VECTOR_LIMIT_SIZE
 #endif
 #ifndef FUSION_MAX_MAP_SIZE
- #define FUSION_MAX_MAP_SIZE GT_VECTOR_LIMIT_SIZE
+#define FUSION_MAX_MAP_SIZE GT_VECTOR_LIMIT_SIZE
 #endif
 #ifndef BOOST_MPL_LIMIT_VECTOR_SIZE
- #define BOOST_MPL_LIMIT_VECTOR_SIZE GT_VECTOR_LIMIT_SIZE
+#define BOOST_MPL_LIMIT_VECTOR_SIZE GT_VECTOR_LIMIT_SIZE
 #endif
 #include <driver-includes/gridtools_includes.hpp>
 using namespace gridtools::dawn;
 
-
-namespace dawn_generated{
-namespace cuda{
-__global__ void __launch_bounds__(32)  tridiagonal_solve_stencil_stencil49_ms107_kernel(const int isize, const int jsize, const int ksize, const int stride_111_1, const int stride_111_2, ::dawn::float_type * const a, ::dawn::float_type * const b, ::dawn::float_type * const c, ::dawn::float_type * const d) {
+namespace dawn_generated {
+namespace cuda {
+__global__ void __launch_bounds__(32) tridiagonal_solve_stencil_stencil49_ms107_kernel(
+    const int isize, const int jsize, const int ksize, const int stride_111_1,
+    const int stride_111_2, ::dawn::float_type* const a, ::dawn::float_type* const b,
+    ::dawn::float_type* const c, ::dawn::float_type* const d) {
 
   // Start kernel
   ::dawn::float_type c_kcache[2];
@@ -79,83 +81,102 @@ __global__ void __launch_bounds__(32)  tridiagonal_solve_stencil_stencil49_ms107
   // Regions (a,h,e) and (c,i,g) are executed by two specialized warp
   int iblock = 0 - 1;
   int jblock = 0 - 1;
-if(threadIdx.y < +1) {
+  if(threadIdx.y < +1) {
     iblock = threadIdx.x;
     jblock = (int)threadIdx.y + 0;
-}
+  }
   // initialized iterators
-  int idx111 = (blockIdx.x*32+iblock)*1+(blockIdx.y*1+jblock)*stride_111_1;
+  int idx111 = (blockIdx.x * 32 + iblock) * 1 + (blockIdx.y * 1 + jblock) * stride_111_1;
 
   // Pre-fill of kcaches
-for(int k = 0+0; k <= 0+0; ++k) {
+  for(int k = 0 + 0; k <= 0 + 0; ++k) {
 
     // Head fill of kcaches
-  if(iblock >= 0 && iblock <= block_size_i -1 + 0 && jblock >= 0 && jblock <= block_size_j -1 + 0) {
-      c_kcache[1] =c[idx111];
-  }  if(iblock >= 0 && iblock <= block_size_i -1 + 0 && jblock >= 0 && jblock <= block_size_j -1 + 0) {
-c_kcache[1] = (c_kcache[1] / __ldg(&(b[idx111])));
-  }
+    if(iblock >= 0 && iblock <= block_size_i - 1 + 0 && jblock >= 0 &&
+       jblock <= block_size_j - 1 + 0) {
+      c_kcache[1] = c[idx111];
+    }
+    if(iblock >= 0 && iblock <= block_size_i - 1 + 0 && jblock >= 0 &&
+       jblock <= block_size_j - 1 + 0) {
+      c_kcache[1] = (c_kcache[1] / __ldg(&(b[idx111])));
+    }
     // Flush of kcaches
 
     // Flush of kcaches
-  if(iblock >= 0 && iblock <= block_size_i -1 + 0 && jblock >= 0 && jblock <= block_size_j -1 + 0) {
-      c[idx111]= c_kcache[1];
-  }
+    if(iblock >= 0 && iblock <= block_size_i - 1 + 0 && jblock >= 0 &&
+       jblock <= block_size_j - 1 + 0) {
+      c[idx111] = c_kcache[1];
+    }
     // Slide kcaches
     c_kcache[0] = c_kcache[1];
 
     // increment iterators
-    idx111+=stride_111_2;
-}
+    idx111 += stride_111_2;
+  }
   // Final flush of kcaches
-if(iblock >= 0 && iblock <= block_size_i -1 + 0 && jblock >= 0 && jblock <= block_size_j -1 + 0) {
-}
+  if(iblock >= 0 && iblock <= block_size_i - 1 + 0 && jblock >= 0 &&
+     jblock <= block_size_j - 1 + 0) {
+  }
   // Final flush of kcaches
 
   // Final flush of kcaches
 
   // Pre-fill of kcaches
-if(iblock >= 0 && iblock <= block_size_i -1 + 0 && jblock >= 0 && jblock <= block_size_j -1 + 0) {
-    d_kcache[0] =d[idx111+stride_111_2*-1];
-}for(int k = 1+0; k <=  ksize - 1 + 0+0; ++k) {
+  if(iblock >= 0 && iblock <= block_size_i - 1 + 0 && jblock >= 0 &&
+     jblock <= block_size_j - 1 + 0) {
+    d_kcache[0] = d[idx111 + stride_111_2 * -1];
+  }
+  for(int k = 1 + 0; k <= ksize - 1 + 0 + 0; ++k) {
 
     // Head fill of kcaches
-  if(iblock >= 0 && iblock <= block_size_i -1 + 0 && jblock >= 0 && jblock <= block_size_j -1 + 0) {
-      c_kcache[1] =c[idx111];
-      d_kcache[1] =d[idx111];
-  }  if(iblock >= 0 && iblock <= block_size_i -1 + 0 && jblock >= 0 && jblock <= block_size_j -1 + 0) {
-c_kcache[1] = (c_kcache[1] / __ldg(&(b[idx111])));
-  }  if(iblock >= 0 && iblock <= block_size_i -1 + 0 && jblock >= 0 && jblock <= block_size_j -1 + 0) {
-int __local_m_100 = ((::dawn::float_type) 1.0 / (__ldg(&(b[idx111])) - (__ldg(&(a[idx111])) * c_kcache[0])));
-c_kcache[1] = (c_kcache[1] * __local_m_100);
-d_kcache[1] = ((d_kcache[1] - (__ldg(&(a[idx111])) * d_kcache[0])) * __local_m_100);
-  }
+    if(iblock >= 0 && iblock <= block_size_i - 1 + 0 && jblock >= 0 &&
+       jblock <= block_size_j - 1 + 0) {
+      c_kcache[1] = c[idx111];
+      d_kcache[1] = d[idx111];
+    }
+    if(iblock >= 0 && iblock <= block_size_i - 1 + 0 && jblock >= 0 &&
+       jblock <= block_size_j - 1 + 0) {
+      c_kcache[1] = (c_kcache[1] / __ldg(&(b[idx111])));
+    }
+    if(iblock >= 0 && iblock <= block_size_i - 1 + 0 && jblock >= 0 &&
+       jblock <= block_size_j - 1 + 0) {
+      int __local_m_100 =
+          ((::dawn::float_type)1.0 / (__ldg(&(b[idx111])) - (__ldg(&(a[idx111])) * c_kcache[0])));
+      c_kcache[1] = (c_kcache[1] * __local_m_100);
+      d_kcache[1] = ((d_kcache[1] - (__ldg(&(a[idx111])) * d_kcache[0])) * __local_m_100);
+    }
     // Flush of kcaches
 
     // Flush of kcaches
-  if(iblock >= 0 && iblock <= block_size_i -1 + 0 && jblock >= 0 && jblock <= block_size_j -1 + 0) {
-      c[idx111+stride_111_2*-1]= c_kcache[0];
-    if( k - 1 >= 1) {
-        d[idx111+stride_111_2*-1]= d_kcache[0];
-    }  }
+    if(iblock >= 0 && iblock <= block_size_i - 1 + 0 && jblock >= 0 &&
+       jblock <= block_size_j - 1 + 0) {
+      c[idx111 + stride_111_2 * -1] = c_kcache[0];
+      if(k - 1 >= 1) {
+        d[idx111 + stride_111_2 * -1] = d_kcache[0];
+      }
+    }
     // Slide kcaches
     c_kcache[0] = c_kcache[1];
     d_kcache[0] = d_kcache[1];
 
     // increment iterators
-    idx111+=stride_111_2;
-}
+    idx111 += stride_111_2;
+  }
   // Final flush of kcaches
-if(iblock >= 0 && iblock <= block_size_i -1 + 0 && jblock >= 0 && jblock <= block_size_j -1 + 0) {
-    c[idx111+stride_111_2*-1]= c_kcache[0];
-  if(  ksize - 1 + 1 - 1 >= 1) {
-      d[idx111+stride_111_2*-1]= d_kcache[0];
-  }}
+  if(iblock >= 0 && iblock <= block_size_i - 1 + 0 && jblock >= 0 &&
+     jblock <= block_size_j - 1 + 0) {
+    c[idx111 + stride_111_2 * -1] = c_kcache[0];
+    if(ksize - 1 + 1 - 1 >= 1) {
+      d[idx111 + stride_111_2 * -1] = d_kcache[0];
+    }
+  }
   // Final flush of kcaches
 
   // Final flush of kcaches
 }
-__global__ void __launch_bounds__(32)  tridiagonal_solve_stencil_stencil49_ms108_kernel(const int isize, const int jsize, const int ksize, const int stride_111_1, const int stride_111_2, ::dawn::float_type * const c, ::dawn::float_type * const d) {
+__global__ void __launch_bounds__(32) tridiagonal_solve_stencil_stencil49_ms108_kernel(
+    const int isize, const int jsize, const int ksize, const int stride_111_1,
+    const int stride_111_2, ::dawn::float_type* const c, ::dawn::float_type* const d) {
 
   // Start kernel
   ::dawn::float_type d_kcache[2];
@@ -193,45 +214,54 @@ __global__ void __launch_bounds__(32)  tridiagonal_solve_stencil_stencil49_ms108
   // Regions (a,h,e) and (c,i,g) are executed by two specialized warp
   int iblock = 0 - 1;
   int jblock = 0 - 1;
-if(threadIdx.y < +1) {
+  if(threadIdx.y < +1) {
     iblock = threadIdx.x;
     jblock = (int)threadIdx.y + 0;
-}
+  }
   // initialized iterators
-  int idx111 = (blockIdx.x*32+iblock)*1+(blockIdx.y*1+jblock)*stride_111_1;
+  int idx111 = (blockIdx.x * 32 + iblock) * 1 + (blockIdx.y * 1 + jblock) * stride_111_1;
 
   // jump iterators to match the beginning of next interval
-  idx111 += stride_111_2*(ksize - 1+-1);
+  idx111 += stride_111_2 * (ksize - 1 + -1);
 
   // Pre-fill of kcaches
-if(iblock >= 0 && iblock <= block_size_i -1 + 0 && jblock >= 0 && jblock <= block_size_j -1 + 0) {
-    d_kcache[1] =d[idx111+stride_111_2*1];
-}for(int k =  ksize - 1 + -1+0; k >= 0+0; --k) {
+  if(iblock >= 0 && iblock <= block_size_i - 1 + 0 && jblock >= 0 &&
+     jblock <= block_size_j - 1 + 0) {
+    d_kcache[1] = d[idx111 + stride_111_2 * 1];
+  }
+  for(int k = ksize - 1 + -1 + 0; k >= 0 + 0; --k) {
 
     // Head fill of kcaches
-  if(iblock >= 0 && iblock <= block_size_i -1 + 0 && jblock >= 0 && jblock <= block_size_j -1 + 0) {
-      d_kcache[0] =d[idx111];
-  }  if(iblock >= 0 && iblock <= block_size_i -1 + 0 && jblock >= 0 && jblock <= block_size_j -1 + 0) {
-d_kcache[0] -= (__ldg(&(c[idx111])) * d_kcache[1]);
-  }
+    if(iblock >= 0 && iblock <= block_size_i - 1 + 0 && jblock >= 0 &&
+       jblock <= block_size_j - 1 + 0) {
+      d_kcache[0] = d[idx111];
+    }
+    if(iblock >= 0 && iblock <= block_size_i - 1 + 0 && jblock >= 0 &&
+       jblock <= block_size_j - 1 + 0) {
+      d_kcache[0] -= (__ldg(&(c[idx111])) * d_kcache[1]);
+    }
     // Flush of kcaches
 
     // Flush of kcaches
-  if(iblock >= 0 && iblock <= block_size_i -1 + 0 && jblock >= 0 && jblock <= block_size_j -1 + 0) {
-    if(  ksize - 1 + -1 - k >= 1) {
-        d[idx111+stride_111_2*1]= d_kcache[1];
-    }  }
+    if(iblock >= 0 && iblock <= block_size_i - 1 + 0 && jblock >= 0 &&
+       jblock <= block_size_j - 1 + 0) {
+      if(ksize - 1 + -1 - k >= 1) {
+        d[idx111 + stride_111_2 * 1] = d_kcache[1];
+      }
+    }
     // Slide kcaches
     d_kcache[1] = d_kcache[0];
 
     // increment iterators
-    idx111-=stride_111_2;
-}
+    idx111 -= stride_111_2;
+  }
   // Final flush of kcaches
-if(iblock >= 0 && iblock <= block_size_i -1 + 0 && jblock >= 0 && jblock <= block_size_j -1 + 0) {
-  if(  ksize - 1 + -1 - -1 >= 1) {
-      d[idx111+stride_111_2*1]= d_kcache[1];
-  }}
+  if(iblock >= 0 && iblock <= block_size_i - 1 + 0 && jblock >= 0 &&
+     jblock <= block_size_j - 1 + 0) {
+    if(ksize - 1 + -1 - -1 >= 1) {
+      d[idx111 + stride_111_2 * 1] = d_kcache[1];
+    }
+  }
   // Final flush of kcaches
 
   // Final flush of kcaches
@@ -239,14 +269,11 @@ if(iblock >= 0 && iblock <= block_size_i -1 + 0 && jblock >= 0 && jblock <= bloc
 
 class tridiagonal_solve_stencil {
 public:
-
   struct sbase : public timer_cuda {
 
-    sbase(std::string name) : timer_cuda(name){}
+    sbase(std::string name) : timer_cuda(name) {}
 
-    double get_time() {
-      return total_time();
-    }
+    double get_time() { return total_time(); }
   };
 
   struct stencil_49 : public sbase {
@@ -254,49 +281,60 @@ public:
     // Members
 
     // Temporary storage typedefs
-    using tmp_halo_t = gridtools::halo< 0,0, 0, 0, 0>;
-    using tmp_meta_data_t = storage_traits_t::storage_info_t< 0, 5, tmp_halo_t >;
-    using tmp_storage_t = storage_traits_t::data_store_t< ::dawn::float_type, tmp_meta_data_t>;
+    using tmp_halo_t = gridtools::halo<0, 0, 0, 0, 0>;
+    using tmp_meta_data_t = storage_traits_t::storage_info_t<0, 5, tmp_halo_t>;
+    using tmp_storage_t = storage_traits_t::data_store_t<::dawn::float_type, tmp_meta_data_t>;
     const gridtools::dawn::domain m_dom;
-  public:
 
-    stencil_49(const gridtools::dawn::domain& dom_, int rank, int xcols, int ycols) : sbase("stencil_49"), m_dom(dom_){}
-    static constexpr ::dawn::driver::cartesian_extent a_extent = {0,0, 0,0, 0,0};
-    static constexpr ::dawn::driver::cartesian_extent b_extent = {0,0, 0,0, 0,0};
-    static constexpr ::dawn::driver::cartesian_extent c_extent = {0,0, 0,0, -1,0};
-    static constexpr ::dawn::driver::cartesian_extent d_extent = {0,0, 0,0, -1,1};
+  public:
+    stencil_49(const gridtools::dawn::domain& dom_, int rank, int xcols, int ycols)
+        : sbase("stencil_49"), m_dom(dom_) {}
+    static constexpr ::dawn::driver::cartesian_extent a_extent = {0, 0, 0, 0, 0, 0};
+    static constexpr ::dawn::driver::cartesian_extent b_extent = {0, 0, 0, 0, 0, 0};
+    static constexpr ::dawn::driver::cartesian_extent c_extent = {0, 0, 0, 0, -1, 0};
+    static constexpr ::dawn::driver::cartesian_extent d_extent = {0, 0, 0, 0, -1, 1};
 
     void run(storage_ijk_t a_ds, storage_ijk_t b_ds, storage_ijk_t c_ds, storage_ijk_t d_ds) {
 
       // starting timers
       start();
-      {;
-      gridtools::data_view<storage_ijk_t> a= gridtools::make_device_view(a_ds);
-      gridtools::data_view<storage_ijk_t> b= gridtools::make_device_view(b_ds);
-      gridtools::data_view<storage_ijk_t> c= gridtools::make_device_view(c_ds);
-      gridtools::data_view<storage_ijk_t> d= gridtools::make_device_view(d_ds);
-      const unsigned int nx = m_dom.isize() - m_dom.iminus() - m_dom.iplus();
-      const unsigned int ny = m_dom.jsize() - m_dom.jminus() - m_dom.jplus();
-      const unsigned int nz = m_dom.ksize() - m_dom.kminus() - m_dom.kplus();
-      dim3 threads(32,1+0,1);
-      const unsigned int nbx = (nx + 32 - 1) / 32;
-      const unsigned int nby = (ny + 1 - 1) / 1;
-      const unsigned int nbz = 1;
-      dim3 blocks(nbx, nby, nbz);
-      tridiagonal_solve_stencil_stencil49_ms107_kernel<<<blocks, threads>>>(nx,ny,nz,a_ds.strides()[1],a_ds.strides()[2],(a.data()+a_ds.get_storage_info_ptr()->index(a.begin<0>(), a.begin<1>(),0 )),(b.data()+b_ds.get_storage_info_ptr()->index(b.begin<0>(), b.begin<1>(),0 )),(c.data()+c_ds.get_storage_info_ptr()->index(c.begin<0>(), c.begin<1>(),0 )),(d.data()+d_ds.get_storage_info_ptr()->index(d.begin<0>(), d.begin<1>(),0 )));
+      {
+        ;
+        gridtools::data_view<storage_ijk_t> a = gridtools::make_device_view(a_ds);
+        gridtools::data_view<storage_ijk_t> b = gridtools::make_device_view(b_ds);
+        gridtools::data_view<storage_ijk_t> c = gridtools::make_device_view(c_ds);
+        gridtools::data_view<storage_ijk_t> d = gridtools::make_device_view(d_ds);
+        const unsigned int nx = m_dom.isize() - m_dom.iminus() - m_dom.iplus();
+        const unsigned int ny = m_dom.jsize() - m_dom.jminus() - m_dom.jplus();
+        const unsigned int nz = m_dom.ksize() - m_dom.kminus() - m_dom.kplus();
+        dim3 threads(32, 1 + 0, 1);
+        const unsigned int nbx = (nx + 32 - 1) / 32;
+        const unsigned int nby = (ny + 1 - 1) / 1;
+        const unsigned int nbz = 1;
+        dim3 blocks(nbx, nby, nbz);
+        tridiagonal_solve_stencil_stencil49_ms107_kernel<<<blocks, threads>>>(
+            nx, ny, nz, a_ds.strides()[1], a_ds.strides()[2],
+            (a.data() + a_ds.get_storage_info_ptr()->index(a.begin<0>(), a.begin<1>(), 0)),
+            (b.data() + b_ds.get_storage_info_ptr()->index(b.begin<0>(), b.begin<1>(), 0)),
+            (c.data() + c_ds.get_storage_info_ptr()->index(c.begin<0>(), c.begin<1>(), 0)),
+            (d.data() + d_ds.get_storage_info_ptr()->index(d.begin<0>(), d.begin<1>(), 0)));
       };
-      {;
-      gridtools::data_view<storage_ijk_t> c= gridtools::make_device_view(c_ds);
-      gridtools::data_view<storage_ijk_t> d= gridtools::make_device_view(d_ds);
-      const unsigned int nx = m_dom.isize() - m_dom.iminus() - m_dom.iplus();
-      const unsigned int ny = m_dom.jsize() - m_dom.jminus() - m_dom.jplus();
-      const unsigned int nz = m_dom.ksize() - m_dom.kminus() - m_dom.kplus();
-      dim3 threads(32,1+0,1);
-      const unsigned int nbx = (nx + 32 - 1) / 32;
-      const unsigned int nby = (ny + 1 - 1) / 1;
-      const unsigned int nbz = 1;
-      dim3 blocks(nbx, nby, nbz);
-      tridiagonal_solve_stencil_stencil49_ms108_kernel<<<blocks, threads>>>(nx,ny,nz,c_ds.strides()[1],c_ds.strides()[2],(c.data()+c_ds.get_storage_info_ptr()->index(c.begin<0>(), c.begin<1>(),0 )),(d.data()+d_ds.get_storage_info_ptr()->index(d.begin<0>(), d.begin<1>(),0 )));
+      {
+        ;
+        gridtools::data_view<storage_ijk_t> c = gridtools::make_device_view(c_ds);
+        gridtools::data_view<storage_ijk_t> d = gridtools::make_device_view(d_ds);
+        const unsigned int nx = m_dom.isize() - m_dom.iminus() - m_dom.iplus();
+        const unsigned int ny = m_dom.jsize() - m_dom.jminus() - m_dom.jplus();
+        const unsigned int nz = m_dom.ksize() - m_dom.kminus() - m_dom.kplus();
+        dim3 threads(32, 1 + 0, 1);
+        const unsigned int nbx = (nx + 32 - 1) / 32;
+        const unsigned int nby = (ny + 1 - 1) / 1;
+        const unsigned int nbz = 1;
+        dim3 blocks(nbx, nby, nbz);
+        tridiagonal_solve_stencil_stencil49_ms108_kernel<<<blocks, threads>>>(
+            nx, ny, nz, c_ds.strides()[1], c_ds.strides()[2],
+            (c.data() + c_ds.get_storage_info_ptr()->index(c.begin<0>(), c.begin<1>(), 0)),
+            (d.data() + d_ds.get_storage_info_ptr()->index(d.begin<0>(), d.begin<1>(), 0)));
       };
 
       // stopping timers
@@ -305,44 +343,43 @@ public:
   };
   static constexpr const char* s_name = "tridiagonal_solve_stencil";
   stencil_49 m_stencil_49;
-public:
 
+public:
   tridiagonal_solve_stencil(const tridiagonal_solve_stencil&) = delete;
 
   // Members
 
   // Stencil-Data
 
-  tridiagonal_solve_stencil(const gridtools::dawn::domain& dom, int rank = 1, int xcols = 1, int ycols = 1) : m_stencil_49(dom, rank, xcols, ycols){}
+  tridiagonal_solve_stencil(const gridtools::dawn::domain& dom, int rank = 1, int xcols = 1,
+                            int ycols = 1)
+      : m_stencil_49(dom, rank, xcols, ycols) {}
 
-  template<typename S>
+  template <typename S>
   void sync_storages(S field) {
     field.sync();
   }
 
-  template<typename S0, typename ... S>
+  template <typename S0, typename... S>
   void sync_storages(S0 f0, S... fields) {
     f0.sync();
     sync_storages(fields...);
   }
 
   void run(storage_ijk_t a, storage_ijk_t b, storage_ijk_t c, storage_ijk_t d) {
-    sync_storages(a,b,c,d);
-    m_stencil_49.run(a,b,c,d);
-;
-    sync_storages(a,b,c,d);
+    sync_storages(a, b, c, d);
+    m_stencil_49.run(a, b, c, d);
+    ;
+    sync_storages(a, b, c, d);
   }
 
-  std::string get_name()  const {
-    return std::string(s_name);
-  }
+  std::string get_name() const { return std::string(s_name); }
 
-  void reset_meters() {
-m_stencil_49.reset();  }
+  void reset_meters() { m_stencil_49.reset(); }
 
   double get_total_time() {
     double res = 0;
-    res +=m_stencil_49.get_time();
+    res += m_stencil_49.get_time();
     return res;
   }
 };

--- a/dawn/test/unit-test/dawn/CodeGen/reference/conditional_stencil.cpp
+++ b/dawn/test/unit-test/dawn/CodeGen/reference/conditional_stencil.cpp
@@ -2,77 +2,75 @@
 #undef DAWN_BACKEND_T
 #define DAWN_BACKEND_T CXXNAIVE
 #ifndef BOOST_RESULT_OF_USE_TR1
- #define BOOST_RESULT_OF_USE_TR1 1
+#define BOOST_RESULT_OF_USE_TR1 1
 #endif
 #ifndef BOOST_NO_CXX11_DECLTYPE
- #define BOOST_NO_CXX11_DECLTYPE 1
+#define BOOST_NO_CXX11_DECLTYPE 1
 #endif
 #ifndef GRIDTOOLS_DAWN_HALO_EXTENT
- #define GRIDTOOLS_DAWN_HALO_EXTENT 3
+#define GRIDTOOLS_DAWN_HALO_EXTENT 3
 #endif
 #ifndef BOOST_PP_VARIADICS
- #define BOOST_PP_VARIADICS 1
+#define BOOST_PP_VARIADICS 1
 #endif
 #ifndef BOOST_FUSION_DONT_USE_PREPROCESSED_FILES
- #define BOOST_FUSION_DONT_USE_PREPROCESSED_FILES 1
+#define BOOST_FUSION_DONT_USE_PREPROCESSED_FILES 1
 #endif
 #ifndef BOOST_MPL_CFG_NO_PREPROCESSED_HEADERS
- #define BOOST_MPL_CFG_NO_PREPROCESSED_HEADERS 1
+#define BOOST_MPL_CFG_NO_PREPROCESSED_HEADERS 1
 #endif
 #ifndef GT_VECTOR_LIMIT_SIZE
- #define GT_VECTOR_LIMIT_SIZE 30
+#define GT_VECTOR_LIMIT_SIZE 30
 #endif
 #ifndef BOOST_FUSION_INVOKE_MAX_ARITY
- #define BOOST_FUSION_INVOKE_MAX_ARITY GT_VECTOR_LIMIT_SIZE
+#define BOOST_FUSION_INVOKE_MAX_ARITY GT_VECTOR_LIMIT_SIZE
 #endif
 #ifndef FUSION_MAX_VECTOR_SIZE
- #define FUSION_MAX_VECTOR_SIZE GT_VECTOR_LIMIT_SIZE
+#define FUSION_MAX_VECTOR_SIZE GT_VECTOR_LIMIT_SIZE
 #endif
 #ifndef FUSION_MAX_MAP_SIZE
- #define FUSION_MAX_MAP_SIZE GT_VECTOR_LIMIT_SIZE
+#define FUSION_MAX_MAP_SIZE GT_VECTOR_LIMIT_SIZE
 #endif
 #ifndef BOOST_MPL_LIMIT_VECTOR_SIZE
- #define BOOST_MPL_LIMIT_VECTOR_SIZE GT_VECTOR_LIMIT_SIZE
+#define BOOST_MPL_LIMIT_VECTOR_SIZE GT_VECTOR_LIMIT_SIZE
 #endif
 #include <driver-includes/gridtools_includes.hpp>
 using namespace gridtools::dawn;
-namespace dawn_generated{
-namespace cxxnaive{
+namespace dawn_generated {
+namespace cxxnaive {
 
 struct globals {
   int var1;
   bool var2;
 
-  globals() : var1(1){
-  }
+  globals() : var1(1) {}
 };
 } // namespace cxxnaive
 } // namespace dawn_generated
 
-
-namespace dawn_generated{
-namespace cxxnaive{
+namespace dawn_generated {
+namespace cxxnaive {
 
 class conditional_stencil {
 private:
-
   struct stencil_21 {
 
     // Members
 
     // Temporary storages
-    using tmp_halo_t = gridtools::halo< GRIDTOOLS_DAWN_HALO_EXTENT, GRIDTOOLS_DAWN_HALO_EXTENT, 0>;
-    using tmp_meta_data_t = storage_traits_t::storage_info_t< 0, 3, tmp_halo_t >;
-    using tmp_storage_t = storage_traits_t::data_store_t< ::dawn::float_type, tmp_meta_data_t>;
+    using tmp_halo_t = gridtools::halo<GRIDTOOLS_DAWN_HALO_EXTENT, GRIDTOOLS_DAWN_HALO_EXTENT, 0>;
+    using tmp_meta_data_t = storage_traits_t::storage_info_t<0, 3, tmp_halo_t>;
+    using tmp_storage_t = storage_traits_t::data_store_t<::dawn::float_type, tmp_meta_data_t>;
     const gridtools::dawn::domain m_dom;
     const globals& m_globals;
 
     // Input/Output storages
   public:
-
-    stencil_21(const gridtools::dawn::domain& dom_, globals& globals_, int rank, int xcols, int ycols) : m_dom(dom_), m_globals(globals_){}
-    static constexpr ::dawn::driver::cartesian_extent in_extent = {-1,1, -1,1, 0,0};
-    static constexpr ::dawn::driver::cartesian_extent out_extent = {0,0, 0,0, 0,0};
+    stencil_21(const gridtools::dawn::domain& dom_, globals& globals_, int rank, int xcols,
+               int ycols)
+        : m_dom(dom_), m_globals(globals_) {}
+    static constexpr ::dawn::driver::cartesian_extent in_extent = {-1, 1, -1, 1, 0, 0};
+    static constexpr ::dawn::driver::cartesian_extent out_extent = {0, 0, 0, 0, 0, 0};
 
     void run(storage_ijk_t& in_, storage_ijk_t& out_) {
       int iMin = m_dom.iminus();
@@ -83,41 +81,42 @@ private:
       int kMax = m_dom.ksize() - m_dom.kplus() - 1;
       in_.sync();
       out_.sync();
-{      gridtools::data_view<storage_ijk_t> in= gridtools::make_host_view(in_);
-      std::array<int,3> in_offsets{0,0,0};
-      gridtools::data_view<storage_ijk_t> out= gridtools::make_host_view(out_);
-      std::array<int,3> out_offsets{0,0,0};
-    for(int k = kMin + 0+0; k <= kMax + 0+0; ++k) {
-      for(int i = iMin+0; i  <=  iMax+0; ++i) {
-        for(int j = jMin+0; j  <=  jMax+0; ++j) {
-if((m_globals.var1 == (int) 1))
-{
-  out(i+0, j+0, k+0) = in(i+1, j+0, k+0);
-}
-else
-{
-  out(i+0, j+0, k+0) = in(i+-1, j+0, k+0);
-}
-if((m_globals.var1 == (int) 1))
-{
-  out(i+0, j+0, k+0) = in(i+0, j+1, k+0);
-}
-else
-{
-  out(i+0, j+0, k+0) = in(i+0, j+-1, k+0);
-}
-        }      }    }}      in_.sync();
+      {
+        gridtools::data_view<storage_ijk_t> in = gridtools::make_host_view(in_);
+        std::array<int, 3> in_offsets{0, 0, 0};
+        gridtools::data_view<storage_ijk_t> out = gridtools::make_host_view(out_);
+        std::array<int, 3> out_offsets{0, 0, 0};
+        for(int k = kMin + 0 + 0; k <= kMax + 0 + 0; ++k) {
+          for(int i = iMin + 0; i <= iMax + 0; ++i) {
+            for(int j = jMin + 0; j <= jMax + 0; ++j) {
+              if((m_globals.var1 == (int)1)) {
+                out(i + 0, j + 0, k + 0) = in(i + 1, j + 0, k + 0);
+              } else {
+                out(i + 0, j + 0, k + 0) = in(i + -1, j + 0, k + 0);
+              }
+              if((m_globals.var1 == (int)1)) {
+                out(i + 0, j + 0, k + 0) = in(i + 0, j + 1, k + 0);
+              } else {
+                out(i + 0, j + 0, k + 0) = in(i + 0, j + -1, k + 0);
+              }
+            }
+          }
+        }
+      }
+      in_.sync();
       out_.sync();
     }
   };
   static constexpr const char* s_name = "conditional_stencil";
   globals m_globals;
   stencil_21 m_stencil_21;
-public:
 
+public:
   conditional_stencil(const conditional_stencil&) = delete;
 
-  conditional_stencil(const gridtools::dawn::domain& dom, int rank = 1, int xcols = 1, int ycols = 1) : m_stencil_21(dom, m_globals, rank, xcols, ycols){
+  conditional_stencil(const gridtools::dawn::domain& dom, int rank = 1, int xcols = 1,
+                      int ycols = 1)
+      : m_stencil_21(dom, m_globals, rank, xcols, ycols) {
     assert(dom.isize() >= dom.iminus() + dom.iplus());
     assert(dom.jsize() >= dom.jminus() + dom.jplus());
     assert(dom.ksize() >= dom.kminus() + dom.kplus());
@@ -126,25 +125,15 @@ public:
 
   // Access-wrapper for globally defined variables
 
-  int get_var1() {
-    return m_globals.var1;
-  }
+  int get_var1() { return m_globals.var1; }
 
-  void set_var1(int var1) {
-    m_globals.var1=var1;
-  }
+  void set_var1(int var1) { m_globals.var1 = var1; }
 
-  bool get_var2() {
-    return m_globals.var2;
-  }
+  bool get_var2() { return m_globals.var2; }
 
-  void set_var2(bool var2) {
-    m_globals.var2=var2;
-  }
+  void set_var2(bool var2) { m_globals.var2 = var2; }
 
-  void run(storage_ijk_t in, storage_ijk_t out) {
-    m_stencil_21.run(in,out);
-  }
+  void run(storage_ijk_t in, storage_ijk_t out) { m_stencil_21.run(in, out); }
 };
 } // namespace cxxnaive
 } // namespace dawn_generated

--- a/dawn/test/unit-test/dawn/CodeGen/reference/conditional_stencil.cu
+++ b/dawn/test/unit-test/dawn/CodeGen/reference/conditional_stencil.cu
@@ -2,57 +2,59 @@
 #undef DAWN_BACKEND_T
 #define DAWN_BACKEND_T CUDA
 #ifndef BOOST_RESULT_OF_USE_TR1
- #define BOOST_RESULT_OF_USE_TR1 1
+#define BOOST_RESULT_OF_USE_TR1 1
 #endif
 #ifndef BOOST_NO_CXX11_DECLTYPE
- #define BOOST_NO_CXX11_DECLTYPE 1
+#define BOOST_NO_CXX11_DECLTYPE 1
 #endif
 #ifndef GRIDTOOLS_DAWN_HALO_EXTENT
- #define GRIDTOOLS_DAWN_HALO_EXTENT 3
+#define GRIDTOOLS_DAWN_HALO_EXTENT 3
 #endif
 #ifndef BOOST_PP_VARIADICS
- #define BOOST_PP_VARIADICS 1
+#define BOOST_PP_VARIADICS 1
 #endif
 #ifndef BOOST_FUSION_DONT_USE_PREPROCESSED_FILES
- #define BOOST_FUSION_DONT_USE_PREPROCESSED_FILES 1
+#define BOOST_FUSION_DONT_USE_PREPROCESSED_FILES 1
 #endif
 #ifndef BOOST_MPL_CFG_NO_PREPROCESSED_HEADERS
- #define BOOST_MPL_CFG_NO_PREPROCESSED_HEADERS 1
+#define BOOST_MPL_CFG_NO_PREPROCESSED_HEADERS 1
 #endif
 #ifndef GT_VECTOR_LIMIT_SIZE
- #define GT_VECTOR_LIMIT_SIZE 30
+#define GT_VECTOR_LIMIT_SIZE 30
 #endif
 #ifndef BOOST_FUSION_INVOKE_MAX_ARITY
- #define BOOST_FUSION_INVOKE_MAX_ARITY GT_VECTOR_LIMIT_SIZE
+#define BOOST_FUSION_INVOKE_MAX_ARITY GT_VECTOR_LIMIT_SIZE
 #endif
 #ifndef FUSION_MAX_VECTOR_SIZE
- #define FUSION_MAX_VECTOR_SIZE GT_VECTOR_LIMIT_SIZE
+#define FUSION_MAX_VECTOR_SIZE GT_VECTOR_LIMIT_SIZE
 #endif
 #ifndef FUSION_MAX_MAP_SIZE
- #define FUSION_MAX_MAP_SIZE GT_VECTOR_LIMIT_SIZE
+#define FUSION_MAX_MAP_SIZE GT_VECTOR_LIMIT_SIZE
 #endif
 #ifndef BOOST_MPL_LIMIT_VECTOR_SIZE
- #define BOOST_MPL_LIMIT_VECTOR_SIZE GT_VECTOR_LIMIT_SIZE
+#define BOOST_MPL_LIMIT_VECTOR_SIZE GT_VECTOR_LIMIT_SIZE
 #endif
 #include <driver-includes/gridtools_includes.hpp>
 using namespace gridtools::dawn;
-namespace dawn_generated{
-namespace cuda{
+namespace dawn_generated {
+namespace cuda {
 
 struct globals {
   int var1;
   bool var2;
 
-  globals() : var1(1){
-  }
+  globals() : var1(1) {}
 };
 } // namespace cuda
 } // namespace dawn_generated
 
-
-namespace dawn_generated{
-namespace cuda{
-__global__ void __launch_bounds__(128)  conditional_stencil_stencil21_ms41_kernel(globals globals_, const int isize, const int jsize, const int ksize, const int stride_111_1, const int stride_111_2, ::dawn::float_type * const in, ::dawn::float_type * const out) {
+namespace dawn_generated {
+namespace cuda {
+__global__ void __launch_bounds__(128)
+    conditional_stencil_stencil21_ms41_kernel(globals globals_, const int isize, const int jsize,
+                                              const int ksize, const int stride_111_1,
+                                              const int stride_111_2, ::dawn::float_type* const in,
+                                              ::dawn::float_type* const out) {
 
   // Start kernel
   const unsigned int nx = isize;
@@ -89,52 +91,47 @@ __global__ void __launch_bounds__(128)  conditional_stencil_stencil21_ms41_kerne
   // Regions (a,h,e) and (c,i,g) are executed by two specialized warp
   int iblock = 0 - 1;
   int jblock = 0 - 1;
-if(threadIdx.y < +4) {
+  if(threadIdx.y < +4) {
     iblock = threadIdx.x;
     jblock = (int)threadIdx.y + 0;
-}
-  // initialized iterators
-  int idx111 = (blockIdx.x*32+iblock)*1+(blockIdx.y*4+jblock)*stride_111_1;
-
-  // jump iterators to match the intersection of beginning of next interval and the parallel execution block
-  idx111 += max(0, blockIdx.z * 4) * stride_111_2;
-  int kleg_lower_bound = max(0,blockIdx.z*4);
-  int kleg_upper_bound = min( ksize - 1 + 0,(blockIdx.z+1)*4-1);;
-for(int k = kleg_lower_bound+0; k <= kleg_upper_bound+0; ++k) {
-  if(iblock >= 0 && iblock <= block_size_i -1 + 0 && jblock >= 0 && jblock <= block_size_j -1 + 0) {
-if((globals_.var1 == (int) 1))
-{
-  out[idx111] = __ldg(&(in[idx111+1*1]));
-}
-else
-{
-  out[idx111] = __ldg(&(in[idx111+1*-1]));
-}
-if((globals_.var1 == (int) 1))
-{
-  out[idx111] = __ldg(&(in[idx111+stride_111_1*1]));
-}
-else
-{
-  out[idx111] = __ldg(&(in[idx111+stride_111_1*-1]));
-}
   }
+  // initialized iterators
+  int idx111 = (blockIdx.x * 32 + iblock) * 1 + (blockIdx.y * 4 + jblock) * stride_111_1;
+
+  // jump iterators to match the intersection of beginning of next interval and the parallel
+  // execution block
+  idx111 += max(0, blockIdx.z * 4) * stride_111_2;
+  int kleg_lower_bound = max(0, blockIdx.z * 4);
+  int kleg_upper_bound = min(ksize - 1 + 0, (blockIdx.z + 1) * 4 - 1);
+  ;
+  for(int k = kleg_lower_bound + 0; k <= kleg_upper_bound + 0; ++k) {
+    if(iblock >= 0 && iblock <= block_size_i - 1 + 0 && jblock >= 0 &&
+       jblock <= block_size_j - 1 + 0) {
+      if((globals_.var1 == (int)1)) {
+        out[idx111] = __ldg(&(in[idx111 + 1 * 1]));
+      } else {
+        out[idx111] = __ldg(&(in[idx111 + 1 * -1]));
+      }
+      if((globals_.var1 == (int)1)) {
+        out[idx111] = __ldg(&(in[idx111 + stride_111_1 * 1]));
+      } else {
+        out[idx111] = __ldg(&(in[idx111 + stride_111_1 * -1]));
+      }
+    }
     // Slide kcaches
 
     // increment iterators
-    idx111+=stride_111_2;
-}}
+    idx111 += stride_111_2;
+  }
+}
 
 class conditional_stencil {
 public:
-
   struct sbase : public timer_cuda {
 
-    sbase(std::string name) : timer_cuda(name){}
+    sbase(std::string name) : timer_cuda(name) {}
 
-    double get_time() {
-      return total_time();
-    }
+    double get_time() { return total_time(); }
   };
 
   struct stencil_21 : public sbase {
@@ -142,33 +139,39 @@ public:
     // Members
 
     // Temporary storage typedefs
-    using tmp_halo_t = gridtools::halo< 0,0, 0, 0, 0>;
-    using tmp_meta_data_t = storage_traits_t::storage_info_t< 0, 5, tmp_halo_t >;
-    using tmp_storage_t = storage_traits_t::data_store_t< ::dawn::float_type, tmp_meta_data_t>;
+    using tmp_halo_t = gridtools::halo<0, 0, 0, 0, 0>;
+    using tmp_meta_data_t = storage_traits_t::storage_info_t<0, 5, tmp_halo_t>;
+    using tmp_storage_t = storage_traits_t::data_store_t<::dawn::float_type, tmp_meta_data_t>;
     globals& m_globals;
     const gridtools::dawn::domain m_dom;
-  public:
 
-    stencil_21(const gridtools::dawn::domain& dom_, globals& globals_, int rank, int xcols, int ycols) : sbase("stencil_21"), m_dom(dom_), m_globals(globals_){}
-    static constexpr ::dawn::driver::cartesian_extent in_extent = {-1,1, -1,1, 0,0};
-    static constexpr ::dawn::driver::cartesian_extent out_extent = {0,0, 0,0, 0,0};
+  public:
+    stencil_21(const gridtools::dawn::domain& dom_, globals& globals_, int rank, int xcols,
+               int ycols)
+        : sbase("stencil_21"), m_dom(dom_), m_globals(globals_) {}
+    static constexpr ::dawn::driver::cartesian_extent in_extent = {-1, 1, -1, 1, 0, 0};
+    static constexpr ::dawn::driver::cartesian_extent out_extent = {0, 0, 0, 0, 0, 0};
 
     void run(storage_ijk_t in_ds, storage_ijk_t out_ds) {
 
       // starting timers
       start();
-      {;
-      gridtools::data_view<storage_ijk_t> in= gridtools::make_device_view(in_ds);
-      gridtools::data_view<storage_ijk_t> out= gridtools::make_device_view(out_ds);
-      const unsigned int nx = m_dom.isize() - m_dom.iminus() - m_dom.iplus();
-      const unsigned int ny = m_dom.jsize() - m_dom.jminus() - m_dom.jplus();
-      const unsigned int nz = m_dom.ksize() - m_dom.kminus() - m_dom.kplus();
-      dim3 threads(32,4+0,1);
-      const unsigned int nbx = (nx + 32 - 1) / 32;
-      const unsigned int nby = (ny + 4 - 1) / 4;
-      const unsigned int nbz = (m_dom.ksize()+4-1) / 4;
-      dim3 blocks(nbx, nby, nbz);
-      conditional_stencil_stencil21_ms41_kernel<<<blocks, threads>>>(m_globals,nx,ny,nz,in_ds.strides()[1],in_ds.strides()[2],(in.data()+in_ds.get_storage_info_ptr()->index(in.begin<0>(), in.begin<1>(),0 )),(out.data()+out_ds.get_storage_info_ptr()->index(out.begin<0>(), out.begin<1>(),0 )));
+      {
+        ;
+        gridtools::data_view<storage_ijk_t> in = gridtools::make_device_view(in_ds);
+        gridtools::data_view<storage_ijk_t> out = gridtools::make_device_view(out_ds);
+        const unsigned int nx = m_dom.isize() - m_dom.iminus() - m_dom.iplus();
+        const unsigned int ny = m_dom.jsize() - m_dom.jminus() - m_dom.jplus();
+        const unsigned int nz = m_dom.ksize() - m_dom.kminus() - m_dom.kplus();
+        dim3 threads(32, 4 + 0, 1);
+        const unsigned int nbx = (nx + 32 - 1) / 32;
+        const unsigned int nby = (ny + 4 - 1) / 4;
+        const unsigned int nbz = (m_dom.ksize() + 4 - 1) / 4;
+        dim3 blocks(nbx, nby, nbz);
+        conditional_stencil_stencil21_ms41_kernel<<<blocks, threads>>>(
+            m_globals, nx, ny, nz, in_ds.strides()[1], in_ds.strides()[2],
+            (in.data() + in_ds.get_storage_info_ptr()->index(in.begin<0>(), in.begin<1>(), 0)),
+            (out.data() + out_ds.get_storage_info_ptr()->index(out.begin<0>(), out.begin<1>(), 0)));
       };
 
       // stopping timers
@@ -177,8 +180,8 @@ public:
   };
   static constexpr const char* s_name = "conditional_stencil";
   stencil_21 m_stencil_21;
-public:
 
+public:
   conditional_stencil(const conditional_stencil&) = delete;
 
   // Members
@@ -186,54 +189,45 @@ public:
   // Stencil-Data
   globals m_globals;
 
-  conditional_stencil(const gridtools::dawn::domain& dom, int rank = 1, int xcols = 1, int ycols = 1) : m_stencil_21(dom,m_globals, rank, xcols, ycols){}
+  conditional_stencil(const gridtools::dawn::domain& dom, int rank = 1, int xcols = 1,
+                      int ycols = 1)
+      : m_stencil_21(dom, m_globals, rank, xcols, ycols) {}
 
   // Access-wrapper for globally defined variables
 
-  int get_var1() {
-    return m_globals.var1;
-  }
+  int get_var1() { return m_globals.var1; }
 
-  void set_var1(int var1) {
-    m_globals.var1=var1;
-  }
+  void set_var1(int var1) { m_globals.var1 = var1; }
 
-  bool get_var2() {
-    return m_globals.var2;
-  }
+  bool get_var2() { return m_globals.var2; }
 
-  void set_var2(bool var2) {
-    m_globals.var2=var2;
-  }
+  void set_var2(bool var2) { m_globals.var2 = var2; }
 
-  template<typename S>
+  template <typename S>
   void sync_storages(S field) {
     field.sync();
   }
 
-  template<typename S0, typename ... S>
+  template <typename S0, typename... S>
   void sync_storages(S0 f0, S... fields) {
     f0.sync();
     sync_storages(fields...);
   }
 
   void run(storage_ijk_t in, storage_ijk_t out) {
-    sync_storages(in,out);
-    m_stencil_21.run(in,out);
-;
-    sync_storages(in,out);
+    sync_storages(in, out);
+    m_stencil_21.run(in, out);
+    ;
+    sync_storages(in, out);
   }
 
-  std::string get_name()  const {
-    return std::string(s_name);
-  }
+  std::string get_name() const { return std::string(s_name); }
 
-  void reset_meters() {
-m_stencil_21.reset();  }
+  void reset_meters() { m_stencil_21.reset(); }
 
   double get_total_time() {
     double res = 0;
-    res +=m_stencil_21.get_time();
+    res += m_stencil_21.get_time();
     return res;
   }
 };

--- a/dawn/test/unit-test/dawn/CodeGen/reference/global_indexing.cpp
+++ b/dawn/test/unit-test/dawn/CodeGen/reference/global_indexing.cpp
@@ -2,55 +2,54 @@
 #undef DAWN_BACKEND_T
 #define DAWN_BACKEND_T CXXNAIVE
 #ifndef BOOST_RESULT_OF_USE_TR1
- #define BOOST_RESULT_OF_USE_TR1 1
+#define BOOST_RESULT_OF_USE_TR1 1
 #endif
 #ifndef BOOST_NO_CXX11_DECLTYPE
- #define BOOST_NO_CXX11_DECLTYPE 1
+#define BOOST_NO_CXX11_DECLTYPE 1
 #endif
 #ifndef GRIDTOOLS_DAWN_HALO_EXTENT
- #define GRIDTOOLS_DAWN_HALO_EXTENT 3
+#define GRIDTOOLS_DAWN_HALO_EXTENT 3
 #endif
 #ifndef BOOST_PP_VARIADICS
- #define BOOST_PP_VARIADICS 1
+#define BOOST_PP_VARIADICS 1
 #endif
 #ifndef BOOST_FUSION_DONT_USE_PREPROCESSED_FILES
- #define BOOST_FUSION_DONT_USE_PREPROCESSED_FILES 1
+#define BOOST_FUSION_DONT_USE_PREPROCESSED_FILES 1
 #endif
 #ifndef BOOST_MPL_CFG_NO_PREPROCESSED_HEADERS
- #define BOOST_MPL_CFG_NO_PREPROCESSED_HEADERS 1
+#define BOOST_MPL_CFG_NO_PREPROCESSED_HEADERS 1
 #endif
 #ifndef GT_VECTOR_LIMIT_SIZE
- #define GT_VECTOR_LIMIT_SIZE 30
+#define GT_VECTOR_LIMIT_SIZE 30
 #endif
 #ifndef BOOST_FUSION_INVOKE_MAX_ARITY
- #define BOOST_FUSION_INVOKE_MAX_ARITY GT_VECTOR_LIMIT_SIZE
+#define BOOST_FUSION_INVOKE_MAX_ARITY GT_VECTOR_LIMIT_SIZE
 #endif
 #ifndef FUSION_MAX_VECTOR_SIZE
- #define FUSION_MAX_VECTOR_SIZE GT_VECTOR_LIMIT_SIZE
+#define FUSION_MAX_VECTOR_SIZE GT_VECTOR_LIMIT_SIZE
 #endif
 #ifndef FUSION_MAX_MAP_SIZE
- #define FUSION_MAX_MAP_SIZE GT_VECTOR_LIMIT_SIZE
+#define FUSION_MAX_MAP_SIZE GT_VECTOR_LIMIT_SIZE
 #endif
 #ifndef BOOST_MPL_LIMIT_VECTOR_SIZE
- #define BOOST_MPL_LIMIT_VECTOR_SIZE GT_VECTOR_LIMIT_SIZE
+#define BOOST_MPL_LIMIT_VECTOR_SIZE GT_VECTOR_LIMIT_SIZE
 #endif
 #include <driver-includes/gridtools_includes.hpp>
 using namespace gridtools::dawn;
 
-
-namespace dawn_generated{
-namespace cxxnaive{
+namespace dawn_generated {
+namespace cxxnaive {
 
 class generated {
 private:
-
   struct stencil_28 {
 
     // Members
     std::array<int, 2> stage14GlobalJIndices;
     std::array<unsigned int, 2> globalOffsets;
 
-    static std::array<unsigned int, 2> computeGlobalOffsets(int rank, const gridtools::dawn::domain& dom, int xcols, int ycols) {
+    static std::array<unsigned int, 2>
+    computeGlobalOffsets(int rank, const gridtools::dawn::domain& dom, int xcols, int ycols) {
       unsigned int rankOnDefaultFace = rank % (xcols * ycols);
       unsigned int row = rankOnDefaultFace / xcols;
       unsigned int col = rankOnDefaultFace % ycols;
@@ -62,17 +61,18 @@ private:
     }
 
     // Temporary storages
-    using tmp_halo_t = gridtools::halo< GRIDTOOLS_DAWN_HALO_EXTENT, GRIDTOOLS_DAWN_HALO_EXTENT, 0>;
-    using tmp_meta_data_t = storage_traits_t::storage_info_t< 0, 3, tmp_halo_t >;
-    using tmp_storage_t = storage_traits_t::data_store_t< ::dawn::float_type, tmp_meta_data_t>;
+    using tmp_halo_t = gridtools::halo<GRIDTOOLS_DAWN_HALO_EXTENT, GRIDTOOLS_DAWN_HALO_EXTENT, 0>;
+    using tmp_meta_data_t = storage_traits_t::storage_info_t<0, 3, tmp_halo_t>;
+    using tmp_storage_t = storage_traits_t::data_store_t<::dawn::float_type, tmp_meta_data_t>;
     const gridtools::dawn::domain m_dom;
 
     // Input/Output storages
   public:
-
-    stencil_28(const gridtools::dawn::domain& dom_, int rank, int xcols, int ycols) : m_dom(dom_), stage14GlobalJIndices({dom_.jminus() + 0 , dom_.jminus() + 2}), globalOffsets({computeGlobalOffsets(rank, m_dom, xcols, ycols)}){}
-    static constexpr ::dawn::driver::cartesian_extent in_field_extent = {0,0, 0,0, 0,0};
-    static constexpr ::dawn::driver::cartesian_extent out_field_extent = {0,0, 0,0, 0,0};
+    stencil_28(const gridtools::dawn::domain& dom_, int rank, int xcols, int ycols)
+        : m_dom(dom_), stage14GlobalJIndices({dom_.jminus() + 0, dom_.jminus() + 2}),
+          globalOffsets({computeGlobalOffsets(rank, m_dom, xcols, ycols)}) {}
+    static constexpr ::dawn::driver::cartesian_extent in_field_extent = {0, 0, 0, 0, 0, 0};
+    static constexpr ::dawn::driver::cartesian_extent out_field_extent = {0, 0, 0, 0, 0, 0};
 
     void run(storage_ijk_t& in_field_, storage_ijk_t& out_field_) {
       int iMin = m_dom.iminus();
@@ -83,33 +83,43 @@ private:
       int kMax = m_dom.ksize() - m_dom.kplus() - 1;
       in_field_.sync();
       out_field_.sync();
-{      gridtools::data_view<storage_ijk_t> in_field= gridtools::make_host_view(in_field_);
-      std::array<int,3> in_field_offsets{0,0,0};
-      gridtools::data_view<storage_ijk_t> out_field= gridtools::make_host_view(out_field_);
-      std::array<int,3> out_field_offsets{0,0,0};
-    for(int k = kMin + 0+0; k <= kMax + 0+0; ++k) {
-      for(int i = iMin+0; i  <=  iMax+0; ++i) {
-        for(int j = jMin+0; j  <=  jMax+0; ++j) {
-{
-  out_field(i+0, j+0, k+0) = in_field(i+0, j+0, k+0);
-}
-        }      }      for(int i = iMin+0; i  <=  iMax+0; ++i) {
-        for(int j = jMin+0; j  <=  jMax+0; ++j) {
-          if(checkOffset(stage14GlobalJIndices[0], stage14GlobalJIndices[1], globalOffsets[1] + j)) {
-{
-  out_field(i+0, j+0, k+0) = (int) 10;
-}
-          }        }      }    }}      in_field_.sync();
+      {
+        gridtools::data_view<storage_ijk_t> in_field = gridtools::make_host_view(in_field_);
+        std::array<int, 3> in_field_offsets{0, 0, 0};
+        gridtools::data_view<storage_ijk_t> out_field = gridtools::make_host_view(out_field_);
+        std::array<int, 3> out_field_offsets{0, 0, 0};
+        for(int k = kMin + 0 + 0; k <= kMax + 0 + 0; ++k) {
+          for(int i = iMin + 0; i <= iMax + 0; ++i) {
+            for(int j = jMin + 0; j <= jMax + 0; ++j) {
+              {
+                out_field(i + 0, j + 0, k + 0) = in_field(i + 0, j + 0, k + 0);
+              }
+            }
+          }
+          for(int i = iMin + 0; i <= iMax + 0; ++i) {
+            for(int j = jMin + 0; j <= jMax + 0; ++j) {
+              if(checkOffset(stage14GlobalJIndices[0], stage14GlobalJIndices[1],
+                             globalOffsets[1] + j)) {
+                {
+                  out_field(i + 0, j + 0, k + 0) = (int)10;
+                }
+              }
+            }
+          }
+        }
+      }
+      in_field_.sync();
       out_field_.sync();
     }
   };
   static constexpr const char* s_name = "generated";
   stencil_28 m_stencil_28;
-public:
 
+public:
   generated(const generated&) = delete;
 
-  generated(const gridtools::dawn::domain& dom, int rank = 1, int xcols = 1, int ycols = 1) : m_stencil_28(dom, rank, xcols, ycols){
+  generated(const gridtools::dawn::domain& dom, int rank = 1, int xcols = 1, int ycols = 1)
+      : m_stencil_28(dom, rank, xcols, ycols) {
     assert(dom.isize() >= dom.iminus() + dom.iplus());
     assert(dom.jsize() >= dom.jminus() + dom.jplus());
     assert(dom.ksize() >= dom.kminus() + dom.kplus());
@@ -117,7 +127,7 @@ public:
   }
 
   void run(storage_ijk_t in_field, storage_ijk_t out_field) {
-    m_stencil_28.run(in_field,out_field);
+    m_stencil_28.run(in_field, out_field);
   }
 };
 } // namespace cxxnaive

--- a/dawn/test/unit-test/dawn/CodeGen/reference/global_indexing.cu
+++ b/dawn/test/unit-test/dawn/CodeGen/reference/global_indexing.cu
@@ -2,50 +2,53 @@
 #undef DAWN_BACKEND_T
 #define DAWN_BACKEND_T CUDA
 #ifndef BOOST_RESULT_OF_USE_TR1
- #define BOOST_RESULT_OF_USE_TR1 1
+#define BOOST_RESULT_OF_USE_TR1 1
 #endif
 #ifndef BOOST_NO_CXX11_DECLTYPE
- #define BOOST_NO_CXX11_DECLTYPE 1
+#define BOOST_NO_CXX11_DECLTYPE 1
 #endif
 #ifndef GRIDTOOLS_DAWN_HALO_EXTENT
- #define GRIDTOOLS_DAWN_HALO_EXTENT 3
+#define GRIDTOOLS_DAWN_HALO_EXTENT 3
 #endif
 #ifndef BOOST_PP_VARIADICS
- #define BOOST_PP_VARIADICS 1
+#define BOOST_PP_VARIADICS 1
 #endif
 #ifndef BOOST_FUSION_DONT_USE_PREPROCESSED_FILES
- #define BOOST_FUSION_DONT_USE_PREPROCESSED_FILES 1
+#define BOOST_FUSION_DONT_USE_PREPROCESSED_FILES 1
 #endif
 #ifndef BOOST_MPL_CFG_NO_PREPROCESSED_HEADERS
- #define BOOST_MPL_CFG_NO_PREPROCESSED_HEADERS 1
+#define BOOST_MPL_CFG_NO_PREPROCESSED_HEADERS 1
 #endif
 #ifndef GT_VECTOR_LIMIT_SIZE
- #define GT_VECTOR_LIMIT_SIZE 30
+#define GT_VECTOR_LIMIT_SIZE 30
 #endif
 #ifndef BOOST_FUSION_INVOKE_MAX_ARITY
- #define BOOST_FUSION_INVOKE_MAX_ARITY GT_VECTOR_LIMIT_SIZE
+#define BOOST_FUSION_INVOKE_MAX_ARITY GT_VECTOR_LIMIT_SIZE
 #endif
 #ifndef FUSION_MAX_VECTOR_SIZE
- #define FUSION_MAX_VECTOR_SIZE GT_VECTOR_LIMIT_SIZE
+#define FUSION_MAX_VECTOR_SIZE GT_VECTOR_LIMIT_SIZE
 #endif
 #ifndef FUSION_MAX_MAP_SIZE
- #define FUSION_MAX_MAP_SIZE GT_VECTOR_LIMIT_SIZE
+#define FUSION_MAX_MAP_SIZE GT_VECTOR_LIMIT_SIZE
 #endif
 #ifndef BOOST_MPL_LIMIT_VECTOR_SIZE
- #define BOOST_MPL_LIMIT_VECTOR_SIZE GT_VECTOR_LIMIT_SIZE
+#define BOOST_MPL_LIMIT_VECTOR_SIZE GT_VECTOR_LIMIT_SIZE
 #endif
 #include <driver-includes/gridtools_includes.hpp>
 using namespace gridtools::dawn;
 
-
-namespace dawn_generated{
-namespace cuda{
+namespace dawn_generated {
+namespace cuda {
 __constant__ int stage14GlobalJIndices_[2];
 __constant__ unsigned globalOffsets_[2];
 __device__ bool checkOffset(unsigned int min, unsigned int max, unsigned int val) {
   return (min <= val && val < max);
 }
-__global__ void __launch_bounds__(128)  generated_stencil28_ms27_kernel(const int isize, const int jsize, const int ksize, const int stride_111_1, const int stride_111_2, ::dawn::float_type * const in_field, ::dawn::float_type * const out_field) {
+__global__ void __launch_bounds__(128)
+    generated_stencil28_ms27_kernel(const int isize, const int jsize, const int ksize,
+                                    const int stride_111_1, const int stride_111_2,
+                                    ::dawn::float_type* const in_field,
+                                    ::dawn::float_type* const out_field) {
 
   // Start kernel
   const unsigned int nx = isize;
@@ -82,43 +85,48 @@ __global__ void __launch_bounds__(128)  generated_stencil28_ms27_kernel(const in
   // Regions (a,h,e) and (c,i,g) are executed by two specialized warp
   int iblock = 0 - 1;
   int jblock = 0 - 1;
-if(threadIdx.y < +4) {
+  if(threadIdx.y < +4) {
     iblock = threadIdx.x;
     jblock = (int)threadIdx.y + 0;
-}
-  // initialized iterators
-  int idx111 = (blockIdx.x*32+iblock)*1+(blockIdx.y*4+jblock)*stride_111_1;
-
-  // jump iterators to match the intersection of beginning of next interval and the parallel execution block
-  idx111 += max(0, blockIdx.z * 4) * stride_111_2;
-  int kleg_lower_bound = max(0,blockIdx.z*4);
-  int kleg_upper_bound = min( ksize - 1 + 0,(blockIdx.z+1)*4-1);;
-for(int k = kleg_lower_bound+0; k <= kleg_upper_bound+0; ++k) {
-  if(iblock >= 0 && iblock <= block_size_i -1 + 0 && jblock >= 0 && jblock <= block_size_j -1 + 0) {
-{
-  out_field[idx111] = __ldg(&(in_field[idx111]));
-}
-  }  if(iblock >= 0 && iblock <= block_size_i -1 + 0 && jblock >= 0 && jblock <= block_size_j -1 + 0 && checkOffset(stage14GlobalJIndices_[0], stage14GlobalJIndices_[1], globalOffsets_[1] + jblock)) {
-{
-  out_field[idx111] = (int) 10;
-}
   }
+  // initialized iterators
+  int idx111 = (blockIdx.x * 32 + iblock) * 1 + (blockIdx.y * 4 + jblock) * stride_111_1;
+
+  // jump iterators to match the intersection of beginning of next interval and the parallel
+  // execution block
+  idx111 += max(0, blockIdx.z * 4) * stride_111_2;
+  int kleg_lower_bound = max(0, blockIdx.z * 4);
+  int kleg_upper_bound = min(ksize - 1 + 0, (blockIdx.z + 1) * 4 - 1);
+  ;
+  for(int k = kleg_lower_bound + 0; k <= kleg_upper_bound + 0; ++k) {
+    if(iblock >= 0 && iblock <= block_size_i - 1 + 0 && jblock >= 0 &&
+       jblock <= block_size_j - 1 + 0) {
+      {
+        out_field[idx111] = __ldg(&(in_field[idx111]));
+      }
+    }
+    if(iblock >= 0 && iblock <= block_size_i - 1 + 0 && jblock >= 0 &&
+       jblock <= block_size_j - 1 + 0 &&
+       checkOffset(stage14GlobalJIndices_[0], stage14GlobalJIndices_[1],
+                   globalOffsets_[1] + jblock)) {
+      {
+        out_field[idx111] = (int)10;
+      }
+    }
     // Slide kcaches
 
     // increment iterators
-    idx111+=stride_111_2;
-}}
+    idx111 += stride_111_2;
+  }
+}
 
 class generated {
 public:
-
   struct sbase : public timer_cuda {
 
-    sbase(std::string name) : timer_cuda(name){}
+    sbase(std::string name) : timer_cuda(name) {}
 
-    double get_time() {
-      return total_time();
-    }
+    double get_time() { return total_time(); }
   };
 
   struct stencil_28 : public sbase {
@@ -127,7 +135,8 @@ public:
     std::array<int, 2> stage14GlobalJIndices;
     std::array<unsigned int, 2> globalOffsets;
 
-    static std::array<unsigned int, 2> computeGlobalOffsets(int rank, const gridtools::dawn::domain& dom, int xcols, int ycols) {
+    static std::array<unsigned int, 2>
+    computeGlobalOffsets(int rank, const gridtools::dawn::domain& dom, int xcols, int ycols) {
       unsigned int rankOnDefaultFace = rank % (xcols * ycols);
       unsigned int row = rankOnDefaultFace / xcols;
       unsigned int col = rankOnDefaultFace % ycols;
@@ -135,34 +144,45 @@ public:
     }
 
     // Temporary storage typedefs
-    using tmp_halo_t = gridtools::halo< 0,0, 0, 0, 0>;
-    using tmp_meta_data_t = storage_traits_t::storage_info_t< 0, 5, tmp_halo_t >;
-    using tmp_storage_t = storage_traits_t::data_store_t< ::dawn::float_type, tmp_meta_data_t>;
+    using tmp_halo_t = gridtools::halo<0, 0, 0, 0, 0>;
+    using tmp_meta_data_t = storage_traits_t::storage_info_t<0, 5, tmp_halo_t>;
+    using tmp_storage_t = storage_traits_t::data_store_t<::dawn::float_type, tmp_meta_data_t>;
     const gridtools::dawn::domain m_dom;
-  public:
 
-    stencil_28(const gridtools::dawn::domain& dom_, int rank, int xcols, int ycols) : sbase("stencil_28"), m_dom(dom_), stage14GlobalJIndices({dom_.jminus() + 0 , dom_.jminus() + 2}), globalOffsets({computeGlobalOffsets(rank, m_dom, xcols, ycols)}){}
-    static constexpr ::dawn::driver::cartesian_extent in_field_extent = {0,0, 0,0, 0,0};
-    static constexpr ::dawn::driver::cartesian_extent out_field_extent = {0,0, 0,0, 0,0};
+  public:
+    stencil_28(const gridtools::dawn::domain& dom_, int rank, int xcols, int ycols)
+        : sbase("stencil_28"), m_dom(dom_),
+          stage14GlobalJIndices({dom_.jminus() + 0, dom_.jminus() + 2}),
+          globalOffsets({computeGlobalOffsets(rank, m_dom, xcols, ycols)}) {}
+    static constexpr ::dawn::driver::cartesian_extent in_field_extent = {0, 0, 0, 0, 0, 0};
+    static constexpr ::dawn::driver::cartesian_extent out_field_extent = {0, 0, 0, 0, 0, 0};
 
     void run(storage_ijk_t in_field_ds, storage_ijk_t out_field_ds) {
 
       // starting timers
       start();
-      {;
-      gridtools::data_view<storage_ijk_t> in_field= gridtools::make_device_view(in_field_ds);
-      gridtools::data_view<storage_ijk_t> out_field= gridtools::make_device_view(out_field_ds);
-      const unsigned int nx = m_dom.isize() - m_dom.iminus() - m_dom.iplus();
-      const unsigned int ny = m_dom.jsize() - m_dom.jminus() - m_dom.jplus();
-      const unsigned int nz = m_dom.ksize() - m_dom.kminus() - m_dom.kplus();
-      dim3 threads(32,4+0,1);
-      const unsigned int nbx = (nx + 32 - 1) / 32;
-      const unsigned int nby = (ny + 4 - 1) / 4;
-      const unsigned int nbz = (m_dom.ksize()+4-1) / 4;
-      cudaMemcpyToSymbol(stage14GlobalJIndices_, stage14GlobalJIndices.data(), sizeof(int) * stage14GlobalJIndices.size());
-      cudaMemcpyToSymbol(globalOffsets_, globalOffsets.data(), sizeof(unsigned) * globalOffsets.size());
-      dim3 blocks(nbx, nby, nbz);
-      generated_stencil28_ms27_kernel<<<blocks, threads>>>(nx,ny,nz,in_field_ds.strides()[1],in_field_ds.strides()[2],(in_field.data()+in_field_ds.get_storage_info_ptr()->index(in_field.begin<0>(), in_field.begin<1>(),0 )),(out_field.data()+out_field_ds.get_storage_info_ptr()->index(out_field.begin<0>(), out_field.begin<1>(),0 )));
+      {
+        ;
+        gridtools::data_view<storage_ijk_t> in_field = gridtools::make_device_view(in_field_ds);
+        gridtools::data_view<storage_ijk_t> out_field = gridtools::make_device_view(out_field_ds);
+        const unsigned int nx = m_dom.isize() - m_dom.iminus() - m_dom.iplus();
+        const unsigned int ny = m_dom.jsize() - m_dom.jminus() - m_dom.jplus();
+        const unsigned int nz = m_dom.ksize() - m_dom.kminus() - m_dom.kplus();
+        dim3 threads(32, 4 + 0, 1);
+        const unsigned int nbx = (nx + 32 - 1) / 32;
+        const unsigned int nby = (ny + 4 - 1) / 4;
+        const unsigned int nbz = (m_dom.ksize() + 4 - 1) / 4;
+        cudaMemcpyToSymbol(stage14GlobalJIndices_, stage14GlobalJIndices.data(),
+                           sizeof(int) * stage14GlobalJIndices.size());
+        cudaMemcpyToSymbol(globalOffsets_, globalOffsets.data(),
+                           sizeof(unsigned) * globalOffsets.size());
+        dim3 blocks(nbx, nby, nbz);
+        generated_stencil28_ms27_kernel<<<blocks, threads>>>(
+            nx, ny, nz, in_field_ds.strides()[1], in_field_ds.strides()[2],
+            (in_field.data() + in_field_ds.get_storage_info_ptr()->index(in_field.begin<0>(),
+                                                                         in_field.begin<1>(), 0)),
+            (out_field.data() + out_field_ds.get_storage_info_ptr()->index(
+                                    out_field.begin<0>(), out_field.begin<1>(), 0)));
       };
 
       // stopping timers
@@ -171,44 +191,42 @@ public:
   };
   static constexpr const char* s_name = "generated";
   stencil_28 m_stencil_28;
-public:
 
+public:
   generated(const generated&) = delete;
 
   // Members
 
   // Stencil-Data
 
-  generated(const gridtools::dawn::domain& dom, int rank = 1, int xcols = 1, int ycols = 1) : m_stencil_28(dom, rank, xcols, ycols){}
+  generated(const gridtools::dawn::domain& dom, int rank = 1, int xcols = 1, int ycols = 1)
+      : m_stencil_28(dom, rank, xcols, ycols) {}
 
-  template<typename S>
+  template <typename S>
   void sync_storages(S field) {
     field.sync();
   }
 
-  template<typename S0, typename ... S>
+  template <typename S0, typename... S>
   void sync_storages(S0 f0, S... fields) {
     f0.sync();
     sync_storages(fields...);
   }
 
   void run(storage_ijk_t in_field, storage_ijk_t out_field) {
-    sync_storages(in_field,out_field);
-    m_stencil_28.run(in_field,out_field);
-;
-    sync_storages(in_field,out_field);
+    sync_storages(in_field, out_field);
+    m_stencil_28.run(in_field, out_field);
+    ;
+    sync_storages(in_field, out_field);
   }
 
-  std::string get_name()  const {
-    return std::string(s_name);
-  }
+  std::string get_name() const { return std::string(s_name); }
 
-  void reset_meters() {
-m_stencil_28.reset();  }
+  void reset_meters() { m_stencil_28.reset(); }
 
   double get_total_time() {
     double res = 0;
-    res +=m_stencil_28.get_time();
+    res += m_stencil_28.get_time();
     return res;
   }
 };

--- a/dawn/test/unit-test/dawn/CodeGen/reference/laplacian_stencil.cpp
+++ b/dawn/test/unit-test/dawn/CodeGen/reference/laplacian_stencil.cpp
@@ -2,64 +2,61 @@
 #undef DAWN_BACKEND_T
 #define DAWN_BACKEND_T CXXNAIVE
 #ifndef BOOST_RESULT_OF_USE_TR1
- #define BOOST_RESULT_OF_USE_TR1 1
+#define BOOST_RESULT_OF_USE_TR1 1
 #endif
 #ifndef BOOST_NO_CXX11_DECLTYPE
- #define BOOST_NO_CXX11_DECLTYPE 1
+#define BOOST_NO_CXX11_DECLTYPE 1
 #endif
 #ifndef GRIDTOOLS_DAWN_HALO_EXTENT
- #define GRIDTOOLS_DAWN_HALO_EXTENT 3
+#define GRIDTOOLS_DAWN_HALO_EXTENT 3
 #endif
 #ifndef BOOST_PP_VARIADICS
- #define BOOST_PP_VARIADICS 1
+#define BOOST_PP_VARIADICS 1
 #endif
 #ifndef BOOST_FUSION_DONT_USE_PREPROCESSED_FILES
- #define BOOST_FUSION_DONT_USE_PREPROCESSED_FILES 1
+#define BOOST_FUSION_DONT_USE_PREPROCESSED_FILES 1
 #endif
 #ifndef BOOST_MPL_CFG_NO_PREPROCESSED_HEADERS
- #define BOOST_MPL_CFG_NO_PREPROCESSED_HEADERS 1
+#define BOOST_MPL_CFG_NO_PREPROCESSED_HEADERS 1
 #endif
 #ifndef GT_VECTOR_LIMIT_SIZE
- #define GT_VECTOR_LIMIT_SIZE 30
+#define GT_VECTOR_LIMIT_SIZE 30
 #endif
 #ifndef BOOST_FUSION_INVOKE_MAX_ARITY
- #define BOOST_FUSION_INVOKE_MAX_ARITY GT_VECTOR_LIMIT_SIZE
+#define BOOST_FUSION_INVOKE_MAX_ARITY GT_VECTOR_LIMIT_SIZE
 #endif
 #ifndef FUSION_MAX_VECTOR_SIZE
- #define FUSION_MAX_VECTOR_SIZE GT_VECTOR_LIMIT_SIZE
+#define FUSION_MAX_VECTOR_SIZE GT_VECTOR_LIMIT_SIZE
 #endif
 #ifndef FUSION_MAX_MAP_SIZE
- #define FUSION_MAX_MAP_SIZE GT_VECTOR_LIMIT_SIZE
+#define FUSION_MAX_MAP_SIZE GT_VECTOR_LIMIT_SIZE
 #endif
 #ifndef BOOST_MPL_LIMIT_VECTOR_SIZE
- #define BOOST_MPL_LIMIT_VECTOR_SIZE GT_VECTOR_LIMIT_SIZE
+#define BOOST_MPL_LIMIT_VECTOR_SIZE GT_VECTOR_LIMIT_SIZE
 #endif
 #include <driver-includes/gridtools_includes.hpp>
 using namespace gridtools::dawn;
 
-
-namespace dawn_generated{
-namespace cxxnaive{
+namespace dawn_generated {
+namespace cxxnaive {
 
 class generated {
 private:
-
   struct stencil_47 {
 
     // Members
 
     // Temporary storages
-    using tmp_halo_t = gridtools::halo< GRIDTOOLS_DAWN_HALO_EXTENT, GRIDTOOLS_DAWN_HALO_EXTENT, 0>;
-    using tmp_meta_data_t = storage_traits_t::storage_info_t< 0, 3, tmp_halo_t >;
-    using tmp_storage_t = storage_traits_t::data_store_t< ::dawn::float_type, tmp_meta_data_t>;
+    using tmp_halo_t = gridtools::halo<GRIDTOOLS_DAWN_HALO_EXTENT, GRIDTOOLS_DAWN_HALO_EXTENT, 0>;
+    using tmp_meta_data_t = storage_traits_t::storage_info_t<0, 3, tmp_halo_t>;
+    using tmp_storage_t = storage_traits_t::data_store_t<::dawn::float_type, tmp_meta_data_t>;
     const gridtools::dawn::domain m_dom;
 
     // Input/Output storages
   public:
-
-    stencil_47(const gridtools::dawn::domain& dom_, int rank, int xcols, int ycols) : m_dom(dom_){}
-    static constexpr ::dawn::driver::cartesian_extent in_extent = {-1,1, -1,1, 0,0};
-    static constexpr ::dawn::driver::cartesian_extent out_extent = {0,0, 0,0, 0,0};
+    stencil_47(const gridtools::dawn::domain& dom_, int rank, int xcols, int ycols) : m_dom(dom_) {}
+    static constexpr ::dawn::driver::cartesian_extent in_extent = {-1, 1, -1, 1, 0, 0};
+    static constexpr ::dawn::driver::cartesian_extent out_extent = {0, 0, 0, 0, 0, 0};
 
     void run(storage_ijk_t& in_, storage_ijk_t& out_) {
       int iMin = m_dom.iminus();
@@ -70,37 +67,46 @@ private:
       int kMax = m_dom.ksize() - m_dom.kplus() - 1;
       in_.sync();
       out_.sync();
-{      gridtools::data_view<storage_ijk_t> in= gridtools::make_host_view(in_);
-      std::array<int,3> in_offsets{0,0,0};
-      gridtools::data_view<storage_ijk_t> out= gridtools::make_host_view(out_);
-      std::array<int,3> out_offsets{0,0,0};
-    for(int k = kMin + 0+0; k <= kMax + 0+0; ++k) {
-      for(int i = iMin+0; i  <=  iMax+0; ++i) {
-        for(int j = jMin+0; j  <=  jMax+0; ++j) {
-::dawn::float_type dx;
-{
-  out(i+0, j+0, k+0) = (((int) -4 * (in(i+0, j+0, k+0) + (in(i+1, j+0, k+0) + (in(i+-1, j+0, k+0) + (in(i+0, j+-1, k+0) + in(i+0, j+1, k+0)))))) / (dx * dx));
-}
-        }      }    }}      in_.sync();
+      {
+        gridtools::data_view<storage_ijk_t> in = gridtools::make_host_view(in_);
+        std::array<int, 3> in_offsets{0, 0, 0};
+        gridtools::data_view<storage_ijk_t> out = gridtools::make_host_view(out_);
+        std::array<int, 3> out_offsets{0, 0, 0};
+        for(int k = kMin + 0 + 0; k <= kMax + 0 + 0; ++k) {
+          for(int i = iMin + 0; i <= iMax + 0; ++i) {
+            for(int j = jMin + 0; j <= jMax + 0; ++j) {
+              ::dawn::float_type dx;
+              {
+                out(i + 0, j + 0, k + 0) =
+                    (((int)-4 * (in(i + 0, j + 0, k + 0) +
+                                 (in(i + 1, j + 0, k + 0) +
+                                  (in(i + -1, j + 0, k + 0) +
+                                   (in(i + 0, j + -1, k + 0) + in(i + 0, j + 1, k + 0)))))) /
+                     (dx * dx));
+              }
+            }
+          }
+        }
+      }
+      in_.sync();
       out_.sync();
     }
   };
   static constexpr const char* s_name = "generated";
   stencil_47 m_stencil_47;
-public:
 
+public:
   generated(const generated&) = delete;
 
-  generated(const gridtools::dawn::domain& dom, int rank = 1, int xcols = 1, int ycols = 1) : m_stencil_47(dom, rank, xcols, ycols){
+  generated(const gridtools::dawn::domain& dom, int rank = 1, int xcols = 1, int ycols = 1)
+      : m_stencil_47(dom, rank, xcols, ycols) {
     assert(dom.isize() >= dom.iminus() + dom.iplus());
     assert(dom.jsize() >= dom.jminus() + dom.jplus());
     assert(dom.ksize() >= dom.kminus() + dom.kplus());
     assert(dom.ksize() >= 1);
   }
 
-  void run(storage_ijk_t in, storage_ijk_t out) {
-    m_stencil_47.run(in,out);
-  }
+  void run(storage_ijk_t in, storage_ijk_t out) { m_stencil_47.run(in, out); }
 };
 } // namespace cxxnaive
 } // namespace dawn_generated

--- a/dawn/test/unit-test/dawn/CodeGen/reference/laplacian_stencil.cu
+++ b/dawn/test/unit-test/dawn/CodeGen/reference/laplacian_stencil.cu
@@ -2,45 +2,47 @@
 #undef DAWN_BACKEND_T
 #define DAWN_BACKEND_T CUDA
 #ifndef BOOST_RESULT_OF_USE_TR1
- #define BOOST_RESULT_OF_USE_TR1 1
+#define BOOST_RESULT_OF_USE_TR1 1
 #endif
 #ifndef BOOST_NO_CXX11_DECLTYPE
- #define BOOST_NO_CXX11_DECLTYPE 1
+#define BOOST_NO_CXX11_DECLTYPE 1
 #endif
 #ifndef GRIDTOOLS_DAWN_HALO_EXTENT
- #define GRIDTOOLS_DAWN_HALO_EXTENT 3
+#define GRIDTOOLS_DAWN_HALO_EXTENT 3
 #endif
 #ifndef BOOST_PP_VARIADICS
- #define BOOST_PP_VARIADICS 1
+#define BOOST_PP_VARIADICS 1
 #endif
 #ifndef BOOST_FUSION_DONT_USE_PREPROCESSED_FILES
- #define BOOST_FUSION_DONT_USE_PREPROCESSED_FILES 1
+#define BOOST_FUSION_DONT_USE_PREPROCESSED_FILES 1
 #endif
 #ifndef BOOST_MPL_CFG_NO_PREPROCESSED_HEADERS
- #define BOOST_MPL_CFG_NO_PREPROCESSED_HEADERS 1
+#define BOOST_MPL_CFG_NO_PREPROCESSED_HEADERS 1
 #endif
 #ifndef GT_VECTOR_LIMIT_SIZE
- #define GT_VECTOR_LIMIT_SIZE 30
+#define GT_VECTOR_LIMIT_SIZE 30
 #endif
 #ifndef BOOST_FUSION_INVOKE_MAX_ARITY
- #define BOOST_FUSION_INVOKE_MAX_ARITY GT_VECTOR_LIMIT_SIZE
+#define BOOST_FUSION_INVOKE_MAX_ARITY GT_VECTOR_LIMIT_SIZE
 #endif
 #ifndef FUSION_MAX_VECTOR_SIZE
- #define FUSION_MAX_VECTOR_SIZE GT_VECTOR_LIMIT_SIZE
+#define FUSION_MAX_VECTOR_SIZE GT_VECTOR_LIMIT_SIZE
 #endif
 #ifndef FUSION_MAX_MAP_SIZE
- #define FUSION_MAX_MAP_SIZE GT_VECTOR_LIMIT_SIZE
+#define FUSION_MAX_MAP_SIZE GT_VECTOR_LIMIT_SIZE
 #endif
 #ifndef BOOST_MPL_LIMIT_VECTOR_SIZE
- #define BOOST_MPL_LIMIT_VECTOR_SIZE GT_VECTOR_LIMIT_SIZE
+#define BOOST_MPL_LIMIT_VECTOR_SIZE GT_VECTOR_LIMIT_SIZE
 #endif
 #include <driver-includes/gridtools_includes.hpp>
 using namespace gridtools::dawn;
 
-
-namespace dawn_generated{
-namespace cuda{
-__global__ void __launch_bounds__(128)  generated_stencil47_ms46_kernel(const int isize, const int jsize, const int ksize, const int stride_111_1, const int stride_111_2, ::dawn::float_type * const in, ::dawn::float_type * const out) {
+namespace dawn_generated {
+namespace cuda {
+__global__ void __launch_bounds__(128)
+    generated_stencil47_ms46_kernel(const int isize, const int jsize, const int ksize,
+                                    const int stride_111_1, const int stride_111_2,
+                                    ::dawn::float_type* const in, ::dawn::float_type* const out) {
 
   // Start kernel
   const unsigned int nx = isize;
@@ -77,40 +79,46 @@ __global__ void __launch_bounds__(128)  generated_stencil47_ms46_kernel(const in
   // Regions (a,h,e) and (c,i,g) are executed by two specialized warp
   int iblock = 0 - 1;
   int jblock = 0 - 1;
-if(threadIdx.y < +4) {
+  if(threadIdx.y < +4) {
     iblock = threadIdx.x;
     jblock = (int)threadIdx.y + 0;
-}
-  // initialized iterators
-  int idx111 = (blockIdx.x*32+iblock)*1+(blockIdx.y*4+jblock)*stride_111_1;
-
-  // jump iterators to match the intersection of beginning of next interval and the parallel execution block
-  idx111 += max(0, blockIdx.z * 4) * stride_111_2;
-  int kleg_lower_bound = max(0,blockIdx.z*4);
-  int kleg_upper_bound = min( ksize - 1 + 0,(blockIdx.z+1)*4-1);;
-for(int k = kleg_lower_bound+0; k <= kleg_upper_bound+0; ++k) {
-  if(iblock >= 0 && iblock <= block_size_i -1 + 0 && jblock >= 0 && jblock <= block_size_j -1 + 0) {
-::dawn::float_type dx;
-{
-  out[idx111] = (((int) -4 * (__ldg(&(in[idx111])) + (__ldg(&(in[idx111+1*1])) + (__ldg(&(in[idx111+1*-1])) + (__ldg(&(in[idx111+stride_111_1*-1])) + __ldg(&(in[idx111+stride_111_1*1]))))))) / (dx * dx));
-}
   }
+  // initialized iterators
+  int idx111 = (blockIdx.x * 32 + iblock) * 1 + (blockIdx.y * 4 + jblock) * stride_111_1;
+
+  // jump iterators to match the intersection of beginning of next interval and the parallel
+  // execution block
+  idx111 += max(0, blockIdx.z * 4) * stride_111_2;
+  int kleg_lower_bound = max(0, blockIdx.z * 4);
+  int kleg_upper_bound = min(ksize - 1 + 0, (blockIdx.z + 1) * 4 - 1);
+  ;
+  for(int k = kleg_lower_bound + 0; k <= kleg_upper_bound + 0; ++k) {
+    if(iblock >= 0 && iblock <= block_size_i - 1 + 0 && jblock >= 0 &&
+       jblock <= block_size_j - 1 + 0) {
+      ::dawn::float_type dx;
+      {
+        out[idx111] =
+            (((int)-4 * (__ldg(&(in[idx111])) + (__ldg(&(in[idx111 + 1 * 1])) +
+                                                 (__ldg(&(in[idx111 + 1 * -1])) +
+                                                  (__ldg(&(in[idx111 + stride_111_1 * -1])) +
+                                                   __ldg(&(in[idx111 + stride_111_1 * 1]))))))) /
+             (dx * dx));
+      }
+    }
     // Slide kcaches
 
     // increment iterators
-    idx111+=stride_111_2;
-}}
+    idx111 += stride_111_2;
+  }
+}
 
 class generated {
 public:
-
   struct sbase : public timer_cuda {
 
-    sbase(std::string name) : timer_cuda(name){}
+    sbase(std::string name) : timer_cuda(name) {}
 
-    double get_time() {
-      return total_time();
-    }
+    double get_time() { return total_time(); }
   };
 
   struct stencil_47 : public sbase {
@@ -118,32 +126,37 @@ public:
     // Members
 
     // Temporary storage typedefs
-    using tmp_halo_t = gridtools::halo< 0,0, 0, 0, 0>;
-    using tmp_meta_data_t = storage_traits_t::storage_info_t< 0, 5, tmp_halo_t >;
-    using tmp_storage_t = storage_traits_t::data_store_t< ::dawn::float_type, tmp_meta_data_t>;
+    using tmp_halo_t = gridtools::halo<0, 0, 0, 0, 0>;
+    using tmp_meta_data_t = storage_traits_t::storage_info_t<0, 5, tmp_halo_t>;
+    using tmp_storage_t = storage_traits_t::data_store_t<::dawn::float_type, tmp_meta_data_t>;
     const gridtools::dawn::domain m_dom;
-  public:
 
-    stencil_47(const gridtools::dawn::domain& dom_, int rank, int xcols, int ycols) : sbase("stencil_47"), m_dom(dom_){}
-    static constexpr ::dawn::driver::cartesian_extent in_extent = {-1,1, -1,1, 0,0};
-    static constexpr ::dawn::driver::cartesian_extent out_extent = {0,0, 0,0, 0,0};
+  public:
+    stencil_47(const gridtools::dawn::domain& dom_, int rank, int xcols, int ycols)
+        : sbase("stencil_47"), m_dom(dom_) {}
+    static constexpr ::dawn::driver::cartesian_extent in_extent = {-1, 1, -1, 1, 0, 0};
+    static constexpr ::dawn::driver::cartesian_extent out_extent = {0, 0, 0, 0, 0, 0};
 
     void run(storage_ijk_t in_ds, storage_ijk_t out_ds) {
 
       // starting timers
       start();
-      {;
-      gridtools::data_view<storage_ijk_t> in= gridtools::make_device_view(in_ds);
-      gridtools::data_view<storage_ijk_t> out= gridtools::make_device_view(out_ds);
-      const unsigned int nx = m_dom.isize() - m_dom.iminus() - m_dom.iplus();
-      const unsigned int ny = m_dom.jsize() - m_dom.jminus() - m_dom.jplus();
-      const unsigned int nz = m_dom.ksize() - m_dom.kminus() - m_dom.kplus();
-      dim3 threads(32,4+0,1);
-      const unsigned int nbx = (nx + 32 - 1) / 32;
-      const unsigned int nby = (ny + 4 - 1) / 4;
-      const unsigned int nbz = (m_dom.ksize()+4-1) / 4;
-      dim3 blocks(nbx, nby, nbz);
-      generated_stencil47_ms46_kernel<<<blocks, threads>>>(nx,ny,nz,in_ds.strides()[1],in_ds.strides()[2],(in.data()+in_ds.get_storage_info_ptr()->index(in.begin<0>(), in.begin<1>(),0 )),(out.data()+out_ds.get_storage_info_ptr()->index(out.begin<0>(), out.begin<1>(),0 )));
+      {
+        ;
+        gridtools::data_view<storage_ijk_t> in = gridtools::make_device_view(in_ds);
+        gridtools::data_view<storage_ijk_t> out = gridtools::make_device_view(out_ds);
+        const unsigned int nx = m_dom.isize() - m_dom.iminus() - m_dom.iplus();
+        const unsigned int ny = m_dom.jsize() - m_dom.jminus() - m_dom.jplus();
+        const unsigned int nz = m_dom.ksize() - m_dom.kminus() - m_dom.kplus();
+        dim3 threads(32, 4 + 0, 1);
+        const unsigned int nbx = (nx + 32 - 1) / 32;
+        const unsigned int nby = (ny + 4 - 1) / 4;
+        const unsigned int nbz = (m_dom.ksize() + 4 - 1) / 4;
+        dim3 blocks(nbx, nby, nbz);
+        generated_stencil47_ms46_kernel<<<blocks, threads>>>(
+            nx, ny, nz, in_ds.strides()[1], in_ds.strides()[2],
+            (in.data() + in_ds.get_storage_info_ptr()->index(in.begin<0>(), in.begin<1>(), 0)),
+            (out.data() + out_ds.get_storage_info_ptr()->index(out.begin<0>(), out.begin<1>(), 0)));
       };
 
       // stopping timers
@@ -152,44 +165,42 @@ public:
   };
   static constexpr const char* s_name = "generated";
   stencil_47 m_stencil_47;
-public:
 
+public:
   generated(const generated&) = delete;
 
   // Members
 
   // Stencil-Data
 
-  generated(const gridtools::dawn::domain& dom, int rank = 1, int xcols = 1, int ycols = 1) : m_stencil_47(dom, rank, xcols, ycols){}
+  generated(const gridtools::dawn::domain& dom, int rank = 1, int xcols = 1, int ycols = 1)
+      : m_stencil_47(dom, rank, xcols, ycols) {}
 
-  template<typename S>
+  template <typename S>
   void sync_storages(S field) {
     field.sync();
   }
 
-  template<typename S0, typename ... S>
+  template <typename S0, typename... S>
   void sync_storages(S0 f0, S... fields) {
     f0.sync();
     sync_storages(fields...);
   }
 
   void run(storage_ijk_t in, storage_ijk_t out) {
-    sync_storages(in,out);
-    m_stencil_47.run(in,out);
-;
-    sync_storages(in,out);
+    sync_storages(in, out);
+    m_stencil_47.run(in, out);
+    ;
+    sync_storages(in, out);
   }
 
-  std::string get_name()  const {
-    return std::string(s_name);
-  }
+  std::string get_name() const { return std::string(s_name); }
 
-  void reset_meters() {
-m_stencil_47.reset();  }
+  void reset_meters() { m_stencil_47.reset(); }
 
   double get_total_time() {
     double res = 0;
-    res +=m_stencil_47.get_time();
+    res += m_stencil_47.get_time();
     return res;
   }
 };

--- a/dawn/test/unit-test/dawn/CodeGen/reference/laplacian_stencil_nosync.cu
+++ b/dawn/test/unit-test/dawn/CodeGen/reference/laplacian_stencil_nosync.cu
@@ -2,45 +2,47 @@
 #undef DAWN_BACKEND_T
 #define DAWN_BACKEND_T CUDA
 #ifndef BOOST_RESULT_OF_USE_TR1
- #define BOOST_RESULT_OF_USE_TR1 1
+#define BOOST_RESULT_OF_USE_TR1 1
 #endif
 #ifndef BOOST_NO_CXX11_DECLTYPE
- #define BOOST_NO_CXX11_DECLTYPE 1
+#define BOOST_NO_CXX11_DECLTYPE 1
 #endif
 #ifndef GRIDTOOLS_DAWN_HALO_EXTENT
- #define GRIDTOOLS_DAWN_HALO_EXTENT 3
+#define GRIDTOOLS_DAWN_HALO_EXTENT 3
 #endif
 #ifndef BOOST_PP_VARIADICS
- #define BOOST_PP_VARIADICS 1
+#define BOOST_PP_VARIADICS 1
 #endif
 #ifndef BOOST_FUSION_DONT_USE_PREPROCESSED_FILES
- #define BOOST_FUSION_DONT_USE_PREPROCESSED_FILES 1
+#define BOOST_FUSION_DONT_USE_PREPROCESSED_FILES 1
 #endif
 #ifndef BOOST_MPL_CFG_NO_PREPROCESSED_HEADERS
- #define BOOST_MPL_CFG_NO_PREPROCESSED_HEADERS 1
+#define BOOST_MPL_CFG_NO_PREPROCESSED_HEADERS 1
 #endif
 #ifndef GT_VECTOR_LIMIT_SIZE
- #define GT_VECTOR_LIMIT_SIZE 30
+#define GT_VECTOR_LIMIT_SIZE 30
 #endif
 #ifndef BOOST_FUSION_INVOKE_MAX_ARITY
- #define BOOST_FUSION_INVOKE_MAX_ARITY GT_VECTOR_LIMIT_SIZE
+#define BOOST_FUSION_INVOKE_MAX_ARITY GT_VECTOR_LIMIT_SIZE
 #endif
 #ifndef FUSION_MAX_VECTOR_SIZE
- #define FUSION_MAX_VECTOR_SIZE GT_VECTOR_LIMIT_SIZE
+#define FUSION_MAX_VECTOR_SIZE GT_VECTOR_LIMIT_SIZE
 #endif
 #ifndef FUSION_MAX_MAP_SIZE
- #define FUSION_MAX_MAP_SIZE GT_VECTOR_LIMIT_SIZE
+#define FUSION_MAX_MAP_SIZE GT_VECTOR_LIMIT_SIZE
 #endif
 #ifndef BOOST_MPL_LIMIT_VECTOR_SIZE
- #define BOOST_MPL_LIMIT_VECTOR_SIZE GT_VECTOR_LIMIT_SIZE
+#define BOOST_MPL_LIMIT_VECTOR_SIZE GT_VECTOR_LIMIT_SIZE
 #endif
 #include <driver-includes/gridtools_includes.hpp>
 using namespace gridtools::dawn;
 
-
-namespace dawn_generated{
-namespace cuda{
-__global__ void __launch_bounds__(128)  generated_stencil47_ms46_kernel(const int isize, const int jsize, const int ksize, const int stride_111_1, const int stride_111_2, ::dawn::float_type * const in, ::dawn::float_type * const out) {
+namespace dawn_generated {
+namespace cuda {
+__global__ void __launch_bounds__(128)
+    generated_stencil47_ms46_kernel(const int isize, const int jsize, const int ksize,
+                                    const int stride_111_1, const int stride_111_2,
+                                    ::dawn::float_type* const in, ::dawn::float_type* const out) {
 
   // Start kernel
   const unsigned int nx = isize;
@@ -77,40 +79,46 @@ __global__ void __launch_bounds__(128)  generated_stencil47_ms46_kernel(const in
   // Regions (a,h,e) and (c,i,g) are executed by two specialized warp
   int iblock = 0 - 1;
   int jblock = 0 - 1;
-if(threadIdx.y < +4) {
+  if(threadIdx.y < +4) {
     iblock = threadIdx.x;
     jblock = (int)threadIdx.y + 0;
-}
-  // initialized iterators
-  int idx111 = (blockIdx.x*32+iblock)*1+(blockIdx.y*4+jblock)*stride_111_1;
-
-  // jump iterators to match the intersection of beginning of next interval and the parallel execution block
-  idx111 += max(0, blockIdx.z * 4) * stride_111_2;
-  int kleg_lower_bound = max(0,blockIdx.z*4);
-  int kleg_upper_bound = min( ksize - 1 + 0,(blockIdx.z+1)*4-1);;
-for(int k = kleg_lower_bound+0; k <= kleg_upper_bound+0; ++k) {
-  if(iblock >= 0 && iblock <= block_size_i -1 + 0 && jblock >= 0 && jblock <= block_size_j -1 + 0) {
-::dawn::float_type dx;
-{
-  out[idx111] = (((int) -4 * (__ldg(&(in[idx111])) + (__ldg(&(in[idx111+1*1])) + (__ldg(&(in[idx111+1*-1])) + (__ldg(&(in[idx111+stride_111_1*-1])) + __ldg(&(in[idx111+stride_111_1*1]))))))) / (dx * dx));
-}
   }
+  // initialized iterators
+  int idx111 = (blockIdx.x * 32 + iblock) * 1 + (blockIdx.y * 4 + jblock) * stride_111_1;
+
+  // jump iterators to match the intersection of beginning of next interval and the parallel
+  // execution block
+  idx111 += max(0, blockIdx.z * 4) * stride_111_2;
+  int kleg_lower_bound = max(0, blockIdx.z * 4);
+  int kleg_upper_bound = min(ksize - 1 + 0, (blockIdx.z + 1) * 4 - 1);
+  ;
+  for(int k = kleg_lower_bound + 0; k <= kleg_upper_bound + 0; ++k) {
+    if(iblock >= 0 && iblock <= block_size_i - 1 + 0 && jblock >= 0 &&
+       jblock <= block_size_j - 1 + 0) {
+      ::dawn::float_type dx;
+      {
+        out[idx111] =
+            (((int)-4 * (__ldg(&(in[idx111])) + (__ldg(&(in[idx111 + 1 * 1])) +
+                                                 (__ldg(&(in[idx111 + 1 * -1])) +
+                                                  (__ldg(&(in[idx111 + stride_111_1 * -1])) +
+                                                   __ldg(&(in[idx111 + stride_111_1 * 1]))))))) /
+             (dx * dx));
+      }
+    }
     // Slide kcaches
 
     // increment iterators
-    idx111+=stride_111_2;
-}}
+    idx111 += stride_111_2;
+  }
+}
 
 class generated {
 public:
-
   struct sbase : public timer_cuda {
 
-    sbase(std::string name) : timer_cuda(name){}
+    sbase(std::string name) : timer_cuda(name) {}
 
-    double get_time() {
-      return total_time();
-    }
+    double get_time() { return total_time(); }
   };
 
   struct stencil_47 : public sbase {
@@ -118,32 +126,37 @@ public:
     // Members
 
     // Temporary storage typedefs
-    using tmp_halo_t = gridtools::halo< 0,0, 0, 0, 0>;
-    using tmp_meta_data_t = storage_traits_t::storage_info_t< 0, 5, tmp_halo_t >;
-    using tmp_storage_t = storage_traits_t::data_store_t< ::dawn::float_type, tmp_meta_data_t>;
+    using tmp_halo_t = gridtools::halo<0, 0, 0, 0, 0>;
+    using tmp_meta_data_t = storage_traits_t::storage_info_t<0, 5, tmp_halo_t>;
+    using tmp_storage_t = storage_traits_t::data_store_t<::dawn::float_type, tmp_meta_data_t>;
     const gridtools::dawn::domain m_dom;
-  public:
 
-    stencil_47(const gridtools::dawn::domain& dom_, int rank, int xcols, int ycols) : sbase("stencil_47"), m_dom(dom_){}
-    static constexpr ::dawn::driver::cartesian_extent in_extent = {-1,1, -1,1, 0,0};
-    static constexpr ::dawn::driver::cartesian_extent out_extent = {0,0, 0,0, 0,0};
+  public:
+    stencil_47(const gridtools::dawn::domain& dom_, int rank, int xcols, int ycols)
+        : sbase("stencil_47"), m_dom(dom_) {}
+    static constexpr ::dawn::driver::cartesian_extent in_extent = {-1, 1, -1, 1, 0, 0};
+    static constexpr ::dawn::driver::cartesian_extent out_extent = {0, 0, 0, 0, 0, 0};
 
     void run(storage_ijk_t in_ds, storage_ijk_t out_ds) {
 
       // starting timers
       start();
-      {;
-      gridtools::data_view<storage_ijk_t> in= gridtools::make_device_view(in_ds);
-      gridtools::data_view<storage_ijk_t> out= gridtools::make_device_view(out_ds);
-      const unsigned int nx = m_dom.isize() - m_dom.iminus() - m_dom.iplus();
-      const unsigned int ny = m_dom.jsize() - m_dom.jminus() - m_dom.jplus();
-      const unsigned int nz = m_dom.ksize() - m_dom.kminus() - m_dom.kplus();
-      dim3 threads(32,4+0,1);
-      const unsigned int nbx = (nx + 32 - 1) / 32;
-      const unsigned int nby = (ny + 4 - 1) / 4;
-      const unsigned int nbz = (m_dom.ksize()+4-1) / 4;
-      dim3 blocks(nbx, nby, nbz);
-      generated_stencil47_ms46_kernel<<<blocks, threads>>>(nx,ny,nz,in_ds.strides()[1],in_ds.strides()[2],(in.data()+in_ds.get_storage_info_ptr()->index(in.begin<0>(), in.begin<1>(),0 )),(out.data()+out_ds.get_storage_info_ptr()->index(out.begin<0>(), out.begin<1>(),0 )));
+      {
+        ;
+        gridtools::data_view<storage_ijk_t> in = gridtools::make_device_view(in_ds);
+        gridtools::data_view<storage_ijk_t> out = gridtools::make_device_view(out_ds);
+        const unsigned int nx = m_dom.isize() - m_dom.iminus() - m_dom.iplus();
+        const unsigned int ny = m_dom.jsize() - m_dom.jminus() - m_dom.jplus();
+        const unsigned int nz = m_dom.ksize() - m_dom.kminus() - m_dom.kplus();
+        dim3 threads(32, 4 + 0, 1);
+        const unsigned int nbx = (nx + 32 - 1) / 32;
+        const unsigned int nby = (ny + 4 - 1) / 4;
+        const unsigned int nbz = (m_dom.ksize() + 4 - 1) / 4;
+        dim3 blocks(nbx, nby, nbz);
+        generated_stencil47_ms46_kernel<<<blocks, threads>>>(
+            nx, ny, nz, in_ds.strides()[1], in_ds.strides()[2],
+            (in.data() + in_ds.get_storage_info_ptr()->index(in.begin<0>(), in.begin<1>(), 0)),
+            (out.data() + out_ds.get_storage_info_ptr()->index(out.begin<0>(), out.begin<1>(), 0)));
       };
 
       // stopping timers
@@ -152,42 +165,40 @@ public:
   };
   static constexpr const char* s_name = "generated";
   stencil_47 m_stencil_47;
-public:
 
+public:
   generated(const generated&) = delete;
 
   // Members
 
   // Stencil-Data
 
-  generated(const gridtools::dawn::domain& dom, int rank = 1, int xcols = 1, int ycols = 1) : m_stencil_47(dom, rank, xcols, ycols){}
+  generated(const gridtools::dawn::domain& dom, int rank = 1, int xcols = 1, int ycols = 1)
+      : m_stencil_47(dom, rank, xcols, ycols) {}
 
-  template<typename S>
+  template <typename S>
   void sync_storages(S field) {
     field.sync();
   }
 
-  template<typename S0, typename ... S>
+  template <typename S0, typename... S>
   void sync_storages(S0 f0, S... fields) {
     f0.sync();
     sync_storages(fields...);
   }
 
   void run(storage_ijk_t in, storage_ijk_t out) {
-    m_stencil_47.run(in,out);
-;
+    m_stencil_47.run(in, out);
+    ;
   }
 
-  std::string get_name()  const {
-    return std::string(s_name);
-  }
+  std::string get_name() const { return std::string(s_name); }
 
-  void reset_meters() {
-m_stencil_47.reset();  }
+  void reset_meters() { m_stencil_47.reset(); }
 
   double get_total_time() {
     double res = 0;
-    res +=m_stencil_47.get_time();
+    res += m_stencil_47.get_time();
     return res;
   }
 };

--- a/dawn/test/unit-test/dawn/CodeGen/reference/laplacian_stencil_opt.cpp
+++ b/dawn/test/unit-test/dawn/CodeGen/reference/laplacian_stencil_opt.cpp
@@ -2,65 +2,62 @@
 #undef DAWN_BACKEND_T
 #define DAWN_BACKEND_T CXXOPT
 #ifndef BOOST_RESULT_OF_USE_TR1
- #define BOOST_RESULT_OF_USE_TR1 1
+#define BOOST_RESULT_OF_USE_TR1 1
 #endif
 #ifndef BOOST_NO_CXX11_DECLTYPE
- #define BOOST_NO_CXX11_DECLTYPE 1
+#define BOOST_NO_CXX11_DECLTYPE 1
 #endif
 #ifndef GRIDTOOLS_DAWN_HALO_EXTENT
- #define GRIDTOOLS_DAWN_HALO_EXTENT 3
+#define GRIDTOOLS_DAWN_HALO_EXTENT 3
 #endif
 #ifndef BOOST_PP_VARIADICS
- #define BOOST_PP_VARIADICS 1
+#define BOOST_PP_VARIADICS 1
 #endif
 #ifndef BOOST_FUSION_DONT_USE_PREPROCESSED_FILES
- #define BOOST_FUSION_DONT_USE_PREPROCESSED_FILES 1
+#define BOOST_FUSION_DONT_USE_PREPROCESSED_FILES 1
 #endif
 #ifndef BOOST_MPL_CFG_NO_PREPROCESSED_HEADERS
- #define BOOST_MPL_CFG_NO_PREPROCESSED_HEADERS 1
+#define BOOST_MPL_CFG_NO_PREPROCESSED_HEADERS 1
 #endif
 #ifndef GT_VECTOR_LIMIT_SIZE
- #define GT_VECTOR_LIMIT_SIZE 30
+#define GT_VECTOR_LIMIT_SIZE 30
 #endif
 #ifndef BOOST_FUSION_INVOKE_MAX_ARITY
- #define BOOST_FUSION_INVOKE_MAX_ARITY GT_VECTOR_LIMIT_SIZE
+#define BOOST_FUSION_INVOKE_MAX_ARITY GT_VECTOR_LIMIT_SIZE
 #endif
 #ifndef FUSION_MAX_VECTOR_SIZE
- #define FUSION_MAX_VECTOR_SIZE GT_VECTOR_LIMIT_SIZE
+#define FUSION_MAX_VECTOR_SIZE GT_VECTOR_LIMIT_SIZE
 #endif
 #ifndef FUSION_MAX_MAP_SIZE
- #define FUSION_MAX_MAP_SIZE GT_VECTOR_LIMIT_SIZE
+#define FUSION_MAX_MAP_SIZE GT_VECTOR_LIMIT_SIZE
 #endif
 #ifndef BOOST_MPL_LIMIT_VECTOR_SIZE
- #define BOOST_MPL_LIMIT_VECTOR_SIZE GT_VECTOR_LIMIT_SIZE
+#define BOOST_MPL_LIMIT_VECTOR_SIZE GT_VECTOR_LIMIT_SIZE
 #endif
 #include <driver-includes/gridtools_includes.hpp>
 using namespace gridtools::dawn;
 #include <omp.h>
 
-
-namespace dawn_generated{
-namespace cxxopt{
+namespace dawn_generated {
+namespace cxxopt {
 
 class generated {
 private:
-
   struct stencil_47 {
 
     // Members
 
     // Temporary storages
-    using tmp_halo_t = gridtools::halo< GRIDTOOLS_DAWN_HALO_EXTENT, GRIDTOOLS_DAWN_HALO_EXTENT, 0>;
-    using tmp_meta_data_t = storage_traits_t::storage_info_t< 0, 3, tmp_halo_t >;
-    using tmp_storage_t = storage_traits_t::data_store_t< ::dawn::float_type, tmp_meta_data_t>;
+    using tmp_halo_t = gridtools::halo<GRIDTOOLS_DAWN_HALO_EXTENT, GRIDTOOLS_DAWN_HALO_EXTENT, 0>;
+    using tmp_meta_data_t = storage_traits_t::storage_info_t<0, 3, tmp_halo_t>;
+    using tmp_storage_t = storage_traits_t::data_store_t<::dawn::float_type, tmp_meta_data_t>;
     const gridtools::dawn::domain m_dom;
 
     // Input/Output storages
   public:
-
-    stencil_47(const gridtools::dawn::domain& dom_, int rank, int xcols, int ycols) : m_dom(dom_){}
-    static constexpr ::dawn::driver::cartesian_extent in_extent = {-1,1, -1,1, 0,0};
-    static constexpr ::dawn::driver::cartesian_extent out_extent = {0,0, 0,0, 0,0};
+    stencil_47(const gridtools::dawn::domain& dom_, int rank, int xcols, int ycols) : m_dom(dom_) {}
+    static constexpr ::dawn::driver::cartesian_extent in_extent = {-1, 1, -1, 1, 0, 0};
+    static constexpr ::dawn::driver::cartesian_extent out_extent = {0, 0, 0, 0, 0, 0};
 
     void run(storage_ijk_t& in_, storage_ijk_t& out_) {
       int iMin = m_dom.iminus();
@@ -71,40 +68,49 @@ private:
       int kMax = m_dom.ksize() - m_dom.kplus() - 1;
       in_.sync();
       out_.sync();
-{      gridtools::data_view<storage_ijk_t> in= gridtools::make_host_view(in_);
-      std::array<int,3> in_offsets{0,0,0};
-      gridtools::data_view<storage_ijk_t> out= gridtools::make_host_view(out_);
-      std::array<int,3> out_offsets{0,0,0};
-    
+      {
+        gridtools::data_view<storage_ijk_t> in = gridtools::make_host_view(in_);
+        std::array<int, 3> in_offsets{0, 0, 0};
+        gridtools::data_view<storage_ijk_t> out = gridtools::make_host_view(out_);
+        std::array<int, 3> out_offsets{0, 0, 0};
+
 #pragma omp parallel for
-for(int k = kMin + 0+0; k <= kMax + 0+0; ++k) {
-      for(int i = iMin+0; i  <=  iMax+0; ++i) {
-        #pragma omp simd
-for(int j = jMin+0; j  <=  jMax+0; ++j) {
-::dawn::float_type dx;
-{
-  out(i+0, j+0, k+0) = (((int) -4 * (in(i+0, j+0, k+0) + (in(i+1, j+0, k+0) + (in(i+-1, j+0, k+0) + (in(i+0, j+-1, k+0) + in(i+0, j+1, k+0)))))) / (dx * dx));
-}
-        }      }    }}      in_.sync();
+        for(int k = kMin + 0 + 0; k <= kMax + 0 + 0; ++k) {
+          for(int i = iMin + 0; i <= iMax + 0; ++i) {
+#pragma omp simd
+            for(int j = jMin + 0; j <= jMax + 0; ++j) {
+              ::dawn::float_type dx;
+              {
+                out(i + 0, j + 0, k + 0) =
+                    (((int)-4 * (in(i + 0, j + 0, k + 0) +
+                                 (in(i + 1, j + 0, k + 0) +
+                                  (in(i + -1, j + 0, k + 0) +
+                                   (in(i + 0, j + -1, k + 0) + in(i + 0, j + 1, k + 0)))))) /
+                     (dx * dx));
+              }
+            }
+          }
+        }
+      }
+      in_.sync();
       out_.sync();
     }
   };
   static constexpr const char* s_name = "generated";
   stencil_47 m_stencil_47;
-public:
 
+public:
   generated(const generated&) = delete;
 
-  generated(const gridtools::dawn::domain& dom, int rank = 1, int xcols = 1, int ycols = 1) : m_stencil_47(dom, rank, xcols, ycols){
+  generated(const gridtools::dawn::domain& dom, int rank = 1, int xcols = 1, int ycols = 1)
+      : m_stencil_47(dom, rank, xcols, ycols) {
     assert(dom.isize() >= dom.iminus() + dom.iplus());
     assert(dom.jsize() >= dom.jminus() + dom.jplus());
     assert(dom.ksize() >= dom.kminus() + dom.kplus());
     assert(dom.ksize() >= 1);
   }
 
-  void run(storage_ijk_t in, storage_ijk_t out) {
-    m_stencil_47.run(in,out);
-  }
+  void run(storage_ijk_t in, storage_ijk_t out) { m_stencil_47.run(in, out); }
 };
 } // namespace cxxopt
 } // namespace dawn_generated

--- a/dawn/test/unit-test/dawn/CodeGen/reference/nonoverlapping_stencil.cpp
+++ b/dawn/test/unit-test/dawn/CodeGen/reference/nonoverlapping_stencil.cpp
@@ -2,64 +2,61 @@
 #undef DAWN_BACKEND_T
 #define DAWN_BACKEND_T CXXNAIVE
 #ifndef BOOST_RESULT_OF_USE_TR1
- #define BOOST_RESULT_OF_USE_TR1 1
+#define BOOST_RESULT_OF_USE_TR1 1
 #endif
 #ifndef BOOST_NO_CXX11_DECLTYPE
- #define BOOST_NO_CXX11_DECLTYPE 1
+#define BOOST_NO_CXX11_DECLTYPE 1
 #endif
 #ifndef GRIDTOOLS_DAWN_HALO_EXTENT
- #define GRIDTOOLS_DAWN_HALO_EXTENT 3
+#define GRIDTOOLS_DAWN_HALO_EXTENT 3
 #endif
 #ifndef BOOST_PP_VARIADICS
- #define BOOST_PP_VARIADICS 1
+#define BOOST_PP_VARIADICS 1
 #endif
 #ifndef BOOST_FUSION_DONT_USE_PREPROCESSED_FILES
- #define BOOST_FUSION_DONT_USE_PREPROCESSED_FILES 1
+#define BOOST_FUSION_DONT_USE_PREPROCESSED_FILES 1
 #endif
 #ifndef BOOST_MPL_CFG_NO_PREPROCESSED_HEADERS
- #define BOOST_MPL_CFG_NO_PREPROCESSED_HEADERS 1
+#define BOOST_MPL_CFG_NO_PREPROCESSED_HEADERS 1
 #endif
 #ifndef GT_VECTOR_LIMIT_SIZE
- #define GT_VECTOR_LIMIT_SIZE 30
+#define GT_VECTOR_LIMIT_SIZE 30
 #endif
 #ifndef BOOST_FUSION_INVOKE_MAX_ARITY
- #define BOOST_FUSION_INVOKE_MAX_ARITY GT_VECTOR_LIMIT_SIZE
+#define BOOST_FUSION_INVOKE_MAX_ARITY GT_VECTOR_LIMIT_SIZE
 #endif
 #ifndef FUSION_MAX_VECTOR_SIZE
- #define FUSION_MAX_VECTOR_SIZE GT_VECTOR_LIMIT_SIZE
+#define FUSION_MAX_VECTOR_SIZE GT_VECTOR_LIMIT_SIZE
 #endif
 #ifndef FUSION_MAX_MAP_SIZE
- #define FUSION_MAX_MAP_SIZE GT_VECTOR_LIMIT_SIZE
+#define FUSION_MAX_MAP_SIZE GT_VECTOR_LIMIT_SIZE
 #endif
 #ifndef BOOST_MPL_LIMIT_VECTOR_SIZE
- #define BOOST_MPL_LIMIT_VECTOR_SIZE GT_VECTOR_LIMIT_SIZE
+#define BOOST_MPL_LIMIT_VECTOR_SIZE GT_VECTOR_LIMIT_SIZE
 #endif
 #include <driver-includes/gridtools_includes.hpp>
 using namespace gridtools::dawn;
 
-
-namespace dawn_generated{
-namespace cxxnaive{
+namespace dawn_generated {
+namespace cxxnaive {
 
 class generated {
 private:
-
   struct stencil_59 {
 
     // Members
 
     // Temporary storages
-    using tmp_halo_t = gridtools::halo< GRIDTOOLS_DAWN_HALO_EXTENT, GRIDTOOLS_DAWN_HALO_EXTENT, 0>;
-    using tmp_meta_data_t = storage_traits_t::storage_info_t< 0, 3, tmp_halo_t >;
-    using tmp_storage_t = storage_traits_t::data_store_t< ::dawn::float_type, tmp_meta_data_t>;
+    using tmp_halo_t = gridtools::halo<GRIDTOOLS_DAWN_HALO_EXTENT, GRIDTOOLS_DAWN_HALO_EXTENT, 0>;
+    using tmp_meta_data_t = storage_traits_t::storage_info_t<0, 3, tmp_halo_t>;
+    using tmp_storage_t = storage_traits_t::data_store_t<::dawn::float_type, tmp_meta_data_t>;
     const gridtools::dawn::domain m_dom;
 
     // Input/Output storages
   public:
-
-    stencil_59(const gridtools::dawn::domain& dom_, int rank, int xcols, int ycols) : m_dom(dom_){}
-    static constexpr ::dawn::driver::cartesian_extent in_extent = {-1,1, -1,1, 0,0};
-    static constexpr ::dawn::driver::cartesian_extent out_extent = {0,0, 0,0, 0,0};
+    stencil_59(const gridtools::dawn::domain& dom_, int rank, int xcols, int ycols) : m_dom(dom_) {}
+    static constexpr ::dawn::driver::cartesian_extent in_extent = {-1, 1, -1, 1, 0, 0};
+    static constexpr ::dawn::driver::cartesian_extent out_extent = {0, 0, 0, 0, 0, 0};
 
     void run(storage_ijk_t& in_, storage_ijk_t& out_) {
       int iMin = m_dom.iminus();
@@ -70,43 +67,55 @@ private:
       int kMax = m_dom.ksize() - m_dom.kplus() - 1;
       in_.sync();
       out_.sync();
-{      gridtools::data_view<storage_ijk_t> in= gridtools::make_host_view(in_);
-      std::array<int,3> in_offsets{0,0,0};
-      gridtools::data_view<storage_ijk_t> out= gridtools::make_host_view(out_);
-      std::array<int,3> out_offsets{0,0,0};
-    for(int k = kMin + 0+0; k <= kMin + 10+0; ++k) {
-      for(int i = iMin+0; i  <=  iMax+0; ++i) {
-        for(int j = jMin+0; j  <=  jMax+0; ++j) {
-::dawn::float_type dx;
-{
-  out(i+0, j+0, k+0) = (((int) -4 * (in(i+0, j+0, k+0) + (in(i+1, j+0, k+0) + (in(i+-1, j+0, k+0) + (in(i+0, j+-1, k+0) + in(i+0, j+1, k+0)))))) / (dx * dx));
-}
-        }      }    }    for(int k = kMin + 15+0; k <= kMax + 0+0; ++k) {
-      for(int i = iMin+0; i  <=  iMax+0; ++i) {
-        for(int j = jMin+0; j  <=  jMax+0; ++j) {
-{
-  out(i+0, j+0, k+0) = (int) 10;
-}
-        }      }    }}      in_.sync();
+      {
+        gridtools::data_view<storage_ijk_t> in = gridtools::make_host_view(in_);
+        std::array<int, 3> in_offsets{0, 0, 0};
+        gridtools::data_view<storage_ijk_t> out = gridtools::make_host_view(out_);
+        std::array<int, 3> out_offsets{0, 0, 0};
+        for(int k = kMin + 0 + 0; k <= kMin + 10 + 0; ++k) {
+          for(int i = iMin + 0; i <= iMax + 0; ++i) {
+            for(int j = jMin + 0; j <= jMax + 0; ++j) {
+              ::dawn::float_type dx;
+              {
+                out(i + 0, j + 0, k + 0) =
+                    (((int)-4 * (in(i + 0, j + 0, k + 0) +
+                                 (in(i + 1, j + 0, k + 0) +
+                                  (in(i + -1, j + 0, k + 0) +
+                                   (in(i + 0, j + -1, k + 0) + in(i + 0, j + 1, k + 0)))))) /
+                     (dx * dx));
+              }
+            }
+          }
+        }
+        for(int k = kMin + 15 + 0; k <= kMax + 0 + 0; ++k) {
+          for(int i = iMin + 0; i <= iMax + 0; ++i) {
+            for(int j = jMin + 0; j <= jMax + 0; ++j) {
+              {
+                out(i + 0, j + 0, k + 0) = (int)10;
+              }
+            }
+          }
+        }
+      }
+      in_.sync();
       out_.sync();
     }
   };
   static constexpr const char* s_name = "generated";
   stencil_59 m_stencil_59;
-public:
 
+public:
   generated(const generated&) = delete;
 
-  generated(const gridtools::dawn::domain& dom, int rank = 1, int xcols = 1, int ycols = 1) : m_stencil_59(dom, rank, xcols, ycols){
+  generated(const gridtools::dawn::domain& dom, int rank = 1, int xcols = 1, int ycols = 1)
+      : m_stencil_59(dom, rank, xcols, ycols) {
     assert(dom.isize() >= dom.iminus() + dom.iplus());
     assert(dom.jsize() >= dom.jminus() + dom.jplus());
     assert(dom.ksize() >= dom.kminus() + dom.kplus());
     assert(dom.ksize() >= 1);
   }
 
-  void run(storage_ijk_t in, storage_ijk_t out) {
-    m_stencil_59.run(in,out);
-  }
+  void run(storage_ijk_t in, storage_ijk_t out) { m_stencil_59.run(in, out); }
 };
 } // namespace cxxnaive
 } // namespace dawn_generated

--- a/dawn/test/unit-test/dawn/CodeGen/reference/nonoverlapping_stencil.cu
+++ b/dawn/test/unit-test/dawn/CodeGen/reference/nonoverlapping_stencil.cu
@@ -2,45 +2,47 @@
 #undef DAWN_BACKEND_T
 #define DAWN_BACKEND_T CUDA
 #ifndef BOOST_RESULT_OF_USE_TR1
- #define BOOST_RESULT_OF_USE_TR1 1
+#define BOOST_RESULT_OF_USE_TR1 1
 #endif
 #ifndef BOOST_NO_CXX11_DECLTYPE
- #define BOOST_NO_CXX11_DECLTYPE 1
+#define BOOST_NO_CXX11_DECLTYPE 1
 #endif
 #ifndef GRIDTOOLS_DAWN_HALO_EXTENT
- #define GRIDTOOLS_DAWN_HALO_EXTENT 3
+#define GRIDTOOLS_DAWN_HALO_EXTENT 3
 #endif
 #ifndef BOOST_PP_VARIADICS
- #define BOOST_PP_VARIADICS 1
+#define BOOST_PP_VARIADICS 1
 #endif
 #ifndef BOOST_FUSION_DONT_USE_PREPROCESSED_FILES
- #define BOOST_FUSION_DONT_USE_PREPROCESSED_FILES 1
+#define BOOST_FUSION_DONT_USE_PREPROCESSED_FILES 1
 #endif
 #ifndef BOOST_MPL_CFG_NO_PREPROCESSED_HEADERS
- #define BOOST_MPL_CFG_NO_PREPROCESSED_HEADERS 1
+#define BOOST_MPL_CFG_NO_PREPROCESSED_HEADERS 1
 #endif
 #ifndef GT_VECTOR_LIMIT_SIZE
- #define GT_VECTOR_LIMIT_SIZE 30
+#define GT_VECTOR_LIMIT_SIZE 30
 #endif
 #ifndef BOOST_FUSION_INVOKE_MAX_ARITY
- #define BOOST_FUSION_INVOKE_MAX_ARITY GT_VECTOR_LIMIT_SIZE
+#define BOOST_FUSION_INVOKE_MAX_ARITY GT_VECTOR_LIMIT_SIZE
 #endif
 #ifndef FUSION_MAX_VECTOR_SIZE
- #define FUSION_MAX_VECTOR_SIZE GT_VECTOR_LIMIT_SIZE
+#define FUSION_MAX_VECTOR_SIZE GT_VECTOR_LIMIT_SIZE
 #endif
 #ifndef FUSION_MAX_MAP_SIZE
- #define FUSION_MAX_MAP_SIZE GT_VECTOR_LIMIT_SIZE
+#define FUSION_MAX_MAP_SIZE GT_VECTOR_LIMIT_SIZE
 #endif
 #ifndef BOOST_MPL_LIMIT_VECTOR_SIZE
- #define BOOST_MPL_LIMIT_VECTOR_SIZE GT_VECTOR_LIMIT_SIZE
+#define BOOST_MPL_LIMIT_VECTOR_SIZE GT_VECTOR_LIMIT_SIZE
 #endif
 #include <driver-includes/gridtools_includes.hpp>
 using namespace gridtools::dawn;
 
-
-namespace dawn_generated{
-namespace cuda{
-__global__ void __launch_bounds__(128)  generated_stencil59_ms58_kernel(const int isize, const int jsize, const int ksize, const int stride_111_1, const int stride_111_2, ::dawn::float_type * const in, ::dawn::float_type * const out) {
+namespace dawn_generated {
+namespace cuda {
+__global__ void __launch_bounds__(128)
+    generated_stencil59_ms58_kernel(const int isize, const int jsize, const int ksize,
+                                    const int stride_111_1, const int stride_111_2,
+                                    ::dawn::float_type* const in, ::dawn::float_type* const out) {
 
   // Start kernel
   const unsigned int nx = isize;
@@ -77,23 +79,29 @@ __global__ void __launch_bounds__(128)  generated_stencil59_ms58_kernel(const in
   // Regions (a,h,e) and (c,i,g) are executed by two specialized warp
   int iblock = 0 - 1;
   int jblock = 0 - 1;
-if(threadIdx.y < +4) {
+  if(threadIdx.y < +4) {
     iblock = threadIdx.x;
     jblock = (int)threadIdx.y + 0;
-}
+  }
   // initialized iterators
-  int idx111 = (blockIdx.x*32+iblock)*1+(blockIdx.y*4+jblock)*stride_111_1;
+  int idx111 = (blockIdx.x * 32 + iblock) * 1 + (blockIdx.y * 4 + jblock) * stride_111_1;
 
   // Pre-fill of kcaches
-for(int k = 0+0; k <= 10+0; ++k) {
+  for(int k = 0 + 0; k <= 10 + 0; ++k) {
 
     // Head fill of kcaches
-  if(iblock >= 0 && iblock <= block_size_i -1 + 0 && jblock >= 0 && jblock <= block_size_j -1 + 0) {
-::dawn::float_type dx;
-{
-  out[idx111] = (((int) -4 * (__ldg(&(in[idx111])) + (__ldg(&(in[idx111+1*1])) + (__ldg(&(in[idx111+1*-1])) + (__ldg(&(in[idx111+stride_111_1*-1])) + __ldg(&(in[idx111+stride_111_1*1]))))))) / (dx * dx));
-}
-  }
+    if(iblock >= 0 && iblock <= block_size_i - 1 + 0 && jblock >= 0 &&
+       jblock <= block_size_j - 1 + 0) {
+      ::dawn::float_type dx;
+      {
+        out[idx111] =
+            (((int)-4 * (__ldg(&(in[idx111])) + (__ldg(&(in[idx111 + 1 * 1])) +
+                                                 (__ldg(&(in[idx111 + 1 * -1])) +
+                                                  (__ldg(&(in[idx111 + stride_111_1 * -1])) +
+                                                   __ldg(&(in[idx111 + stride_111_1 * 1]))))))) /
+             (dx * dx));
+      }
+    }
     // Flush of kcaches
 
     // Flush of kcaches
@@ -101,8 +109,8 @@ for(int k = 0+0; k <= 10+0; ++k) {
     // Slide kcaches
 
     // increment iterators
-    idx111+=stride_111_2;
-}
+    idx111 += stride_111_2;
+  }
   // Final flush of kcaches
 
   // Final flush of kcaches
@@ -110,17 +118,18 @@ for(int k = 0+0; k <= 10+0; ++k) {
   // Final flush of kcaches
 
   // jump iterators to match the beginning of next interval
-  idx111 += stride_111_2*(4);
+  idx111 += stride_111_2 * (4);
 
   // Pre-fill of kcaches
-for(int k = 15+0; k <=  ksize - 1 + 0+0; ++k) {
+  for(int k = 15 + 0; k <= ksize - 1 + 0 + 0; ++k) {
 
     // Head fill of kcaches
-  if(iblock >= 0 && iblock <= block_size_i -1 + 0 && jblock >= 0 && jblock <= block_size_j -1 + 0) {
-{
-  out[idx111] = (int) 10;
-}
-  }
+    if(iblock >= 0 && iblock <= block_size_i - 1 + 0 && jblock >= 0 &&
+       jblock <= block_size_j - 1 + 0) {
+      {
+        out[idx111] = (int)10;
+      }
+    }
     // Flush of kcaches
 
     // Flush of kcaches
@@ -128,8 +137,8 @@ for(int k = 15+0; k <=  ksize - 1 + 0+0; ++k) {
     // Slide kcaches
 
     // increment iterators
-    idx111+=stride_111_2;
-}
+    idx111 += stride_111_2;
+  }
   // Final flush of kcaches
 
   // Final flush of kcaches
@@ -139,14 +148,11 @@ for(int k = 15+0; k <=  ksize - 1 + 0+0; ++k) {
 
 class generated {
 public:
-
   struct sbase : public timer_cuda {
 
-    sbase(std::string name) : timer_cuda(name){}
+    sbase(std::string name) : timer_cuda(name) {}
 
-    double get_time() {
-      return total_time();
-    }
+    double get_time() { return total_time(); }
   };
 
   struct stencil_59 : public sbase {
@@ -154,32 +160,37 @@ public:
     // Members
 
     // Temporary storage typedefs
-    using tmp_halo_t = gridtools::halo< 0,0, 0, 0, 0>;
-    using tmp_meta_data_t = storage_traits_t::storage_info_t< 0, 5, tmp_halo_t >;
-    using tmp_storage_t = storage_traits_t::data_store_t< ::dawn::float_type, tmp_meta_data_t>;
+    using tmp_halo_t = gridtools::halo<0, 0, 0, 0, 0>;
+    using tmp_meta_data_t = storage_traits_t::storage_info_t<0, 5, tmp_halo_t>;
+    using tmp_storage_t = storage_traits_t::data_store_t<::dawn::float_type, tmp_meta_data_t>;
     const gridtools::dawn::domain m_dom;
-  public:
 
-    stencil_59(const gridtools::dawn::domain& dom_, int rank, int xcols, int ycols) : sbase("stencil_59"), m_dom(dom_){}
-    static constexpr ::dawn::driver::cartesian_extent in_extent = {-1,1, -1,1, 0,0};
-    static constexpr ::dawn::driver::cartesian_extent out_extent = {0,0, 0,0, 0,0};
+  public:
+    stencil_59(const gridtools::dawn::domain& dom_, int rank, int xcols, int ycols)
+        : sbase("stencil_59"), m_dom(dom_) {}
+    static constexpr ::dawn::driver::cartesian_extent in_extent = {-1, 1, -1, 1, 0, 0};
+    static constexpr ::dawn::driver::cartesian_extent out_extent = {0, 0, 0, 0, 0, 0};
 
     void run(storage_ijk_t in_ds, storage_ijk_t out_ds) {
 
       // starting timers
       start();
-      {;
-      gridtools::data_view<storage_ijk_t> in= gridtools::make_device_view(in_ds);
-      gridtools::data_view<storage_ijk_t> out= gridtools::make_device_view(out_ds);
-      const unsigned int nx = m_dom.isize() - m_dom.iminus() - m_dom.iplus();
-      const unsigned int ny = m_dom.jsize() - m_dom.jminus() - m_dom.jplus();
-      const unsigned int nz = m_dom.ksize() - m_dom.kminus() - m_dom.kplus();
-      dim3 threads(32,4+0,1);
-      const unsigned int nbx = (nx + 32 - 1) / 32;
-      const unsigned int nby = (ny + 4 - 1) / 4;
-      const unsigned int nbz = 1;
-      dim3 blocks(nbx, nby, nbz);
-      generated_stencil59_ms58_kernel<<<blocks, threads>>>(nx,ny,nz,in_ds.strides()[1],in_ds.strides()[2],(in.data()+in_ds.get_storage_info_ptr()->index(in.begin<0>(), in.begin<1>(),0 )),(out.data()+out_ds.get_storage_info_ptr()->index(out.begin<0>(), out.begin<1>(),0 )));
+      {
+        ;
+        gridtools::data_view<storage_ijk_t> in = gridtools::make_device_view(in_ds);
+        gridtools::data_view<storage_ijk_t> out = gridtools::make_device_view(out_ds);
+        const unsigned int nx = m_dom.isize() - m_dom.iminus() - m_dom.iplus();
+        const unsigned int ny = m_dom.jsize() - m_dom.jminus() - m_dom.jplus();
+        const unsigned int nz = m_dom.ksize() - m_dom.kminus() - m_dom.kplus();
+        dim3 threads(32, 4 + 0, 1);
+        const unsigned int nbx = (nx + 32 - 1) / 32;
+        const unsigned int nby = (ny + 4 - 1) / 4;
+        const unsigned int nbz = 1;
+        dim3 blocks(nbx, nby, nbz);
+        generated_stencil59_ms58_kernel<<<blocks, threads>>>(
+            nx, ny, nz, in_ds.strides()[1], in_ds.strides()[2],
+            (in.data() + in_ds.get_storage_info_ptr()->index(in.begin<0>(), in.begin<1>(), 0)),
+            (out.data() + out_ds.get_storage_info_ptr()->index(out.begin<0>(), out.begin<1>(), 0)));
       };
 
       // stopping timers
@@ -188,44 +199,42 @@ public:
   };
   static constexpr const char* s_name = "generated";
   stencil_59 m_stencil_59;
-public:
 
+public:
   generated(const generated&) = delete;
 
   // Members
 
   // Stencil-Data
 
-  generated(const gridtools::dawn::domain& dom, int rank = 1, int xcols = 1, int ycols = 1) : m_stencil_59(dom, rank, xcols, ycols){}
+  generated(const gridtools::dawn::domain& dom, int rank = 1, int xcols = 1, int ycols = 1)
+      : m_stencil_59(dom, rank, xcols, ycols) {}
 
-  template<typename S>
+  template <typename S>
   void sync_storages(S field) {
     field.sync();
   }
 
-  template<typename S0, typename ... S>
+  template <typename S0, typename... S>
   void sync_storages(S0 f0, S... fields) {
     f0.sync();
     sync_storages(fields...);
   }
 
   void run(storage_ijk_t in, storage_ijk_t out) {
-    sync_storages(in,out);
-    m_stencil_59.run(in,out);
-;
-    sync_storages(in,out);
+    sync_storages(in, out);
+    m_stencil_59.run(in, out);
+    ;
+    sync_storages(in, out);
   }
 
-  std::string get_name()  const {
-    return std::string(s_name);
-  }
+  std::string get_name() const { return std::string(s_name); }
 
-  void reset_meters() {
-m_stencil_59.reset();  }
+  void reset_meters() { m_stencil_59.reset(); }
 
   double get_total_time() {
     double res = 0;
-    res +=m_stencil_59.get_time();
+    res += m_stencil_59.get_time();
     return res;
   }
 };

--- a/dawn/test/unit-test/dawn/CodeGen/reference/update_dz_c.cpp
+++ b/dawn/test/unit-test/dawn/CodeGen/reference/update_dz_c.cpp
@@ -2,67 +2,64 @@
 #undef DAWN_BACKEND_T
 #define DAWN_BACKEND_T CXXNAIVE
 #ifndef BOOST_RESULT_OF_USE_TR1
- #define BOOST_RESULT_OF_USE_TR1 1
+#define BOOST_RESULT_OF_USE_TR1 1
 #endif
 #ifndef BOOST_NO_CXX11_DECLTYPE
- #define BOOST_NO_CXX11_DECLTYPE 1
+#define BOOST_NO_CXX11_DECLTYPE 1
 #endif
 #ifndef GRIDTOOLS_DAWN_HALO_EXTENT
- #define GRIDTOOLS_DAWN_HALO_EXTENT 3
+#define GRIDTOOLS_DAWN_HALO_EXTENT 3
 #endif
 #ifndef BOOST_PP_VARIADICS
- #define BOOST_PP_VARIADICS 1
+#define BOOST_PP_VARIADICS 1
 #endif
 #ifndef BOOST_FUSION_DONT_USE_PREPROCESSED_FILES
- #define BOOST_FUSION_DONT_USE_PREPROCESSED_FILES 1
+#define BOOST_FUSION_DONT_USE_PREPROCESSED_FILES 1
 #endif
 #ifndef BOOST_MPL_CFG_NO_PREPROCESSED_HEADERS
- #define BOOST_MPL_CFG_NO_PREPROCESSED_HEADERS 1
+#define BOOST_MPL_CFG_NO_PREPROCESSED_HEADERS 1
 #endif
 #ifndef GT_VECTOR_LIMIT_SIZE
- #define GT_VECTOR_LIMIT_SIZE 30
+#define GT_VECTOR_LIMIT_SIZE 30
 #endif
 #ifndef BOOST_FUSION_INVOKE_MAX_ARITY
- #define BOOST_FUSION_INVOKE_MAX_ARITY GT_VECTOR_LIMIT_SIZE
+#define BOOST_FUSION_INVOKE_MAX_ARITY GT_VECTOR_LIMIT_SIZE
 #endif
 #ifndef FUSION_MAX_VECTOR_SIZE
- #define FUSION_MAX_VECTOR_SIZE GT_VECTOR_LIMIT_SIZE
+#define FUSION_MAX_VECTOR_SIZE GT_VECTOR_LIMIT_SIZE
 #endif
 #ifndef FUSION_MAX_MAP_SIZE
- #define FUSION_MAX_MAP_SIZE GT_VECTOR_LIMIT_SIZE
+#define FUSION_MAX_MAP_SIZE GT_VECTOR_LIMIT_SIZE
 #endif
 #ifndef BOOST_MPL_LIMIT_VECTOR_SIZE
- #define BOOST_MPL_LIMIT_VECTOR_SIZE GT_VECTOR_LIMIT_SIZE
+#define BOOST_MPL_LIMIT_VECTOR_SIZE GT_VECTOR_LIMIT_SIZE
 #endif
 #include <driver-includes/gridtools_includes.hpp>
 using namespace gridtools::dawn;
-namespace dawn_generated{
-namespace cxxnaive{
+namespace dawn_generated {
+namespace cxxnaive {
 
 struct globals {
   double dt;
 
-  globals() : dt(0){
-  }
+  globals() : dt(0) {}
 };
 } // namespace cxxnaive
 } // namespace dawn_generated
 
-
-namespace dawn_generated{
-namespace cxxnaive{
+namespace dawn_generated {
+namespace cxxnaive {
 
 class update_dz_c {
 private:
-
   struct stencil_443 {
 
     // Members
 
     // Temporary storages
-    using tmp_halo_t = gridtools::halo< GRIDTOOLS_DAWN_HALO_EXTENT, GRIDTOOLS_DAWN_HALO_EXTENT, 0>;
-    using tmp_meta_data_t = storage_traits_t::storage_info_t< 0, 3, tmp_halo_t >;
-    using tmp_storage_t = storage_traits_t::data_store_t< ::dawn::float_type, tmp_meta_data_t>;
+    using tmp_halo_t = gridtools::halo<GRIDTOOLS_DAWN_HALO_EXTENT, GRIDTOOLS_DAWN_HALO_EXTENT, 0>;
+    using tmp_meta_data_t = storage_traits_t::storage_info_t<0, 3, tmp_halo_t>;
+    using tmp_storage_t = storage_traits_t::data_store_t<::dawn::float_type, tmp_meta_data_t>;
     const gridtools::dawn::domain m_dom;
     const globals& m_globals;
 
@@ -72,21 +69,28 @@ private:
     tmp_storage_t m_yfx;
     tmp_storage_t m_fx;
     tmp_storage_t m_fy;
+
   public:
+    stencil_443(const gridtools::dawn::domain& dom_, globals& globals_, int rank, int xcols,
+                int ycols)
+        : m_dom(dom_), m_globals(globals_),
+          m_tmp_meta_data(dom_.isize() + 1, dom_.jsize() + 1, dom_.ksize() + 2 * 0),
+          m_xfx(m_tmp_meta_data), m_yfx(m_tmp_meta_data), m_fx(m_tmp_meta_data),
+          m_fy(m_tmp_meta_data) {}
+    static constexpr ::dawn::driver::cartesian_extent dp_ref_extent = {0, 1, 0, 1, -2, 1};
+    static constexpr ::dawn::driver::cartesian_extent zs_extent = {0, 0, 0, 0, 0, 0};
+    static constexpr ::dawn::driver::cartesian_extent area_extent = {0, 0, 0, 0, 0, 0};
+    static constexpr ::dawn::driver::cartesian_extent ut_extent = {0, 1, 0, 1, -2, 1};
+    static constexpr ::dawn::driver::cartesian_extent vt_extent = {0, 1, 0, 1, -2, 1};
+    static constexpr ::dawn::driver::cartesian_extent gz_extent = {0, 0, 0, 0, 0, 0};
+    static constexpr ::dawn::driver::cartesian_extent gz_x_extent = {-1, 1, 0, 1, 0, 0};
+    static constexpr ::dawn::driver::cartesian_extent gz_y_extent = {0, 1, -1, 1, 0, 0};
+    static constexpr ::dawn::driver::cartesian_extent ws3_extent = {0, 0, 0, 0, 0, 0};
+    static constexpr ::dawn::driver::cartesian_extent gz_0_extent = {0, 0, 0, 0, 0, 1};
 
-    stencil_443(const gridtools::dawn::domain& dom_, globals& globals_, int rank, int xcols, int ycols) : m_dom(dom_), m_globals(globals_), m_tmp_meta_data(dom_.isize() + 1, dom_.jsize() + 1, dom_.ksize() + 2*0), m_xfx(m_tmp_meta_data), m_yfx(m_tmp_meta_data), m_fx(m_tmp_meta_data), m_fy(m_tmp_meta_data){}
-    static constexpr ::dawn::driver::cartesian_extent dp_ref_extent = {0,1, 0,1, -2,1};
-    static constexpr ::dawn::driver::cartesian_extent zs_extent = {0,0, 0,0, 0,0};
-    static constexpr ::dawn::driver::cartesian_extent area_extent = {0,0, 0,0, 0,0};
-    static constexpr ::dawn::driver::cartesian_extent ut_extent = {0,1, 0,1, -2,1};
-    static constexpr ::dawn::driver::cartesian_extent vt_extent = {0,1, 0,1, -2,1};
-    static constexpr ::dawn::driver::cartesian_extent gz_extent = {0,0, 0,0, 0,0};
-    static constexpr ::dawn::driver::cartesian_extent gz_x_extent = {-1,1, 0,1, 0,0};
-    static constexpr ::dawn::driver::cartesian_extent gz_y_extent = {0,1, -1,1, 0,0};
-    static constexpr ::dawn::driver::cartesian_extent ws3_extent = {0,0, 0,0, 0,0};
-    static constexpr ::dawn::driver::cartesian_extent gz_0_extent = {0,0, 0,0, 0,1};
-
-    void run(storage_ijk_t& dp_ref_, storage_ijk_t& zs_, storage_ijk_t& area_, storage_ijk_t& ut_, storage_ijk_t& vt_, storage_ijk_t& gz_, storage_ijk_t& gz_x_, storage_ijk_t& gz_y_, storage_ijk_t& ws3_, storage_ijk_t& gz_0_) {
+    void run(storage_ijk_t& dp_ref_, storage_ijk_t& zs_, storage_ijk_t& area_, storage_ijk_t& ut_,
+             storage_ijk_t& vt_, storage_ijk_t& gz_, storage_ijk_t& gz_x_, storage_ijk_t& gz_y_,
+             storage_ijk_t& ws3_, storage_ijk_t& gz_0_) {
       int iMin = m_dom.iminus();
       int iMax = m_dom.isize() - m_dom.iplus() - 1;
       int jMin = m_dom.jminus();
@@ -103,247 +107,329 @@ private:
       gz_y_.sync();
       ws3_.sync();
       gz_0_.sync();
-{      gridtools::data_view<storage_ijk_t> dp_ref= gridtools::make_host_view(dp_ref_);
-      std::array<int,3> dp_ref_offsets{0,0,0};
-      gridtools::data_view<storage_ijk_t> zs= gridtools::make_host_view(zs_);
-      std::array<int,3> zs_offsets{0,0,0};
-      gridtools::data_view<storage_ijk_t> area= gridtools::make_host_view(area_);
-      std::array<int,3> area_offsets{0,0,0};
-      gridtools::data_view<storage_ijk_t> ut= gridtools::make_host_view(ut_);
-      std::array<int,3> ut_offsets{0,0,0};
-      gridtools::data_view<storage_ijk_t> vt= gridtools::make_host_view(vt_);
-      std::array<int,3> vt_offsets{0,0,0};
-      gridtools::data_view<storage_ijk_t> gz= gridtools::make_host_view(gz_);
-      std::array<int,3> gz_offsets{0,0,0};
-      gridtools::data_view<storage_ijk_t> gz_x= gridtools::make_host_view(gz_x_);
-      std::array<int,3> gz_x_offsets{0,0,0};
-      gridtools::data_view<storage_ijk_t> gz_y= gridtools::make_host_view(gz_y_);
-      std::array<int,3> gz_y_offsets{0,0,0};
-      gridtools::data_view<storage_ijk_t> ws3= gridtools::make_host_view(ws3_);
-      std::array<int,3> ws3_offsets{0,0,0};
-      gridtools::data_view<storage_ijk_t> gz_0= gridtools::make_host_view(gz_0_);
-      std::array<int,3> gz_0_offsets{0,0,0};
-      gridtools::data_view<tmp_storage_t> xfx= gridtools::make_host_view(m_xfx);
-      std::array<int,3> xfx_offsets{0,0,0};
-      gridtools::data_view<tmp_storage_t> yfx= gridtools::make_host_view(m_yfx);
-      std::array<int,3> yfx_offsets{0,0,0};
-      gridtools::data_view<tmp_storage_t> fx= gridtools::make_host_view(m_fx);
-      std::array<int,3> fx_offsets{0,0,0};
-      gridtools::data_view<tmp_storage_t> fy= gridtools::make_host_view(m_fy);
-      std::array<int,3> fy_offsets{0,0,0};
-    for(int k = kMin + 0+0; k <= kMin + 1+0; ++k) {
-      for(int i = iMin+0; i  <=  iMax+1; ++i) {
-        for(int j = jMin+0; j  <=  jMax+1; ++j) {
-::dawn::float_type __local_ratio__d15_16_429 = (dp_ref(i+0, j+0, k+0) / (dp_ref(i+0, j+0, k+0) + dp_ref(i+0, j+0, k+1)));
-xfx(i+0, j+0, k+0) = (ut(i+0, j+0, k+0) + ((ut(i+0, j+0, k+0) - ut(i+0, j+0, k+1)) * __local_ratio__d15_16_429));
-::dawn::float_type __local_ratio__d15_17_431 = (dp_ref(i+0, j+0, k+0) / (dp_ref(i+0, j+0, k+0) + dp_ref(i+0, j+0, k+1)));
-yfx(i+0, j+0, k+0) = (vt(i+0, j+0, k+0) + ((vt(i+0, j+0, k+0) - vt(i+0, j+0, k+1)) * __local_ratio__d15_17_431));
-        }      }    }}{      gridtools::data_view<storage_ijk_t> dp_ref= gridtools::make_host_view(dp_ref_);
-      std::array<int,3> dp_ref_offsets{0,0,0};
-      gridtools::data_view<storage_ijk_t> zs= gridtools::make_host_view(zs_);
-      std::array<int,3> zs_offsets{0,0,0};
-      gridtools::data_view<storage_ijk_t> area= gridtools::make_host_view(area_);
-      std::array<int,3> area_offsets{0,0,0};
-      gridtools::data_view<storage_ijk_t> ut= gridtools::make_host_view(ut_);
-      std::array<int,3> ut_offsets{0,0,0};
-      gridtools::data_view<storage_ijk_t> vt= gridtools::make_host_view(vt_);
-      std::array<int,3> vt_offsets{0,0,0};
-      gridtools::data_view<storage_ijk_t> gz= gridtools::make_host_view(gz_);
-      std::array<int,3> gz_offsets{0,0,0};
-      gridtools::data_view<storage_ijk_t> gz_x= gridtools::make_host_view(gz_x_);
-      std::array<int,3> gz_x_offsets{0,0,0};
-      gridtools::data_view<storage_ijk_t> gz_y= gridtools::make_host_view(gz_y_);
-      std::array<int,3> gz_y_offsets{0,0,0};
-      gridtools::data_view<storage_ijk_t> ws3= gridtools::make_host_view(ws3_);
-      std::array<int,3> ws3_offsets{0,0,0};
-      gridtools::data_view<storage_ijk_t> gz_0= gridtools::make_host_view(gz_0_);
-      std::array<int,3> gz_0_offsets{0,0,0};
-      gridtools::data_view<tmp_storage_t> xfx= gridtools::make_host_view(m_xfx);
-      std::array<int,3> xfx_offsets{0,0,0};
-      gridtools::data_view<tmp_storage_t> yfx= gridtools::make_host_view(m_yfx);
-      std::array<int,3> yfx_offsets{0,0,0};
-      gridtools::data_view<tmp_storage_t> fx= gridtools::make_host_view(m_fx);
-      std::array<int,3> fx_offsets{0,0,0};
-      gridtools::data_view<tmp_storage_t> fy= gridtools::make_host_view(m_fy);
-      std::array<int,3> fy_offsets{0,0,0};
-    for(int k = kMax + -1+0; k <= kMax + 0+0; ++k) {
-      for(int i = iMin+0; i  <=  iMax+1; ++i) {
-        for(int j = jMin+0; j  <=  jMax+1; ++j) {
-::dawn::float_type __local_ratio__c74_19_433 = (dp_ref(i+0, j+0, k+-1) / (dp_ref(i+0, j+0, k+-2) + dp_ref(i+0, j+0, k+-1)));
-xfx(i+0, j+0, k+0) = (ut(i+0, j+0, k+-1) + ((ut(i+0, j+0, k+-1) - ut(i+0, j+0, k+-2)) * __local_ratio__c74_19_433));
-::dawn::float_type __local_ratio__c74_20_434 = (dp_ref(i+0, j+0, k+-1) / (dp_ref(i+0, j+0, k+-2) + dp_ref(i+0, j+0, k+-1)));
-yfx(i+0, j+0, k+0) = (vt(i+0, j+0, k+-1) + ((vt(i+0, j+0, k+-1) - vt(i+0, j+0, k+-2)) * __local_ratio__c74_20_434));
-        }      }    }}{      gridtools::data_view<storage_ijk_t> dp_ref= gridtools::make_host_view(dp_ref_);
-      std::array<int,3> dp_ref_offsets{0,0,0};
-      gridtools::data_view<storage_ijk_t> zs= gridtools::make_host_view(zs_);
-      std::array<int,3> zs_offsets{0,0,0};
-      gridtools::data_view<storage_ijk_t> area= gridtools::make_host_view(area_);
-      std::array<int,3> area_offsets{0,0,0};
-      gridtools::data_view<storage_ijk_t> ut= gridtools::make_host_view(ut_);
-      std::array<int,3> ut_offsets{0,0,0};
-      gridtools::data_view<storage_ijk_t> vt= gridtools::make_host_view(vt_);
-      std::array<int,3> vt_offsets{0,0,0};
-      gridtools::data_view<storage_ijk_t> gz= gridtools::make_host_view(gz_);
-      std::array<int,3> gz_offsets{0,0,0};
-      gridtools::data_view<storage_ijk_t> gz_x= gridtools::make_host_view(gz_x_);
-      std::array<int,3> gz_x_offsets{0,0,0};
-      gridtools::data_view<storage_ijk_t> gz_y= gridtools::make_host_view(gz_y_);
-      std::array<int,3> gz_y_offsets{0,0,0};
-      gridtools::data_view<storage_ijk_t> ws3= gridtools::make_host_view(ws3_);
-      std::array<int,3> ws3_offsets{0,0,0};
-      gridtools::data_view<storage_ijk_t> gz_0= gridtools::make_host_view(gz_0_);
-      std::array<int,3> gz_0_offsets{0,0,0};
-      gridtools::data_view<tmp_storage_t> xfx= gridtools::make_host_view(m_xfx);
-      std::array<int,3> xfx_offsets{0,0,0};
-      gridtools::data_view<tmp_storage_t> yfx= gridtools::make_host_view(m_yfx);
-      std::array<int,3> yfx_offsets{0,0,0};
-      gridtools::data_view<tmp_storage_t> fx= gridtools::make_host_view(m_fx);
-      std::array<int,3> fx_offsets{0,0,0};
-      gridtools::data_view<tmp_storage_t> fy= gridtools::make_host_view(m_fy);
-      std::array<int,3> fy_offsets{0,0,0};
-    for(int k = kMin + 1+0; k <= kMax + -1+0; ++k) {
-      for(int i = iMin+0; i  <=  iMax+1; ++i) {
-        for(int j = jMin+0; j  <=  jMax+1; ++j) {
-::dawn::float_type __local_int_ratio__330_22_435 = ((::dawn::float_type) 1.0 / (dp_ref(i+0, j+0, k+-1) + dp_ref(i+0, j+0, k+0)));
-xfx(i+0, j+0, k+0) = (((dp_ref(i+0, j+0, k+0) * ut(i+0, j+0, k+-1)) + (dp_ref(i+0, j+0, k+-1) * ut(i+0, j+0, k+0))) * __local_int_ratio__330_22_435);
-::dawn::float_type __local_int_ratio__330_23_436 = ((::dawn::float_type) 1.0 / (dp_ref(i+0, j+0, k+-1) + dp_ref(i+0, j+0, k+0)));
-yfx(i+0, j+0, k+0) = (((dp_ref(i+0, j+0, k+0) * vt(i+0, j+0, k+-1)) + (dp_ref(i+0, j+0, k+-1) * vt(i+0, j+0, k+0))) * __local_int_ratio__330_23_436);
-        }      }    }}{      gridtools::data_view<storage_ijk_t> dp_ref= gridtools::make_host_view(dp_ref_);
-      std::array<int,3> dp_ref_offsets{0,0,0};
-      gridtools::data_view<storage_ijk_t> zs= gridtools::make_host_view(zs_);
-      std::array<int,3> zs_offsets{0,0,0};
-      gridtools::data_view<storage_ijk_t> area= gridtools::make_host_view(area_);
-      std::array<int,3> area_offsets{0,0,0};
-      gridtools::data_view<storage_ijk_t> ut= gridtools::make_host_view(ut_);
-      std::array<int,3> ut_offsets{0,0,0};
-      gridtools::data_view<storage_ijk_t> vt= gridtools::make_host_view(vt_);
-      std::array<int,3> vt_offsets{0,0,0};
-      gridtools::data_view<storage_ijk_t> gz= gridtools::make_host_view(gz_);
-      std::array<int,3> gz_offsets{0,0,0};
-      gridtools::data_view<storage_ijk_t> gz_x= gridtools::make_host_view(gz_x_);
-      std::array<int,3> gz_x_offsets{0,0,0};
-      gridtools::data_view<storage_ijk_t> gz_y= gridtools::make_host_view(gz_y_);
-      std::array<int,3> gz_y_offsets{0,0,0};
-      gridtools::data_view<storage_ijk_t> ws3= gridtools::make_host_view(ws3_);
-      std::array<int,3> ws3_offsets{0,0,0};
-      gridtools::data_view<storage_ijk_t> gz_0= gridtools::make_host_view(gz_0_);
-      std::array<int,3> gz_0_offsets{0,0,0};
-      gridtools::data_view<tmp_storage_t> xfx= gridtools::make_host_view(m_xfx);
-      std::array<int,3> xfx_offsets{0,0,0};
-      gridtools::data_view<tmp_storage_t> yfx= gridtools::make_host_view(m_yfx);
-      std::array<int,3> yfx_offsets{0,0,0};
-      gridtools::data_view<tmp_storage_t> fx= gridtools::make_host_view(m_fx);
-      std::array<int,3> fx_offsets{0,0,0};
-      gridtools::data_view<tmp_storage_t> fy= gridtools::make_host_view(m_fy);
-      std::array<int,3> fy_offsets{0,0,0};
-    for(int k = kMin + 0+0; k <= kMax + 0+0; ++k) {
-      for(int i = iMin+0; i  <=  iMax+1; ++i) {
-        for(int j = jMin+0; j  <=  jMax+1; ++j) {
-::dawn::float_type __local_fx__389_25_437 = (xfx(i+0, j+0, k+0) * ((xfx(i+0, j+0, k+0) > (::dawn::float_type) 0.0) ? gz_x(i+-1, j+0, k+0) : gz_x(i+0, j+0, k+0)));
-::dawn::float_type __local_fy__389_25_438 = (yfx(i+0, j+0, k+0) * ((yfx(i+0, j+0, k+0) > (::dawn::float_type) 0.0) ? gz_y(i+0, j+-1, k+0) : gz_y(i+0, j+0, k+0)));
-fx(i+0, j+0, k+0) = __local_fx__389_25_437;
-fy(i+0, j+0, k+0) = __local_fy__389_25_438;
-        }      }      for(int i = iMin+0; i  <=  iMax+0; ++i) {
-        for(int j = jMin+0; j  <=  jMax+0; ++j) {
-gz_0(i+0, j+0, k+0) = ((((((gz_y(i+0, j+0, k+0) * area(i+0, j+0, k+0)) + fx(i+0, j+0, k+0)) - fx(i+1, j+0, k+0)) + fy(i+0, j+0, k+0)) - fy(i+0, j+1, k+0)) / ((((area(i+0, j+0, k+0) + xfx(i+0, j+0, k+0)) - xfx(i+1, j+0, k+0)) + yfx(i+0, j+0, k+0)) - yfx(i+0, j+1, k+0)));
-        }      }    }}{      gridtools::data_view<storage_ijk_t> dp_ref= gridtools::make_host_view(dp_ref_);
-      std::array<int,3> dp_ref_offsets{0,0,0};
-      gridtools::data_view<storage_ijk_t> zs= gridtools::make_host_view(zs_);
-      std::array<int,3> zs_offsets{0,0,0};
-      gridtools::data_view<storage_ijk_t> area= gridtools::make_host_view(area_);
-      std::array<int,3> area_offsets{0,0,0};
-      gridtools::data_view<storage_ijk_t> ut= gridtools::make_host_view(ut_);
-      std::array<int,3> ut_offsets{0,0,0};
-      gridtools::data_view<storage_ijk_t> vt= gridtools::make_host_view(vt_);
-      std::array<int,3> vt_offsets{0,0,0};
-      gridtools::data_view<storage_ijk_t> gz= gridtools::make_host_view(gz_);
-      std::array<int,3> gz_offsets{0,0,0};
-      gridtools::data_view<storage_ijk_t> gz_x= gridtools::make_host_view(gz_x_);
-      std::array<int,3> gz_x_offsets{0,0,0};
-      gridtools::data_view<storage_ijk_t> gz_y= gridtools::make_host_view(gz_y_);
-      std::array<int,3> gz_y_offsets{0,0,0};
-      gridtools::data_view<storage_ijk_t> ws3= gridtools::make_host_view(ws3_);
-      std::array<int,3> ws3_offsets{0,0,0};
-      gridtools::data_view<storage_ijk_t> gz_0= gridtools::make_host_view(gz_0_);
-      std::array<int,3> gz_0_offsets{0,0,0};
-      gridtools::data_view<tmp_storage_t> xfx= gridtools::make_host_view(m_xfx);
-      std::array<int,3> xfx_offsets{0,0,0};
-      gridtools::data_view<tmp_storage_t> yfx= gridtools::make_host_view(m_yfx);
-      std::array<int,3> yfx_offsets{0,0,0};
-      gridtools::data_view<tmp_storage_t> fx= gridtools::make_host_view(m_fx);
-      std::array<int,3> fx_offsets{0,0,0};
-      gridtools::data_view<tmp_storage_t> fy= gridtools::make_host_view(m_fy);
-      std::array<int,3> fy_offsets{0,0,0};
-    for(int k = kMax + -1+0; k <= kMax + 0+0; ++k) {
-      for(int i = iMin+0; i  <=  iMax+0; ++i) {
-        for(int j = jMin+0; j  <=  jMax+0; ++j) {
-gz_0(i+0, j+0, k+0) = gz(i+0, j+0, k+0);
-        }      }    }}{      gridtools::data_view<storage_ijk_t> dp_ref= gridtools::make_host_view(dp_ref_);
-      std::array<int,3> dp_ref_offsets{0,0,0};
-      gridtools::data_view<storage_ijk_t> zs= gridtools::make_host_view(zs_);
-      std::array<int,3> zs_offsets{0,0,0};
-      gridtools::data_view<storage_ijk_t> area= gridtools::make_host_view(area_);
-      std::array<int,3> area_offsets{0,0,0};
-      gridtools::data_view<storage_ijk_t> ut= gridtools::make_host_view(ut_);
-      std::array<int,3> ut_offsets{0,0,0};
-      gridtools::data_view<storage_ijk_t> vt= gridtools::make_host_view(vt_);
-      std::array<int,3> vt_offsets{0,0,0};
-      gridtools::data_view<storage_ijk_t> gz= gridtools::make_host_view(gz_);
-      std::array<int,3> gz_offsets{0,0,0};
-      gridtools::data_view<storage_ijk_t> gz_x= gridtools::make_host_view(gz_x_);
-      std::array<int,3> gz_x_offsets{0,0,0};
-      gridtools::data_view<storage_ijk_t> gz_y= gridtools::make_host_view(gz_y_);
-      std::array<int,3> gz_y_offsets{0,0,0};
-      gridtools::data_view<storage_ijk_t> ws3= gridtools::make_host_view(ws3_);
-      std::array<int,3> ws3_offsets{0,0,0};
-      gridtools::data_view<storage_ijk_t> gz_0= gridtools::make_host_view(gz_0_);
-      std::array<int,3> gz_0_offsets{0,0,0};
-      gridtools::data_view<tmp_storage_t> xfx= gridtools::make_host_view(m_xfx);
-      std::array<int,3> xfx_offsets{0,0,0};
-      gridtools::data_view<tmp_storage_t> yfx= gridtools::make_host_view(m_yfx);
-      std::array<int,3> yfx_offsets{0,0,0};
-      gridtools::data_view<tmp_storage_t> fx= gridtools::make_host_view(m_fx);
-      std::array<int,3> fx_offsets{0,0,0};
-      gridtools::data_view<tmp_storage_t> fy= gridtools::make_host_view(m_fy);
-      std::array<int,3> fy_offsets{0,0,0};
-    for(int k = kMax + -1+0; k <= kMax + 0+0; ++k) {
-      for(int i = iMin+0; i  <=  iMax+0; ++i) {
-        for(int j = jMin+0; j  <=  jMax+0; ++j) {
-ws3(i+0, j+0, k+0) = ((zs(i+0, j+0, k+0) - gz_0(i+0, j+0, k+0)) * ((::dawn::float_type) 1.0 / m_globals.dt));
-        }      }    }}{      gridtools::data_view<storage_ijk_t> dp_ref= gridtools::make_host_view(dp_ref_);
-      std::array<int,3> dp_ref_offsets{0,0,0};
-      gridtools::data_view<storage_ijk_t> zs= gridtools::make_host_view(zs_);
-      std::array<int,3> zs_offsets{0,0,0};
-      gridtools::data_view<storage_ijk_t> area= gridtools::make_host_view(area_);
-      std::array<int,3> area_offsets{0,0,0};
-      gridtools::data_view<storage_ijk_t> ut= gridtools::make_host_view(ut_);
-      std::array<int,3> ut_offsets{0,0,0};
-      gridtools::data_view<storage_ijk_t> vt= gridtools::make_host_view(vt_);
-      std::array<int,3> vt_offsets{0,0,0};
-      gridtools::data_view<storage_ijk_t> gz= gridtools::make_host_view(gz_);
-      std::array<int,3> gz_offsets{0,0,0};
-      gridtools::data_view<storage_ijk_t> gz_x= gridtools::make_host_view(gz_x_);
-      std::array<int,3> gz_x_offsets{0,0,0};
-      gridtools::data_view<storage_ijk_t> gz_y= gridtools::make_host_view(gz_y_);
-      std::array<int,3> gz_y_offsets{0,0,0};
-      gridtools::data_view<storage_ijk_t> ws3= gridtools::make_host_view(ws3_);
-      std::array<int,3> ws3_offsets{0,0,0};
-      gridtools::data_view<storage_ijk_t> gz_0= gridtools::make_host_view(gz_0_);
-      std::array<int,3> gz_0_offsets{0,0,0};
-      gridtools::data_view<tmp_storage_t> xfx= gridtools::make_host_view(m_xfx);
-      std::array<int,3> xfx_offsets{0,0,0};
-      gridtools::data_view<tmp_storage_t> yfx= gridtools::make_host_view(m_yfx);
-      std::array<int,3> yfx_offsets{0,0,0};
-      gridtools::data_view<tmp_storage_t> fx= gridtools::make_host_view(m_fx);
-      std::array<int,3> fx_offsets{0,0,0};
-      gridtools::data_view<tmp_storage_t> fy= gridtools::make_host_view(m_fy);
-      std::array<int,3> fy_offsets{0,0,0};
-    for(int k = kMin + 0+0; k <= kMax + -1+0; ++k) {
-      for(int i = iMin+0; i  <=  iMax+0; ++i) {
-        for(int j = jMin+0; j  <=  jMax+0; ++j) {
-::dawn::float_type __local_gz_442 = (gz_0(i+0, j+0, k+1) + (::dawn::float_type) 2.0);
-gz(i+0, j+0, k+0) = ((gz(i+0, j+0, k+0) > __local_gz_442) ? gz(i+0, j+0, k+0) : __local_gz_442);
-        }      }    }}      dp_ref_.sync();
+      {
+        gridtools::data_view<storage_ijk_t> dp_ref = gridtools::make_host_view(dp_ref_);
+        std::array<int, 3> dp_ref_offsets{0, 0, 0};
+        gridtools::data_view<storage_ijk_t> zs = gridtools::make_host_view(zs_);
+        std::array<int, 3> zs_offsets{0, 0, 0};
+        gridtools::data_view<storage_ijk_t> area = gridtools::make_host_view(area_);
+        std::array<int, 3> area_offsets{0, 0, 0};
+        gridtools::data_view<storage_ijk_t> ut = gridtools::make_host_view(ut_);
+        std::array<int, 3> ut_offsets{0, 0, 0};
+        gridtools::data_view<storage_ijk_t> vt = gridtools::make_host_view(vt_);
+        std::array<int, 3> vt_offsets{0, 0, 0};
+        gridtools::data_view<storage_ijk_t> gz = gridtools::make_host_view(gz_);
+        std::array<int, 3> gz_offsets{0, 0, 0};
+        gridtools::data_view<storage_ijk_t> gz_x = gridtools::make_host_view(gz_x_);
+        std::array<int, 3> gz_x_offsets{0, 0, 0};
+        gridtools::data_view<storage_ijk_t> gz_y = gridtools::make_host_view(gz_y_);
+        std::array<int, 3> gz_y_offsets{0, 0, 0};
+        gridtools::data_view<storage_ijk_t> ws3 = gridtools::make_host_view(ws3_);
+        std::array<int, 3> ws3_offsets{0, 0, 0};
+        gridtools::data_view<storage_ijk_t> gz_0 = gridtools::make_host_view(gz_0_);
+        std::array<int, 3> gz_0_offsets{0, 0, 0};
+        gridtools::data_view<tmp_storage_t> xfx = gridtools::make_host_view(m_xfx);
+        std::array<int, 3> xfx_offsets{0, 0, 0};
+        gridtools::data_view<tmp_storage_t> yfx = gridtools::make_host_view(m_yfx);
+        std::array<int, 3> yfx_offsets{0, 0, 0};
+        gridtools::data_view<tmp_storage_t> fx = gridtools::make_host_view(m_fx);
+        std::array<int, 3> fx_offsets{0, 0, 0};
+        gridtools::data_view<tmp_storage_t> fy = gridtools::make_host_view(m_fy);
+        std::array<int, 3> fy_offsets{0, 0, 0};
+        for(int k = kMin + 0 + 0; k <= kMin + 1 + 0; ++k) {
+          for(int i = iMin + 0; i <= iMax + 1; ++i) {
+            for(int j = jMin + 0; j <= jMax + 1; ++j) {
+              ::dawn::float_type __local_ratio__d15_16_429 =
+                  (dp_ref(i + 0, j + 0, k + 0) /
+                   (dp_ref(i + 0, j + 0, k + 0) + dp_ref(i + 0, j + 0, k + 1)));
+              xfx(i + 0, j + 0, k + 0) =
+                  (ut(i + 0, j + 0, k + 0) + ((ut(i + 0, j + 0, k + 0) - ut(i + 0, j + 0, k + 1)) *
+                                              __local_ratio__d15_16_429));
+              ::dawn::float_type __local_ratio__d15_17_431 =
+                  (dp_ref(i + 0, j + 0, k + 0) /
+                   (dp_ref(i + 0, j + 0, k + 0) + dp_ref(i + 0, j + 0, k + 1)));
+              yfx(i + 0, j + 0, k + 0) =
+                  (vt(i + 0, j + 0, k + 0) + ((vt(i + 0, j + 0, k + 0) - vt(i + 0, j + 0, k + 1)) *
+                                              __local_ratio__d15_17_431));
+            }
+          }
+        }
+      }
+      {
+        gridtools::data_view<storage_ijk_t> dp_ref = gridtools::make_host_view(dp_ref_);
+        std::array<int, 3> dp_ref_offsets{0, 0, 0};
+        gridtools::data_view<storage_ijk_t> zs = gridtools::make_host_view(zs_);
+        std::array<int, 3> zs_offsets{0, 0, 0};
+        gridtools::data_view<storage_ijk_t> area = gridtools::make_host_view(area_);
+        std::array<int, 3> area_offsets{0, 0, 0};
+        gridtools::data_view<storage_ijk_t> ut = gridtools::make_host_view(ut_);
+        std::array<int, 3> ut_offsets{0, 0, 0};
+        gridtools::data_view<storage_ijk_t> vt = gridtools::make_host_view(vt_);
+        std::array<int, 3> vt_offsets{0, 0, 0};
+        gridtools::data_view<storage_ijk_t> gz = gridtools::make_host_view(gz_);
+        std::array<int, 3> gz_offsets{0, 0, 0};
+        gridtools::data_view<storage_ijk_t> gz_x = gridtools::make_host_view(gz_x_);
+        std::array<int, 3> gz_x_offsets{0, 0, 0};
+        gridtools::data_view<storage_ijk_t> gz_y = gridtools::make_host_view(gz_y_);
+        std::array<int, 3> gz_y_offsets{0, 0, 0};
+        gridtools::data_view<storage_ijk_t> ws3 = gridtools::make_host_view(ws3_);
+        std::array<int, 3> ws3_offsets{0, 0, 0};
+        gridtools::data_view<storage_ijk_t> gz_0 = gridtools::make_host_view(gz_0_);
+        std::array<int, 3> gz_0_offsets{0, 0, 0};
+        gridtools::data_view<tmp_storage_t> xfx = gridtools::make_host_view(m_xfx);
+        std::array<int, 3> xfx_offsets{0, 0, 0};
+        gridtools::data_view<tmp_storage_t> yfx = gridtools::make_host_view(m_yfx);
+        std::array<int, 3> yfx_offsets{0, 0, 0};
+        gridtools::data_view<tmp_storage_t> fx = gridtools::make_host_view(m_fx);
+        std::array<int, 3> fx_offsets{0, 0, 0};
+        gridtools::data_view<tmp_storage_t> fy = gridtools::make_host_view(m_fy);
+        std::array<int, 3> fy_offsets{0, 0, 0};
+        for(int k = kMax + -1 + 0; k <= kMax + 0 + 0; ++k) {
+          for(int i = iMin + 0; i <= iMax + 1; ++i) {
+            for(int j = jMin + 0; j <= jMax + 1; ++j) {
+              ::dawn::float_type __local_ratio__c74_19_433 =
+                  (dp_ref(i + 0, j + 0, k + -1) /
+                   (dp_ref(i + 0, j + 0, k + -2) + dp_ref(i + 0, j + 0, k + -1)));
+              xfx(i + 0, j + 0, k + 0) = (ut(i + 0, j + 0, k + -1) +
+                                          ((ut(i + 0, j + 0, k + -1) - ut(i + 0, j + 0, k + -2)) *
+                                           __local_ratio__c74_19_433));
+              ::dawn::float_type __local_ratio__c74_20_434 =
+                  (dp_ref(i + 0, j + 0, k + -1) /
+                   (dp_ref(i + 0, j + 0, k + -2) + dp_ref(i + 0, j + 0, k + -1)));
+              yfx(i + 0, j + 0, k + 0) = (vt(i + 0, j + 0, k + -1) +
+                                          ((vt(i + 0, j + 0, k + -1) - vt(i + 0, j + 0, k + -2)) *
+                                           __local_ratio__c74_20_434));
+            }
+          }
+        }
+      }
+      {
+        gridtools::data_view<storage_ijk_t> dp_ref = gridtools::make_host_view(dp_ref_);
+        std::array<int, 3> dp_ref_offsets{0, 0, 0};
+        gridtools::data_view<storage_ijk_t> zs = gridtools::make_host_view(zs_);
+        std::array<int, 3> zs_offsets{0, 0, 0};
+        gridtools::data_view<storage_ijk_t> area = gridtools::make_host_view(area_);
+        std::array<int, 3> area_offsets{0, 0, 0};
+        gridtools::data_view<storage_ijk_t> ut = gridtools::make_host_view(ut_);
+        std::array<int, 3> ut_offsets{0, 0, 0};
+        gridtools::data_view<storage_ijk_t> vt = gridtools::make_host_view(vt_);
+        std::array<int, 3> vt_offsets{0, 0, 0};
+        gridtools::data_view<storage_ijk_t> gz = gridtools::make_host_view(gz_);
+        std::array<int, 3> gz_offsets{0, 0, 0};
+        gridtools::data_view<storage_ijk_t> gz_x = gridtools::make_host_view(gz_x_);
+        std::array<int, 3> gz_x_offsets{0, 0, 0};
+        gridtools::data_view<storage_ijk_t> gz_y = gridtools::make_host_view(gz_y_);
+        std::array<int, 3> gz_y_offsets{0, 0, 0};
+        gridtools::data_view<storage_ijk_t> ws3 = gridtools::make_host_view(ws3_);
+        std::array<int, 3> ws3_offsets{0, 0, 0};
+        gridtools::data_view<storage_ijk_t> gz_0 = gridtools::make_host_view(gz_0_);
+        std::array<int, 3> gz_0_offsets{0, 0, 0};
+        gridtools::data_view<tmp_storage_t> xfx = gridtools::make_host_view(m_xfx);
+        std::array<int, 3> xfx_offsets{0, 0, 0};
+        gridtools::data_view<tmp_storage_t> yfx = gridtools::make_host_view(m_yfx);
+        std::array<int, 3> yfx_offsets{0, 0, 0};
+        gridtools::data_view<tmp_storage_t> fx = gridtools::make_host_view(m_fx);
+        std::array<int, 3> fx_offsets{0, 0, 0};
+        gridtools::data_view<tmp_storage_t> fy = gridtools::make_host_view(m_fy);
+        std::array<int, 3> fy_offsets{0, 0, 0};
+        for(int k = kMin + 1 + 0; k <= kMax + -1 + 0; ++k) {
+          for(int i = iMin + 0; i <= iMax + 1; ++i) {
+            for(int j = jMin + 0; j <= jMax + 1; ++j) {
+              ::dawn::float_type __local_int_ratio__330_22_435 =
+                  ((::dawn::float_type)1.0 /
+                   (dp_ref(i + 0, j + 0, k + -1) + dp_ref(i + 0, j + 0, k + 0)));
+              xfx(i + 0, j + 0, k + 0) =
+                  (((dp_ref(i + 0, j + 0, k + 0) * ut(i + 0, j + 0, k + -1)) +
+                    (dp_ref(i + 0, j + 0, k + -1) * ut(i + 0, j + 0, k + 0))) *
+                   __local_int_ratio__330_22_435);
+              ::dawn::float_type __local_int_ratio__330_23_436 =
+                  ((::dawn::float_type)1.0 /
+                   (dp_ref(i + 0, j + 0, k + -1) + dp_ref(i + 0, j + 0, k + 0)));
+              yfx(i + 0, j + 0, k + 0) =
+                  (((dp_ref(i + 0, j + 0, k + 0) * vt(i + 0, j + 0, k + -1)) +
+                    (dp_ref(i + 0, j + 0, k + -1) * vt(i + 0, j + 0, k + 0))) *
+                   __local_int_ratio__330_23_436);
+            }
+          }
+        }
+      }
+      {
+        gridtools::data_view<storage_ijk_t> dp_ref = gridtools::make_host_view(dp_ref_);
+        std::array<int, 3> dp_ref_offsets{0, 0, 0};
+        gridtools::data_view<storage_ijk_t> zs = gridtools::make_host_view(zs_);
+        std::array<int, 3> zs_offsets{0, 0, 0};
+        gridtools::data_view<storage_ijk_t> area = gridtools::make_host_view(area_);
+        std::array<int, 3> area_offsets{0, 0, 0};
+        gridtools::data_view<storage_ijk_t> ut = gridtools::make_host_view(ut_);
+        std::array<int, 3> ut_offsets{0, 0, 0};
+        gridtools::data_view<storage_ijk_t> vt = gridtools::make_host_view(vt_);
+        std::array<int, 3> vt_offsets{0, 0, 0};
+        gridtools::data_view<storage_ijk_t> gz = gridtools::make_host_view(gz_);
+        std::array<int, 3> gz_offsets{0, 0, 0};
+        gridtools::data_view<storage_ijk_t> gz_x = gridtools::make_host_view(gz_x_);
+        std::array<int, 3> gz_x_offsets{0, 0, 0};
+        gridtools::data_view<storage_ijk_t> gz_y = gridtools::make_host_view(gz_y_);
+        std::array<int, 3> gz_y_offsets{0, 0, 0};
+        gridtools::data_view<storage_ijk_t> ws3 = gridtools::make_host_view(ws3_);
+        std::array<int, 3> ws3_offsets{0, 0, 0};
+        gridtools::data_view<storage_ijk_t> gz_0 = gridtools::make_host_view(gz_0_);
+        std::array<int, 3> gz_0_offsets{0, 0, 0};
+        gridtools::data_view<tmp_storage_t> xfx = gridtools::make_host_view(m_xfx);
+        std::array<int, 3> xfx_offsets{0, 0, 0};
+        gridtools::data_view<tmp_storage_t> yfx = gridtools::make_host_view(m_yfx);
+        std::array<int, 3> yfx_offsets{0, 0, 0};
+        gridtools::data_view<tmp_storage_t> fx = gridtools::make_host_view(m_fx);
+        std::array<int, 3> fx_offsets{0, 0, 0};
+        gridtools::data_view<tmp_storage_t> fy = gridtools::make_host_view(m_fy);
+        std::array<int, 3> fy_offsets{0, 0, 0};
+        for(int k = kMin + 0 + 0; k <= kMax + 0 + 0; ++k) {
+          for(int i = iMin + 0; i <= iMax + 1; ++i) {
+            for(int j = jMin + 0; j <= jMax + 1; ++j) {
+              ::dawn::float_type __local_fx__389_25_437 =
+                  (xfx(i + 0, j + 0, k + 0) * ((xfx(i + 0, j + 0, k + 0) > (::dawn::float_type)0.0)
+                                                   ? gz_x(i + -1, j + 0, k + 0)
+                                                   : gz_x(i + 0, j + 0, k + 0)));
+              ::dawn::float_type __local_fy__389_25_438 =
+                  (yfx(i + 0, j + 0, k + 0) * ((yfx(i + 0, j + 0, k + 0) > (::dawn::float_type)0.0)
+                                                   ? gz_y(i + 0, j + -1, k + 0)
+                                                   : gz_y(i + 0, j + 0, k + 0)));
+              fx(i + 0, j + 0, k + 0) = __local_fx__389_25_437;
+              fy(i + 0, j + 0, k + 0) = __local_fy__389_25_438;
+            }
+          }
+          for(int i = iMin + 0; i <= iMax + 0; ++i) {
+            for(int j = jMin + 0; j <= jMax + 0; ++j) {
+              gz_0(i + 0, j + 0, k + 0) =
+                  ((((((gz_y(i + 0, j + 0, k + 0) * area(i + 0, j + 0, k + 0)) +
+                       fx(i + 0, j + 0, k + 0)) -
+                      fx(i + 1, j + 0, k + 0)) +
+                     fy(i + 0, j + 0, k + 0)) -
+                    fy(i + 0, j + 1, k + 0)) /
+                   ((((area(i + 0, j + 0, k + 0) + xfx(i + 0, j + 0, k + 0)) -
+                      xfx(i + 1, j + 0, k + 0)) +
+                     yfx(i + 0, j + 0, k + 0)) -
+                    yfx(i + 0, j + 1, k + 0)));
+            }
+          }
+        }
+      }
+      {
+        gridtools::data_view<storage_ijk_t> dp_ref = gridtools::make_host_view(dp_ref_);
+        std::array<int, 3> dp_ref_offsets{0, 0, 0};
+        gridtools::data_view<storage_ijk_t> zs = gridtools::make_host_view(zs_);
+        std::array<int, 3> zs_offsets{0, 0, 0};
+        gridtools::data_view<storage_ijk_t> area = gridtools::make_host_view(area_);
+        std::array<int, 3> area_offsets{0, 0, 0};
+        gridtools::data_view<storage_ijk_t> ut = gridtools::make_host_view(ut_);
+        std::array<int, 3> ut_offsets{0, 0, 0};
+        gridtools::data_view<storage_ijk_t> vt = gridtools::make_host_view(vt_);
+        std::array<int, 3> vt_offsets{0, 0, 0};
+        gridtools::data_view<storage_ijk_t> gz = gridtools::make_host_view(gz_);
+        std::array<int, 3> gz_offsets{0, 0, 0};
+        gridtools::data_view<storage_ijk_t> gz_x = gridtools::make_host_view(gz_x_);
+        std::array<int, 3> gz_x_offsets{0, 0, 0};
+        gridtools::data_view<storage_ijk_t> gz_y = gridtools::make_host_view(gz_y_);
+        std::array<int, 3> gz_y_offsets{0, 0, 0};
+        gridtools::data_view<storage_ijk_t> ws3 = gridtools::make_host_view(ws3_);
+        std::array<int, 3> ws3_offsets{0, 0, 0};
+        gridtools::data_view<storage_ijk_t> gz_0 = gridtools::make_host_view(gz_0_);
+        std::array<int, 3> gz_0_offsets{0, 0, 0};
+        gridtools::data_view<tmp_storage_t> xfx = gridtools::make_host_view(m_xfx);
+        std::array<int, 3> xfx_offsets{0, 0, 0};
+        gridtools::data_view<tmp_storage_t> yfx = gridtools::make_host_view(m_yfx);
+        std::array<int, 3> yfx_offsets{0, 0, 0};
+        gridtools::data_view<tmp_storage_t> fx = gridtools::make_host_view(m_fx);
+        std::array<int, 3> fx_offsets{0, 0, 0};
+        gridtools::data_view<tmp_storage_t> fy = gridtools::make_host_view(m_fy);
+        std::array<int, 3> fy_offsets{0, 0, 0};
+        for(int k = kMax + -1 + 0; k <= kMax + 0 + 0; ++k) {
+          for(int i = iMin + 0; i <= iMax + 0; ++i) {
+            for(int j = jMin + 0; j <= jMax + 0; ++j) {
+              gz_0(i + 0, j + 0, k + 0) = gz(i + 0, j + 0, k + 0);
+            }
+          }
+        }
+      }
+      {
+        gridtools::data_view<storage_ijk_t> dp_ref = gridtools::make_host_view(dp_ref_);
+        std::array<int, 3> dp_ref_offsets{0, 0, 0};
+        gridtools::data_view<storage_ijk_t> zs = gridtools::make_host_view(zs_);
+        std::array<int, 3> zs_offsets{0, 0, 0};
+        gridtools::data_view<storage_ijk_t> area = gridtools::make_host_view(area_);
+        std::array<int, 3> area_offsets{0, 0, 0};
+        gridtools::data_view<storage_ijk_t> ut = gridtools::make_host_view(ut_);
+        std::array<int, 3> ut_offsets{0, 0, 0};
+        gridtools::data_view<storage_ijk_t> vt = gridtools::make_host_view(vt_);
+        std::array<int, 3> vt_offsets{0, 0, 0};
+        gridtools::data_view<storage_ijk_t> gz = gridtools::make_host_view(gz_);
+        std::array<int, 3> gz_offsets{0, 0, 0};
+        gridtools::data_view<storage_ijk_t> gz_x = gridtools::make_host_view(gz_x_);
+        std::array<int, 3> gz_x_offsets{0, 0, 0};
+        gridtools::data_view<storage_ijk_t> gz_y = gridtools::make_host_view(gz_y_);
+        std::array<int, 3> gz_y_offsets{0, 0, 0};
+        gridtools::data_view<storage_ijk_t> ws3 = gridtools::make_host_view(ws3_);
+        std::array<int, 3> ws3_offsets{0, 0, 0};
+        gridtools::data_view<storage_ijk_t> gz_0 = gridtools::make_host_view(gz_0_);
+        std::array<int, 3> gz_0_offsets{0, 0, 0};
+        gridtools::data_view<tmp_storage_t> xfx = gridtools::make_host_view(m_xfx);
+        std::array<int, 3> xfx_offsets{0, 0, 0};
+        gridtools::data_view<tmp_storage_t> yfx = gridtools::make_host_view(m_yfx);
+        std::array<int, 3> yfx_offsets{0, 0, 0};
+        gridtools::data_view<tmp_storage_t> fx = gridtools::make_host_view(m_fx);
+        std::array<int, 3> fx_offsets{0, 0, 0};
+        gridtools::data_view<tmp_storage_t> fy = gridtools::make_host_view(m_fy);
+        std::array<int, 3> fy_offsets{0, 0, 0};
+        for(int k = kMax + -1 + 0; k <= kMax + 0 + 0; ++k) {
+          for(int i = iMin + 0; i <= iMax + 0; ++i) {
+            for(int j = jMin + 0; j <= jMax + 0; ++j) {
+              ws3(i + 0, j + 0, k + 0) = ((zs(i + 0, j + 0, k + 0) - gz_0(i + 0, j + 0, k + 0)) *
+                                          ((::dawn::float_type)1.0 / m_globals.dt));
+            }
+          }
+        }
+      }
+      {
+        gridtools::data_view<storage_ijk_t> dp_ref = gridtools::make_host_view(dp_ref_);
+        std::array<int, 3> dp_ref_offsets{0, 0, 0};
+        gridtools::data_view<storage_ijk_t> zs = gridtools::make_host_view(zs_);
+        std::array<int, 3> zs_offsets{0, 0, 0};
+        gridtools::data_view<storage_ijk_t> area = gridtools::make_host_view(area_);
+        std::array<int, 3> area_offsets{0, 0, 0};
+        gridtools::data_view<storage_ijk_t> ut = gridtools::make_host_view(ut_);
+        std::array<int, 3> ut_offsets{0, 0, 0};
+        gridtools::data_view<storage_ijk_t> vt = gridtools::make_host_view(vt_);
+        std::array<int, 3> vt_offsets{0, 0, 0};
+        gridtools::data_view<storage_ijk_t> gz = gridtools::make_host_view(gz_);
+        std::array<int, 3> gz_offsets{0, 0, 0};
+        gridtools::data_view<storage_ijk_t> gz_x = gridtools::make_host_view(gz_x_);
+        std::array<int, 3> gz_x_offsets{0, 0, 0};
+        gridtools::data_view<storage_ijk_t> gz_y = gridtools::make_host_view(gz_y_);
+        std::array<int, 3> gz_y_offsets{0, 0, 0};
+        gridtools::data_view<storage_ijk_t> ws3 = gridtools::make_host_view(ws3_);
+        std::array<int, 3> ws3_offsets{0, 0, 0};
+        gridtools::data_view<storage_ijk_t> gz_0 = gridtools::make_host_view(gz_0_);
+        std::array<int, 3> gz_0_offsets{0, 0, 0};
+        gridtools::data_view<tmp_storage_t> xfx = gridtools::make_host_view(m_xfx);
+        std::array<int, 3> xfx_offsets{0, 0, 0};
+        gridtools::data_view<tmp_storage_t> yfx = gridtools::make_host_view(m_yfx);
+        std::array<int, 3> yfx_offsets{0, 0, 0};
+        gridtools::data_view<tmp_storage_t> fx = gridtools::make_host_view(m_fx);
+        std::array<int, 3> fx_offsets{0, 0, 0};
+        gridtools::data_view<tmp_storage_t> fy = gridtools::make_host_view(m_fy);
+        std::array<int, 3> fy_offsets{0, 0, 0};
+        for(int k = kMin + 0 + 0; k <= kMax + -1 + 0; ++k) {
+          for(int i = iMin + 0; i <= iMax + 0; ++i) {
+            for(int j = jMin + 0; j <= jMax + 0; ++j) {
+              ::dawn::float_type __local_gz_442 =
+                  (gz_0(i + 0, j + 0, k + 1) + (::dawn::float_type)2.0);
+              gz(i + 0, j + 0, k + 0) =
+                  ((gz(i + 0, j + 0, k + 0) > __local_gz_442) ? gz(i + 0, j + 0, k + 0)
+                                                              : __local_gz_442);
+            }
+          }
+        }
+      }
+      dp_ref_.sync();
       zs_.sync();
       area_.sync();
       ut_.sync();
@@ -358,15 +444,18 @@ gz(i+0, j+0, k+0) = ((gz(i+0, j+0, k+0) > __local_gz_442) ? gz(i+0, j+0, k+0) : 
   static constexpr const char* s_name = "update_dz_c";
   globals m_globals;
   stencil_443 m_stencil_443;
-public:
 
+public:
   update_dz_c(const update_dz_c&) = delete;
 
   // Members
   gridtools::dawn::meta_data_t m_meta_data;
   gridtools::dawn::storage_t m_gz_0;
 
-  update_dz_c(const gridtools::dawn::domain& dom, int rank = 1, int xcols = 1, int ycols = 1) : m_stencil_443(dom, m_globals, rank, xcols, ycols), m_meta_data(dom.isize(), dom.jsize(), dom.ksize() /*+ 2 *0*/ + 1), m_gz_0 (m_meta_data, "gz_0"){
+  update_dz_c(const gridtools::dawn::domain& dom, int rank = 1, int xcols = 1, int ycols = 1)
+      : m_stencil_443(dom, m_globals, rank, xcols, ycols),
+        m_meta_data(dom.isize(), dom.jsize(), dom.ksize() /*+ 2 *0*/ + 1),
+        m_gz_0(m_meta_data, "gz_0") {
     assert(dom.isize() >= dom.iminus() + dom.iplus());
     assert(dom.jsize() >= dom.jminus() + dom.jplus());
     assert(dom.ksize() >= dom.kminus() + dom.kplus());
@@ -375,16 +464,14 @@ public:
 
   // Access-wrapper for globally defined variables
 
-  double get_dt() {
-    return m_globals.dt;
-  }
+  double get_dt() { return m_globals.dt; }
 
-  void set_dt(double dt) {
-    m_globals.dt=dt;
-  }
+  void set_dt(double dt) { m_globals.dt = dt; }
 
-  void run(storage_ijk_t dp_ref, storage_ijk_t zs, storage_ijk_t area, storage_ijk_t ut, storage_ijk_t vt, storage_ijk_t gz, storage_ijk_t gz_x, storage_ijk_t gz_y, storage_ijk_t ws3) {
-    m_stencil_443.run(dp_ref,zs,area,ut,vt,gz,gz_x,gz_y,ws3,m_gz_0);
+  void run(storage_ijk_t dp_ref, storage_ijk_t zs, storage_ijk_t area, storage_ijk_t ut,
+           storage_ijk_t vt, storage_ijk_t gz, storage_ijk_t gz_x, storage_ijk_t gz_y,
+           storage_ijk_t ws3) {
+    m_stencil_443.run(dp_ref, zs, area, ut, vt, gz, gz_x, gz_y, ws3, m_gz_0);
   }
 };
 } // namespace cxxnaive

--- a/dawn/test/unit-test/dawn/CodeGen/reference/update_dz_c.cu
+++ b/dawn/test/unit-test/dawn/CodeGen/reference/update_dz_c.cu
@@ -2,60 +2,67 @@
 #undef DAWN_BACKEND_T
 #define DAWN_BACKEND_T CUDA
 #ifndef BOOST_RESULT_OF_USE_TR1
- #define BOOST_RESULT_OF_USE_TR1 1
+#define BOOST_RESULT_OF_USE_TR1 1
 #endif
 #ifndef BOOST_NO_CXX11_DECLTYPE
- #define BOOST_NO_CXX11_DECLTYPE 1
+#define BOOST_NO_CXX11_DECLTYPE 1
 #endif
 #ifndef GRIDTOOLS_DAWN_HALO_EXTENT
- #define GRIDTOOLS_DAWN_HALO_EXTENT 3
+#define GRIDTOOLS_DAWN_HALO_EXTENT 3
 #endif
 #ifndef BOOST_PP_VARIADICS
- #define BOOST_PP_VARIADICS 1
+#define BOOST_PP_VARIADICS 1
 #endif
 #ifndef BOOST_FUSION_DONT_USE_PREPROCESSED_FILES
- #define BOOST_FUSION_DONT_USE_PREPROCESSED_FILES 1
+#define BOOST_FUSION_DONT_USE_PREPROCESSED_FILES 1
 #endif
 #ifndef BOOST_MPL_CFG_NO_PREPROCESSED_HEADERS
- #define BOOST_MPL_CFG_NO_PREPROCESSED_HEADERS 1
+#define BOOST_MPL_CFG_NO_PREPROCESSED_HEADERS 1
 #endif
 #ifndef GT_VECTOR_LIMIT_SIZE
- #define GT_VECTOR_LIMIT_SIZE 30
+#define GT_VECTOR_LIMIT_SIZE 30
 #endif
 #ifndef BOOST_FUSION_INVOKE_MAX_ARITY
- #define BOOST_FUSION_INVOKE_MAX_ARITY GT_VECTOR_LIMIT_SIZE
+#define BOOST_FUSION_INVOKE_MAX_ARITY GT_VECTOR_LIMIT_SIZE
 #endif
 #ifndef FUSION_MAX_VECTOR_SIZE
- #define FUSION_MAX_VECTOR_SIZE GT_VECTOR_LIMIT_SIZE
+#define FUSION_MAX_VECTOR_SIZE GT_VECTOR_LIMIT_SIZE
 #endif
 #ifndef FUSION_MAX_MAP_SIZE
- #define FUSION_MAX_MAP_SIZE GT_VECTOR_LIMIT_SIZE
+#define FUSION_MAX_MAP_SIZE GT_VECTOR_LIMIT_SIZE
 #endif
 #ifndef BOOST_MPL_LIMIT_VECTOR_SIZE
- #define BOOST_MPL_LIMIT_VECTOR_SIZE GT_VECTOR_LIMIT_SIZE
+#define BOOST_MPL_LIMIT_VECTOR_SIZE GT_VECTOR_LIMIT_SIZE
 #endif
 #include <driver-includes/gridtools_includes.hpp>
 using namespace gridtools::dawn;
-namespace dawn_generated{
-namespace cuda{
+namespace dawn_generated {
+namespace cuda {
 
 struct globals {
   double dt;
 
-  globals() : dt(0){
-  }
+  globals() : dt(0) {}
 };
 } // namespace cuda
 } // namespace dawn_generated
 
-
-namespace dawn_generated{
-namespace cuda{
-template<typename TmpStorage>__global__ void __launch_bounds__(192)  update_dz_c_stencil443_ms653_kernel(globals globals_, const int isize, const int jsize, const int ksize, const int stride_111_1, const int stride_111_2, const int tmpBeginIIndex, const int tmpBeginJIndex, const int jstride_tmp, const int kstride_tmp, ::dawn::float_type * const dp_ref, ::dawn::float_type * const ut, ::dawn::float_type * const vt, gridtools::data_view<TmpStorage>xfx_dv, gridtools::data_view<TmpStorage>yfx_dv) {
+namespace dawn_generated {
+namespace cuda {
+template <typename TmpStorage>
+__global__ void __launch_bounds__(192)
+    update_dz_c_stencil443_ms653_kernel(globals globals_, const int isize, const int jsize,
+                                        const int ksize, const int stride_111_1,
+                                        const int stride_111_2, const int tmpBeginIIndex,
+                                        const int tmpBeginJIndex, const int jstride_tmp,
+                                        const int kstride_tmp, ::dawn::float_type* const dp_ref,
+                                        ::dawn::float_type* const ut, ::dawn::float_type* const vt,
+                                        gridtools::data_view<TmpStorage> xfx_dv,
+                                        gridtools::data_view<TmpStorage> yfx_dv) {
 
   // Start kernel
-  ::dawn::float_type* xfx = &xfx_dv(tmpBeginIIndex,tmpBeginJIndex,blockIdx.x,blockIdx.y,0);
-  ::dawn::float_type* yfx = &yfx_dv(tmpBeginIIndex,tmpBeginJIndex,blockIdx.x,blockIdx.y,0);
+  ::dawn::float_type* xfx = &xfx_dv(tmpBeginIIndex, tmpBeginJIndex, blockIdx.x, blockIdx.y, 0);
+  ::dawn::float_type* yfx = &yfx_dv(tmpBeginIIndex, tmpBeginJIndex, blockIdx.x, blockIdx.y, 0);
   const unsigned int nx = isize;
   const unsigned int ny = jsize;
   const int block_size_i = (blockIdx.x + 1) * 32 < nx ? 32 : nx - blockIdx.x * 32;
@@ -90,42 +97,64 @@ template<typename TmpStorage>__global__ void __launch_bounds__(192)  update_dz_c
   // Regions (a,h,e) and (c,i,g) are executed by two specialized warp
   int iblock = 0 - 1;
   int jblock = 0 - 1;
-if(threadIdx.y < +5) {
+  if(threadIdx.y < +5) {
     iblock = threadIdx.x;
     jblock = (int)threadIdx.y + 0;
-}else if(threadIdx.y < 6) {
+  } else if(threadIdx.y < 6) {
     iblock = threadIdx.x % 1 + 32;
-    jblock = (int)threadIdx.x / 1+0;
-}
+    jblock = (int)threadIdx.x / 1 + 0;
+  }
   // initialized iterators
-  int idx111 = (blockIdx.x*32+iblock)*1+(blockIdx.y*4+jblock)*stride_111_1;
-  int idx_tmp = (iblock+0)*1 + (jblock+0)*jstride_tmp;
+  int idx111 = (blockIdx.x * 32 + iblock) * 1 + (blockIdx.y * 4 + jblock) * stride_111_1;
+  int idx_tmp = (iblock + 0) * 1 + (jblock + 0) * jstride_tmp;
 
-  // jump iterators to match the intersection of beginning of next interval and the parallel execution block
+  // jump iterators to match the intersection of beginning of next interval and the parallel
+  // execution block
   idx111 += max(0, blockIdx.z * 4) * stride_111_2;
 
-  // jump tmp iterators to match the intersection of beginning of next interval and the parallel execution block
+  // jump tmp iterators to match the intersection of beginning of next interval and the parallel
+  // execution block
   idx_tmp += max(0, blockIdx.z * 4) * kstride_tmp;
-  int kleg_lower_bound = max(0,blockIdx.z*4);
-  int kleg_upper_bound = min(1,(blockIdx.z+1)*4-1);;
-for(int k = kleg_lower_bound+0; k <= kleg_upper_bound+0; ++k) {
-  if(iblock >= 0 && iblock <= block_size_i -1 + 1 && jblock >= 0 && jblock <= block_size_j -1 + 1) {
-::dawn::float_type __local_ratio__d15_16_429 = (__ldg(&(dp_ref[idx111])) / (__ldg(&(dp_ref[idx111])) + __ldg(&(dp_ref[idx111+stride_111_2*1]))));
-xfx[idx_tmp] = (__ldg(&(ut[idx111])) + ((__ldg(&(ut[idx111])) - __ldg(&(ut[idx111+stride_111_2*1]))) * __local_ratio__d15_16_429));
-::dawn::float_type __local_ratio__d15_17_431 = (__ldg(&(dp_ref[idx111])) / (__ldg(&(dp_ref[idx111])) + __ldg(&(dp_ref[idx111+stride_111_2*1]))));
-yfx[idx_tmp] = (__ldg(&(vt[idx111])) + ((__ldg(&(vt[idx111])) - __ldg(&(vt[idx111+stride_111_2*1]))) * __local_ratio__d15_17_431));
-  }
+  int kleg_lower_bound = max(0, blockIdx.z * 4);
+  int kleg_upper_bound = min(1, (blockIdx.z + 1) * 4 - 1);
+  ;
+  for(int k = kleg_lower_bound + 0; k <= kleg_upper_bound + 0; ++k) {
+    if(iblock >= 0 && iblock <= block_size_i - 1 + 1 && jblock >= 0 &&
+       jblock <= block_size_j - 1 + 1) {
+      ::dawn::float_type __local_ratio__d15_16_429 =
+          (__ldg(&(dp_ref[idx111])) /
+           (__ldg(&(dp_ref[idx111])) + __ldg(&(dp_ref[idx111 + stride_111_2 * 1]))));
+      xfx[idx_tmp] = (__ldg(&(ut[idx111])) +
+                      ((__ldg(&(ut[idx111])) - __ldg(&(ut[idx111 + stride_111_2 * 1]))) *
+                       __local_ratio__d15_16_429));
+      ::dawn::float_type __local_ratio__d15_17_431 =
+          (__ldg(&(dp_ref[idx111])) /
+           (__ldg(&(dp_ref[idx111])) + __ldg(&(dp_ref[idx111 + stride_111_2 * 1]))));
+      yfx[idx_tmp] = (__ldg(&(vt[idx111])) +
+                      ((__ldg(&(vt[idx111])) - __ldg(&(vt[idx111 + stride_111_2 * 1]))) *
+                       __local_ratio__d15_17_431));
+    }
     // Slide kcaches
 
     // increment iterators
-    idx111+=stride_111_2;
+    idx111 += stride_111_2;
     idx_tmp += kstride_tmp;
-}}
-template<typename TmpStorage>__global__ void __launch_bounds__(192)  update_dz_c_stencil443_ms656_kernel(globals globals_, const int isize, const int jsize, const int ksize, const int stride_111_1, const int stride_111_2, const int tmpBeginIIndex, const int tmpBeginJIndex, const int jstride_tmp, const int kstride_tmp, ::dawn::float_type * const dp_ref, ::dawn::float_type * const ut, ::dawn::float_type * const vt, gridtools::data_view<TmpStorage>xfx_dv, gridtools::data_view<TmpStorage>yfx_dv) {
+  }
+}
+template <typename TmpStorage>
+__global__ void __launch_bounds__(192)
+    update_dz_c_stencil443_ms656_kernel(globals globals_, const int isize, const int jsize,
+                                        const int ksize, const int stride_111_1,
+                                        const int stride_111_2, const int tmpBeginIIndex,
+                                        const int tmpBeginJIndex, const int jstride_tmp,
+                                        const int kstride_tmp, ::dawn::float_type* const dp_ref,
+                                        ::dawn::float_type* const ut, ::dawn::float_type* const vt,
+                                        gridtools::data_view<TmpStorage> xfx_dv,
+                                        gridtools::data_view<TmpStorage> yfx_dv) {
 
   // Start kernel
-  ::dawn::float_type* xfx = &xfx_dv(tmpBeginIIndex,tmpBeginJIndex,blockIdx.x,blockIdx.y,0);
-  ::dawn::float_type* yfx = &yfx_dv(tmpBeginIIndex,tmpBeginJIndex,blockIdx.x,blockIdx.y,0);
+  ::dawn::float_type* xfx = &xfx_dv(tmpBeginIIndex, tmpBeginJIndex, blockIdx.x, blockIdx.y, 0);
+  ::dawn::float_type* yfx = &yfx_dv(tmpBeginIIndex, tmpBeginJIndex, blockIdx.x, blockIdx.y, 0);
   const unsigned int nx = isize;
   const unsigned int ny = jsize;
   const int block_size_i = (blockIdx.x + 1) * 32 < nx ? 32 : nx - blockIdx.x * 32;
@@ -160,42 +189,68 @@ template<typename TmpStorage>__global__ void __launch_bounds__(192)  update_dz_c
   // Regions (a,h,e) and (c,i,g) are executed by two specialized warp
   int iblock = 0 - 1;
   int jblock = 0 - 1;
-if(threadIdx.y < +5) {
+  if(threadIdx.y < +5) {
     iblock = threadIdx.x;
     jblock = (int)threadIdx.y + 0;
-}else if(threadIdx.y < 6) {
+  } else if(threadIdx.y < 6) {
     iblock = threadIdx.x % 1 + 32;
-    jblock = (int)threadIdx.x / 1+0;
-}
-  // initialized iterators
-  int idx111 = (blockIdx.x*32+iblock)*1+(blockIdx.y*4+jblock)*stride_111_1;
-  int idx_tmp = (iblock+0)*1 + (jblock+0)*jstride_tmp;
-
-  // jump iterators to match the intersection of beginning of next interval and the parallel execution block
-  idx111 += max(ksize - 1+-1, blockIdx.z * 4) * stride_111_2;
-
-  // jump tmp iterators to match the intersection of beginning of next interval and the parallel execution block
-  idx_tmp += max(ksize - 1+-1, blockIdx.z * 4) * kstride_tmp;
-  int kleg_lower_bound = max( ksize - 1 + -1,blockIdx.z*4);
-  int kleg_upper_bound = min( ksize - 1 + 0,(blockIdx.z+1)*4-1);;
-for(int k = kleg_lower_bound+0; k <= kleg_upper_bound+0; ++k) {
-  if(iblock >= 0 && iblock <= block_size_i -1 + 1 && jblock >= 0 && jblock <= block_size_j -1 + 1) {
-::dawn::float_type __local_ratio__c74_19_433 = (__ldg(&(dp_ref[idx111+stride_111_2*-1])) / (__ldg(&(dp_ref[idx111+stride_111_2*-2])) + __ldg(&(dp_ref[idx111+stride_111_2*-1]))));
-xfx[idx_tmp] = (__ldg(&(ut[idx111+stride_111_2*-1])) + ((__ldg(&(ut[idx111+stride_111_2*-1])) - __ldg(&(ut[idx111+stride_111_2*-2]))) * __local_ratio__c74_19_433));
-::dawn::float_type __local_ratio__c74_20_434 = (__ldg(&(dp_ref[idx111+stride_111_2*-1])) / (__ldg(&(dp_ref[idx111+stride_111_2*-2])) + __ldg(&(dp_ref[idx111+stride_111_2*-1]))));
-yfx[idx_tmp] = (__ldg(&(vt[idx111+stride_111_2*-1])) + ((__ldg(&(vt[idx111+stride_111_2*-1])) - __ldg(&(vt[idx111+stride_111_2*-2]))) * __local_ratio__c74_20_434));
+    jblock = (int)threadIdx.x / 1 + 0;
   }
+  // initialized iterators
+  int idx111 = (blockIdx.x * 32 + iblock) * 1 + (blockIdx.y * 4 + jblock) * stride_111_1;
+  int idx_tmp = (iblock + 0) * 1 + (jblock + 0) * jstride_tmp;
+
+  // jump iterators to match the intersection of beginning of next interval and the parallel
+  // execution block
+  idx111 += max(ksize - 1 + -1, blockIdx.z * 4) * stride_111_2;
+
+  // jump tmp iterators to match the intersection of beginning of next interval and the parallel
+  // execution block
+  idx_tmp += max(ksize - 1 + -1, blockIdx.z * 4) * kstride_tmp;
+  int kleg_lower_bound = max(ksize - 1 + -1, blockIdx.z * 4);
+  int kleg_upper_bound = min(ksize - 1 + 0, (blockIdx.z + 1) * 4 - 1);
+  ;
+  for(int k = kleg_lower_bound + 0; k <= kleg_upper_bound + 0; ++k) {
+    if(iblock >= 0 && iblock <= block_size_i - 1 + 1 && jblock >= 0 &&
+       jblock <= block_size_j - 1 + 1) {
+      ::dawn::float_type __local_ratio__c74_19_433 =
+          (__ldg(&(dp_ref[idx111 + stride_111_2 * -1])) /
+           (__ldg(&(dp_ref[idx111 + stride_111_2 * -2])) +
+            __ldg(&(dp_ref[idx111 + stride_111_2 * -1]))));
+      xfx[idx_tmp] =
+          (__ldg(&(ut[idx111 + stride_111_2 * -1])) +
+           ((__ldg(&(ut[idx111 + stride_111_2 * -1])) - __ldg(&(ut[idx111 + stride_111_2 * -2]))) *
+            __local_ratio__c74_19_433));
+      ::dawn::float_type __local_ratio__c74_20_434 =
+          (__ldg(&(dp_ref[idx111 + stride_111_2 * -1])) /
+           (__ldg(&(dp_ref[idx111 + stride_111_2 * -2])) +
+            __ldg(&(dp_ref[idx111 + stride_111_2 * -1]))));
+      yfx[idx_tmp] =
+          (__ldg(&(vt[idx111 + stride_111_2 * -1])) +
+           ((__ldg(&(vt[idx111 + stride_111_2 * -1])) - __ldg(&(vt[idx111 + stride_111_2 * -2]))) *
+            __local_ratio__c74_20_434));
+    }
     // Slide kcaches
 
     // increment iterators
-    idx111+=stride_111_2;
+    idx111 += stride_111_2;
     idx_tmp += kstride_tmp;
-}}
-template<typename TmpStorage>__global__ void __launch_bounds__(192)  update_dz_c_stencil443_ms659_kernel(globals globals_, const int isize, const int jsize, const int ksize, const int stride_111_1, const int stride_111_2, const int tmpBeginIIndex, const int tmpBeginJIndex, const int jstride_tmp, const int kstride_tmp, ::dawn::float_type * const dp_ref, ::dawn::float_type * const ut, ::dawn::float_type * const vt, gridtools::data_view<TmpStorage>xfx_dv, gridtools::data_view<TmpStorage>yfx_dv) {
+  }
+}
+template <typename TmpStorage>
+__global__ void __launch_bounds__(192)
+    update_dz_c_stencil443_ms659_kernel(globals globals_, const int isize, const int jsize,
+                                        const int ksize, const int stride_111_1,
+                                        const int stride_111_2, const int tmpBeginIIndex,
+                                        const int tmpBeginJIndex, const int jstride_tmp,
+                                        const int kstride_tmp, ::dawn::float_type* const dp_ref,
+                                        ::dawn::float_type* const ut, ::dawn::float_type* const vt,
+                                        gridtools::data_view<TmpStorage> xfx_dv,
+                                        gridtools::data_view<TmpStorage> yfx_dv) {
 
   // Start kernel
-  ::dawn::float_type* xfx = &xfx_dv(tmpBeginIIndex,tmpBeginJIndex,blockIdx.x,blockIdx.y,0);
-  ::dawn::float_type* yfx = &yfx_dv(tmpBeginIIndex,tmpBeginJIndex,blockIdx.x,blockIdx.y,0);
+  ::dawn::float_type* xfx = &xfx_dv(tmpBeginIIndex, tmpBeginJIndex, blockIdx.x, blockIdx.y, 0);
+  ::dawn::float_type* yfx = &yfx_dv(tmpBeginIIndex, tmpBeginJIndex, blockIdx.x, blockIdx.y, 0);
   const unsigned int nx = isize;
   const unsigned int ny = jsize;
   const int block_size_i = (blockIdx.x + 1) * 32 < nx ? 32 : nx - blockIdx.x * 32;
@@ -230,44 +285,64 @@ template<typename TmpStorage>__global__ void __launch_bounds__(192)  update_dz_c
   // Regions (a,h,e) and (c,i,g) are executed by two specialized warp
   int iblock = 0 - 1;
   int jblock = 0 - 1;
-if(threadIdx.y < +5) {
+  if(threadIdx.y < +5) {
     iblock = threadIdx.x;
     jblock = (int)threadIdx.y + 0;
-}else if(threadIdx.y < 6) {
+  } else if(threadIdx.y < 6) {
     iblock = threadIdx.x % 1 + 32;
-    jblock = (int)threadIdx.x / 1+0;
-}
+    jblock = (int)threadIdx.x / 1 + 0;
+  }
   // initialized iterators
-  int idx111 = (blockIdx.x*32+iblock)*1+(blockIdx.y*4+jblock)*stride_111_1;
-  int idx_tmp = (iblock+0)*1 + (jblock+0)*jstride_tmp;
+  int idx111 = (blockIdx.x * 32 + iblock) * 1 + (blockIdx.y * 4 + jblock) * stride_111_1;
+  int idx_tmp = (iblock + 0) * 1 + (jblock + 0) * jstride_tmp;
 
-  // jump iterators to match the intersection of beginning of next interval and the parallel execution block
+  // jump iterators to match the intersection of beginning of next interval and the parallel
+  // execution block
   idx111 += max(1, blockIdx.z * 4) * stride_111_2;
 
-  // jump tmp iterators to match the intersection of beginning of next interval and the parallel execution block
+  // jump tmp iterators to match the intersection of beginning of next interval and the parallel
+  // execution block
   idx_tmp += max(1, blockIdx.z * 4) * kstride_tmp;
-  int kleg_lower_bound = max(1,blockIdx.z*4);
-  int kleg_upper_bound = min( ksize - 1 + -1,(blockIdx.z+1)*4-1);;
-for(int k = kleg_lower_bound+0; k <= kleg_upper_bound+0; ++k) {
-  if(iblock >= 0 && iblock <= block_size_i -1 + 1 && jblock >= 0 && jblock <= block_size_j -1 + 1) {
-::dawn::float_type __local_int_ratio__330_22_435 = ((::dawn::float_type) 1.0 / (__ldg(&(dp_ref[idx111+stride_111_2*-1])) + __ldg(&(dp_ref[idx111]))));
-xfx[idx_tmp] = (((__ldg(&(dp_ref[idx111])) * __ldg(&(ut[idx111+stride_111_2*-1]))) + (__ldg(&(dp_ref[idx111+stride_111_2*-1])) * __ldg(&(ut[idx111])))) * __local_int_ratio__330_22_435);
-::dawn::float_type __local_int_ratio__330_23_436 = ((::dawn::float_type) 1.0 / (__ldg(&(dp_ref[idx111+stride_111_2*-1])) + __ldg(&(dp_ref[idx111]))));
-yfx[idx_tmp] = (((__ldg(&(dp_ref[idx111])) * __ldg(&(vt[idx111+stride_111_2*-1]))) + (__ldg(&(dp_ref[idx111+stride_111_2*-1])) * __ldg(&(vt[idx111])))) * __local_int_ratio__330_23_436);
-  }
+  int kleg_lower_bound = max(1, blockIdx.z * 4);
+  int kleg_upper_bound = min(ksize - 1 + -1, (blockIdx.z + 1) * 4 - 1);
+  ;
+  for(int k = kleg_lower_bound + 0; k <= kleg_upper_bound + 0; ++k) {
+    if(iblock >= 0 && iblock <= block_size_i - 1 + 1 && jblock >= 0 &&
+       jblock <= block_size_j - 1 + 1) {
+      ::dawn::float_type __local_int_ratio__330_22_435 =
+          ((::dawn::float_type)1.0 /
+           (__ldg(&(dp_ref[idx111 + stride_111_2 * -1])) + __ldg(&(dp_ref[idx111]))));
+      xfx[idx_tmp] = (((__ldg(&(dp_ref[idx111])) * __ldg(&(ut[idx111 + stride_111_2 * -1]))) +
+                       (__ldg(&(dp_ref[idx111 + stride_111_2 * -1])) * __ldg(&(ut[idx111])))) *
+                      __local_int_ratio__330_22_435);
+      ::dawn::float_type __local_int_ratio__330_23_436 =
+          ((::dawn::float_type)1.0 /
+           (__ldg(&(dp_ref[idx111 + stride_111_2 * -1])) + __ldg(&(dp_ref[idx111]))));
+      yfx[idx_tmp] = (((__ldg(&(dp_ref[idx111])) * __ldg(&(vt[idx111 + stride_111_2 * -1]))) +
+                       (__ldg(&(dp_ref[idx111 + stride_111_2 * -1])) * __ldg(&(vt[idx111])))) *
+                      __local_int_ratio__330_23_436);
+    }
     // Slide kcaches
 
     // increment iterators
-    idx111+=stride_111_2;
+    idx111 += stride_111_2;
     idx_tmp += kstride_tmp;
-}}
-template<typename TmpStorage>__global__ void __launch_bounds__(192)  update_dz_c_stencil443_ms664_kernel(globals globals_, const int isize, const int jsize, const int ksize, const int stride_111_1, const int stride_111_2, const int tmpBeginIIndex, const int tmpBeginJIndex, const int jstride_tmp, const int kstride_tmp, ::dawn::float_type * const area, ::dawn::float_type * const gz_x, ::dawn::float_type * const gz_y, ::dawn::float_type * const gz_0, gridtools::data_view<TmpStorage>xfx_dv, gridtools::data_view<TmpStorage>yfx_dv, gridtools::data_view<TmpStorage>fx_dv, gridtools::data_view<TmpStorage>fy_dv) {
+  }
+}
+template <typename TmpStorage>
+__global__ void __launch_bounds__(192) update_dz_c_stencil443_ms664_kernel(
+    globals globals_, const int isize, const int jsize, const int ksize, const int stride_111_1,
+    const int stride_111_2, const int tmpBeginIIndex, const int tmpBeginJIndex,
+    const int jstride_tmp, const int kstride_tmp, ::dawn::float_type* const area,
+    ::dawn::float_type* const gz_x, ::dawn::float_type* const gz_y, ::dawn::float_type* const gz_0,
+    gridtools::data_view<TmpStorage> xfx_dv, gridtools::data_view<TmpStorage> yfx_dv,
+    gridtools::data_view<TmpStorage> fx_dv, gridtools::data_view<TmpStorage> fy_dv) {
 
   // Start kernel
-  ::dawn::float_type* xfx = &xfx_dv(tmpBeginIIndex,tmpBeginJIndex,blockIdx.x,blockIdx.y,0);
-  ::dawn::float_type* yfx = &yfx_dv(tmpBeginIIndex,tmpBeginJIndex,blockIdx.x,blockIdx.y,0);
-  ::dawn::float_type* fx = &fx_dv(tmpBeginIIndex,tmpBeginJIndex,blockIdx.x,blockIdx.y,0);
-  ::dawn::float_type* fy = &fy_dv(tmpBeginIIndex,tmpBeginJIndex,blockIdx.x,blockIdx.y,0);
+  ::dawn::float_type* xfx = &xfx_dv(tmpBeginIIndex, tmpBeginJIndex, blockIdx.x, blockIdx.y, 0);
+  ::dawn::float_type* yfx = &yfx_dv(tmpBeginIIndex, tmpBeginJIndex, blockIdx.x, blockIdx.y, 0);
+  ::dawn::float_type* fx = &fx_dv(tmpBeginIIndex, tmpBeginJIndex, blockIdx.x, blockIdx.y, 0);
+  ::dawn::float_type* fy = &fy_dv(tmpBeginIIndex, tmpBeginJIndex, blockIdx.x, blockIdx.y, 0);
   const unsigned int nx = isize;
   const unsigned int ny = jsize;
   const int block_size_i = (blockIdx.x + 1) * 32 < nx ? 32 : nx - blockIdx.x * 32;
@@ -302,40 +377,64 @@ template<typename TmpStorage>__global__ void __launch_bounds__(192)  update_dz_c
   // Regions (a,h,e) and (c,i,g) are executed by two specialized warp
   int iblock = 0 - 1;
   int jblock = 0 - 1;
-if(threadIdx.y < +5) {
+  if(threadIdx.y < +5) {
     iblock = threadIdx.x;
     jblock = (int)threadIdx.y + 0;
-}else if(threadIdx.y < 6) {
+  } else if(threadIdx.y < 6) {
     iblock = threadIdx.x % 1 + 32;
-    jblock = (int)threadIdx.x / 1+0;
-}
+    jblock = (int)threadIdx.x / 1 + 0;
+  }
   // initialized iterators
-  int idx111 = (blockIdx.x*32+iblock)*1+(blockIdx.y*4+jblock)*stride_111_1;
-  int idx_tmp = (iblock+0)*1 + (jblock+0)*jstride_tmp;
+  int idx111 = (blockIdx.x * 32 + iblock) * 1 + (blockIdx.y * 4 + jblock) * stride_111_1;
+  int idx_tmp = (iblock + 0) * 1 + (jblock + 0) * jstride_tmp;
 
-  // jump iterators to match the intersection of beginning of next interval and the parallel execution block
+  // jump iterators to match the intersection of beginning of next interval and the parallel
+  // execution block
   idx111 += max(0, blockIdx.z * 4) * stride_111_2;
 
-  // jump tmp iterators to match the intersection of beginning of next interval and the parallel execution block
+  // jump tmp iterators to match the intersection of beginning of next interval and the parallel
+  // execution block
   idx_tmp += max(0, blockIdx.z * 4) * kstride_tmp;
-  int kleg_lower_bound = max(0,blockIdx.z*4);
-  int kleg_upper_bound = min( ksize - 1 + 0,(blockIdx.z+1)*4-1);;
-for(int k = kleg_lower_bound+0; k <= kleg_upper_bound+0; ++k) {
-  if(iblock >= 0 && iblock <= block_size_i -1 + 1 && jblock >= 0 && jblock <= block_size_j -1 + 1) {
-::dawn::float_type __local_fx__389_25_437 = (__ldg(&(xfx[idx_tmp])) * ((__ldg(&(xfx[idx_tmp])) > (::dawn::float_type) 0.0) ? __ldg(&(gz_x[idx111+1*-1])) : __ldg(&(gz_x[idx111]))));
-::dawn::float_type __local_fy__389_25_438 = (__ldg(&(yfx[idx_tmp])) * ((__ldg(&(yfx[idx_tmp])) > (::dawn::float_type) 0.0) ? __ldg(&(gz_y[idx111+stride_111_1*-1])) : __ldg(&(gz_y[idx111]))));
-fx[idx_tmp] = __local_fx__389_25_437;
-fy[idx_tmp] = __local_fy__389_25_438;
-  }  if(iblock >= 0 && iblock <= block_size_i -1 + 0 && jblock >= 0 && jblock <= block_size_j -1 + 0) {
-gz_0[idx111] = ((((((__ldg(&(gz_y[idx111])) * __ldg(&(area[idx111]))) + fx[idx_tmp]) - fx[idx_tmp+1*1]) + fy[idx_tmp]) - fy[idx_tmp+jstride_tmp*1]) / ((((__ldg(&(area[idx111])) + __ldg(&(xfx[idx_tmp]))) - __ldg(&(xfx[idx_tmp+1*1]))) + __ldg(&(yfx[idx_tmp]))) - __ldg(&(yfx[idx_tmp+jstride_tmp*1]))));
-  }
+  int kleg_lower_bound = max(0, blockIdx.z * 4);
+  int kleg_upper_bound = min(ksize - 1 + 0, (blockIdx.z + 1) * 4 - 1);
+  ;
+  for(int k = kleg_lower_bound + 0; k <= kleg_upper_bound + 0; ++k) {
+    if(iblock >= 0 && iblock <= block_size_i - 1 + 1 && jblock >= 0 &&
+       jblock <= block_size_j - 1 + 1) {
+      ::dawn::float_type __local_fx__389_25_437 =
+          (__ldg(&(xfx[idx_tmp])) * ((__ldg(&(xfx[idx_tmp])) > (::dawn::float_type)0.0)
+                                         ? __ldg(&(gz_x[idx111 + 1 * -1]))
+                                         : __ldg(&(gz_x[idx111]))));
+      ::dawn::float_type __local_fy__389_25_438 =
+          (__ldg(&(yfx[idx_tmp])) * ((__ldg(&(yfx[idx_tmp])) > (::dawn::float_type)0.0)
+                                         ? __ldg(&(gz_y[idx111 + stride_111_1 * -1]))
+                                         : __ldg(&(gz_y[idx111]))));
+      fx[idx_tmp] = __local_fx__389_25_437;
+      fy[idx_tmp] = __local_fy__389_25_438;
+    }
+    if(iblock >= 0 && iblock <= block_size_i - 1 + 0 && jblock >= 0 &&
+       jblock <= block_size_j - 1 + 0) {
+      gz_0[idx111] =
+          ((((((__ldg(&(gz_y[idx111])) * __ldg(&(area[idx111]))) + fx[idx_tmp]) -
+              fx[idx_tmp + 1 * 1]) +
+             fy[idx_tmp]) -
+            fy[idx_tmp + jstride_tmp * 1]) /
+           ((((__ldg(&(area[idx111])) + __ldg(&(xfx[idx_tmp]))) - __ldg(&(xfx[idx_tmp + 1 * 1]))) +
+             __ldg(&(yfx[idx_tmp]))) -
+            __ldg(&(yfx[idx_tmp + jstride_tmp * 1]))));
+    }
     // Slide kcaches
 
     // increment iterators
-    idx111+=stride_111_2;
+    idx111 += stride_111_2;
     idx_tmp += kstride_tmp;
-}}
-__global__ void __launch_bounds__(128)  update_dz_c_stencil443_ms789_kernel(globals globals_, const int isize, const int jsize, const int ksize, const int stride_111_1, const int stride_111_2, ::dawn::float_type * const gz, ::dawn::float_type * const gz_0) {
+  }
+}
+__global__ void __launch_bounds__(128)
+    update_dz_c_stencil443_ms789_kernel(globals globals_, const int isize, const int jsize,
+                                        const int ksize, const int stride_111_1,
+                                        const int stride_111_2, ::dawn::float_type* const gz,
+                                        ::dawn::float_type* const gz_0) {
 
   // Start kernel
   const unsigned int nx = isize;
@@ -372,27 +471,36 @@ __global__ void __launch_bounds__(128)  update_dz_c_stencil443_ms789_kernel(glob
   // Regions (a,h,e) and (c,i,g) are executed by two specialized warp
   int iblock = 0 - 1;
   int jblock = 0 - 1;
-if(threadIdx.y < +4) {
+  if(threadIdx.y < +4) {
     iblock = threadIdx.x;
     jblock = (int)threadIdx.y + 0;
-}
-  // initialized iterators
-  int idx111 = (blockIdx.x*32+iblock)*1+(blockIdx.y*4+jblock)*stride_111_1;
-
-  // jump iterators to match the intersection of beginning of next interval and the parallel execution block
-  idx111 += max(ksize - 1+-1, blockIdx.z * 4) * stride_111_2;
-  int kleg_lower_bound = max( ksize - 1 + -1,blockIdx.z*4);
-  int kleg_upper_bound = min( ksize - 1 + 0,(blockIdx.z+1)*4-1);;
-for(int k = kleg_lower_bound+0; k <= kleg_upper_bound+0; ++k) {
-  if(iblock >= 0 && iblock <= block_size_i -1 + 0 && jblock >= 0 && jblock <= block_size_j -1 + 0) {
-gz_0[idx111] = __ldg(&(gz[idx111]));
   }
+  // initialized iterators
+  int idx111 = (blockIdx.x * 32 + iblock) * 1 + (blockIdx.y * 4 + jblock) * stride_111_1;
+
+  // jump iterators to match the intersection of beginning of next interval and the parallel
+  // execution block
+  idx111 += max(ksize - 1 + -1, blockIdx.z * 4) * stride_111_2;
+  int kleg_lower_bound = max(ksize - 1 + -1, blockIdx.z * 4);
+  int kleg_upper_bound = min(ksize - 1 + 0, (blockIdx.z + 1) * 4 - 1);
+  ;
+  for(int k = kleg_lower_bound + 0; k <= kleg_upper_bound + 0; ++k) {
+    if(iblock >= 0 && iblock <= block_size_i - 1 + 0 && jblock >= 0 &&
+       jblock <= block_size_j - 1 + 0) {
+      gz_0[idx111] = __ldg(&(gz[idx111]));
+    }
     // Slide kcaches
 
     // increment iterators
-    idx111+=stride_111_2;
-}}
-__global__ void __launch_bounds__(128)  update_dz_c_stencil443_ms669_kernel(globals globals_, const int isize, const int jsize, const int ksize, const int stride_111_1, const int stride_111_2, ::dawn::float_type * const zs, ::dawn::float_type * const ws3, ::dawn::float_type * const gz_0) {
+    idx111 += stride_111_2;
+  }
+}
+__global__ void __launch_bounds__(128)
+    update_dz_c_stencil443_ms669_kernel(globals globals_, const int isize, const int jsize,
+                                        const int ksize, const int stride_111_1,
+                                        const int stride_111_2, ::dawn::float_type* const zs,
+                                        ::dawn::float_type* const ws3,
+                                        ::dawn::float_type* const gz_0) {
 
   // Start kernel
   const unsigned int nx = isize;
@@ -429,27 +537,36 @@ __global__ void __launch_bounds__(128)  update_dz_c_stencil443_ms669_kernel(glob
   // Regions (a,h,e) and (c,i,g) are executed by two specialized warp
   int iblock = 0 - 1;
   int jblock = 0 - 1;
-if(threadIdx.y < +4) {
+  if(threadIdx.y < +4) {
     iblock = threadIdx.x;
     jblock = (int)threadIdx.y + 0;
-}
-  // initialized iterators
-  int idx111 = (blockIdx.x*32+iblock)*1+(blockIdx.y*4+jblock)*stride_111_1;
-
-  // jump iterators to match the intersection of beginning of next interval and the parallel execution block
-  idx111 += max(ksize - 1+-1, blockIdx.z * 4) * stride_111_2;
-  int kleg_lower_bound = max( ksize - 1 + -1,blockIdx.z*4);
-  int kleg_upper_bound = min( ksize - 1 + 0,(blockIdx.z+1)*4-1);;
-for(int k = kleg_lower_bound+0; k <= kleg_upper_bound+0; ++k) {
-  if(iblock >= 0 && iblock <= block_size_i -1 + 0 && jblock >= 0 && jblock <= block_size_j -1 + 0) {
-ws3[idx111] = ((__ldg(&(zs[idx111])) - __ldg(&(gz_0[idx111]))) * ((::dawn::float_type) 1.0 / globals_.dt));
   }
+  // initialized iterators
+  int idx111 = (blockIdx.x * 32 + iblock) * 1 + (blockIdx.y * 4 + jblock) * stride_111_1;
+
+  // jump iterators to match the intersection of beginning of next interval and the parallel
+  // execution block
+  idx111 += max(ksize - 1 + -1, blockIdx.z * 4) * stride_111_2;
+  int kleg_lower_bound = max(ksize - 1 + -1, blockIdx.z * 4);
+  int kleg_upper_bound = min(ksize - 1 + 0, (blockIdx.z + 1) * 4 - 1);
+  ;
+  for(int k = kleg_lower_bound + 0; k <= kleg_upper_bound + 0; ++k) {
+    if(iblock >= 0 && iblock <= block_size_i - 1 + 0 && jblock >= 0 &&
+       jblock <= block_size_j - 1 + 0) {
+      ws3[idx111] = ((__ldg(&(zs[idx111])) - __ldg(&(gz_0[idx111]))) *
+                     ((::dawn::float_type)1.0 / globals_.dt));
+    }
     // Slide kcaches
 
     // increment iterators
-    idx111+=stride_111_2;
-}}
-__global__ void __launch_bounds__(128)  update_dz_c_stencil443_ms673_kernel(globals globals_, const int isize, const int jsize, const int ksize, const int stride_111_1, const int stride_111_2, ::dawn::float_type * const gz, ::dawn::float_type * const gz_0) {
+    idx111 += stride_111_2;
+  }
+}
+__global__ void __launch_bounds__(128)
+    update_dz_c_stencil443_ms673_kernel(globals globals_, const int isize, const int jsize,
+                                        const int ksize, const int stride_111_1,
+                                        const int stride_111_2, ::dawn::float_type* const gz,
+                                        ::dawn::float_type* const gz_0) {
 
   // Start kernel
   const unsigned int nx = isize;
@@ -486,38 +603,40 @@ __global__ void __launch_bounds__(128)  update_dz_c_stencil443_ms673_kernel(glob
   // Regions (a,h,e) and (c,i,g) are executed by two specialized warp
   int iblock = 0 - 1;
   int jblock = 0 - 1;
-if(threadIdx.y < +4) {
+  if(threadIdx.y < +4) {
     iblock = threadIdx.x;
     jblock = (int)threadIdx.y + 0;
-}
+  }
   // initialized iterators
-  int idx111 = (blockIdx.x*32+iblock)*1+(blockIdx.y*4+jblock)*stride_111_1;
+  int idx111 = (blockIdx.x * 32 + iblock) * 1 + (blockIdx.y * 4 + jblock) * stride_111_1;
 
-  // jump iterators to match the intersection of beginning of next interval and the parallel execution block
+  // jump iterators to match the intersection of beginning of next interval and the parallel
+  // execution block
   idx111 += max(0, blockIdx.z * 4) * stride_111_2;
-  int kleg_lower_bound = max(0,blockIdx.z*4);
-  int kleg_upper_bound = min( ksize - 1 + -1,(blockIdx.z+1)*4-1);;
-for(int k = kleg_lower_bound+0; k <= kleg_upper_bound+0; ++k) {
-  if(iblock >= 0 && iblock <= block_size_i -1 + 0 && jblock >= 0 && jblock <= block_size_j -1 + 0) {
-::dawn::float_type __local_gz_442 = (__ldg(&(gz_0[idx111+stride_111_2*1])) + (::dawn::float_type) 2.0);
-gz[idx111] = ((gz[idx111] > __local_gz_442) ? gz[idx111] : __local_gz_442);
-  }
+  int kleg_lower_bound = max(0, blockIdx.z * 4);
+  int kleg_upper_bound = min(ksize - 1 + -1, (blockIdx.z + 1) * 4 - 1);
+  ;
+  for(int k = kleg_lower_bound + 0; k <= kleg_upper_bound + 0; ++k) {
+    if(iblock >= 0 && iblock <= block_size_i - 1 + 0 && jblock >= 0 &&
+       jblock <= block_size_j - 1 + 0) {
+      ::dawn::float_type __local_gz_442 =
+          (__ldg(&(gz_0[idx111 + stride_111_2 * 1])) + (::dawn::float_type)2.0);
+      gz[idx111] = ((gz[idx111] > __local_gz_442) ? gz[idx111] : __local_gz_442);
+    }
     // Slide kcaches
 
     // increment iterators
-    idx111+=stride_111_2;
-}}
+    idx111 += stride_111_2;
+  }
+}
 
 class update_dz_c {
 public:
-
   struct sbase : public timer_cuda {
 
-    sbase(std::string name) : timer_cuda(name){}
+    sbase(std::string name) : timer_cuda(name) {}
 
-    double get_time() {
-      return total_time();
-    }
+    double get_time() { return total_time(); }
   };
 
   struct stencil_443 : public sbase {
@@ -525,9 +644,9 @@ public:
     // Members
 
     // Temporary storage typedefs
-    using tmp_halo_t = gridtools::halo< 0,0, 0, 0, 0>;
-    using tmp_meta_data_t = storage_traits_t::storage_info_t< 0, 5, tmp_halo_t >;
-    using tmp_storage_t = storage_traits_t::data_store_t< ::dawn::float_type, tmp_meta_data_t>;
+    using tmp_halo_t = gridtools::halo<0, 0, 0, 0, 0>;
+    using tmp_meta_data_t = storage_traits_t::storage_info_t<0, 5, tmp_halo_t>;
+    using tmp_storage_t = storage_traits_t::data_store_t<::dawn::float_type, tmp_meta_data_t>;
     globals& m_globals;
     const gridtools::dawn::domain m_dom;
 
@@ -537,130 +656,202 @@ public:
     tmp_storage_t m_yfx;
     tmp_storage_t m_fx;
     tmp_storage_t m_fy;
+
   public:
+    stencil_443(const gridtools::dawn::domain& dom_, globals& globals_, int rank, int xcols,
+                int ycols)
+        : sbase("stencil_443"), m_dom(dom_), m_globals(globals_),
+          m_tmp_meta_data(32 + 1, 4 + 1, (dom_.isize() + 32 - 1) / 32, (dom_.jsize() + 4 - 1) / 4,
+                          dom_.ksize() + 2 * 0),
+          m_xfx(m_tmp_meta_data), m_yfx(m_tmp_meta_data), m_fx(m_tmp_meta_data),
+          m_fy(m_tmp_meta_data) {}
+    static constexpr ::dawn::driver::cartesian_extent dp_ref_extent = {0, 1, 0, 1, -2, 1};
+    static constexpr ::dawn::driver::cartesian_extent zs_extent = {0, 0, 0, 0, 0, 0};
+    static constexpr ::dawn::driver::cartesian_extent area_extent = {0, 0, 0, 0, 0, 0};
+    static constexpr ::dawn::driver::cartesian_extent ut_extent = {0, 1, 0, 1, -2, 1};
+    static constexpr ::dawn::driver::cartesian_extent vt_extent = {0, 1, 0, 1, -2, 1};
+    static constexpr ::dawn::driver::cartesian_extent gz_extent = {0, 0, 0, 0, 0, 0};
+    static constexpr ::dawn::driver::cartesian_extent gz_x_extent = {-1, 1, 0, 1, 0, 0};
+    static constexpr ::dawn::driver::cartesian_extent gz_y_extent = {0, 1, -1, 1, 0, 0};
+    static constexpr ::dawn::driver::cartesian_extent ws3_extent = {0, 0, 0, 0, 0, 0};
+    static constexpr ::dawn::driver::cartesian_extent gz_0_extent = {0, 0, 0, 0, 0, 1};
 
-    stencil_443(const gridtools::dawn::domain& dom_, globals& globals_, int rank, int xcols, int ycols) : sbase("stencil_443"), m_dom(dom_), m_globals(globals_), m_tmp_meta_data(32+1, 4+1, (dom_.isize()+ 32 - 1) / 32, (dom_.jsize()+ 4 - 1) / 4, dom_.ksize() + 2 * 0), m_xfx(m_tmp_meta_data), m_yfx(m_tmp_meta_data), m_fx(m_tmp_meta_data), m_fy(m_tmp_meta_data){}
-    static constexpr ::dawn::driver::cartesian_extent dp_ref_extent = {0,1, 0,1, -2,1};
-    static constexpr ::dawn::driver::cartesian_extent zs_extent = {0,0, 0,0, 0,0};
-    static constexpr ::dawn::driver::cartesian_extent area_extent = {0,0, 0,0, 0,0};
-    static constexpr ::dawn::driver::cartesian_extent ut_extent = {0,1, 0,1, -2,1};
-    static constexpr ::dawn::driver::cartesian_extent vt_extent = {0,1, 0,1, -2,1};
-    static constexpr ::dawn::driver::cartesian_extent gz_extent = {0,0, 0,0, 0,0};
-    static constexpr ::dawn::driver::cartesian_extent gz_x_extent = {-1,1, 0,1, 0,0};
-    static constexpr ::dawn::driver::cartesian_extent gz_y_extent = {0,1, -1,1, 0,0};
-    static constexpr ::dawn::driver::cartesian_extent ws3_extent = {0,0, 0,0, 0,0};
-    static constexpr ::dawn::driver::cartesian_extent gz_0_extent = {0,0, 0,0, 0,1};
-
-    void run(storage_ijk_t dp_ref_ds, storage_ijk_t zs_ds, storage_ijk_t area_ds, storage_ijk_t ut_ds, storage_ijk_t vt_ds, storage_ijk_t gz_ds, storage_ijk_t gz_x_ds, storage_ijk_t gz_y_ds, storage_ijk_t ws3_ds, storage_ijk_t gz_0_ds) {
+    void run(storage_ijk_t dp_ref_ds, storage_ijk_t zs_ds, storage_ijk_t area_ds,
+             storage_ijk_t ut_ds, storage_ijk_t vt_ds, storage_ijk_t gz_ds, storage_ijk_t gz_x_ds,
+             storage_ijk_t gz_y_ds, storage_ijk_t ws3_ds, storage_ijk_t gz_0_ds) {
 
       // starting timers
       start();
-      {;
-      gridtools::data_view<storage_ijk_t> dp_ref= gridtools::make_device_view(dp_ref_ds);
-      gridtools::data_view<storage_ijk_t> ut= gridtools::make_device_view(ut_ds);
-      gridtools::data_view<storage_ijk_t> vt= gridtools::make_device_view(vt_ds);
-      gridtools::data_view<tmp_storage_t> xfx= gridtools::make_device_view( m_xfx);
-      gridtools::data_view<tmp_storage_t> yfx= gridtools::make_device_view( m_yfx);
-      const unsigned int nx = m_dom.isize() - m_dom.iminus() - m_dom.iplus();
-      const unsigned int ny = m_dom.jsize() - m_dom.jminus() - m_dom.jplus();
-      const unsigned int nz = m_dom.ksize() - m_dom.kminus() - m_dom.kplus();
-      dim3 threads(32,4+2,1);
-      const unsigned int nbx = (nx + 32 - 1) / 32;
-      const unsigned int nby = (ny + 4 - 1) / 4;
-      const unsigned int nbz = (m_dom.ksize()+4-1) / 4;
-      dim3 blocks(nbx, nby, nbz);
-      update_dz_c_stencil443_ms653_kernel<<<blocks, threads>>>(m_globals,nx,ny,nz,dp_ref_ds.strides()[1],dp_ref_ds.strides()[2],m_xfx.get_storage_info_ptr()->template begin<0>(),m_xfx.get_storage_info_ptr()->template begin<1>(),m_xfx.get_storage_info_ptr()->template stride<1>(),m_xfx.get_storage_info_ptr()->template stride<4>(),(dp_ref.data()+dp_ref_ds.get_storage_info_ptr()->index(dp_ref.begin<0>(), dp_ref.begin<1>(),0 )),(ut.data()+ut_ds.get_storage_info_ptr()->index(ut.begin<0>(), ut.begin<1>(),0 )),(vt.data()+vt_ds.get_storage_info_ptr()->index(vt.begin<0>(), vt.begin<1>(),0 )),xfx,yfx);
+      {
+        ;
+        gridtools::data_view<storage_ijk_t> dp_ref = gridtools::make_device_view(dp_ref_ds);
+        gridtools::data_view<storage_ijk_t> ut = gridtools::make_device_view(ut_ds);
+        gridtools::data_view<storage_ijk_t> vt = gridtools::make_device_view(vt_ds);
+        gridtools::data_view<tmp_storage_t> xfx = gridtools::make_device_view(m_xfx);
+        gridtools::data_view<tmp_storage_t> yfx = gridtools::make_device_view(m_yfx);
+        const unsigned int nx = m_dom.isize() - m_dom.iminus() - m_dom.iplus();
+        const unsigned int ny = m_dom.jsize() - m_dom.jminus() - m_dom.jplus();
+        const unsigned int nz = m_dom.ksize() - m_dom.kminus() - m_dom.kplus();
+        dim3 threads(32, 4 + 2, 1);
+        const unsigned int nbx = (nx + 32 - 1) / 32;
+        const unsigned int nby = (ny + 4 - 1) / 4;
+        const unsigned int nbz = (m_dom.ksize() + 4 - 1) / 4;
+        dim3 blocks(nbx, nby, nbz);
+        update_dz_c_stencil443_ms653_kernel<<<blocks, threads>>>(
+            m_globals, nx, ny, nz, dp_ref_ds.strides()[1], dp_ref_ds.strides()[2],
+            m_xfx.get_storage_info_ptr()->template begin<0>(),
+            m_xfx.get_storage_info_ptr()->template begin<1>(),
+            m_xfx.get_storage_info_ptr()->template stride<1>(),
+            m_xfx.get_storage_info_ptr()->template stride<4>(),
+            (dp_ref.data() +
+             dp_ref_ds.get_storage_info_ptr()->index(dp_ref.begin<0>(), dp_ref.begin<1>(), 0)),
+            (ut.data() + ut_ds.get_storage_info_ptr()->index(ut.begin<0>(), ut.begin<1>(), 0)),
+            (vt.data() + vt_ds.get_storage_info_ptr()->index(vt.begin<0>(), vt.begin<1>(), 0)), xfx,
+            yfx);
       };
-      {;
-      gridtools::data_view<storage_ijk_t> dp_ref= gridtools::make_device_view(dp_ref_ds);
-      gridtools::data_view<storage_ijk_t> ut= gridtools::make_device_view(ut_ds);
-      gridtools::data_view<storage_ijk_t> vt= gridtools::make_device_view(vt_ds);
-      gridtools::data_view<tmp_storage_t> xfx= gridtools::make_device_view( m_xfx);
-      gridtools::data_view<tmp_storage_t> yfx= gridtools::make_device_view( m_yfx);
-      const unsigned int nx = m_dom.isize() - m_dom.iminus() - m_dom.iplus();
-      const unsigned int ny = m_dom.jsize() - m_dom.jminus() - m_dom.jplus();
-      const unsigned int nz = m_dom.ksize() - m_dom.kminus() - m_dom.kplus();
-      dim3 threads(32,4+2,1);
-      const unsigned int nbx = (nx + 32 - 1) / 32;
-      const unsigned int nby = (ny + 4 - 1) / 4;
-      const unsigned int nbz = (m_dom.ksize()+4-1) / 4;
-      dim3 blocks(nbx, nby, nbz);
-      update_dz_c_stencil443_ms656_kernel<<<blocks, threads>>>(m_globals,nx,ny,nz,dp_ref_ds.strides()[1],dp_ref_ds.strides()[2],m_xfx.get_storage_info_ptr()->template begin<0>(),m_xfx.get_storage_info_ptr()->template begin<1>(),m_xfx.get_storage_info_ptr()->template stride<1>(),m_xfx.get_storage_info_ptr()->template stride<4>(),(dp_ref.data()+dp_ref_ds.get_storage_info_ptr()->index(dp_ref.begin<0>(), dp_ref.begin<1>(),0 )),(ut.data()+ut_ds.get_storage_info_ptr()->index(ut.begin<0>(), ut.begin<1>(),0 )),(vt.data()+vt_ds.get_storage_info_ptr()->index(vt.begin<0>(), vt.begin<1>(),0 )),xfx,yfx);
+      {
+        ;
+        gridtools::data_view<storage_ijk_t> dp_ref = gridtools::make_device_view(dp_ref_ds);
+        gridtools::data_view<storage_ijk_t> ut = gridtools::make_device_view(ut_ds);
+        gridtools::data_view<storage_ijk_t> vt = gridtools::make_device_view(vt_ds);
+        gridtools::data_view<tmp_storage_t> xfx = gridtools::make_device_view(m_xfx);
+        gridtools::data_view<tmp_storage_t> yfx = gridtools::make_device_view(m_yfx);
+        const unsigned int nx = m_dom.isize() - m_dom.iminus() - m_dom.iplus();
+        const unsigned int ny = m_dom.jsize() - m_dom.jminus() - m_dom.jplus();
+        const unsigned int nz = m_dom.ksize() - m_dom.kminus() - m_dom.kplus();
+        dim3 threads(32, 4 + 2, 1);
+        const unsigned int nbx = (nx + 32 - 1) / 32;
+        const unsigned int nby = (ny + 4 - 1) / 4;
+        const unsigned int nbz = (m_dom.ksize() + 4 - 1) / 4;
+        dim3 blocks(nbx, nby, nbz);
+        update_dz_c_stencil443_ms656_kernel<<<blocks, threads>>>(
+            m_globals, nx, ny, nz, dp_ref_ds.strides()[1], dp_ref_ds.strides()[2],
+            m_xfx.get_storage_info_ptr()->template begin<0>(),
+            m_xfx.get_storage_info_ptr()->template begin<1>(),
+            m_xfx.get_storage_info_ptr()->template stride<1>(),
+            m_xfx.get_storage_info_ptr()->template stride<4>(),
+            (dp_ref.data() +
+             dp_ref_ds.get_storage_info_ptr()->index(dp_ref.begin<0>(), dp_ref.begin<1>(), 0)),
+            (ut.data() + ut_ds.get_storage_info_ptr()->index(ut.begin<0>(), ut.begin<1>(), 0)),
+            (vt.data() + vt_ds.get_storage_info_ptr()->index(vt.begin<0>(), vt.begin<1>(), 0)), xfx,
+            yfx);
       };
-      {;
-      gridtools::data_view<storage_ijk_t> dp_ref= gridtools::make_device_view(dp_ref_ds);
-      gridtools::data_view<storage_ijk_t> ut= gridtools::make_device_view(ut_ds);
-      gridtools::data_view<storage_ijk_t> vt= gridtools::make_device_view(vt_ds);
-      gridtools::data_view<tmp_storage_t> xfx= gridtools::make_device_view( m_xfx);
-      gridtools::data_view<tmp_storage_t> yfx= gridtools::make_device_view( m_yfx);
-      const unsigned int nx = m_dom.isize() - m_dom.iminus() - m_dom.iplus();
-      const unsigned int ny = m_dom.jsize() - m_dom.jminus() - m_dom.jplus();
-      const unsigned int nz = m_dom.ksize() - m_dom.kminus() - m_dom.kplus();
-      dim3 threads(32,4+2,1);
-      const unsigned int nbx = (nx + 32 - 1) / 32;
-      const unsigned int nby = (ny + 4 - 1) / 4;
-      const unsigned int nbz = (m_dom.ksize()+4-1) / 4;
-      dim3 blocks(nbx, nby, nbz);
-      update_dz_c_stencil443_ms659_kernel<<<blocks, threads>>>(m_globals,nx,ny,nz,dp_ref_ds.strides()[1],dp_ref_ds.strides()[2],m_xfx.get_storage_info_ptr()->template begin<0>(),m_xfx.get_storage_info_ptr()->template begin<1>(),m_xfx.get_storage_info_ptr()->template stride<1>(),m_xfx.get_storage_info_ptr()->template stride<4>(),(dp_ref.data()+dp_ref_ds.get_storage_info_ptr()->index(dp_ref.begin<0>(), dp_ref.begin<1>(),0 )),(ut.data()+ut_ds.get_storage_info_ptr()->index(ut.begin<0>(), ut.begin<1>(),0 )),(vt.data()+vt_ds.get_storage_info_ptr()->index(vt.begin<0>(), vt.begin<1>(),0 )),xfx,yfx);
+      {
+        ;
+        gridtools::data_view<storage_ijk_t> dp_ref = gridtools::make_device_view(dp_ref_ds);
+        gridtools::data_view<storage_ijk_t> ut = gridtools::make_device_view(ut_ds);
+        gridtools::data_view<storage_ijk_t> vt = gridtools::make_device_view(vt_ds);
+        gridtools::data_view<tmp_storage_t> xfx = gridtools::make_device_view(m_xfx);
+        gridtools::data_view<tmp_storage_t> yfx = gridtools::make_device_view(m_yfx);
+        const unsigned int nx = m_dom.isize() - m_dom.iminus() - m_dom.iplus();
+        const unsigned int ny = m_dom.jsize() - m_dom.jminus() - m_dom.jplus();
+        const unsigned int nz = m_dom.ksize() - m_dom.kminus() - m_dom.kplus();
+        dim3 threads(32, 4 + 2, 1);
+        const unsigned int nbx = (nx + 32 - 1) / 32;
+        const unsigned int nby = (ny + 4 - 1) / 4;
+        const unsigned int nbz = (m_dom.ksize() + 4 - 1) / 4;
+        dim3 blocks(nbx, nby, nbz);
+        update_dz_c_stencil443_ms659_kernel<<<blocks, threads>>>(
+            m_globals, nx, ny, nz, dp_ref_ds.strides()[1], dp_ref_ds.strides()[2],
+            m_xfx.get_storage_info_ptr()->template begin<0>(),
+            m_xfx.get_storage_info_ptr()->template begin<1>(),
+            m_xfx.get_storage_info_ptr()->template stride<1>(),
+            m_xfx.get_storage_info_ptr()->template stride<4>(),
+            (dp_ref.data() +
+             dp_ref_ds.get_storage_info_ptr()->index(dp_ref.begin<0>(), dp_ref.begin<1>(), 0)),
+            (ut.data() + ut_ds.get_storage_info_ptr()->index(ut.begin<0>(), ut.begin<1>(), 0)),
+            (vt.data() + vt_ds.get_storage_info_ptr()->index(vt.begin<0>(), vt.begin<1>(), 0)), xfx,
+            yfx);
       };
-      {;
-      gridtools::data_view<storage_ijk_t> area= gridtools::make_device_view(area_ds);
-      gridtools::data_view<storage_ijk_t> gz_x= gridtools::make_device_view(gz_x_ds);
-      gridtools::data_view<storage_ijk_t> gz_y= gridtools::make_device_view(gz_y_ds);
-      gridtools::data_view<storage_ijk_t> gz_0= gridtools::make_device_view(gz_0_ds);
-      gridtools::data_view<tmp_storage_t> xfx= gridtools::make_device_view( m_xfx);
-      gridtools::data_view<tmp_storage_t> yfx= gridtools::make_device_view( m_yfx);
-      gridtools::data_view<tmp_storage_t> fx= gridtools::make_device_view( m_fx);
-      gridtools::data_view<tmp_storage_t> fy= gridtools::make_device_view( m_fy);
-      const unsigned int nx = m_dom.isize() - m_dom.iminus() - m_dom.iplus();
-      const unsigned int ny = m_dom.jsize() - m_dom.jminus() - m_dom.jplus();
-      const unsigned int nz = m_dom.ksize() - m_dom.kminus() - m_dom.kplus();
-      dim3 threads(32,4+2,1);
-      const unsigned int nbx = (nx + 32 - 1) / 32;
-      const unsigned int nby = (ny + 4 - 1) / 4;
-      const unsigned int nbz = (m_dom.ksize()+4-1) / 4;
-      dim3 blocks(nbx, nby, nbz);
-      update_dz_c_stencil443_ms664_kernel<<<blocks, threads>>>(m_globals,nx,ny,nz,area_ds.strides()[1],area_ds.strides()[2],m_xfx.get_storage_info_ptr()->template begin<0>(),m_xfx.get_storage_info_ptr()->template begin<1>(),m_xfx.get_storage_info_ptr()->template stride<1>(),m_xfx.get_storage_info_ptr()->template stride<4>(),(area.data()+area_ds.get_storage_info_ptr()->index(area.begin<0>(), area.begin<1>(),0 )),(gz_x.data()+gz_x_ds.get_storage_info_ptr()->index(gz_x.begin<0>(), gz_x.begin<1>(),0 )),(gz_y.data()+gz_y_ds.get_storage_info_ptr()->index(gz_y.begin<0>(), gz_y.begin<1>(),0 )),(gz_0.data()+gz_0_ds.get_storage_info_ptr()->index(gz_0.begin<0>(), gz_0.begin<1>(),0 )),xfx,yfx,fx,fy);
+      {
+        ;
+        gridtools::data_view<storage_ijk_t> area = gridtools::make_device_view(area_ds);
+        gridtools::data_view<storage_ijk_t> gz_x = gridtools::make_device_view(gz_x_ds);
+        gridtools::data_view<storage_ijk_t> gz_y = gridtools::make_device_view(gz_y_ds);
+        gridtools::data_view<storage_ijk_t> gz_0 = gridtools::make_device_view(gz_0_ds);
+        gridtools::data_view<tmp_storage_t> xfx = gridtools::make_device_view(m_xfx);
+        gridtools::data_view<tmp_storage_t> yfx = gridtools::make_device_view(m_yfx);
+        gridtools::data_view<tmp_storage_t> fx = gridtools::make_device_view(m_fx);
+        gridtools::data_view<tmp_storage_t> fy = gridtools::make_device_view(m_fy);
+        const unsigned int nx = m_dom.isize() - m_dom.iminus() - m_dom.iplus();
+        const unsigned int ny = m_dom.jsize() - m_dom.jminus() - m_dom.jplus();
+        const unsigned int nz = m_dom.ksize() - m_dom.kminus() - m_dom.kplus();
+        dim3 threads(32, 4 + 2, 1);
+        const unsigned int nbx = (nx + 32 - 1) / 32;
+        const unsigned int nby = (ny + 4 - 1) / 4;
+        const unsigned int nbz = (m_dom.ksize() + 4 - 1) / 4;
+        dim3 blocks(nbx, nby, nbz);
+        update_dz_c_stencil443_ms664_kernel<<<blocks, threads>>>(
+            m_globals, nx, ny, nz, area_ds.strides()[1], area_ds.strides()[2],
+            m_xfx.get_storage_info_ptr()->template begin<0>(),
+            m_xfx.get_storage_info_ptr()->template begin<1>(),
+            m_xfx.get_storage_info_ptr()->template stride<1>(),
+            m_xfx.get_storage_info_ptr()->template stride<4>(),
+            (area.data() +
+             area_ds.get_storage_info_ptr()->index(area.begin<0>(), area.begin<1>(), 0)),
+            (gz_x.data() +
+             gz_x_ds.get_storage_info_ptr()->index(gz_x.begin<0>(), gz_x.begin<1>(), 0)),
+            (gz_y.data() +
+             gz_y_ds.get_storage_info_ptr()->index(gz_y.begin<0>(), gz_y.begin<1>(), 0)),
+            (gz_0.data() +
+             gz_0_ds.get_storage_info_ptr()->index(gz_0.begin<0>(), gz_0.begin<1>(), 0)),
+            xfx, yfx, fx, fy);
       };
-      {;
-      gridtools::data_view<storage_ijk_t> gz= gridtools::make_device_view(gz_ds);
-      gridtools::data_view<storage_ijk_t> gz_0= gridtools::make_device_view(gz_0_ds);
-      const unsigned int nx = m_dom.isize() - m_dom.iminus() - m_dom.iplus();
-      const unsigned int ny = m_dom.jsize() - m_dom.jminus() - m_dom.jplus();
-      const unsigned int nz = m_dom.ksize() - m_dom.kminus() - m_dom.kplus();
-      dim3 threads(32,4+0,1);
-      const unsigned int nbx = (nx + 32 - 1) / 32;
-      const unsigned int nby = (ny + 4 - 1) / 4;
-      const unsigned int nbz = (m_dom.ksize()+4-1) / 4;
-      dim3 blocks(nbx, nby, nbz);
-      update_dz_c_stencil443_ms789_kernel<<<blocks, threads>>>(m_globals,nx,ny,nz,gz_ds.strides()[1],gz_ds.strides()[2],(gz.data()+gz_ds.get_storage_info_ptr()->index(gz.begin<0>(), gz.begin<1>(),0 )),(gz_0.data()+gz_0_ds.get_storage_info_ptr()->index(gz_0.begin<0>(), gz_0.begin<1>(),0 )));
+      {
+        ;
+        gridtools::data_view<storage_ijk_t> gz = gridtools::make_device_view(gz_ds);
+        gridtools::data_view<storage_ijk_t> gz_0 = gridtools::make_device_view(gz_0_ds);
+        const unsigned int nx = m_dom.isize() - m_dom.iminus() - m_dom.iplus();
+        const unsigned int ny = m_dom.jsize() - m_dom.jminus() - m_dom.jplus();
+        const unsigned int nz = m_dom.ksize() - m_dom.kminus() - m_dom.kplus();
+        dim3 threads(32, 4 + 0, 1);
+        const unsigned int nbx = (nx + 32 - 1) / 32;
+        const unsigned int nby = (ny + 4 - 1) / 4;
+        const unsigned int nbz = (m_dom.ksize() + 4 - 1) / 4;
+        dim3 blocks(nbx, nby, nbz);
+        update_dz_c_stencil443_ms789_kernel<<<blocks, threads>>>(
+            m_globals, nx, ny, nz, gz_ds.strides()[1], gz_ds.strides()[2],
+            (gz.data() + gz_ds.get_storage_info_ptr()->index(gz.begin<0>(), gz.begin<1>(), 0)),
+            (gz_0.data() +
+             gz_0_ds.get_storage_info_ptr()->index(gz_0.begin<0>(), gz_0.begin<1>(), 0)));
       };
-      {;
-      gridtools::data_view<storage_ijk_t> zs= gridtools::make_device_view(zs_ds);
-      gridtools::data_view<storage_ijk_t> ws3= gridtools::make_device_view(ws3_ds);
-      gridtools::data_view<storage_ijk_t> gz_0= gridtools::make_device_view(gz_0_ds);
-      const unsigned int nx = m_dom.isize() - m_dom.iminus() - m_dom.iplus();
-      const unsigned int ny = m_dom.jsize() - m_dom.jminus() - m_dom.jplus();
-      const unsigned int nz = m_dom.ksize() - m_dom.kminus() - m_dom.kplus();
-      dim3 threads(32,4+0,1);
-      const unsigned int nbx = (nx + 32 - 1) / 32;
-      const unsigned int nby = (ny + 4 - 1) / 4;
-      const unsigned int nbz = (m_dom.ksize()+4-1) / 4;
-      dim3 blocks(nbx, nby, nbz);
-      update_dz_c_stencil443_ms669_kernel<<<blocks, threads>>>(m_globals,nx,ny,nz,zs_ds.strides()[1],zs_ds.strides()[2],(zs.data()+zs_ds.get_storage_info_ptr()->index(zs.begin<0>(), zs.begin<1>(),0 )),(ws3.data()+ws3_ds.get_storage_info_ptr()->index(ws3.begin<0>(), ws3.begin<1>(),0 )),(gz_0.data()+gz_0_ds.get_storage_info_ptr()->index(gz_0.begin<0>(), gz_0.begin<1>(),0 )));
+      {
+        ;
+        gridtools::data_view<storage_ijk_t> zs = gridtools::make_device_view(zs_ds);
+        gridtools::data_view<storage_ijk_t> ws3 = gridtools::make_device_view(ws3_ds);
+        gridtools::data_view<storage_ijk_t> gz_0 = gridtools::make_device_view(gz_0_ds);
+        const unsigned int nx = m_dom.isize() - m_dom.iminus() - m_dom.iplus();
+        const unsigned int ny = m_dom.jsize() - m_dom.jminus() - m_dom.jplus();
+        const unsigned int nz = m_dom.ksize() - m_dom.kminus() - m_dom.kplus();
+        dim3 threads(32, 4 + 0, 1);
+        const unsigned int nbx = (nx + 32 - 1) / 32;
+        const unsigned int nby = (ny + 4 - 1) / 4;
+        const unsigned int nbz = (m_dom.ksize() + 4 - 1) / 4;
+        dim3 blocks(nbx, nby, nbz);
+        update_dz_c_stencil443_ms669_kernel<<<blocks, threads>>>(
+            m_globals, nx, ny, nz, zs_ds.strides()[1], zs_ds.strides()[2],
+            (zs.data() + zs_ds.get_storage_info_ptr()->index(zs.begin<0>(), zs.begin<1>(), 0)),
+            (ws3.data() + ws3_ds.get_storage_info_ptr()->index(ws3.begin<0>(), ws3.begin<1>(), 0)),
+            (gz_0.data() +
+             gz_0_ds.get_storage_info_ptr()->index(gz_0.begin<0>(), gz_0.begin<1>(), 0)));
       };
-      {;
-      gridtools::data_view<storage_ijk_t> gz= gridtools::make_device_view(gz_ds);
-      gridtools::data_view<storage_ijk_t> gz_0= gridtools::make_device_view(gz_0_ds);
-      const unsigned int nx = m_dom.isize() - m_dom.iminus() - m_dom.iplus();
-      const unsigned int ny = m_dom.jsize() - m_dom.jminus() - m_dom.jplus();
-      const unsigned int nz = m_dom.ksize() - m_dom.kminus() - m_dom.kplus();
-      dim3 threads(32,4+0,1);
-      const unsigned int nbx = (nx + 32 - 1) / 32;
-      const unsigned int nby = (ny + 4 - 1) / 4;
-      const unsigned int nbz = (m_dom.ksize()+4-1) / 4;
-      dim3 blocks(nbx, nby, nbz);
-      update_dz_c_stencil443_ms673_kernel<<<blocks, threads>>>(m_globals,nx,ny,nz,gz_ds.strides()[1],gz_ds.strides()[2],(gz.data()+gz_ds.get_storage_info_ptr()->index(gz.begin<0>(), gz.begin<1>(),0 )),(gz_0.data()+gz_0_ds.get_storage_info_ptr()->index(gz_0.begin<0>(), gz_0.begin<1>(),0 )));
+      {
+        ;
+        gridtools::data_view<storage_ijk_t> gz = gridtools::make_device_view(gz_ds);
+        gridtools::data_view<storage_ijk_t> gz_0 = gridtools::make_device_view(gz_0_ds);
+        const unsigned int nx = m_dom.isize() - m_dom.iminus() - m_dom.iplus();
+        const unsigned int ny = m_dom.jsize() - m_dom.jminus() - m_dom.jplus();
+        const unsigned int nz = m_dom.ksize() - m_dom.kminus() - m_dom.kplus();
+        dim3 threads(32, 4 + 0, 1);
+        const unsigned int nbx = (nx + 32 - 1) / 32;
+        const unsigned int nby = (ny + 4 - 1) / 4;
+        const unsigned int nbz = (m_dom.ksize() + 4 - 1) / 4;
+        dim3 blocks(nbx, nby, nbz);
+        update_dz_c_stencil443_ms673_kernel<<<blocks, threads>>>(
+            m_globals, nx, ny, nz, gz_ds.strides()[1], gz_ds.strides()[2],
+            (gz.data() + gz_ds.get_storage_info_ptr()->index(gz.begin<0>(), gz.begin<1>(), 0)),
+            (gz_0.data() +
+             gz_0_ds.get_storage_info_ptr()->index(gz_0.begin<0>(), gz_0.begin<1>(), 0)));
       };
 
       // stopping timers
@@ -669,8 +860,8 @@ public:
   };
   static constexpr const char* s_name = "update_dz_c";
   stencil_443 m_stencil_443;
-public:
 
+public:
   update_dz_c(const update_dz_c&) = delete;
 
   // Members
@@ -680,46 +871,44 @@ public:
   gridtools::dawn::storage_t m_gz_0;
   globals m_globals;
 
-  update_dz_c(const gridtools::dawn::domain& dom, int rank = 1, int xcols = 1, int ycols = 1) : m_stencil_443(dom,m_globals, rank, xcols, ycols), m_meta_data(dom.isize(), dom.jsize(), dom.ksize() /*+ 2 *0*/ + 1), m_gz_0 (m_meta_data, "gz_0"){}
+  update_dz_c(const gridtools::dawn::domain& dom, int rank = 1, int xcols = 1, int ycols = 1)
+      : m_stencil_443(dom, m_globals, rank, xcols, ycols),
+        m_meta_data(dom.isize(), dom.jsize(), dom.ksize() /*+ 2 *0*/ + 1),
+        m_gz_0(m_meta_data, "gz_0") {}
 
   // Access-wrapper for globally defined variables
 
-  double get_dt() {
-    return m_globals.dt;
-  }
+  double get_dt() { return m_globals.dt; }
 
-  void set_dt(double dt) {
-    m_globals.dt=dt;
-  }
+  void set_dt(double dt) { m_globals.dt = dt; }
 
-  template<typename S>
+  template <typename S>
   void sync_storages(S field) {
     field.sync();
   }
 
-  template<typename S0, typename ... S>
+  template <typename S0, typename... S>
   void sync_storages(S0 f0, S... fields) {
     f0.sync();
     sync_storages(fields...);
   }
 
-  void run(storage_ijk_t dp_ref, storage_ijk_t zs, storage_ijk_t area, storage_ijk_t ut, storage_ijk_t vt, storage_ijk_t gz, storage_ijk_t gz_x, storage_ijk_t gz_y, storage_ijk_t ws3) {
-    sync_storages(dp_ref,zs,area,ut,vt,gz,gz_x,gz_y,ws3);
-    m_stencil_443.run(dp_ref,zs,area,ut,vt,gz,gz_x,gz_y,ws3,m_gz_0);
-;
-    sync_storages(dp_ref,zs,area,ut,vt,gz,gz_x,gz_y,ws3);
+  void run(storage_ijk_t dp_ref, storage_ijk_t zs, storage_ijk_t area, storage_ijk_t ut,
+           storage_ijk_t vt, storage_ijk_t gz, storage_ijk_t gz_x, storage_ijk_t gz_y,
+           storage_ijk_t ws3) {
+    sync_storages(dp_ref, zs, area, ut, vt, gz, gz_x, gz_y, ws3);
+    m_stencil_443.run(dp_ref, zs, area, ut, vt, gz, gz_x, gz_y, ws3, m_gz_0);
+    ;
+    sync_storages(dp_ref, zs, area, ut, vt, gz, gz_x, gz_y, ws3);
   }
 
-  std::string get_name()  const {
-    return std::string(s_name);
-  }
+  std::string get_name() const { return std::string(s_name); }
 
-  void reset_meters() {
-m_stencil_443.reset();  }
+  void reset_meters() { m_stencil_443.reset(); }
 
   double get_total_time() {
     double res = 0;
-    res +=m_stencil_443.get_time();
+    res += m_stencil_443.get_time();
     return res;
   }
 };


### PR DESCRIPTION
## Technical Description

The formatting style for the generated code:

```
  clang::format::FormatStyle style =
      clang::format::getLLVMStyle(clang::format::FormatStyle::LanguageKind::LK_Cpp);
  style.PointerAlignment = clang::format::FormatStyle::PAS_Left;
  style.ColumnLimit = 100;
  style.SpaceBeforeParens = clang::format::FormatStyle::SBPO_Never;
  style.AlwaysBreakTemplateDeclarations = clang::format::FormatStyle::BTDS_Yes;
```

is chosen so that it reflects the formatting style in the dawn project:

```
BasedOnStyle:                                           LLVM
ColumnLimit:                                            100
PointerAlignment:                                       Left
SpaceBeforeParens:                                      Never
AlwaysBreakTemplateDeclarations:                        true
```

Dawn now depends on `clang` and `llvm`.

### Resolves

https://github.com/MeteoSwiss-APN/dawn/issues/878