### PR TITLE
Remove conditional for missing value on pentagons

### DIFF
--- a/dawn/src/dawn/CodeGen/Cuda-ico/ASTStencilBody.cpp
+++ b/dawn/src/dawn/CodeGen/Cuda-ico/ASTStencilBody.cpp
@@ -269,7 +269,7 @@ void ASTStencilBody::visit(const std::shared_ptr<ast::VarDeclStmt>& stmt) {
 }
 
 bool ASTStencilBody::hasIrregularPentagons(const std::vector<ast::LocationType>& chain) {
-  assert(chain.size() > 1);
+  DAWN_ASSERT(chain.size() > 1);
   return (std::count(chain.begin(), chain.end() - 1, ast::LocationType::Vertices) != 0);
 }
 

--- a/dawn/src/dawn/CodeGen/Cuda-ico/ASTStencilBody.h
+++ b/dawn/src/dawn/CodeGen/Cuda-ico/ASTStencilBody.h
@@ -96,6 +96,7 @@ protected:
   int nestingOfStencilFunArgLists_;
 
   std::string makeIndexString(const std::shared_ptr<ast::FieldAccessExpr>& expr, std::string kiter);
+  bool hasIrregularPentagons(const std::vector<ast::LocationType>& chain);
 
 public:
   using Base = ASTCodeGenCXX;

--- a/dawn/src/dawn/CodeGen/Cuda-ico/CudaIcoCodeGen.cpp
+++ b/dawn/src/dawn/CodeGen/Cuda-ico/CudaIcoCodeGen.cpp
@@ -1629,7 +1629,7 @@ std::unique_ptr<TranslationUnit> CudaIcoCodeGen::generateCode() {
       "#include \"driver-includes/math.hpp\"",
       "#include \"driver-includes/timer_cuda.hpp\"",
       "#include <chrono>",
-      "#define BLOCK_SIZE 128",
+      "#define BLOCK_SIZE 16",
       "#define LEVELS_PER_THREAD 4",
       "using namespace gridtools::dawn;",
   };

