### PR TITLE
Make getShape convenience method in atlas_interface consistent

### DIFF
--- a/dawn/src/interface/atlas_interface.hpp
+++ b/dawn/src/interface/atlas_interface.hpp
@@ -156,8 +156,8 @@ public:
     return sparse_dimension_.shape(0) * sparse_dimension_.shape(1) * sparse_dimension_.shape(2);
   }
   std::tuple<size_t, size_t, size_t> getShape() const {
-    return std::make_tuple(sparse_dimension_.shape(0), sparse_dimension_.shape(1),
-                           sparse_dimension_.shape(2));
+    return std::make_tuple(sparse_dimension_.shape(0), sparse_dimension_.shape(2),
+                           sparse_dimension_.shape(1));
   }
 
   SparseDimension(atlas::array::ArrayView<T, 3> const& sparse_dimension)


### PR DESCRIPTION
## Technical Description

Joerg Behrens reported the following:

in the file `dawn/src/interface/atlas_interface.hpp` you define the class
`SparseDimension`. There, the access `operator()` seems to expect the
following order of dimensions `(elem_dim, sparse_dim, level_dim)`, e.g.:

```
T const& operator()(int elem_idx, int sparse_dim_idx, int level)
```

The `getShape()` method, however, returns the field shape in the class
internal order of dimensions which seems to be (elem_dim, level_dim,
sparse_dim).

Therefore the field shape given by `getShape()` seems to be inconsistent
with the field access or, in other words: The shape does not give the
access bounds of the access operator as would be expected (I am only
guessing the semantics from the method name - which triggers my Fortran
background).

In my opinion a consistent `getShape` method would return something like

```
std::make_tuple(
   sparse_dimension_.shape(0),
   sparse_dimension_.shape(2),
   sparse_dimension_.shape(1));
```

This PR implements the suggested `getShape` method.

### Testing

This method is dead code in the dawn repo, so this remains untested!

