### PR TITLE
Fix Serialization 

### DIFF
--- a/dawn/src/dawn/CodeGen/Cuda-ico/CudaIcoCodeGen.cpp
+++ b/dawn/src/dawn/CodeGen/Cuda-ico/CudaIcoCodeGen.cpp
@@ -21,6 +21,7 @@
 #include "dawn/AST/LocationType.h"
 #include "dawn/CodeGen/CXXUtil.h"
 #include "dawn/CodeGen/Cuda-ico/LocToStringUtils.h"
+#include "dawn/CodeGen/Cuda-ico/ReductionMerger.h"
 #include "dawn/CodeGen/Cuda/CodeGeneratorHelper.h"
 #include "dawn/CodeGen/F90Util.h"
 #include "dawn/CodeGen/IcoChainSizes.h"
@@ -153,16 +154,18 @@ run(const std::map<std::string, std::shared_ptr<iir::StencilInstantiation>>&
       options.OutputCHeader == "" ? std::nullopt : std::make_optional(options.OutputCHeader),
       options.OutputFortranInterface == "" ? std::nullopt
                                            : std::make_optional(options.OutputFortranInterface),
-      Padding{options.paddingCells, options.paddingEdges, options.paddingVertices});
+      Padding{options.paddingCells, options.paddingEdges, options.paddingVertices},
+      options.MergeReductions);
 
   return CG.generateCode();
 }
 
 CudaIcoCodeGen::CudaIcoCodeGen(const StencilInstantiationContext& ctx, int maxHaloPoints,
                                std::optional<std::string> outputCHeader,
-                               std::optional<std::string> outputFortranInterface, Padding padding)
-    : CodeGen(ctx, maxHaloPoints, padding), codeGenOptions_{outputCHeader, outputFortranInterface} {
-}
+                               std::optional<std::string> outputFortranInterface, Padding padding,
+                               bool mergeReductions)
+    : CodeGen(ctx, maxHaloPoints, padding), codeGenOptions_{outputCHeader, outputFortranInterface,
+                                                            mergeReductions} {}
 
 CudaIcoCodeGen::~CudaIcoCodeGen() {}
 
