### PR TITLE
block size 1 for K dimension

### DIFF
--- a/dawn/src/dawn/CodeGen/Cuda-ico/CudaIcoCodeGen.cpp
+++ b/dawn/src/dawn/CodeGen/Cuda-ico/CudaIcoCodeGen.cpp
@@ -247,8 +247,7 @@ void CudaIcoCodeGen::generateGpuMesh(
 
 void CudaIcoCodeGen::generateGridFun(MemberFunction& gridFun) {
   gridFun.addStatement("int dK = (kSize + LEVELS_PER_THREAD - 1) / LEVELS_PER_THREAD");
-  gridFun.addStatement(
-      "return dim3((elSize + BLOCK_SIZE - 1) / BLOCK_SIZE, (dK + BLOCK_SIZE - 1) / BLOCK_SIZE, 1)");
+  gridFun.addStatement("return dim3((elSize + BLOCK_SIZE - 1) / BLOCK_SIZE, dK, 1)");
 }
 
 void CudaIcoCodeGen::generateRunFun(
@@ -271,7 +270,7 @@ void CudaIcoCodeGen::generateRunFun(
       stageLocType.insert(*stage->getLocationType());
     }
   }
-  runFun.addStatement("dim3 dB(BLOCK_SIZE, BLOCK_SIZE, 1)");
+  runFun.addStatement("dim3 dB(BLOCK_SIZE, 1, 1)");
 
   // start timers
   runFun.addStatement("sbase::start()");
@@ -324,8 +323,8 @@ void CudaIcoCodeGen::generateRunFun(
                    ? "mesh_.DomainUpper({::dawn::LocationType::" + locToStringPlural(loc) + "," +
                          spaceMagicNumToEnum(iterSpace->upperLevel()) + "," +
                          std::to_string(iterSpace->upperOffset()) + "})" +
-                         "- mesh_.DomainLower({::dawn::LocationType::" + locToStringPlural(loc) + "," +
-                         spaceMagicNumToEnum(iterSpace->lowerLevel()) + "," +
+                         "- mesh_.DomainLower({::dawn::LocationType::" + locToStringPlural(loc) +
+                         "," + spaceMagicNumToEnum(iterSpace->lowerLevel()) + "," +
                          std::to_string(iterSpace->lowerOffset()) + "}) + 1"
                    : "mesh_.Num" + locToStringPlural(loc);
       };
@@ -1629,8 +1628,8 @@ std::unique_ptr<TranslationUnit> CudaIcoCodeGen::generateCode() {
       "#include \"driver-includes/math.hpp\"",
       "#include \"driver-includes/timer_cuda.hpp\"",
       "#include <chrono>",
-      "#define BLOCK_SIZE 16",
-      "#define LEVELS_PER_THREAD 1",
+      "#define BLOCK_SIZE 128",
+      "#define LEVELS_PER_THREAD 4",
       "using namespace gridtools::dawn;",
   };
 

--- a/dawn/src/dawn/CodeGen/Cuda-ico/CudaIcoCodeGen.cpp
+++ b/dawn/src/dawn/CodeGen/Cuda-ico/CudaIcoCodeGen.cpp
@@ -1629,7 +1629,7 @@ std::unique_ptr<TranslationUnit> CudaIcoCodeGen::generateCode() {
       "#include \"driver-includes/timer_cuda.hpp\"",
       "#include <chrono>",
       "#define BLOCK_SIZE 128",
-      "#define LEVELS_PER_THREAD 4",
+      "#define LEVELS_PER_THREAD 1",
       "using namespace gridtools::dawn;",
   };
 


### PR DESCRIPTION
## Technical Description

It sets cuda block size in K to 1. That means all cuda threads of different levels fall into different cuda blocks. 
The reason for this is to optimize the resources when Ksize != Y x BLOCKSIZE. 
There were two arguments in favor of blocking cuda threads in the vertical: 
* input field accesses at displace k offset could be found in cache if contiguous threads in the vertical compute in the same SM. 
* lookup tables can also be cached and reused among multiple k levels. 

The same effect for cache behaviour is achieved using LEVELS_PER_THREAD. However overall the best value of LEVELS_PER_THREAD is 1. 

### Perf results: 

See columns C & G
https://docs.google.com/spreadsheets/d/1w2mkdWLVXPOrvufPAwRRhscuT--37qf3o2uhZKG7tqU/edit#gid=730428313
