### PR TITLE
Set protobuf version to be <3.20.0

### DIFF
--- a/dawn/setup.py
+++ b/dawn/setup.py
@@ -46,7 +46,7 @@ with open(os.path.join(DAWN_DIR, "cmake", "FetchProtobuf.cmake"), "r") as f:
     protobuf_version = m.group("version")
 
 # Dependencies
-REQUIRED = ["attrs>=19", "black>=19.3b0", f"protobuf>={protobuf_version}", "pytest>=4.3.0"]
+REQUIRED = ["attrs>=19", "black>=19.3b0", f"protobuf>={protobuf_version},<3.20.0", "pytest>=4.3.0"]
 EXTRAS = {"dev": ["pytest"]}
 
 # Get the Dawn version string


### PR DESCRIPTION
## Technical Description

It seems google broke backwards compatibility with protobuf ~3.21, so we put a maximum version of <3.20.0 to protobuf since dawn is very near to end-of-life
