### PR TITLE
Vtk precision fixes

### DIFF
--- a/dawn/src/driver-includes/to_vtk.cpp
+++ b/dawn/src/driver-includes/to_vtk.cpp
@@ -52,6 +52,8 @@ public:
 
     fs << "POINTS " << num_verts * num_k << " double\n";
 
+    fs << std::setprecision(std::numeric_limits<double>::max_digits10);
+
     for(int k = 0; k < num_k; k++) {
       for(int nodeIter = 0; nodeIter < num_verts; nodeIter++) {
         double x = vlat[nodeIter];
@@ -171,6 +173,8 @@ void dense_cells_to_vtk(int start_idx, int end_idx, int num_k, int dense_stride,
 
   output.cellData() << "SCALARS " << std::string(field_name) << " double 1\nLOOKUP_TABLE default\n";
 
+  output.cellData() << std::setprecision(std::numeric_limits<double>::max_digits10);
+
   for(int k = 0; k < num_k; k++) {
     for(int cellIter = 0; cellIter < mesh_info_vtk.mesh_num_cells; cellIter++) {
       if(cellIter < start_idx || cellIter > end_idx) {
@@ -216,6 +220,8 @@ void dense_verts_to_vtk(int start_idx, int end_idx, int num_k, int dense_stride,
   auto& output = getStencilFieldsVtkOutput(num_k, std::string(stencil_name), iter);
 
   output.pointData() << "SCALARS " << std::string(field_name) << " double 1\nLOOKUP_TABLE default\n";
+
+  output.pointData() << std::setprecision(std::numeric_limits<double>::max_digits10);
 
   for(int k = 0; k < num_k; k++) {
     for(int pointIter = 0; pointIter < mesh_info_vtk.mesh_num_verts; pointIter++) {
@@ -269,6 +275,8 @@ void dense_edges_to_vtk(int start_idx, int end_idx, int num_k, int dense_stride,
   auto& output = getStencilFieldsVtkOutput(num_k, std::string(stencil_name), iter);
   // Edges not supported by vtk, need to interpolate into cells.
   output.cellData() << "SCALARS " << std::string(field_name) << " double 1\nLOOKUP_TABLE default\n";
+
+  output.cellData() << std::setprecision(std::numeric_limits<double>::max_digits10);
 
   for(int k = 0; k < num_k; k++) {
     for(int cellIter = 0; cellIter < mesh_info_vtk.mesh_num_cells; cellIter++) {

--- a/dawn/src/driver-includes/to_vtk.cpp
+++ b/dawn/src/driver-includes/to_vtk.cpp
@@ -111,13 +111,22 @@ public:
 // (stencil_name, iteration) -> vtk_output_handle
 std::map<std::pair<std::string, int>, StencilFieldsVtkOutput> stencil_to_output_map;
 
-static std::string formatNaNs(const double value) {
-  if(std::isnan(value)) {
-    return "nan";
-  }
+// wrapper type so we can overload `std::ostream <<` and get vtk compatible formatting for NaNs
+struct formatNaNs {
+  double value;
+  formatNaNs(double value): value(value) {}
+};
 
-  return std::to_string(value);
+std::ostream& operator<<(std::ostream& os, const formatNaNs& wrapper)
+{
+  if(std::isnan(wrapper.value)) {
+    os << "nan";
+  } else {
+    os << wrapper.value;
+  }
+  return os;
 }
+
 
 namespace {
 StencilFieldsVtkOutput& getStencilFieldsVtkOutput(int num_k, std::string stencil_name, int iter) {

--- a/dawn/src/driver-includes/to_vtk.cpp
+++ b/dawn/src/driver-includes/to_vtk.cpp
@@ -148,7 +148,7 @@ void dense_cells_to_csv(int start_idx, int end_idx, int num_k, int dense_stride,
   fs << field_name;
   fs << "\"\n";
 
-  fs << std::setprecision(std::numeric_limits<long double>::digits10 + 1);
+  fs << std::setprecision(std::numeric_limits<double>::max_digits10);
 
   for(int k = 0; k < num_k; k++) {
     for(int cellIter = 0; cellIter < mesh_info_vtk.mesh_num_cells; cellIter++) {
@@ -194,7 +194,7 @@ void dense_verts_to_csv(int start_idx, int end_idx, int num_k, int dense_stride,
   fs << field_name;
   fs << "\"\n";
 
-  fs << std::setprecision(std::numeric_limits<long double>::digits10 + 1);
+  fs << std::setprecision(std::numeric_limits<double>::max_digits10);
 
   for(int k = 0; k < num_k; k++) {
     for(int vertIter = 0; vertIter < mesh_info_vtk.mesh_num_verts; vertIter++) {
@@ -240,7 +240,7 @@ void dense_edges_to_csv(int start_idx, int end_idx, int num_k, int dense_stride,
   fs << field_name;
   fs << "\"\n";
 
-  fs << std::setprecision(std::numeric_limits<long double>::digits10 + 1);
+  fs << std::setprecision(std::numeric_limits<double>::max_digits10);
 
   for(int k = 0; k < num_k; k++) {
     for(int cellIter = 0; cellIter < mesh_info_vtk.mesh_num_cells; cellIter++) {

--- a/dawn/src/driver-includes/to_vtk.cpp
+++ b/dawn/src/driver-includes/to_vtk.cpp
@@ -50,7 +50,7 @@ public:
     fs << "# vtk DataFile Version 3.0\n2D scalar data\nASCII\nDATASET "
           "UNSTRUCTURED_GRID\n";
 
-    fs << "POINTS " << num_verts * num_k << " float\n";
+    fs << "POINTS " << num_verts * num_k << " double\n";
 
     for(int k = 0; k < num_k; k++) {
       for(int nodeIter = 0; nodeIter < num_verts; nodeIter++) {
@@ -169,7 +169,7 @@ void dense_cells_to_vtk(int start_idx, int end_idx, int num_k, int dense_stride,
 
   auto& output = getStencilFieldsVtkOutput(num_k, std::string(stencil_name), iter);
 
-  output.cellData() << "SCALARS " << std::string(field_name) << " float 1\nLOOKUP_TABLE default\n";
+  output.cellData() << "SCALARS " << std::string(field_name) << " double 1\nLOOKUP_TABLE default\n";
 
   for(int k = 0; k < num_k; k++) {
     for(int cellIter = 0; cellIter < mesh_info_vtk.mesh_num_cells; cellIter++) {
@@ -215,7 +215,7 @@ void dense_verts_to_vtk(int start_idx, int end_idx, int num_k, int dense_stride,
 
   auto& output = getStencilFieldsVtkOutput(num_k, std::string(stencil_name), iter);
 
-  output.pointData() << "SCALARS " << std::string(field_name) << " float 1\nLOOKUP_TABLE default\n";
+  output.pointData() << "SCALARS " << std::string(field_name) << " double 1\nLOOKUP_TABLE default\n";
 
   for(int k = 0; k < num_k; k++) {
     for(int pointIter = 0; pointIter < mesh_info_vtk.mesh_num_verts; pointIter++) {
@@ -268,7 +268,7 @@ void dense_edges_to_vtk(int start_idx, int end_idx, int num_k, int dense_stride,
 
   auto& output = getStencilFieldsVtkOutput(num_k, std::string(stencil_name), iter);
   // Edges not supported by vtk, need to interpolate into cells.
-  output.cellData() << "SCALARS " << std::string(field_name) << " float 1\nLOOKUP_TABLE default\n";
+  output.cellData() << "SCALARS " << std::string(field_name) << " double 1\nLOOKUP_TABLE default\n";
 
   for(int k = 0; k < num_k; k++) {
     for(int cellIter = 0; cellIter < mesh_info_vtk.mesh_num_cells; cellIter++) {


### PR DESCRIPTION
## Technical Description

Serializing double precision fields to vtk was lossy due to a number of factors. This and related issues are fixed here:

- Changed vtk data types from `float` to `double`.
- Added `setprecision` to vtk functions
- Fixed `formatNaN` to respect `setprecision` (for more see below)
- Fixed types and `max_digits10` for `setprecision` (for more see below)

#### Regarding `formatNaN`

I considered various different options. Before, the function `formatNaNs` returned a string and the function didn't respect `setprecision`. I wanted that `formatNaNs` respects `setprecision` while also formating NaNs correctly (as `"nan"`). I could have also used a string stream and then set the precision each time before formatting the double into that string stream. However, this means the function won't respect `setprecision` of other streams and the precision isn't really customizable for a user.
Using this wrapper type, I can customize the formatting of NaNs, but also ensure that `setprecision` of the stream is respected.

I'm unsure whether the struct should still be named `formatNaNs`. I considered various alternatives, but couldn't come up with anything that I think is better. So I thought I'll stick with the simple solution for now. Additionally, the struct and the overloading of the `std::ostream <<` operator are only local to the `.cpp` file. So even though the solution is a bit hacky, it's only confined to this file. If in the future we want to use this trick elsewhere, we should probably consider better ways to name the struct and overload the operator (or a different implementation alltogether). However, because it's confined only to this file and it's a simple implementation that works, I thought it's fine like this.

#### Regarding `std::setprecision(std::numeric_limits<double>::max_digits10);`

`long double` is wrong in those cases, because all fields are statically typed as `double`.

I believe `max_digits10` is the correct value we're looking for here. We've had this already before here: https://github.com/MeteoSwiss-APN/dawn/pull/992

There's also:

> `max_digits10` is the number of decimal digits needed to guarantee correct float → text → float round-trip.

from here: https://stackoverflow.com/a/22458961/12958632

### Resolves / Enhances

Resolves lossy serialization of double precision fields to vtk.

### Testing

Tested manually with ICON and ParaView.