### PR TITLE
Make Verification Functions Run in Same Stream as Kernel

### DIFF
--- a/dawn/src/dawn/CodeGen/Cuda-ico/CudaIcoCodeGen.cpp
+++ b/dawn/src/dawn/CodeGen/Cuda-ico/CudaIcoCodeGen.cpp
@@ -709,6 +709,12 @@ void CudaIcoCodeGen::generateStencilClasses(
     meshGetter.addStatement("return mesh_");
     meshGetter.commit();
 
+    auto streamGetter = stencilClass.addMemberFunction("static cudaStream_t", "getStream");
+    streamGetter.finishArgs();
+    streamGetter.startBody();
+    streamGetter.addStatement("return stream_");
+    streamGetter.commit();
+
     auto kSizeGetter = stencilClass.addMemberFunction("static int", "getKSize");
     kSizeGetter.finishArgs();
     kSizeGetter.startBody();
@@ -1016,6 +1022,7 @@ void CudaIcoCodeGen::generateAllAPIVerifyFunctions(
       verifyAPI.startBody();
       verifyAPI.addStatement("using namespace std::chrono");
       verifyAPI.addStatement("const auto &mesh = " + fullStencilName + "::" + "getMesh()");
+      verifyAPI.addStatement("cudaStream_t stream = " + fullStencilName + "::" + "getStream()");
       verifyAPI.addStatement("int kSize = " + fullStencilName + "::" + "getKSize()");
       verifyAPI.addStatement(
           "high_resolution_clock::time_point t_start = high_resolution_clock::now()");
@@ -1045,7 +1052,7 @@ void CudaIcoCodeGen::generateAllAPIVerifyFunctions(
                     "::" + chainToSparseSizeString(unstrDims.getIterSpace());
         }
 
-        verifyAPI.addStatement("isValid = ::dawn::verify_field(" + num_el + ", " + fieldInfo.Name +
+        verifyAPI.addStatement("isValid = ::dawn::verify_field(stream, " + num_el + ", " + fieldInfo.Name +
                                "_dsl" + "," + fieldInfo.Name + ", \"" + fieldInfo.Name + "\"" +
                                "," + fieldInfo.Name + "_rel_tol" + "," + fieldInfo.Name +
                                "_abs_tol" + ")");

--- a/dawn/src/driver-includes/cuda_verify.hpp
+++ b/dawn/src/driver-includes/cuda_verify.hpp
@@ -54,7 +54,7 @@ __global__ void compare_kernel(const int num_el, const double* __restrict__ dsl,
   error[pidx] = compute_error<error_type>::impl(fortran[pidx], dsl[pidx]);
 }
 
-bool verify_field(const int num_el, const double* dsl, const double* actual, std::string name,
+bool verify_field(cudaStream_t stream, const int num_el, const double* dsl, const double* actual, std::string name,
                   const double rel_tol, const double abs_tol);
 
 } // namespace dawn


### PR DESCRIPTION
## Technical Description

The verification functions in our `cuda_verify` files did not respect the stream being set in the setup function of the stencil. This was safe since the verification functions call a `cudaDeviceSynchronize()` (both explicitly as well as implicitly using `cudaMalloc`). However, it is still good practice to run everything in the stream that the user set. 


