### PR TITLE
Add VarAccessExpr to Integrity Checking

### DIFF
--- a/dawn/src/dawn/IIR/StencilMetaInformation.h
+++ b/dawn/src/dawn/IIR/StencilMetaInformation.h
@@ -228,8 +228,6 @@ public:
   bool hasNameToAccessID(const std::string& name) const {
     return AccessIDToNameMap_.reverseHas(name);
   }
-  /// @brief Get the field-AccessID set
-  const std::set<int>& getFieldAccessIDSet() const;
 
   /// @brief Get the field-AccessID set
   const std::set<int>& getGlobalVariableAccessIDSet() const;

--- a/dawn/src/dawn/Validator/IntegrityChecker.h
+++ b/dawn/src/dawn/Validator/IntegrityChecker.h
@@ -14,8 +14,8 @@
 
 #pragma once
 
-#include "dawn/IIR/ASTExpr.h"
 #include "dawn/AST/ASTUtil.h"
+#include "dawn/IIR/ASTExpr.h"
 #include "dawn/IIR/StencilInstantiation.h"
 #include "dawn/Support/Exception.h"
 
@@ -38,19 +38,11 @@ public:
 
   void run();
 
-  void visit(const std::shared_ptr<ast::BlockStmt>& stmt) override;
-  void visit(const std::shared_ptr<ast::ExprStmt>& stmt) override;
-  void visit(const std::shared_ptr<ast::ReturnStmt>& stmt) override;
-  void visit(const std::shared_ptr<ast::IfStmt>& stmt) override;
-  void visit(const std::shared_ptr<ast::VarDeclStmt>& stmt) override;
+  void visit(const std::shared_ptr<ast::VarAccessExpr>& stmt) override;
   void visit(const std::shared_ptr<ast::AssignmentExpr>& expr) override;
   void visit(const std::shared_ptr<ast::FieldAccessExpr>& expr) override;
-  void visit(const std::shared_ptr<ast::UnaryOperator>& expr) override;
   void visit(const std::shared_ptr<ast::ReductionOverNeighborExpr>& expr) override;
   void visit(const std::shared_ptr<ast::LoopStmt>& expr) override;
-  void visit(const std::shared_ptr<ast::BinaryOperator>& expr) override;
-  void visit(const std::shared_ptr<ast::TernaryOperator>& expr) override;
-  void visit(const std::shared_ptr<ast::FunCallExpr>& expr) override;
 
 private:
   void iterate(iir::StencilInstantiation* instantiation);


### PR DESCRIPTION
## Technical Description

During the stencil integration a bug in the dawn integrity checking was noticed with situations of the form:

```
@stencil
def test_stencil(
    levelmask: Field[K],    b: Field[Edge, K]       
) -> None:
    a: Field[Edge, K]
    with domain.upward as k:
        a = 0.0
        if (levelmask[k]):
            a = b   
```

This (valid) code was rejected by dawn if `--default-opt` was set. In the issue it was theorized that the `levelmask` is to blame, since the error message read " trying to assign verticald field to fulld field!". This turned out not to be true; the error was in fact a missing visitor looking at `VarAccessExpr`. If `--default-opt` is set, the field `a` is demoted to a local scalar variable. Since there was no visitor for this variable, the `IntegrityChecker` was indeed comparing the dimensions of `levelmask` and `b`. This PR resolves this by adding the appropriate visitor.

### Resolves / Enhances

Fixes #1143 

### Example

Example is posted above

### Testing

A new test was added to `TestIntegrityChecker`, exercising the example above

### Dependencies

This PR is independent. 