--- a/dawn/src/dawn/CodeGen/Cuda-ico/CudaIcoCodeGen.cpp
+++ b/dawn/src/dawn/CodeGen/Cuda-ico/CudaIcoCodeGen.cpp
@@ -324,7 +324,7 @@ void CudaIcoCodeGen::generateRunFun(
                    ? "mesh_.DomainUpper({::dawn::LocationType::" + locToStringPlural(loc) + "," +
                          spaceMagicNumToEnum(iterSpace->upperLevel()) + "," +
                          std::to_string(iterSpace->upperOffset()) + "})" +
-                                                  "- mesh_.DomainLower({::dawn::LocationType::" + locToStringPlural(loc) + "," +
+                         "- mesh_.DomainLower({::dawn::LocationType::" + locToStringPlural(loc) + "," +
                          spaceMagicNumToEnum(iterSpace->lowerLevel()) + "," +
                          std::to_string(iterSpace->lowerOffset()) + "}) + 1"
                    : "mesh_.Num" + locToStringPlural(loc);

--- a/dawn/src/dawn/CodeGen/Cuda-ico/CudaIcoCodeGen.cpp
+++ b/dawn/src/dawn/CodeGen/Cuda-ico/CudaIcoCodeGen.cpp
@@ -247,8 +247,7 @@ void CudaIcoCodeGen::generateGpuMesh(
 
 void CudaIcoCodeGen::generateGridFun(MemberFunction& gridFun) {
   gridFun.addStatement("int dK = (kSize + LEVELS_PER_THREAD - 1) / LEVELS_PER_THREAD");
-  gridFun.addStatement(
-      "return dim3((elSize + BLOCK_SIZE - 1) / BLOCK_SIZE, (dK + BLOCK_SIZE - 1) / BLOCK_SIZE, 1)");
+  gridFun.addStatement("return dim3((elSize + BLOCK_SIZE - 1) / BLOCK_SIZE, dK, 1)");
 }
 
 void CudaIcoCodeGen::generateRunFun(
@@ -271,7 +270,7 @@ void CudaIcoCodeGen::generateRunFun(
       stageLocType.insert(*stage->getLocationType());
     }
   }
-  runFun.addStatement("dim3 dB(BLOCK_SIZE, BLOCK_SIZE, 1)");
+  runFun.addStatement("dim3 dB(BLOCK_SIZE, 1, 1)");
 
   // start timers
   runFun.addStatement("sbase::start()");
@@ -324,8 +323,8 @@ void CudaIcoCodeGen::generateRunFun(
                    ? "mesh_.DomainUpper({::dawn::LocationType::" + locToStringPlural(loc) + "," +
                          spaceMagicNumToEnum(iterSpace->upperLevel()) + "," +
                          std::to_string(iterSpace->upperOffset()) + "})" +
-                         "- mesh_.DomainLower({::dawn::LocationType::" + locToStringPlural(loc) + "," +
-                         spaceMagicNumToEnum(iterSpace->lowerLevel()) + "," +
+                         "- mesh_.DomainLower({::dawn::LocationType::" + locToStringPlural(loc) +
+                         "," + spaceMagicNumToEnum(iterSpace->lowerLevel()) + "," +
                          std::to_string(iterSpace->lowerOffset()) + "}) + 1"
                    : "mesh_.Num" + locToStringPlural(loc);
       };
@@ -1629,8 +1628,8 @@ std::unique_ptr<TranslationUnit> CudaIcoCodeGen::generateCode() {
       "#include \"driver-includes/math.hpp\"",
       "#include \"driver-includes/timer_cuda.hpp\"",
       "#include <chrono>",
-      "#define BLOCK_SIZE 16",
-      "#define LEVELS_PER_THREAD 1",
+      "#define BLOCK_SIZE 128",
+      "#define LEVELS_PER_THREAD 4",
       "using namespace gridtools::dawn;",
   };
 

--- a/dawn/src/dawn/CodeGen/Cuda-ico/CudaIcoCodeGen.cpp
+++ b/dawn/src/dawn/CodeGen/Cuda-ico/CudaIcoCodeGen.cpp
@@ -271,7 +271,7 @@ void CudaIcoCodeGen::generateRunFun(
       stageLocType.insert(*stage->getLocationType());
     }
   }
-  runFun.addStatement("dim3 dB(BLOCK_SIZE, 1, 1)");
+  runFun.addStatement("dim3 dB(BLOCK_SIZE, BLOCK_SIZE, 1)");
 
   // start timers
   runFun.addStatement("sbase::start()");

--- a/dawn/src/dawn/CodeGen/Cuda-ico/CudaIcoCodeGen.cpp
+++ b/dawn/src/dawn/CodeGen/Cuda-ico/CudaIcoCodeGen.cpp
@@ -247,7 +247,8 @@ void CudaIcoCodeGen::generateGpuMesh(
 
 void CudaIcoCodeGen::generateGridFun(MemberFunction& gridFun) {
   gridFun.addStatement("int dK = (kSize + LEVELS_PER_THREAD - 1) / LEVELS_PER_THREAD");
-  gridFun.addStatement("return dim3((elSize + BLOCK_SIZE - 1) / BLOCK_SIZE, dK, 1)");
+  gridFun.addStatement(
+      "return dim3((elSize + BLOCK_SIZE - 1) / BLOCK_SIZE, (dK + BLOCK_SIZE - 1) / BLOCK_SIZE, 1)");
 }
 
 void CudaIcoCodeGen::generateRunFun(

--- a/dawn/src/dawn/CodeGen/Cuda-ico/CudaIcoCodeGen.cpp
+++ b/dawn/src/dawn/CodeGen/Cuda-ico/CudaIcoCodeGen.cpp
@@ -1630,7 +1630,7 @@ std::unique_ptr<TranslationUnit> CudaIcoCodeGen::generateCode() {
       "#include \"driver-includes/timer_cuda.hpp\"",
       "#include <chrono>",
       "#define BLOCK_SIZE 16",
-      "#define LEVELS_PER_THREAD 4",
+      "#define LEVELS_PER_THREAD 1",
       "using namespace gridtools::dawn;",
   };
 

--- a/dawn/src/dawn/CodeGen/Cuda-ico/CudaIcoCodeGen.cpp
+++ b/dawn/src/dawn/CodeGen/Cuda-ico/CudaIcoCodeGen.cpp
@@ -325,7 +325,7 @@ void CudaIcoCodeGen::generateRunFun(
                          spaceMagicNumToEnum(iterSpace->upperLevel()) + "," +
                          std::to_string(iterSpace->upperOffset()) + "})" +
                                                   "- mesh_.DomainLower({::dawn::LocationType::" + locToStringPlural(loc) + "," +
-                         "," + spaceMagicNumToEnum(iterSpace->lowerLevel()) + "," +
+                         spaceMagicNumToEnum(iterSpace->lowerLevel()) + "," +
                          std::to_string(iterSpace->lowerOffset()) + "}) + 1"
                    : "mesh_.Num" + locToStringPlural(loc);
       };

--- a/dawn/src/dawn/CodeGen/Cuda-ico/CudaIcoCodeGen.cpp
+++ b/dawn/src/dawn/CodeGen/Cuda-ico/CudaIcoCodeGen.cpp
@@ -324,7 +324,7 @@ void CudaIcoCodeGen::generateRunFun(
                    ? "mesh_.DomainUpper({::dawn::LocationType::" + locToStringPlural(loc) + "," +
                          spaceMagicNumToEnum(iterSpace->upperLevel()) + "," +
                          std::to_string(iterSpace->upperOffset()) + "})" +
-                         "- mesh_.DomainLower({::dawn::LocationType::" + locToStringPlural(loc) +
+                                                  "- mesh_.DomainLower({::dawn::LocationType::" + locToStringPlural(loc) + "," +
                          "," + spaceMagicNumToEnum(iterSpace->lowerLevel()) + "," +
                          std::to_string(iterSpace->lowerOffset()) + "}) + 1"
                    : "mesh_.Num" + locToStringPlural(loc);


### PR DESCRIPTION
## Technical Description

ICON treats pentagons by setting the value of the connectivity to 0 for the non existing (last) grid point. 
https://gitlab.dkrz.de/dsl/icon-cscs/-/blob/master/src/shr_horizontal/mo_model_domimp_patches.f90#L2066

When translating the lookup tables to C++, this value becomes -1. 
In the cuda kernels, we skip execution of this points with a conditional: 
```
if (nbhIdx == DEVICE_MISSING_VALUE) { continue; }
```
However, this introduces a significant performance penalty in some kernels, i.e. stencil_05.
In this PR, we only code generate this conditional when needed for pentagons: 
if there is a vertex in the location chain, that is not last location. 
For example,
E->C->V will not require code generation of the conditional
E->V->C will require code generation of the conditional
E-> V will not require code generation of the conditional
V-> E will require code generation of the conditional
