### PR TITLE
Unused api fields bugfix

### DIFF
--- a/dawn/src/dawn/CodeGen/Cuda-ico/CudaIcoCodeGen.cpp
+++ b/dawn/src/dawn/CodeGen/Cuda-ico/CudaIcoCodeGen.cpp
@@ -1049,18 +1049,24 @@ void CudaIcoCodeGen::generateAllAPIVerifyFunctions(
       runAndVerifyAPI.addStatement("std::cout << \"[DSL] Running stencil " + wrapperName +
                                    "...\\n\" << std::flush");
 
-      auto getDSLFieldsNames =
-          [&fieldInfos](const iir::Stencil& stencil) -> std::vector<std::string> {
-        auto usedFields = getUsedFields(stencil);
+      auto getDSLFieldsNames = [&fieldInfos, &stencilInstantiation](
+                                   const iir::Stencil& stencil) -> std::vector<std::string> {
+        auto apiFields = stencilInstantiation->getMetaData().getAPIFields();
 
         std::vector<std::string> fieldNames;
-        for(auto fieldID : usedFields) {
-          auto fieldInfo = fieldInfos.at(fieldID);
-          if(fieldInfo.field.getIntend() == dawn::iir::Field::IntendKind::InputOutput ||
-             fieldInfo.field.getIntend() == dawn::iir::Field::IntendKind::Output) {
-            fieldNames.push_back(fieldInfo.Name + "_before");
+        for(auto fieldID : apiFields) {
+
+          if(fieldInfos.count(fieldID) == 0) {
+            // field is unused, so we don't need a `..._before` variant
+            fieldNames.push_back(stencilInstantiation->getMetaData().getNameFromAccessID(fieldID));
           } else {
-            fieldNames.push_back(fieldInfo.Name);
+            auto fieldInfo = fieldInfos.at(fieldID);
+            if(fieldInfo.field.getIntend() == dawn::iir::Field::IntendKind::InputOutput ||
+               fieldInfo.field.getIntend() == dawn::iir::Field::IntendKind::Output) {
+              fieldNames.push_back(fieldInfo.Name + "_before");
+            } else {
+              fieldNames.push_back(fieldInfo.Name);
+            }
           }
         }
         return fieldNames;

--- a/dawn/src/dawn/CodeGen/Cuda-ico/CudaIcoCodeGen.cpp
+++ b/dawn/src/dawn/CodeGen/Cuda-ico/CudaIcoCodeGen.cpp
@@ -1047,7 +1047,7 @@ void CudaIcoCodeGen::generateAllAPIVerifyFunctions(
       runAndVerifyAPI.addStatement("static int iteration = 0");
 
       runAndVerifyAPI.addStatement("std::cout << \"[DSL] Running stencil " + wrapperName +
-                                   "...\\n\" << std::flush");
+                                   " (\" << iteration << \") ...\\n\" << std::flush");
 
       auto getDSLFieldsNames = [&fieldInfos, &stencilInstantiation](
                                    const iir::Stencil& stencil) -> std::vector<std::string> {


### PR DESCRIPTION
## Technical Description

It fixes a bug where broken code gets generated if an API field is unused.
The code generated wrapper function will only pass used API fields to the run call.
If an API field is unused, it will occur in the signature of the run function, but it will be missing when the function is called in the wrapper function. Thus the call is invalid and the generated code is broken.

### Testing

Tested manually with ICON.


