### PR TITLE
Divide Upper and Lower Index for Subdomains

### DIFF
--- a/dawn/src/driver-includes/bindings/dawn_utils.f90
+++ b/dawn/src/driver-includes/bindings/dawn_utils.f90
@@ -43,7 +43,16 @@ implicit none
       integer(c_int), value :: iteration
     end subroutine
 
-    subroutine set_splitter_index(mesh, loc, space, offset, index) bind(c)
+    subroutine set_splitter_index_lower(mesh, loc, space, offset, index) bind(c)
+      use, intrinsic :: iso_c_binding
+      type(c_ptr), value, target :: mesh
+      integer(c_int), value :: loc
+      integer(c_int), value :: space
+      integer(c_int), value :: offset
+      integer(c_int), value :: index
+    end subroutine
+
+    subroutine set_splitter_index_upper(mesh, loc, space, offset, index) bind(c)
       use, intrinsic :: iso_c_binding
       type(c_ptr), value, target :: mesh
       integer(c_int), value :: loc

--- a/dawn/src/driver-includes/cuda_utils.cpp
+++ b/dawn/src/driver-includes/cuda_utils.cpp
@@ -1,9 +1,14 @@
 #include "cuda_utils.hpp"
 
 extern "C" {
-void set_splitter_index(dawn::GlobalGpuTriMesh* globalTriMesh, int loc, int space, int offset,
+void set_splitter_index_lower(dawn::GlobalGpuTriMesh* globalTriMesh, int loc, int space, int offset,
                         int index) {
-  globalTriMesh->set_splitter_index(dawn::LocationType(loc), dawn::UnstructuredSubdomain(space),
+  globalTriMesh->set_splitter_index_lower(dawn::LocationType(loc), dawn::UnstructuredSubdomain(space),
+                                    offset, index);
+}
+void set_splitter_index_upper(dawn::GlobalGpuTriMesh* globalTriMesh, int loc, int space, int offset,
+                        int index) {
+  globalTriMesh->set_splitter_index_upper(dawn::LocationType(loc), dawn::UnstructuredSubdomain(space),
                                     offset, index);
 }
 }

--- a/dawn/src/driver-includes/cuda_utils.hpp
+++ b/dawn/src/driver-includes/cuda_utils.hpp
@@ -41,14 +41,19 @@ inline void gpuAssert(cudaError_t code, const char* file, int line, bool abort =
 namespace dawn {
 
 struct GlobalGpuTriMesh {
-  dawn::unstructured_domain Domain;
+  dawn::unstructured_domain DomainLower;
+  dawn::unstructured_domain DomainUpper;
   int NumEdges;
   int NumCells;
   int NumVertices;
   std::map<dawn::UnstructuredIterationSpace, int*> NeighborTables;
-  void set_splitter_index(dawn::LocationType loc, dawn::UnstructuredSubdomain space, int offset,
+  void set_splitter_index_lower(dawn::LocationType loc, dawn::UnstructuredSubdomain space, int offset,
                           int index) {
-    Domain.set_splitter_index({loc, space, offset}, index);
+    DomainLower.set_splitter_index({loc, space, offset}, index);
+  }
+  void set_splitter_index_upper(dawn::LocationType loc, dawn::UnstructuredSubdomain space, int offset,
+                          int index) {
+    DomainUpper.set_splitter_index({loc, space, offset}, index);
   }
 };
 


### PR DESCRIPTION
## Technical Description

There is not necessarily a relation between the upper and lower indices as retrieved from the `get_indices_(e|c|v)` call. I.e. for

```
CALL get_indices_e(p_patch(jg), 1, 1, 1, edge_start_idx_a, edge_end_idx_b, a, b)
CALL get_indices_e(p_patch(jg), 1, 1, 1, edge_start_idx_b_prime, edge_end_idx_c, b, c)
```

it neither holds that `edge_end_idx_b == edge_end_idx_b_prime` nor |edge_end_idx_b - edge_end_idx_b_prime| == 1`. 

Consequently, we need to also distinguish between upper and lower indices in dawn to avoid awkward workarounds if a index is used as lower and upper index by two different stencils. This PR splits the single subdomain structure into a upper and lower one, both holding a map for subdomain markers.

### Testing

Tested in `ICON-DSL`