@@ -896,22 +899,6 @@ void CudaIcoCodeGen::generateAllAPIVerifyFunctions(
   const std::string fullStencilName =
       "dawn_generated::cuda_ico::" + wrapperName + "::" + stencilName;
 
-  auto getDenseSizeName = [](dawn::ast::LocationType locType) -> std::string {
-    using dawn::ast::LocationType;
-    switch(locType) {
-    case LocationType::Edges:
-      return "dense_size_edges";
-      break;
-    case LocationType::Cells:
-      return "dense_size_cells";
-      break;
-    case LocationType::Vertices:
-      return "dense_size_vertices";
-      break;
-    default:
-      dawn_unreachable("invalid location type");
-    }
-  };
   auto getSerializeCall = [](dawn::ast::LocationType locType) -> std::string {
     using dawn::ast::LocationType;
     switch(locType) {
@@ -1028,6 +1015,11 @@ void CudaIcoCodeGen::generateAllAPIVerifyFunctions(
           verifyAPI.addPreprocessorDirective("endif");
         });
       }
+
+      verifyAPI.addPreprocessorDirective("ifdef __SERIALIZE_ON_ERROR\n"); // newline requried
+      verifyAPI.addStatement("serialize_flush_iter(\"" + wrapperName + "\", iteration)");
+      verifyAPI.addPreprocessorDirective("endif");
+
       verifyAPI.addStatement(
           "high_resolution_clock::time_point t_end = high_resolution_clock::now()");
       verifyAPI.addStatement(
@@ -1150,6 +1142,12 @@ void CudaIcoCodeGen::generateAllCudaKernels(
   ASTStencilBody stencilBodyCXXVisitor(stencilInstantiation->getMetaData(),
                                        codeGenOptions.UnstrPadding);
   const auto& globalsMap = stencilInstantiation->getIIR()->getGlobalVariableMap();
+  std::optional<MergeGroupMap> blockToMergeGroups = std::nullopt;
+  if(codeGenOptions_.MergeReductions) {
+    blockToMergeGroups =
+        ReductionMergeGroupsComputer::ComputeReductionMergeGroups(stencilInstantiation);
+  }
+  stencilBodyCXXVisitor.setBlockToMergeGroupMap(blockToMergeGroups);
 
   for(const auto& ms : iterateIIROver<iir::MultiStage>(*(stencilInstantiation->getIIR()))) {
     for(const auto& stage : ms->getChildren()) {
@@ -1294,10 +1292,12 @@ void CudaIcoCodeGen::generateAllCudaKernels(
           const iir::DoMethod& doMethod = *doMethodPtr;
 
           for(const auto& stmt : doMethod.getAST().getStatements()) {
-            FindReduceOverNeighborExpr findReduceOverNeighborExpr;
+            FindReduceOverNeighborExpr findReduceOverNeighborExpr(doMethod.getAST().getID());
             stmt->accept(findReduceOverNeighborExpr);
             stencilBodyCXXVisitor.setFirstPass();
             for(auto redExpr : findReduceOverNeighborExpr.reduceOverNeighborExprs()) {
+              stencilBodyCXXVisitor.setBlockID(
+                  findReduceOverNeighborExpr.getBlockIDofReduction(redExpr));
               redExpr->accept(stencilBodyCXXVisitor);
             }
             stencilBodyCXXVisitor.setSecondPass();

--- a/dawn/src/driver-includes/to_vtk.cpp
+++ b/dawn/src/driver-includes/to_vtk.cpp
@@ -78,8 +78,8 @@ public:
   }
 
   ~StencilFieldsVtkOutput() {
-    fs << cells_ss.rdbuf();
-    fs << points_ss.rdbuf();
+    fs << cells_ss.str();
+    fs << points_ss.str();
     fs.close();
   }
 
@@ -117,14 +117,15 @@ static std::string formatNaNs(const double value) {
 
 namespace {
 StencilFieldsVtkOutput& getStencilFieldsVtkOutput(int num_k, std::string stencil_name, int iter) {
-  if(stencil_to_output_map.count(std::make_pair(stencil_name, iter - 1))) {
-    stencil_to_output_map.erase(std::make_pair(stencil_name, iter - 1));
-  }
   if(stencil_to_output_map.count(std::make_pair(stencil_name, iter)) == 0) {
     stencil_to_output_map.emplace(std::make_pair(stencil_name, iter),
                                   StencilFieldsVtkOutput(num_k, stencil_name, iter));
   }
   return stencil_to_output_map.at(std::make_pair(stencil_name, iter));
+}
+
+void flushAtIter(std::string stencil_name, int iter) {
+  stencil_to_output_map.erase(std::make_pair(stencil_name, iter - 1));
 }
 
 double* fieldFromGpu(const double* field_gpu, const int size) {
@@ -323,5 +324,9 @@ void serialize_dense_edges(int start_idx, int end_idx, int num_k, int dense_stri
 
   dense_edges_to_vtk(start_idx, end_idx, num_k, dense_stride, field, stencil_name, field_name,
                      iter);
+}
+
+void serialize_flush_iter(const char field_name[50], int iter) {
+  flushAtIter(std::string(field_name), iter);
 }
 }

--- a/dawn/src/driver-includes/to_vtk.cpp
+++ b/dawn/src/driver-includes/to_vtk.cpp
@@ -326,7 +326,7 @@ void serialize_dense_edges(int start_idx, int end_idx, int num_k, int dense_stri
                      iter);
 }
 
-void serialize_flush_iter(const char field_name[50], int iter) {
-  flushAtIter(std::string(field_name), iter);
+void serialize_flush_iter(const char stencil_name[50], int iter) {
+  flushAtIter(std::string(stencil_name), iter);
 }
 }

--- a/dawn/src/driver-includes/to_vtk.cpp
+++ b/dawn/src/driver-includes/to_vtk.cpp
@@ -125,7 +125,7 @@ StencilFieldsVtkOutput& getStencilFieldsVtkOutput(int num_k, std::string stencil
 }
 
 void flushAtIter(std::string stencil_name, int iter) {
-  stencil_to_output_map.erase(std::make_pair(stencil_name, iter - 1));
+  stencil_to_output_map.erase(std::make_pair(stencil_name, iter));
 }
 
 double* fieldFromGpu(const double* field_gpu, const int size) {

--- a/dawn/src/driver-includes/to_vtk.h
+++ b/dawn/src/driver-includes/to_vtk.h
@@ -40,5 +40,5 @@ void serialize_dense_verts(int start_idx, int end_idx, int num_k, int dense_stri
 void serialize_dense_edges(int start_idx, int end_idx, int num_k, int dense_stride,
                            const double* field, const char stencil_name[50],
                            const char field_name[50], int iter);
-void serialize_flush_iter(const char field_name[50], int iter);
+void serialize_flush_iter(const char stencil_name[50], int iter);
 }

--- a/dawn/src/driver-includes/to_vtk.h
+++ b/dawn/src/driver-includes/to_vtk.h
@@ -40,4 +40,5 @@ void serialize_dense_verts(int start_idx, int end_idx, int num_k, int dense_stri
 void serialize_dense_edges(int start_idx, int end_idx, int num_k, int dense_stride,
                            const double* field, const char stencil_name[50],
                            const char field_name[50], int iter);
+void serialize_flush_iter(const char field_name[50], int iter);
 }


### PR DESCRIPTION
## Technical Description

The serialization routines had some problems:

* Calling the destructor the second time a serialization routine is called is not safe. A single stencil may serialize multiple fields in the same iteration
* The use of `rdbuf` caused some problems. See also this [stackoverflow question](https://stackoverflow.com/questions/324711/writing-stringstream-contents-into-ofstream) (later answers)

### Testing

Tested using ICON-DSL

### Dependencies

No dependencies 


