### PR TITLE
Add rank ID to serialized vtk/csv filenames

### DIFF
--- a/dawn/src/driver-includes/to_vtk.cpp
+++ b/dawn/src/driver-includes/to_vtk.cpp
@@ -43,7 +43,9 @@ public:
         *std::max_element(vlon, vlon + num_verts) - *std::min_element(vlon, vlon + num_verts);
     const double range = std::max(lat_range, lon_range);
 
-    fs.open(fname_pre + stencil_name + "_" + std::to_string(iteration) + ".vtk", std::fstream::out);
+    fs.open(fname_pre + stencil_name + "_rank" + std::to_string(mesh_info_vtk.rank_id) + "_" +
+                std::to_string(iteration) + ".vtk",
+            std::fstream::out);
 
     fs << "# vtk DataFile Version 3.0\n2D scalar data\nASCII\nDATASET "
           "UNSTRUCTURED_GRID\n";
@@ -138,8 +140,8 @@ void dense_cells_to_csv(int start_idx, int end_idx, int num_k, int dense_stride,
                         const double* field, const char stencil_name[50], const char field_name[50],
                         int iter) {
   std::fstream fs;
-  fs.open(std::string(stencil_name) + "_" + std::string(field_name) + "_" + std::to_string(iter) +
-              ".csv",
+  fs.open(std::string(stencil_name) + "_rank" + std::to_string(mesh_info_vtk.rank_id) + "_" +
+              std::string(field_name) + "_" + std::to_string(iter) + ".csv",
           std::fstream::out);
 
   fs << "\"";
@@ -184,8 +186,8 @@ void dense_verts_to_csv(int start_idx, int end_idx, int num_k, int dense_stride,
                         const double* field, const char stencil_name[50], const char field_name[50],
                         int iter) {
   std::fstream fs;
-  fs.open(std::string(stencil_name) + "_" + std::string(field_name) + "_" + std::to_string(iter) +
-              ".csv",
+  fs.open(std::string(stencil_name) + "_rank" + std::to_string(mesh_info_vtk.rank_id) + "_" +
+              std::string(field_name) + "_" + std::to_string(iter) + ".csv",
           std::fstream::out);
 
   fs << "\"";
@@ -230,8 +232,8 @@ void dense_edges_to_csv(int start_idx, int end_idx, int num_k, int dense_stride,
                         const double* field, const char stencil_name[50], const char field_name[50],
                         int iter) {
   std::fstream fs;
-  fs.open(std::string(stencil_name) + "_" + std::string(field_name) + "_" + std::to_string(iter) +
-              ".csv",
+  fs.open(std::string(stencil_name) + "_rank" + std::to_string(mesh_info_vtk.rank_id) + "_" +
+              std::string(field_name) + "_" + std::to_string(iter) + ".csv",
           std::fstream::out);
 
   fs << "\"";

--- a/dawn/src/driver-includes/to_vtk.h
+++ b/dawn/src/driver-includes/to_vtk.h
@@ -9,6 +9,7 @@ struct MeshInfoVtk {
   int* mesh_cells_edge_idx = nullptr;   /*[3][num_cells]*/
   double* mesh_vlon = nullptr;          /*[num_vertices]*/
   double* mesh_vlat = nullptr;          /*[num_vertices]*/
+  int rank_id = 0;
 
   bool isInitialized() const {
     return mesh_num_edges && mesh_num_cells && mesh_num_verts && mesh_cells_vertex_idx &&


### PR DESCRIPTION
## Technical Description

Necessary for multi-node output: each mpi work rank in ICON would write independently to its own file.
Example:
```
mo_nh_diffusion_stencil_19_rank0_theta_v_0.csv
mo_nh_diffusion_stencil_19_rank1_theta_v_0.csv
```

Works also with 1 work rank (current setup), the `rank0_` part would be added in any case.
It doesn't necessarily require the code (on the model side) to set the rank ID, if only one work rank is used (as there's a default of 0).

## Testing

In `icon-dsl`.
