### PR TITLE
Fixed multinode verification, fixed hardcoded nproma

### DIFF
--- a/dawn/src/driver-includes/cuda_utils.hpp
+++ b/dawn/src/driver-includes/cuda_utils.hpp
@@ -42,6 +42,7 @@ namespace dawn {
 
 struct GlobalGpuTriMesh {
   dawn::unstructured_domain HorizontalDomain;  
+  int Nproma;
   int NumEdges;
   int NumCells;
   int NumVertices;

--- a/dawn/src/driver-includes/to_json.cpp
+++ b/dawn/src/driver-includes/to_json.cpp
@@ -9,11 +9,10 @@ void MetricsSerialiser::writeJson(int iteration) {
   if((*jsonRecord).is_null()) {
     *jsonRecord = newJsonMetrics;
   } else {
-    json oldJsonMetrics = *jsonRecord;
     json newMetrics = newJsonMetrics[stencil][0];
     bool stencilFound = false;
 
-    for(auto& [stencilName, metricsArr] : oldJsonMetrics.items()) {
+    for(auto& [stencilName, metricsArr] : (*jsonRecord).items()) {
       if(stencilName == stencil) {
         // handle case where iteration does not yet exist for a stencil
         if(metricsArr.size() < iteration + 1) {
@@ -27,7 +26,7 @@ void MetricsSerialiser::writeJson(int iteration) {
 
     if(!stencilFound) {
       // add new stencil metrics object
-      oldJsonMetrics.insert(newJsonMetrics.begin(), newJsonMetrics.end());
+      (*jsonRecord).insert(newJsonMetrics.begin(), newJsonMetrics.end());
     }
   }
 }

--- a/dawn/src/driver-includes/to_json.hpp
+++ b/dawn/src/driver-includes/to_json.hpp
@@ -9,18 +9,14 @@ using json = nlohmann::json;
 
 class MetricsSerialiser {
 public:
+  json* jsonRecord;
   std::string fieldId;
-  std::string path;
   std::string stencil;
   json newJsonMetrics;
-  MetricsSerialiser(VerificationMetrics metricsStruct, std::string metricsPath,
+  MetricsSerialiser(json* jsonRecord, VerificationMetrics metricsStruct,
                     std::string stencilName, std::string fieldIdentifier);
   void writeJson(int iteration);
 
 private:
-  void dumpJson(json j);
-  bool is_empty(std::string);
   json generateJsonFromStruct(VerificationMetrics metrics);
 };
-
-std::string metricsNameFromEnvVar(std::string const& key);


### PR DESCRIPTION
* For multiple nodes multiple verification files are created. Each process writes into a separate file. All stencils get handed a pointer to a shared object at setup time. At the end of an ICON run that object gets dumped into a file.
* Nproma is no longer hard coded but passed to the stencils during setup time. Specifically `Nproma` is now part of the `GlobalGpuTriMesh` struct.