### PR TITLE
Use `srun ... sarus pul image` instead of `sarus pull image` so the container has rights to access the internet

### DIFF
--- a/docker/dawn-env.dockerfile
+++ b/docker/dawn-env.dockerfile
@@ -16,7 +16,7 @@ RUN mkdir -p /usr/src/eckit-1.4.7/build && cd /usr/src/eckit-1.4.7/build && \
     ${ECBUILD_BIN} \
     -DCMAKE_INSTALL_PREFIX=/usr/local/eckit \
     -DCMAKE_BUILD_TYPE=Release \
-    -GNinja -- ../ && \
+    -GNinja ../ && \
     cmake --build . -j $(nproc) --target install && rm -rf /usr/src/eckit-1.4.7/build
 # ---------------------- Atlas ----------------------
 RUN curl -L https://github.com/ecmwf/atlas/archive/0.19.0.tar.gz | \
@@ -27,7 +27,7 @@ RUN mkdir -p /usr/src/atlas-0.19.0/build && cd /usr/src/atlas-0.19.0/build && \
     -DCMAKE_BUILD_TYPE=Release \
     -DENABLE_ATLAS_RUN=OFF \
     -DECKIT_PATH=/usr/local/eckit \
-    -GNinja -- ../ && \
+    -GNinja ../ && \
     cmake --build . -j $(nproc) --target install && rm -rf /usr/src/atlas-0.19.0/build
 # ---------------------- Protobuf ----------------------
 RUN curl -L https://github.com/protocolbuffers/protobuf/releases/download/v3.10.1/protobuf-all-3.10.1.tar.gz | \

--- a/scripts/daint-test
+++ b/scripts/daint-test
@@ -22,7 +22,7 @@ fi
 
 git clone --depth 1 -b $CLANG_GRIDTOOLS_BRANCH $CLANG_GRIDTOOLS_REPOSITORY $(pwd)/clang-gridtools
 
-sarus pull $image
+srun --account=g110 -C gpu sarus pull $image
 
 srun --job-name=dawn_PR \
     --time=01:00:00 \


### PR DESCRIPTION
the dawn jenkins plan (and the corresponding script) did the following, which worked on `daint` until June 6th:
```
sarus pull image
srun sarus run image
```
But since the `daint` update one needs to do the `sarus pull` with `srun` on a compute node:
```
srun sarus pull image
srun sarus run image
```
Otherwise the image cannot access the internet.

The small changes to `docker/dawn-env.dockerfile` are due to cmake not accepting the `--` arguments anymore. This resulted in errors when building new docker images.