### PR TITLE
Use numpy isclose-like verification, allow per field tolerances

### DIFF
--- a/dawn/src/driver-includes/cuda_utils.cpp
+++ b/dawn/src/driver-includes/cuda_utils.cpp
@@ -2,13 +2,13 @@
 
 extern "C" {
 void set_splitter_index_lower(dawn::GlobalGpuTriMesh* globalTriMesh, int loc, int space, int offset,
-                        int index) {
-  globalTriMesh->set_splitter_index_lower(dawn::LocationType(loc), dawn::UnstructuredSubdomain(space),
-                                    offset, index);
+                              int index) {
+  globalTriMesh->set_splitter_index_lower(dawn::LocationType(loc),
+                                          dawn::UnstructuredSubdomain(space), offset, index);
 }
 void set_splitter_index_upper(dawn::GlobalGpuTriMesh* globalTriMesh, int loc, int space, int offset,
-                        int index) {
-  globalTriMesh->set_splitter_index_upper(dawn::LocationType(loc), dawn::UnstructuredSubdomain(space),
-                                    offset, index);
+                              int index) {
+  globalTriMesh->set_splitter_index_upper(dawn::LocationType(loc),
+                                          dawn::UnstructuredSubdomain(space), offset, index);
 }
 }

--- a/dawn/src/driver-includes/cuda_verify.cpp
+++ b/dawn/src/driver-includes/cuda_verify.cpp
@@ -55,14 +55,16 @@ bool verify_field(const int num_el, const double* dsl, const double* actual, std
   maxAbsErr = thrust::reduce(dev_ptr, dev_ptr + num_el, 0., thrust::maximum<double>());
   gpuErrchk(cudaPeekAtLastError());
 
-  std::cout << "[DSL] " << name << " absolute error: " << std::scientific << maxAbsErr << "\n"
+  std::cout << "[DSL] " << name << " maximum absolute error: " << std::scientific << maxAbsErr
+            << "\n"
             << std::flush;
 
   minAbsErr = thrust::reduce(dev_ptr, dev_ptr + num_el, std::numeric_limits<double>::infinity(),
                              thrust::minimum<double>());
   gpuErrchk(cudaPeekAtLastError());
 
-  std::cout << "[DSL] " << name << " absolute error: " << std::scientific << minAbsErr << "\n"
+  std::cout << "[DSL] " << name << " minimum absolute error: " << std::scientific << minAbsErr
+            << "\n"
             << std::flush;
 
   gpuErrchk(cudaFree(gpu_error));

--- a/dawn/src/driver-includes/cuda_verify.cpp
+++ b/dawn/src/driver-includes/cuda_verify.cpp
@@ -1,0 +1,108 @@
+#include "cuda_verify.hpp"
+
+namespace dawn {
+__global__ void isclose_kernel(const int num_el, const double* __restrict__ dsl,
+                               const double* __restrict__ fortran, bool* __restrict__ verified,
+                               const double rel_tol, const double abs_tol) {
+  unsigned int pidx = blockIdx.x * blockDim.x + threadIdx.x;
+  if(pidx >= num_el) {
+    return;
+  }
+
+  // This verification method is inspired by numpy.isclose from Python
+  verified[pidx] = (abs(dsl[pidx] - fortran[pidx]) <= (abs_tol + rel_tol * abs(fortran[pidx])));
+}
+
+bool verify_field(const int num_el, const double* dsl, const double* actual, std::string name,
+                  const double rel_tol, const double abs_tol) {
+  double relErr, absErr;
+  double* gpu_error;
+
+  const int blockSize = 16;
+  dim3 dG((num_el + blockSize - 1) / blockSize);
+  dim3 dB(blockSize);
+
+  gpuErrchk(cudaMalloc((void**)&gpu_error, num_el * sizeof(double)));
+  gpuErrchk(cudaPeekAtLastError());
+  gpuErrchk(cudaDeviceSynchronize());
+
+  compare_kernel<RelErrTag><<<dG, dB>>>(num_el, dsl, actual, gpu_error);
+  gpuErrchk(cudaPeekAtLastError());
+
+  thrust::device_ptr<double> dev_ptr;
+  dev_ptr = thrust::device_pointer_cast(gpu_error);
+  relErr = thrust::reduce(dev_ptr, dev_ptr + num_el, 0., thrust::maximum<double>());
+
+  gpuErrchk(cudaPeekAtLastError());
+  std::cout << "[DSL] " << name << " relative error: " << std::scientific << relErr << "\n"
+            << std::flush;
+
+  compare_kernel<AbsErrTag><<<dG, dB>>>(num_el, dsl, actual, gpu_error);
+  gpuErrchk(cudaPeekAtLastError());
+
+  dev_ptr = thrust::device_pointer_cast(gpu_error);
+  absErr = thrust::reduce(dev_ptr, dev_ptr + num_el, 0., thrust::maximum<double>());
+  gpuErrchk(cudaPeekAtLastError());
+
+  std::cout << "[DSL] " << name << " absolute error: " << std::scientific << absErr << "\n"
+            << std::flush;
+  gpuErrchk(cudaFree(gpu_error));
+  gpuErrchk(cudaPeekAtLastError());
+
+  bool* gpu_verify_bools;
+
+  gpuErrchk(cudaMalloc((void**)&gpu_verify_bools, num_el * sizeof(bool)));
+  gpuErrchk(cudaPeekAtLastError());
+  gpuErrchk(cudaDeviceSynchronize());
+
+  isclose_kernel<<<dG, dB>>>(num_el, dsl, actual, gpu_verify_bools, rel_tol, abs_tol);
+  gpuErrchk(cudaPeekAtLastError());
+
+  thrust::device_ptr<bool> bool_dev_ptr;
+  bool_dev_ptr = thrust::device_pointer_cast(gpu_verify_bools);
+  gpuErrchk(cudaPeekAtLastError());
+
+  bool result = thrust::all_of(bool_dev_ptr, bool_dev_ptr + num_el, thrust::identity<bool>());
+
+  if(!result) {
+    double min, max, avg;
+    thrust::device_ptr<const double> dev_cptr;
+
+    dev_cptr = thrust::device_pointer_cast(actual);
+
+    max = thrust::reduce(dev_cptr, dev_cptr + num_el, -std::numeric_limits<double>::infinity(),
+                         thrust::maximum<double>());
+    gpuErrchk(cudaPeekAtLastError());
+    min = thrust::reduce(dev_cptr, dev_cptr + num_el, std::numeric_limits<double>::infinity(),
+                         thrust::minimum<double>());
+    gpuErrchk(cudaPeekAtLastError());
+    avg = thrust::reduce(dev_cptr, dev_cptr + num_el) / num_el;
+    gpuErrchk(cudaPeekAtLastError());
+
+    std::cout << "[DSL] " << name << " max: " << max << "\n" << std::flush;
+    std::cout << "[DSL] " << name << " min: " << min << "\n" << std::flush;
+    std::cout << "[DSL] " << name << " avg: " << avg << "\n" << std::flush;
+
+    dev_cptr = thrust::device_pointer_cast(dsl);
+
+    max = thrust::reduce(dev_cptr, dev_cptr + num_el, -std::numeric_limits<double>::infinity(),
+                         thrust::maximum<double>());
+    gpuErrchk(cudaPeekAtLastError());
+    min = thrust::reduce(dev_cptr, dev_cptr + num_el, std::numeric_limits<double>::infinity(),
+                         thrust::minimum<double>());
+    gpuErrchk(cudaPeekAtLastError());
+    avg = thrust::reduce(dev_cptr, dev_cptr + num_el) / num_el;
+    gpuErrchk(cudaPeekAtLastError());
+
+    std::cout << "[DSL] " << name << "_dsl max: " << max << "\n" << std::flush;
+    std::cout << "[DSL] " << name << "_dsl min: " << min << "\n" << std::flush;
+    std::cout << "[DSL] " << name << "_dsl avg: " << avg << "\n" << std::flush;
+  }
+
+  gpuErrchk(cudaFree(gpu_verify_bools));
+  gpuErrchk(cudaPeekAtLastError());
+
+  return result;
+}
+
+} // namespace dawn

--- a/dawn/src/driver-includes/cuda_verify.hpp
+++ b/dawn/src/driver-includes/cuda_verify.hpp
@@ -6,6 +6,7 @@
 
 #include <thrust/device_ptr.h>
 #include <thrust/functional.h>
+#include <thrust/logical.h>
 #include <thrust/reduce.h>
 
 namespace {
@@ -33,10 +34,7 @@ template <>
 struct compute_error<RelErrTag> {
   static double __device__ impl(const double expected, const double actual) {
     double error = 0.;
-    if(expected == actual) {
-    } else if(fabs(expected) < 1e-6 && fabs(actual) < 1e-6) {
-      error = fabs(expected - actual);
-    } else {
+    if(expected != actual) {
       error = fabs((expected - actual) / expected);
     }
     return error;
@@ -56,44 +54,7 @@ __global__ void compare_kernel(const int num_el, const double* __restrict__ dsl,
   error[pidx] = compute_error<error_type>::impl(fortran[pidx], dsl[pidx]);
 }
 
-// Returns relative error. Prints relative and absolute error.
-inline double verify_field(const int num_el, const double* dsl, const double* actual,
-                           std::string name) {
-  double relErr, absErr;
-  double* gpu_error;
-
-  const int blockSize = 16;
-  dim3 dG((num_el + blockSize - 1) / blockSize);
-  dim3 dB(blockSize);
-
-  gpuErrchk(cudaMalloc((void**)&gpu_error, num_el * sizeof(double)));
-  gpuErrchk(cudaPeekAtLastError());
-  gpuErrchk(cudaDeviceSynchronize());
-
-  compare_kernel<RelErrTag><<<dG, dB>>>(num_el, dsl, actual, gpu_error);
-  gpuErrchk(cudaPeekAtLastError());
-
-  thrust::device_ptr<double> dev_ptr;
-  dev_ptr = thrust::device_pointer_cast(gpu_error);
-  relErr = thrust::reduce(dev_ptr, dev_ptr + num_el, 0., thrust::maximum<double>());
-
-  gpuErrchk(cudaPeekAtLastError());
-  std::cout << "[DSL] " << name << " relative error: " << std::scientific << relErr << "\n"
-            << std::flush;
-
-  compare_kernel<AbsErrTag><<<dG, dB>>>(num_el, dsl, actual, gpu_error);
-  gpuErrchk(cudaPeekAtLastError());
-
-  dev_ptr = thrust::device_pointer_cast(gpu_error);
-  absErr = thrust::reduce(dev_ptr, dev_ptr + num_el, 0., thrust::maximum<double>());
-  gpuErrchk(cudaPeekAtLastError());
-
-  std::cout << "[DSL] " << name << " absolute error: " << std::scientific << absErr << "\n"
-            << std::flush;
-  gpuErrchk(cudaFree(gpu_error));
-  gpuErrchk(cudaPeekAtLastError());
-
-  return relErr;
-}
+bool verify_field(const int num_el, const double* dsl, const double* actual, std::string name,
+                  const double rel_tol, const double abs_tol);
 
 } // namespace dawn


### PR DESCRIPTION
## Technical Description

Now use `numpy.isclose`-inspired verification method using the following formula:
```
abs(dsl[pidx] - fortran[pidx]) <= (abs_tol + rel_tol * abs(fortran[pidx]))
```
The user now can also provide `abs_tol` and `rel_tol` per OUT/INOUT field and not per kernel. There are default values in place for `abs_tol=0.0` and `rel_tol=1e-12`.

If verification fails, more information about the dsl and reference fields is given now: min, max, average.

### Resolves

The relative error formula below could lead to false positives in verification failure:
```
 double error = 0.;
    if(expected == actual) {
    } else if(fabs(expected) < 1e-6 && fabs(actual) < 1e-6) {
      error = fabs(expected - actual);
    } else {
      error = fabs((expected - actual) / expected);
    }
```
This is no longer in dawn.
