### PR TITLE
Fix Grid Function for Empty Domains

### DIFF
--- a/dawn/src/dawn/CodeGen/Cuda-ico/CudaIcoCodeGen.cpp
+++ b/dawn/src/dawn/CodeGen/Cuda-ico/CudaIcoCodeGen.cpp
@@ -249,10 +249,10 @@ void CudaIcoCodeGen::generateGpuMesh(
 void CudaIcoCodeGen::generateGridFun(MemberFunction& gridFun) {
   gridFun.addBlockStatement("if (kparallel)", [&]() {
     gridFun.addStatement("int dK = (kSize + LEVELS_PER_THREAD - 1) / LEVELS_PER_THREAD");
-    gridFun.addStatement("return dim3(std::max((elSize + BLOCK_SIZE - 1) / BLOCK_SIZE, 1), dK, 1)");
+    gridFun.addStatement("return dim3((elSize + BLOCK_SIZE - 1) / BLOCK_SIZE, dK, 1)");
   });
   gridFun.addBlockStatement("else", [&]() {
-    gridFun.addStatement("return dim3(std::max((elSize + BLOCK_SIZE - 1) / BLOCK_SIZE, 1), 1, 1)");
+    gridFun.addStatement("return dim3((elSize + BLOCK_SIZE - 1) / BLOCK_SIZE, 1, 1)");
   });
 }
 
@@ -276,10 +276,7 @@ void CudaIcoCodeGen::generateRunFun(
       stageLocType.insert(*stage->getLocationType());
     }
   }
-  runFun.addStatement("dim3 dB(BLOCK_SIZE, 1, 1)");
-
-  // start timers
-  runFun.addStatement("sbase::start()");
+  runFun.addStatement("dim3 dB(BLOCK_SIZE, 1, 1)");  
 
   for(const auto& ms : iterateIIROver<iir::MultiStage>(*(stencilInstantiation->getIIR()))) {
     for(const auto& stage : ms->getChildren()) {
@@ -350,6 +347,11 @@ void CudaIcoCodeGen::generateRunFun(
       std::string hOffsetString = "hoffset" + std::to_string(stage->getStageID());
       runFun.addStatement("int " + hSizeString + " = " +
                           numElementsString(*stage->getLocationType(), domain));
+      runFun.addBlockStatement("if (" + hSizeString + " == 0)", [&]() {
+        runFun.addStatement("return");
+      });                          
+      // start timers
+      runFun.addStatement("sbase::start()");                          
       if(domain.has_value()) {
         runFun.addStatement("int " + hOffsetString + " = " +
                             hOffsetSizeString(*stage->getLocationType(), *domain));


### PR DESCRIPTION
## Technical Description

For (horizontal) domains with zero entries a kernel launch grid with `0` blocks was generated, causing a cuda config invalid error during runtime. This PR fixes this issue by bailing out before the kernel launch in this situation. 

### Testing

Tested using ICON-DSL

### Dependencies

This PR is independent. 


