### PR TITLE
Add switch for Atlas Compatibility

### DIFF
--- a/dawn/src/dawn/CodeGen/Cuda-ico/ASTStencilBody.cpp
+++ b/dawn/src/dawn/CodeGen/Cuda-ico/ASTStencilBody.cpp
@@ -387,7 +387,8 @@ std::string ASTStencilBody::getName(const std::shared_ptr<ast::Expr>& expr) cons
   return metadata_.getFieldNameFromAccessID(iir::getAccessID(expr));
 }
 
-ASTStencilBody::ASTStencilBody(const iir::StencilMetaInformation& metadata) : metadata_(metadata) {}
+ASTStencilBody::ASTStencilBody(const iir::StencilMetaInformation& metadata, bool genAtlasCompatCode)
+    : metadata_(metadata), genAtlasCompatCode_(genAtlasCompatCode) {}
 ASTStencilBody::~ASTStencilBody() {}
 
 } // namespace cudaico

--- a/dawn/src/dawn/CodeGen/Cuda-ico/ASTStencilBody.cpp
+++ b/dawn/src/dawn/CodeGen/Cuda-ico/ASTStencilBody.cpp
@@ -52,7 +52,7 @@ void ASTStencilBody::visit(const std::shared_ptr<ast::LoopStmt>& stmt) {
   ss_ << "int nbhIdx = " << chainToTableString(maybeChainPtr->getIterSpace()) << "["
       << "pidx * " << chainToSparseSizeString(maybeChainPtr->getIterSpace()) << " + nbhIter"
       << "];\n";
-  if(hasIrregularPentagons(maybeChainPtr->getChain())) {
+  if(hasIrregularPentagons(maybeChainPtr->getChain()) || genAtlasCompatCode_) {
     ss_ << "if (nbhIdx == DEVICE_MISSING_VALUE) { continue; }";
   }
 
@@ -349,7 +349,7 @@ void ASTStencilBody::visit(const std::shared_ptr<ast::ReductionOverNeighborExpr>
            << "pidx * " << chainToSparseSizeString(expr->getIterSpace()) << " + nbhIter"
            << "];\n";
 
-  if(hasIrregularPentagons(expr->getNbhChain())) {
+  if(hasIrregularPentagons(expr->getNbhChain()) || genAtlasCompatCode_) {
     localSS_ << "if (nbhIdx == DEVICE_MISSING_VALUE) { continue; }";
   }
 

--- a/dawn/src/dawn/CodeGen/Cuda-ico/ASTStencilBody.h
+++ b/dawn/src/dawn/CodeGen/Cuda-ico/ASTStencilBody.h
@@ -85,6 +85,7 @@ protected:
   int parentReductionID_ = -1;
   bool parentIsForLoop_ = false;
   bool firstPass_ = true;
+  bool genAtlasCompatCode_ = false;
 
   int currentBlock_ = -1;
 
@@ -112,6 +113,7 @@ public:
   void setBlockToMergeGroupMap(std::optional<MergeGroupMap> blockToMergeGroupMap) {
     blockToMergeGroupMap_ = blockToMergeGroupMap;
   }
+  void setGenAtlasCompatCode(bool genAtlasCompatCode) { genAtlasCompatCode_ = genAtlasCompatCode; }
 
   /// @name Statement implementation
   /// @{

--- a/dawn/src/dawn/CodeGen/Cuda-ico/ASTStencilBody.h
+++ b/dawn/src/dawn/CodeGen/Cuda-ico/ASTStencilBody.h
@@ -103,7 +103,7 @@ public:
   using Base::visit;
 
   /// @brief constructor
-  ASTStencilBody(const iir::StencilMetaInformation& metadata);
+  ASTStencilBody(const iir::StencilMetaInformation& metadata, bool genAtlasCompatCode);
 
   virtual ~ASTStencilBody();
 
@@ -113,7 +113,6 @@ public:
   void setBlockToMergeGroupMap(std::optional<MergeGroupMap> blockToMergeGroupMap) {
     blockToMergeGroupMap_ = blockToMergeGroupMap;
   }
-  void setGenAtlasCompatCode(bool genAtlasCompatCode) { genAtlasCompatCode_ = genAtlasCompatCode; }
 
   /// @name Statement implementation
   /// @{

--- a/dawn/src/dawn/CodeGen/Cuda-ico/CudaIcoCodeGen.cpp
+++ b/dawn/src/dawn/CodeGen/Cuda-ico/CudaIcoCodeGen.cpp
@@ -155,7 +155,7 @@ run(const std::map<std::string, std::shared_ptr<iir::StencilInstantiation>>&
       options.OutputCHeader == "" ? std::nullopt : std::make_optional(options.OutputCHeader),
       options.OutputFortranInterface == "" ? std::nullopt
                                            : std::make_optional(options.OutputFortranInterface),
-      options.MergeReductions);
+      options.MergeReductions, options.AtlasCompatible);
 
   return CG.generateCode();
 }
@@ -163,9 +163,9 @@ run(const std::map<std::string, std::shared_ptr<iir::StencilInstantiation>>&
 CudaIcoCodeGen::CudaIcoCodeGen(const StencilInstantiationContext& ctx, int maxHaloPoints,
                                std::optional<std::string> outputCHeader,
                                std::optional<std::string> outputFortranInterface,
-                               bool mergeReductions)
+                               bool mergeReductions, bool atlasCompatible)
     : CodeGen(ctx, maxHaloPoints), codeGenOptions_{outputCHeader, outputFortranInterface,
-                                                   mergeReductions} {}
+                                                   mergeReductions, atlasCompatible} {}
 
 CudaIcoCodeGen::~CudaIcoCodeGen() {}
 
@@ -1204,6 +1204,7 @@ void CudaIcoCodeGen::generateAllCudaKernels(
     std::stringstream& ssSW,
     const std::shared_ptr<iir::StencilInstantiation>& stencilInstantiation) {
   ASTStencilBody stencilBodyCXXVisitor(stencilInstantiation->getMetaData());
+  stencilBodyCXXVisitor.setGenAtlasCompatCode(codeGenOptions_.AtlasCompatible);
   const auto& globalsMap = stencilInstantiation->getIIR()->getGlobalVariableMap();
   std::optional<MergeGroupMap> blockToMergeGroups = std::nullopt;
   if(codeGenOptions_.MergeReductions) {

--- a/dawn/src/dawn/CodeGen/Cuda-ico/CudaIcoCodeGen.cpp
+++ b/dawn/src/dawn/CodeGen/Cuda-ico/CudaIcoCodeGen.cpp
@@ -1203,8 +1203,8 @@ std::string CudaIcoCodeGen::comparisonOperator(iir::LoopOrderKind loopOrder) {
 void CudaIcoCodeGen::generateAllCudaKernels(
     std::stringstream& ssSW,
     const std::shared_ptr<iir::StencilInstantiation>& stencilInstantiation) {
-  ASTStencilBody stencilBodyCXXVisitor(stencilInstantiation->getMetaData());
-  stencilBodyCXXVisitor.setGenAtlasCompatCode(codeGenOptions_.AtlasCompatible);
+  ASTStencilBody stencilBodyCXXVisitor(stencilInstantiation->getMetaData(),
+                                       codeGenOptions_.AtlasCompatible);
   const auto& globalsMap = stencilInstantiation->getIIR()->getGlobalVariableMap();
   std::optional<MergeGroupMap> blockToMergeGroups = std::nullopt;
   if(codeGenOptions_.MergeReductions) {

--- a/dawn/src/dawn/CodeGen/Cuda-ico/CudaIcoCodeGen.h
+++ b/dawn/src/dawn/CodeGen/Cuda-ico/CudaIcoCodeGen.h
@@ -47,7 +47,8 @@ public:
   ///@brief constructor
   CudaIcoCodeGen(const StencilInstantiationContext& ctx, int maxHaloPoints,
                  std::optional<std::string> outputCHeader,
-                 std::optional<std::string> outputFortranInterface, bool mergeStages = false);
+                 std::optional<std::string> outputFortranInterface, bool mergeStages = false,
+                 bool atlasCompatible = false);
   virtual ~CudaIcoCodeGen();
   virtual std::unique_ptr<TranslationUnit> generateCode() override;
 
@@ -56,6 +57,7 @@ public:
     std::optional<std::string> OutputCHeader;
     std::optional<std::string> OutputFortranInterface;
     bool MergeReductions;
+    bool AtlasCompatible;
   };
 
 private:

--- a/dawn/src/dawn/CodeGen/Options.inc
+++ b/dawn/src/dawn/CodeGen/Options.inc
@@ -48,5 +48,6 @@ OPT(int, DomainSizeK, 0, "domain-size-k", "", "k domain size for compiler optimi
 OPT(std::string, OutputCHeader, "", "output-c-header", "", "Write C header to <File>", "<File>", true, false)
 OPT(std::string, OutputFortranInterface, "", "output-f90-interface", "", "Write Fortran90 interface to <File>", "<File>", true, false)
 OPT(bool, MergeReductions, false, "merge-reductions", "", "Attempt to merge reductions on same iteration spaces (experimental)", "", false, true)
+OPT(bool, AtlasCompatible, false, "atlas-compatible", "", "Emit code that is save to run on atlas meshes (assume incomplete neighborhoods for all chains)", "", false, true)
 
 // clang-format on

--- a/dawn/src/dawn4py/_dawn4py.cpp
+++ b/dawn/src/dawn4py/_dawn4py.cpp
@@ -183,17 +183,25 @@ PYBIND11_MODULE(_dawn4py, m) {
       .def(py::init([](int MaxHaloSize, bool UseParallelEP, bool RunWithSync, int MaxBlocksPerSM,
                        int nsms, int DomainSizeI, int DomainSizeJ, int DomainSizeK,
                        const std::string& OutputCHeader, const std::string& OutputFortranInterface,
-                       bool MergeReductions) {
-             return dawn::codegen::Options{
-                 MaxHaloSize,    UseParallelEP, RunWithSync, MaxBlocksPerSM, nsms,
-                 DomainSizeI,    DomainSizeJ,   DomainSizeK, OutputCHeader,  OutputFortranInterface,
-                 MergeReductions};
+                       bool MergeReductions, bool AtlasCompatible) {
+             return dawn::codegen::Options{MaxHaloSize,
+                                           UseParallelEP,
+                                           RunWithSync,
+                                           MaxBlocksPerSM,
+                                           nsms,
+                                           DomainSizeI,
+                                           DomainSizeJ,
+                                           DomainSizeK,
+                                           OutputCHeader,
+                                           OutputFortranInterface,
+                                           MergeReductions,
+                                           AtlasCompatible};
            }),
            py::arg("max_halo_size") = 3, py::arg("use_parallel_ep") = false,
            py::arg("run_with_sync") = true, py::arg("max_blocks_per_sm") = 0, py::arg("nsms") = 0,
            py::arg("domain_size_i") = 0, py::arg("domain_size_j") = 0, py::arg("domain_size_k") = 0,
            py::arg("output_c_header") = "", py::arg("output_fortran_interface") = "",
-           py::arg("merge_reductions") = false)
+           py::arg("merge_reductions") = false, py::arg("atlas_compatible") = false)
       .def_readwrite("max_halo_size", &dawn::codegen::Options::MaxHaloSize)
       .def_readwrite("use_parallel_ep", &dawn::codegen::Options::UseParallelEP)
       .def_readwrite("run_with_sync", &dawn::codegen::Options::RunWithSync)
@@ -205,6 +213,7 @@ PYBIND11_MODULE(_dawn4py, m) {
       .def_readwrite("output_c_header", &dawn::codegen::Options::OutputCHeader)
       .def_readwrite("output_fortran_interface", &dawn::codegen::Options::OutputFortranInterface)
       .def_readwrite("merge_reductions", &dawn::codegen::Options::MergeReductions)
+      .def_readwrite("atlas_compatible", &dawn::codegen::Options::AtlasCompatible)
       .def("__repr__", [](const dawn::codegen::Options& self) {
         std::ostringstream ss;
         ss << "max_halo_size=" << self.MaxHaloSize << ",\n    "
@@ -221,7 +230,8 @@ PYBIND11_MODULE(_dawn4py, m) {
            << "output_fortran_interface="
            << "\"" << self.OutputFortranInterface << "\""
            << ",\n    "
-           << "merge_reductions=" << self.MergeReductions;
+           << "merge_reductions=" << self.MergeReductions << ",\n    "
+           << "atlas_compatible=" << self.AtlasCompatible;
         return "CodeGenOptions(\n    " + ss.str() + "\n)";
       });
 


### PR DESCRIPTION
## Technical Description

In `icondusk-e2e` we test on atlas meshes on the full domain. This means that neighborhood entries may be missing even without the pentagon / hexagon issue (at the border). This PR introduces a switch to emit a guard against such neighborhoods for _all_ chains. 

### Example

`./dawn-codegen --atlas-compatible test_reduce.iir -b cuda-ico -o out.cpp`

### Testing

Tested using `icon-dusk` 

### Dependencies

This PR is independent


