### PR TITLE
Make Block Size and Levels per Thread an Option to Codegen

### DIFF
--- a/dawn/src/dawn/CodeGen/Cuda-ico/CudaIcoCodeGen.h
+++ b/dawn/src/dawn/CodeGen/Cuda-ico/CudaIcoCodeGen.h
@@ -47,8 +47,8 @@ public:
   ///@brief constructor
   CudaIcoCodeGen(const StencilInstantiationContext& ctx, int maxHaloPoints,
                  std::optional<std::string> outputCHeader,
-                 std::optional<std::string> outputFortranInterface, bool mergeStages = false,
-                 bool atlasCompatible = false, int blockSize = false, int levelsPerThread = false);
+                 std::optional<std::string> outputFortranInterface, bool mergeStages,
+                 bool atlasCompatible, int blockSize, int levelsPerThread);
   virtual ~CudaIcoCodeGen();
   virtual std::unique_ptr<TranslationUnit> generateCode() override;
 

--- a/dawn/src/dawn/CodeGen/Cuda-ico/CudaIcoCodeGen.h
+++ b/dawn/src/dawn/CodeGen/Cuda-ico/CudaIcoCodeGen.h
@@ -48,16 +48,17 @@ public:
   CudaIcoCodeGen(const StencilInstantiationContext& ctx, int maxHaloPoints,
                  std::optional<std::string> outputCHeader,
                  std::optional<std::string> outputFortranInterface, bool mergeStages = false,
-                 bool atlasCompatible = false);
+                 bool atlasCompatible = false, int blockSize = false, int levelsPerThread = false);
   virtual ~CudaIcoCodeGen();
   virtual std::unique_ptr<TranslationUnit> generateCode() override;
 
   struct CudaIcoCodeGenOptions {
-    // TODO: consider adding options for hard-coded values (e.g. BLOCK_SIZE)
     std::optional<std::string> OutputCHeader;
     std::optional<std::string> OutputFortranInterface;
     bool MergeReductions;
     bool AtlasCompatible;
+    int BlockSize;
+    int LevelsPerThread;
   };
 
 private:

--- a/dawn/src/dawn/CodeGen/Options.inc
+++ b/dawn/src/dawn/CodeGen/Options.inc
@@ -49,5 +49,7 @@ OPT(std::string, OutputCHeader, "", "output-c-header", "", "Write C header to <F
 OPT(std::string, OutputFortranInterface, "", "output-f90-interface", "", "Write Fortran90 interface to <File>", "<File>", true, false)
 OPT(bool, MergeReductions, false, "merge-reductions", "", "Attempt to merge reductions on same iteration spaces (experimental)", "", false, true)
 OPT(bool, AtlasCompatible, false, "atlas-compatible", "", "Emit code that is save to run on atlas meshes (assume incomplete neighborhoods for all chains)", "", false, true)
+OPT(int, BlockSize, 128, "block-size", "", "number of threads per block for cuda-ico backend", "", true, false)
+OPT(int, LevelsPerThread, 1, "levels-per-thread", "", "number of vertical levels each thread works on for cuda-ico backend", "", true, false)
 
 // clang-format on


### PR DESCRIPTION
## Technical Description

Levels per thread and block size were hardcoded based an preliminary tests on daint. Tests on tsa have shown that these values need to be tuneable per stencil (i.e. there is no "global" optimum). This PR introduces the possibility to specify these parameters using command line args to `dawn-codegen`

### Example
```
./dawn-codegen --levels-per-thread=42 --block-size=1337 test_reduce.iir -b cuda-ico -o out.cpp && code out.cpp
```

### Testing

Tested manually

### Dependencies

This PR is independent. 


