### PR TITLE
Swap Dimensions on Sprase Full Fields

### DIFF
--- a/dawn/src/dawn/CodeGen/Cuda-ico/ASTStencilBody.cpp
+++ b/dawn/src/dawn/CodeGen/Cuda-ico/ASTStencilBody.cpp
@@ -165,9 +165,6 @@ std::string ASTStencilBody::makeIndexString(const std::shared_ptr<ast::FieldAcce
     DAWN_ASSERT_MSG(parentIsForLoop_ || parentIsReduction_,
                     "Sparse Field Access not allowed in this context");
     std::string sparseSize = chainToSparseSizeString(unstrDims.getIterSpace());
-
-    // return nbhIterStr() + " * kSize * " + denseSize + " + " + kiterStr + "*" + denseSize + " + " +
-    //        pidxStr();
     return kiterStr + " * " + sparseSize + " * " + denseSize + " + " + nbhIterStr() + " * " + denseSize 
               + " + " + pidxStr();
   }

--- a/dawn/src/dawn/CodeGen/Cuda-ico/ASTStencilBody.cpp
+++ b/dawn/src/dawn/CodeGen/Cuda-ico/ASTStencilBody.cpp
@@ -164,8 +164,12 @@ std::string ASTStencilBody::makeIndexString(const std::shared_ptr<ast::FieldAcce
   if(isFullField && isSparse) {
     DAWN_ASSERT_MSG(parentIsForLoop_ || parentIsReduction_,
                     "Sparse Field Access not allowed in this context");
-    return nbhIterStr() + " * kSize * " + denseSize + " + " + kiterStr + "*" + denseSize + " + " +
-           pidxStr();
+    std::string sparseSize = chainToSparseSizeString(unstrDims.getIterSpace());
+
+    // return nbhIterStr() + " * kSize * " + denseSize + " + " + kiterStr + "*" + denseSize + " + " +
+    //        pidxStr();
+    return kiterStr + " * " + sparseSize + " * " + denseSize + " + " + nbhIterStr() + " * " + denseSize 
+              + " + " + pidxStr();
   }
 
   // 2D
@@ -181,8 +185,7 @@ std::string ASTStencilBody::makeIndexString(const std::shared_ptr<ast::FieldAcce
 
   if(isHorizontal && isSparse) {
     DAWN_ASSERT_MSG(parentIsForLoop_ || parentIsReduction_,
-                    "Sparse Field Access not allowed in this context");
-    std::string sparseSize = chainToSparseSizeString(unstrDims.getIterSpace());
+                    "Sparse Field Access not allowed in this context");    
     return nbhIterStr() + " * " + denseSize + " + " + pidxStr();
   }
 


### PR DESCRIPTION
## Technical Description

Consider [this PR](https://github.com/MeteoSwiss-APN/dawn/commit/91a9bde561881c2408032347c08179718426be58), i.e. introducing a `kSize` per output field in order to be able to merge stencils on different vertical domains. This has some problems, because `k` is not only used as an iterator variable, but also as stride in the case of "full" sparse fields. As a simple fix to this problem, this PR switches the full sparse field layout to: `[numlev, sparse_size, dense]`. 

### Example

Old addressing:
```
sparse_full[nbhIter0 * kSize * CellStride + (kIter + 0) * CellStride + pidx]
```
becomes a problem if the stencil has domain `kSize + 1` but field `sparse_full` is only allcoated for `kSize` levels. Switching the layout to:
```
vcoef[(kIter + 0) * C_E_C_SIZE * CellStride + nbhIter0 * CellStride + pidx]
```
avoids this problem.

### Testing

Tested using icon-cscs

### Dependencies

This PR is independent. 


