### PR TITLE
Add set_splitter_index and some bindings

### DIFF
--- a/dawn/src/driver-includes/bindings/dawn_utils.f90
+++ b/dawn/src/driver-includes/bindings/dawn_utils.f90
@@ -1,0 +1,73 @@
+module dawn_utils
+use iso_c_binding
+
+implicit none
+  interface
+    subroutine dense_cells_to_vtk(start_idx, end_idx, num_k, &
+                                  dense_stride, field, stencil_name, &
+                                  field_name, iteration) bind(c, name="dense_cells_to_vtk")
+      use iso_c_binding
+      integer(c_int), value :: start_idx
+      integer(c_int), value :: end_idx
+      integer(c_int), value :: num_k
+      integer(c_int), value :: dense_stride
+      real(c_double), dimension(*) :: field
+      character(kind=c_char), dimension(*) :: stencil_name
+      character(kind=c_char), dimension(*) :: field_name
+      integer(c_int), value :: iteration
+    end subroutine
+    subroutine dense_edges_to_vtk(start_idx, end_idx, num_k, &
+                                  dense_stride, field, stencil_name, &
+                                  field_name, iteration) bind(c, name="dense_edges_to_vtk")
+      use iso_c_binding
+      integer(c_int), value :: start_idx
+      integer(c_int), value :: end_idx
+      integer(c_int), value :: num_k
+      integer(c_int), value :: dense_stride
+      real(c_double), dimension(*) :: field
+      character(kind=c_char), dimension(*) :: stencil_name
+      character(kind=c_char), dimension(*) :: field_name
+      integer(c_int), value :: iteration
+    end subroutine
+    subroutine dense_verts_to_vtk(start_idx, end_idx, num_k, &
+                                  dense_stride, field, stencil_name, &
+                                  field_name, iteration) bind(c, name="dense_verts_to_vtk")
+      use iso_c_binding
+      integer(c_int), value :: start_idx
+      integer(c_int), value :: end_idx
+      integer(c_int), value :: num_k
+      integer(c_int), value :: dense_stride
+      real(c_double), dimension(*) :: field
+      character(kind=c_char), dimension(*) :: stencil_name
+      character(kind=c_char), dimension(*) :: field_name
+      integer(c_int), value :: iteration
+    end subroutine
+
+    subroutine set_splitter_index(mesh, loc, space, offset, index) bind(c)
+      use, intrinsic :: iso_c_binding
+      type(c_ptr), value, target :: mesh
+      integer(c_int), value :: loc
+      integer(c_int), value :: space
+      integer(c_int), value :: offset
+      integer(c_int), value :: index
+    end subroutine
+
+  end interface
+  contains
+    TYPE, PRIVATE :: LocationType_Values 
+        INTEGER :: Cell ! = 0
+        INTEGER :: Edge ! = 1
+        INTEGER :: Vertex ! = 2
+      END TYPE LocationType_Values
+      !
+    TYPE (LocationType_Values), PUBLIC, PARAMETER :: LocationType = LocationType_Values (0,1,2)
+    TYPE, PRIVATE :: SubdomainMarker_Values 
+      INTEGER :: LB ! = 0
+      INTEGER :: Nudging ! = 1000
+      INTEGER :: Interior ! = 2000
+      INTEGER :: Halo ! = 3000
+      INTEGER :: End ! = 4000
+    END TYPE SubdomainMarker_Values
+    !
+    TYPE (SubdomainMarker_Values), PUBLIC, PARAMETER :: SubdomainMarker = SubdomainMarker_Values (0,1000,2000,3000,4000)
+end module

--- a/dawn/src/driver-includes/cuda_utils.hpp
+++ b/dawn/src/driver-includes/cuda_utils.hpp
@@ -250,3 +250,12 @@ void generateNbhTable(dawn::mesh_t<LibTag> const& mesh, std::vector<dawn::Locati
                        cudaMemcpyHostToDevice));
 }
 } // namespace dawn
+
+extern "C" {
+// For exporting API to Fortran
+void set_splitter_index(dawn::GlobalGpuTriMesh* globalTriMesh, int loc, int space, int offset,
+                        int index) {
+  globalTriMesh->set_splitter_index(dawn::LocationType(loc), dawn::UnstructuredSubdomain(space),
+                                    offset, index);
+}
+}


### PR DESCRIPTION
## Technical Description

Ship with dawn the API to set markers' indices (and its binding). Also add missing bindings to serialization utilities (so that can be used in any place within the model code).
